### PR TITLE
[java] Catch end of file on stdin

### DIFF
--- a/std/java/io/NativeInput.hx
+++ b/std/java/io/NativeInput.hx
@@ -37,17 +37,17 @@ import java.io.EOFException;
 
 	override public function readByte():Int
 	{
+		var ret = 0;
 		try
 		{
-			return stream.read();
+			ret = stream.read();
 		}
-		catch (e:EOFException) {
-			throw new Eof();
-		}
-
 		catch (e:IOException) {
 			throw haxe.io.Error.Custom(e);
 		}
+		if ( ret == -1 )
+			throw new Eof();
+		return ret;
 	}
 
 	override public function readBytes(s:Bytes, pos:Int, len:Int):Int


### PR DESCRIPTION
java.io.NativeInput must expect -1 and not an EOFException
