### PR TITLE
fix for php mysql text/blob problem

### DIFF
--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -172,7 +172,7 @@ class Manager<T : Object> {
 		}
 		s.add(")");
 		unsafeExecute(s.toString());
-		untyped x._lock = false;
+		untyped x._lock = true;
 		// table with one key not defined : suppose autoincrement
 		if( table_keys.length == 1 && Reflect.field(x,table_keys[0]) == null )
 			Reflect.setField(x,table_keys[0],getCnx().lastInsertId());


### PR DESCRIPTION
Checking for binary- or blob-flag if MySQL reports blob-type. 
This should fix string/blob errors ( For example #1920 or #1921 )
