### PR TITLE
Modify haxe.Int64.hx to work on php and fix other issues

### DIFF
--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -21,7 +21,7 @@
  */
 package haxe;
 
-class Int64 {
+class Int64 { 
 
 	var high : Int;
 	var low : Int;
@@ -31,11 +31,38 @@ class Int64 {
 		this.low = i32(low);
 	}
 
-	@:extern static inline function i32(i) {
-		#if (php || js || flash8)
-		return i | 0;
+	#if php
+	/*
+		private function to correctly handle 32-bit integer overflow on php 
+		see: http://stackoverflow.com/questions/300840/force-php-integer-overflow
+	*/
+	private static function i32php(value:Int):Int { 
+			value = (value & untyped __php__("0xFFFFFFFF"));
+ 		    if ( (value & untyped __php__("0x80000000"))!=0 )
+		        value = -(((~value) & untyped __php__("0xFFFFFFFF")) + 1);
+		    return value;
+	}
+	#end
+
+	/*
+		private function to correctly handle 32-bit ushr on php
+		see: https://github.com/HaxeFoundation/haxe/commit/1a878aa90708040a41b0dd59f518d83b09ede209
+	*/
+	private static inline function ushr32(v:Int,n:Int):Int { 
+		#if php
+		 	return (v >> n) & (untyped __php__("0x7fffffff") >> (n-1));
 		#else
-		return i;
+			return v>>>n;
+		#end
+	}
+
+	@:extern static inline function i32(i) {
+		#if (js || flash8)
+			return i | 0;
+		#elseif php
+			return i32php(i); // handle overflow of 32-bit integers correctly 
+		#else
+			return i;
 		#end
 	}
 
@@ -63,15 +90,15 @@ class Int64 {
 		var ten = ofInt(10);
 		while( !isZero(i) ) {
 			var r = divMod(i, ten);
-			str = r.modulus.low + str;
-			i = r.quotient;
+			str = r.modulus.low + str; 
+			i = r.quotient; 
 		}
 		if( neg ) str = "-" + str;
 		return str;
 	}
 
 	public static inline function make( high : Int, low : Int ) : Int64 {
-		return new Int64(high, low);
+		return new Int64(high, low); 
 	}
 
 	public static inline function ofInt( x : Int ) : Int64 {
@@ -84,7 +111,7 @@ class Int64 {
 				return -toInt(neg(x));
 			throw "Overflow";
 		}
-		return x.low;
+		return x.low; 
 	}
 
 	public static function getLow( x : Int64 ) : Int {
@@ -104,8 +131,8 @@ class Int64 {
 	}
 
 	public static function sub( a : Int64, b : Int64 ) : Int64 {
-		var high = a.high - b.high;
-		var low = a.low - b.low;
+		var high = i32(a.high - b.high); // i32() call required to match add
+		var low = i32(a.low - b.low); // i32() call required to match add
 		if( uicompare(a.low,b.low) < 0 )
 			high--;
 		return new Int64(high, low);
@@ -113,14 +140,14 @@ class Int64 {
 
 	public static function mul( a : Int64, b : Int64 ) : Int64 {
 		var mask = 0xFFFF;
-		var al = a.low & mask, ah = a.low >>> 16;
-		var bl = b.low & mask, bh = b.low >>> 16;
+		var al = a.low & mask, ah = ushr32(a.low , 16); 
+		var bl = b.low & mask, bh = ushr32(b.low , 16); 
 		var p00 = al * bl;
 		var p10 = ah * bl;
 		var p01 = al * bh;
 		var p11 = ah * bh;
 		var low = p00;
-		var high = i32(p11 + (p01 >>> 16) + (p10 >>> 16));
+		var high = i32(p11 + ushr32(p01 , 16) + ushr32(p10 , 16));
 		p01 = i32(p01 << 16); low = i32(low + p01); if( uicompare(low, p01) < 0 ) high = i32(high + 1);
 		p10 = i32(p10 << 16); low = i32(low + p10); if( uicompare(low, p10) < 0 ) high = i32(high + 1);
 		high = i32(high + i32mul(a.low,b.high));
@@ -132,39 +159,49 @@ class Int64 {
 		var quotient = new Int64(0, 0);
 		var mask = new Int64(0, 1);
 		divisor = new Int64(divisor.high, divisor.low);
-		while( divisor.high >= 0 ) {
+		while( divisor.high >= 0 ) { 
 			var cmp = ucompare(divisor, modulus);
-			divisor.high = (divisor.high << 1) | (divisor.low >>> 31);
-			divisor.low <<= 1;
-			mask.high = (mask.high << 1) | (mask.low >>> 31);
-			mask.low <<= 1;
+			divisor.high = i32( i32(divisor.high << 1) | ushr32(divisor.low , 31) ); 
+			divisor.low = i32(divisor.low << 1); 
+			mask.high = i32( i32(mask.high << 1) | ushr32(mask.low , 31) ); 
+			mask.low = i32(mask.low << 1);
 			if( cmp >= 0 ) break;
 		}
-		while( (mask.low | mask.high) != 0 ) {
+		while( i32(mask.low | mask.high) != 0 ) { 
 			if( ucompare(modulus, divisor) >= 0 ) {
-				quotient.high |= mask.high;
-				quotient.low |= mask.low;
+				quotient.high= i32(quotient.high | mask.high); 
+				quotient.low= i32(quotient.low | mask.low); 
 				modulus = sub(modulus,divisor);
 			}
-			mask.low = (mask.low >>> 1) | (mask.high << 31);
-			mask.high >>>= 1;
+			mask.low = i32( ushr32(mask.low , 1) | i32(mask.high << 31) ); 
+			mask.high = ushr32(mask.high , 1); 
 
-			divisor.low = (divisor.low >>> 1) | (divisor.high << 31);
-			divisor.high >>>= 1;
+			divisor.low = i32( ushr32(divisor.low , 1) | i32(divisor.high << 31) ); 
+			divisor.high = ushr32(divisor.high , 1); 
 		}
 		return { quotient : quotient, modulus : modulus };
 	}
 
-	public static inline function div( a : Int64, b : Int64 ) : Int64 {
-		var sign = (a.high | b.high) < 0;
+	public static function div( a : Int64, b : Int64 ) : Int64 { 
+		if(b.high==0) // handle special cases of 0 and 1
+			switch(b.low) {
+			case 0:	throw "divide by zero";
+			case 1: return new Int64(a.high,a.low);
+			} 
+		var sign = ((a.high<0) || (b.high<0)) && (!( (a.high<0) && (b.high<0))); // make sure we get the correct sign
 		if( a.high < 0 ) a = neg(a);
 		if( b.high < 0 ) b = neg(b);
 		var q = divMod(a, b).quotient;
 		return sign ? neg(q) : q;
 	}
 
-	public static inline function mod( a : Int64, b : Int64 ) : Int64 {
-		var sign = (a.high | b.high) < 0;
+	public static function mod( a : Int64, b : Int64 ) : Int64 {
+		if(b.high==0) // handle special cases of 0 and 1
+			switch(b.low) {
+			case 0:	throw "modulus by zero";
+			case 1: return ofInt(0);
+			}
+		var sign = a.high<0; // the sign of a modulus is the sign of the value being mod'ed
 		if( a.high < 0 ) a = neg(a);
 		if( b.high < 0 ) b = neg(b);
 		var m = divMod(a, b).modulus;
@@ -172,15 +209,15 @@ class Int64 {
 	}
 
 	public static inline function shl( a : Int64, b : Int ) : Int64 {
-		return if( b & 63 == 0 ) a else if( b & 63 < 32 ) new Int64( (a.high << b) | (a.low >>> (32-(b&63))), a.low << b ) else new Int64( a.low << (b - 32), 0 );
+		return if( b & 63 == 0 ) a else if( b & 63 < 32 ) new Int64( (a.high << b) | ushr32(a.low, i32(32-(b&63))), a.low << b ) else new Int64( a.low << i32(b - 32), 0 );
 	}
 
 	public static inline function shr( a : Int64, b : Int ) : Int64 {
-		return if( b & 63 == 0 ) a else if( b & 63 < 32 ) new Int64( a.high >> b, (a.low >>> b) | (a.high << (32 - (b&63))) ) else new Int64( a.high >> 31, a.high >> (b - 32) );
+		return if( b & 63 == 0 ) a else if( b & 63 < 32 ) new Int64( a.high >> b, ushr32(a.low,b) | (a.high << i32(32 - (b&63))) ) else new Int64( a.high >> 31, a.high >> i32(b - 32) );
 	}
 
 	public static inline function ushr( a : Int64, b : Int ) : Int64 {
-		return if( b & 63 == 0 ) a else if( b & 63 < 32 ) new Int64( a.high >>> b, (a.low >>> b) | (a.high << (32 - (b&63))) ) else new Int64( 0, a.high >>> b - 32 );
+		return if( b & 63 == 0 ) a else if( b & 63 < 32 ) new Int64( ushr32(a.high, b), ushr32(a.low, b) | (a.high << i32(32 - (b&63))) ) else new Int64( 0, ushr32(a.high, i32(b - 32)) );
 	}
 
 	public static inline function and( a : Int64, b : Int64 ) : Int64 {
@@ -196,8 +233,8 @@ class Int64 {
 	}
 
 	public static inline function neg( a : Int64 ) : Int64 {
-		var high = ~a.high;
-		var low = -a.low;
+		var high = i32(~a.high); 
+		var low = i32(-a.low); 
 		if( low == 0 )
 			high++;
 		return new Int64(high,low);
@@ -212,11 +249,11 @@ class Int64 {
 	}
 
 	static function uicompare( a : Int, b : Int ) {
-		return a < 0 ? (b < 0 ? ~b - ~a : 1) : (b < 0 ? -1 : a - b);
+		return a < 0 ? (b < 0 ? i32(~b - ~a) : 1) : (b < 0 ? -1 : i32(a - b));
 	}
 
 	public static inline function compare( a : Int64, b : Int64 ) : Int {
-		var v = a.high - b.high;
+		var v = i32(a.high - b.high); 
 		return if( v != 0 ) v else uicompare(a.low,b.low);
 	}
 


### PR DESCRIPTION
1) On the php platform, integer overflow and ushr are incorrect (for 32-bits Int), this made the 64-bit Int emulation wrong. Special functions now correct for these faults in the Int64 class.
2) Both div and mod should now have the sign correct when double-negative, but a Haxe guru should check the new mod sign logic is as required by Haxe, see http://en.wikipedia.org/wiki/Modulo_operation for the choices available.
3) Special cases of div or mod by 0 or 1 should now be correctly handled, including throwing an error on divide by zero, but again a Haxe guru should check if that is the correct thing to do for Haxe.
