### PR TITLE
fix-evaluation-order-for-ocamlc

### DIFF
--- a/interp.ml
+++ b/interp.ml
@@ -485,7 +485,10 @@ let neko =
 	let vm = Extc.dlcall1 (load "neko_vm_alloc") null in
 	ignore(Extc.dlcall1 (load "neko_vm_select") vm);
 	let loader = Extc.dlcall2 (load "neko_default_loader") null null in
-	let loadprim = Extc.dlcall2 (load "neko_val_field") loader (Extc.dlcall1 (load "neko_val_id") (Extc.dlstring "loadprim")) in
+	let loadprim =
+		let l1 = load "neko_val_field" in
+		let l2 = Extc.dlcall1 (load "neko_val_id") (Extc.dlstring "loadprim") in
+		Extc.dlcall2 (l1) loader (l2) in
 
 	let callN = load "neko_val_callN" in
 	let callEx = load "neko_val_callEx" in

--- a/matcher.ml
+++ b/matcher.ml
@@ -541,7 +541,8 @@ let to_pattern ctx e t =
 		pc_sub_vars = None;
 		pc_reify = false;
 	} in
-	loop pctx e t, pctx.pc_locals
+	let x = loop pctx e t in
+	x, x.pc_locals
 
 let get_pattern_locals ctx e t =
 	try


### PR DESCRIPTION
I'm still unsure about how to change the makefile to allow compiling both haxe versions. At github.com/MarcWeber/haxe you can find a makefile which supports native and binary haxe
