### PR TITLE
Permit json syntax more generally for anon-types.

### DIFF
--- a/genjs.ml
+++ b/genjs.ml
@@ -95,7 +95,7 @@ let valid_js_ident s =
 	with Exit ->
 		false
 
-let field s = if Hashtbl.mem kwds s then "[\"" ^ s ^ "\"]" else "." ^ s
+let field s = if Hashtbl.mem kwds s || not (valid_js_ident s) then "[\"" ^ s ^ "\"]" else "." ^ s
 let ident s = if Hashtbl.mem kwds s then "$" ^ s else s
 let anon_field s = if Hashtbl.mem kwds s || not (valid_js_ident s) then "'" ^ s ^ "'" else s
 let static_field s =

--- a/genphp.ml
+++ b/genphp.ml
@@ -314,12 +314,24 @@ let is_keyword n =
 	| "clone" | "instanceof" | "break" | "case" | "class" | "continue" | "default" | "do" | "else" | "extends" | "for" | "function" | "if" | "new" | "return" | "static" | "switch" | "var" | "while" | "interface" | "implements" | "public" | "private" | "try" | "catch" | "throw" -> true
 	| _ -> false
 
+let valid_php_ident s =
+	try
+		for i = 0 to String.length s - 1 do
+			match String.unsafe_get s i with
+			| 'a'..'z' | 'A'..'Z' | '_' -> ()
+			| '0'..'9' when i > 0 -> ()
+			| _ -> raise Exit
+		done;
+		true
+	with Exit ->
+		false
+
 let s_ident n =
 	let suf = "h" in
 	if (is_keyword n) then (suf ^ n) else n
 
 let s_ident_field n =
-	if (is_keyword n) then ("{\"" ^ (escape_bin n) ^ "\"}") else n
+	if (is_keyword n || not (valid_php_ident n)) then ("{\"" ^ (escape_bin n) ^ "\"}") else n
 
 let s_ident_local n =
 	let suf = "h" in


### PR DESCRIPTION
var obj:{"var":Bool} = {"var":true};
trace(obj."var");

i understand @Simn has said there was 'some' reason this sort of thing hasn't been added before, and whether the exact syntax would be wanted or not is to be decided.

However, even if we reject the obj."var" syntax (Although this is 'so' much better than Reflect use, especcialy since the lifting of the type restriction means such usage is staticly checked now), having the non-haxe-ident fields as part of the type is surely better than allowing things like:

var obj = {x:10};
obj = {x:10, "other_field": 20, "hahah you suck": 30 };

going through compile because the non-haxe idents are just 'not checked'.

The main usage for this sort of thing, like with json syntax itself is for working with js target, in my specific case, providing typed externs for a lib which uses non-haxe idents for object fields, and without this there's just no way to type it nicely without changing the field name and providing a horrible wrapper to then assign the real field using untyped **js**... ew.
