### PR TITLE
Add cache_field to db objects after insert

### DIFF
--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -175,7 +175,7 @@ class Manager<T : Object> {
 		untyped x._lock = true;
 		// table with one key not defined : suppose autoincrement
 		if( table_keys.length == 1 && Reflect.field(x,table_keys[0]) == null )
-			Reflect.setField(x, table_keys[0], getCnx().lastInsertId());
+			Reflect.setField(x,table_keys[0],getCnx().lastInsertId());
 		
 		// make sure there is a cache_field (needed for update)
 		if ( Reflect.field(x, cache_field) == null ) {
@@ -183,7 +183,7 @@ class Manager<T : Object> {
 			var o = untyped __dollar__new(x);
 			untyped __dollar__objsetproto(o, class_proto.prototype);
 			#else
-			var o : T = Type.createEmptyInstance(cast class_proto);
+			var o = untyped __php__("new stdClass()");
 			for( f in Reflect.fields(x) )
 				Reflect.setField(o, f, Reflect.field(x, f));
 			untyped o._manager = this;

--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -175,7 +175,22 @@ class Manager<T : Object> {
 		untyped x._lock = true;
 		// table with one key not defined : suppose autoincrement
 		if( table_keys.length == 1 && Reflect.field(x,table_keys[0]) == null )
-			Reflect.setField(x,table_keys[0],getCnx().lastInsertId());
+			Reflect.setField(x, table_keys[0], getCnx().lastInsertId());
+		
+		// make sure there is a cache_field (needed for update)
+		if ( Reflect.field(x, cache_field) == null ) {
+			#if neko
+			var o = untyped __dollar__new(x);
+			untyped __dollar__objsetproto(o, class_proto.prototype);
+			#else
+			var o : T = Type.createEmptyInstance(cast class_proto);
+			for( f in Reflect.fields(x) )
+				Reflect.setField(o, f, Reflect.field(x, f));
+			untyped o._manager = this;
+			#end
+			untyped o._lock = true;
+			Reflect.setField(x, cache_field, o);
+		}
 		addToCache(x);
 	}
 

--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -181,7 +181,6 @@ class Manager<T : Object> {
 		if ( Reflect.field(x, cache_field) == null ) {
 			#if neko
 			var o = untyped __dollar__new(x);
-			untyped __dollar__objsetproto(o, class_proto.prototype);
 			#else
 			var o = untyped __php__("new stdClass()");
 			for( f in Reflect.fields(x) )


### PR DESCRIPTION
```
dbObject.instert();
...
dbObject.dbField = newValue;
dbObject.update()
```

fails in php with 
`Creating default object from empty value (errno: 2) in [...]\lib\sys\db\Manager.class.php at line #355`
caused by missing `cached_field`.

<!---
@huboard:{"milestone_order":1926.0}
-->
