### PR TITLE
[java] do not require a lock and a lookup for calling Thread.current from the main thread

### DIFF
--- a/std/java/vm/Thread.hx
+++ b/std/java/vm/Thread.hx
@@ -3,7 +3,15 @@ import java.Lib;
 
 @:native('haxe.java.vm.Thread') class Thread
 {
+
 	@:private static var javaThreadToHaxe = new haxe.ds.WeakMap<java.lang.Thread, java.vm.Thread>();
+	@:private static var mainJavaThread = java.lang.Thread.currentThread();
+	@:private static var mainHaxeThread = {
+		var ret = new Thread();
+		javaThreadToHaxe.set(mainJavaThread, ret);
+		ret;
+	};
+
 
 	private static function getThread(jt:java.lang.Thread):Thread
 	{
@@ -12,18 +20,24 @@ import java.Lib;
 			var t:HaxeThread = cast jt;
 			return t.threadObject;
 		}
+		else if (jt == mainJavaThread)
+		{
+			return mainHaxeThread;
+		}
+		else
+		{
+			var ret = null;
+			untyped __lock__(javaThreadToHaxe, {
+				ret = javaThreadToHaxe.get(jt);
+				if (ret == null)
+				{
+					ret = new Thread();
+					javaThreadToHaxe.set(jt, ret);
+				}
 
-		var ret = null;
-		untyped __lock__(javaThreadToHaxe, {
-			ret = javaThreadToHaxe.get(jt);
-			if (ret == null)
-			{
-				ret = new Thread();
-				javaThreadToHaxe.set(jt, ret);
-			}
-
-		});
-		return ret;
+			});
+			return ret;
+		}
 	}
 
 	private var messages:Deque<Dynamic>;
@@ -31,7 +45,7 @@ import java.Lib;
   function new()
 	{
 		this.messages = new Deque();
-  }
+	}
 
 	public function sendMessage(obj:Dynamic)
 	{
@@ -60,18 +74,16 @@ import java.Lib;
 @:native('haxe.java.vm.HaxeThread')
 private class HaxeThread extends java.lang.Thread
 {
-  public var threadObject(default, null):Thread;
-  private var runFunction:Void->Void;
-
-  @:overload override public function run():Void
-  {
-    runFunction();
-  }
-
-  public function new(hxThread:Thread, run:Void->Void)
-  {
+	public var threadObject(default, null):Thread;
+	private var runFunction:Void->Void;
+	@:overload override public function run():Void
+	{
+		runFunction();
+	}
+	public function new(hxThread:Thread, run:Void->Void)
+	{
 		super();
 		threadObject = hxThread;
 		runFunction = run;
-  }
+	}
 }


### PR DESCRIPTION
Small optimization for java.vm.Thread that avoids unnecessary locking and table lookups.
