### PR TITLE
Ignore the difference in Int64Native types because caue.

### DIFF
--- a/std/haxe/rtti/XmlParser.hx
+++ b/std/haxe/rtti/XmlParser.hx
@@ -231,6 +231,7 @@ class XmlParser {
 					else
 						tinf.doc = inf.doc;
 				}
+				if (tinf.path == "haxe._Int64.NativeInt64") continue;
 				if( tinf.module == inf.module && tinf.doc == inf.doc && tinf.isPrivate == inf.isPrivate )
 					switch( ct ) {
 					case TClassdecl(c):


### PR DESCRIPTION
Obviously not ideal, but temp fix if you want to generate docs for java.
