### PR TITLE
add -neko-trace-absolute-path option

### DIFF
--- a/common.ml
+++ b/common.ml
@@ -205,7 +205,7 @@ module Define = struct
 		| Last (* must be last *)
 
 	let infos = function
-		| AbsolutePath -> ("absolute_path","Print absoluate file path in trace output")
+		| AbsolutePath -> ("absolute_path","Print absolute file path in trace output")
 		| AdvancedTelemetry -> ("advanced-telemetry","Allow the SWF to be measured with Monocle tool")
 		| As3 -> ("as3","Defined when outputing flash9 as3 source code")
 		| CheckXmlProxy -> ("check_xml_proxy","Check the used fields of the xml proxy")

--- a/genneko.ml
+++ b/genneko.ml
@@ -50,20 +50,25 @@ let pos ctx p =
 		| false ->
 			try
 				Hashtbl.find files p.pfile
-			with Not_found -> try
-				(* lookup relative path *)
-				let len = String.length p.pfile in
-				let base = List.find (fun path ->
-					let l = String.length path in
-					len > l && String.sub p.pfile 0 l = path
-				) ctx.com.Common.class_path in
-				let l = String.length base in
-				let path = String.sub p.pfile l (len - l) in
+			with Not_found ->
+				let path = (match Common.defined ctx.com Common.Define.AbsolutePath with
+				| true -> if (Filename.is_relative p.pfile)
+					then Filename.concat (Sys.getcwd()) p.pfile
+					else p.pfile
+				| false -> try
+					(* lookup relative path *)
+					let len = String.length p.pfile in
+					let base = List.find (fun path ->
+						let l = String.length path in
+						len > l && String.sub p.pfile 0 l = path
+					) ctx.com.Common.class_path in
+					let l = String.length base in
+					String.sub p.pfile l (len - l)
+
+					with Not_found -> p.pfile
+				) in
 				Hashtbl.add files p.pfile path;
 				path
-			with Not_found ->
-				Hashtbl.add files p.pfile p.pfile;
-				p.pfile
 	) in
 	{
 		psource = file;


### PR DESCRIPTION
It allows to compile absolute paths into a .n file.
Editors like Vim allow loading traces easily

This is the "new feature": (Filename.concat (Sys.getcwd()) p.pfile)
The rest is a small refactoring
