### PR TITLE
PHP target converts SText to haxe.io.Bytes instead of String

### DIFF
--- a/std/php/_std/sys/db/Mysql.hx
+++ b/std/php/_std/sys/db/Mysql.hx
@@ -133,8 +133,6 @@ private class MysqlResultSet implements ResultSet {
 				return untyped __call__("floatval", v);
 			case "datetime", "date":
 				return Date.fromString(v);
-			case "blob":
-				return haxe.io.Bytes.ofData(cast v);
 			default:
 				return v;
 		}


### PR DESCRIPTION
mysql_field_type return blob for (TINYTEXT, TEXT, MEDIUMTEXT, and LONGTEXT) 

@see whole discussion https://groups.google.com/forum/#!msg/haxelang/Aq3iZYdTKh4/7qJTVi4qPfIJ
