### PR TITLE
Don't check for undefined window in js.Browser (browsers have windows)

### DIFF
--- a/genjs.ml
+++ b/genjs.ml
@@ -79,7 +79,7 @@ let kwds =
 		"finally"; "float"; "for"; "function"; "goto"; "if"; "implements"; "import"; "in"; "instanceof"; "int";
 		"interface"; "is"; "long"; "namespace"; "native"; "new"; "null"; "package"; "private"; "protected";
 		"public"; "return"; "short"; "static"; "super"; "switch"; "synchronized"; "this"; "throw"; "throws";
-		"transient"; "true"; "try"; "typeof"; "use"; "var"; "void"; "volatile"; "while"; "with"
+		"transient"; "true"; "try"; "typeof"; "use"; "var"; "void"; "volatile"; "while"; "window"; "with";
 	];
 	h
 

--- a/std/js/Browser.hx
+++ b/std/js/Browser.hx
@@ -25,12 +25,18 @@ import js.html.Storage;
 import js.html.XMLHttpRequest;
 
 class Browser {
+	public static var window(get, never):js.html.DOMWindow;
+	inline static function get_window() return untyped __js__("window");
 
-	public static var window(default,null) : js.html.DOMWindow = untyped __js__("typeof window != \"undefined\" ? window : null");
-	public static var document(default,null) : js.html.Document = untyped __js__("typeof window != \"undefined\" ? window.document : null");
-	public static var location(default,null) : js.html.Location = untyped __js__("typeof window != \"undefined\" ? window.location : null");
-	public static var navigator(default,null) : js.html.Navigator = untyped __js__("typeof window != \"undefined\" ? window.navigator : null");
+	public static var document(get, never):js.html.Document;
+	inline static function get_document() return untyped __js__("window.document");
 
+	public static var location(get, never):js.html.Location;
+	inline static function get_location() return untyped __js__("window.location");
+
+	public static var navigator(get, never):js.html.Navigator;
+	inline static function get_navigator() return untyped __js__("window.navigator");
+	
 	/**
 	 * Safely gets the browser's local storage, or returns null if localStorage is unsupported or
 	 * disabled.


### PR DESCRIPTION
A small change to js.Browser.window and friends resulting in slightly more compact code. I'm not sure I understood the motivation of the original `window == undefined` checks. Even if we are protecting node users who think there is a window to access, an undefined reference error seems about as helpful as a null reference error (unless undefined != null for some reason).

I also added window to the `kwds` hash in `genjs.ml` incase there is a conflict. Apologies if I haven't thought through all the implications, just a small improvement to make things look more "native".

``` haxe
class Test
{
    static function main()
    {
        var element = js.Browser.document.createElement("div");
        element.innerHTML = "Hello World";
        js.Browser.document.appendChild(element);
    }
}
```

Output before:

``` JavaScript
(function () { "use strict";
var Test = function() { }
Test.main = function() {
    var element = js.Browser.document.createElement("div");
    element.innerHTML = "Hello World";
    js.Browser.document.appendChild(element);
}
var js = {}
js.Browser = function() { }
js.Browser.document = typeof window != "undefined" ? window.document : null;
Test.main();
})();
```

Output after:

``` JavaScript
(function () { "use strict";
var Test = function() { }
Test.main = function() {
    var element = window.document.createElement("div");
    element.innerHTML = "Hello World";
    window.document.appendChild(element);
}
Test.main();
})();
```
