### PR TITLE
Fix typo in JqEvent#isPropagationStopped

### DIFF
--- a/std/js/JQuery.hx
+++ b/std/js/JQuery.hx
@@ -56,7 +56,7 @@ typedef JqEvent = {
 	// propagation
 	function isDefaultPrevented() : Bool;
 	function isImmediatePropagationStopped() : Bool;
-	function isPropationStopped() : Bool;
+	function isPropagationStopped() : Bool;
 	function preventDefault() : Void;
 	function stopImmediatePropagation() : Void;
 	function stopPropagation() : Void;


### PR DESCRIPTION
Fixes spelling and aligns JqEvent method name with jQuery event object method name.
