### PR TITLE
ABSTRACTS: Fix @:commutative on ops without a body

### DIFF
--- a/typer.ml
+++ b/typer.ml
@@ -1791,8 +1791,8 @@ let rec type_binop ctx op e1 e2 is_assign_op p =
 			let f,r,assign,commutative = find_overload a pl c e1.etype false in
 			begin match f.cf_expr with
 				| None ->
-					let e1 = match follow e1.etype with TAbstract(a,pl) -> {e1 with etype = apply_params a.a_types pl a.a_this} | _ -> e1 in
 					let e1,e2 = if commutative then e2,e1 else e1,e2 in
+					let e1 = match follow e1.etype with TAbstract(a,pl) -> {e1 with etype = apply_params a.a_types pl a.a_this} | _ -> e1 in
 					cast_rec e1 {e2 with etype = apply_params a.a_types pl a.a_this} r
 				| Some _ ->
 					let e1,e2 = if commutative then e2,e1 else e1,e2 in


### PR DESCRIPTION
`@:commutative` was not working for operators without a body, e.g.:

```
package;

abstract Foo(Int) from Int to Int {
    @:commutative @:op(A+B) public static function add(lhs:Foo, rhs:Int);
}

class Main {
    public static function main() {
        var a : Foo = 1;
        trace( a + 1 );
        trace( 1 + a ); // failed: Cannot add Int and Foo
    }
}
```

This patch should fix the issue.
