### PR TITLE
Allow Dispatch to be subclassed

### DIFF
--- a/std/haxe/web/Dispatch.hx
+++ b/std/haxe/web/Dispatch.hx
@@ -59,7 +59,7 @@ enum DispatchError {
 	DETooManyValues;
 }
 
-private class Redirect {
+class Redirect {
 	public function new() {
 	}
 }
@@ -257,6 +257,9 @@ class Dispatch {
 						default: false;
 						}
 						return MRSpod(i.toString(), lock);
+					}
+					else if ( name == "haxe.web.Dispatch" ) {
+						return MRDispatch;
 					}
 					csup = csup.t.get().superClass;
 				}


### PR DESCRIPTION
Basically the macros only allow arguments of known types, either simple
types (String, Int, Float, Bool) or objects - the only allowed objects
were instances of sys.db.Object subclasses or haxe.web.Dispatch instances.

This patch also allows arguments that are a sub class of haxe.web.Dispatch.

It also makes redirect() public so that the Redirect exception can be
caught by a subclass

**Note**: I didn't see unit tests for Dispatch, but the functionality is covered by unit tests in ufront-mvc, and they are all passing and test it fairly extensively.  This was also mentioned on the mailing list recently and Nicolas suggested sending the pull request.
