### PR TITLE
[cs] fixed urlEncode not encoding '&'

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -50,7 +50,7 @@ class StringTools {
 				return untyped __java__("java.net.URLEncoder.encode(s, \"UTF-8\")")
 			catch (e:Dynamic) throw e;
 		#elseif cs
-			return untyped __cs__("System.Uri.EscapeUriString(s)");
+			return untyped __cs__("System.Uri.EscapeDataString(s)");
 		#else
 			return null;
 		#end


### PR DESCRIPTION
`System.Uri.EscapeUriString` does not encode `&`, we should use `System.Uri.EscapeDataString` instead to make the cs target of urlEncode behave like other targets.