### PR TITLE
TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+
+before_install:
+  - sudo apt-get install python-software-properties -y # for the next command
+  - sudo add-apt-repository ppa:eyecreate/haxe -y      # add the ubuntu ppa that contains neko
+  - sudo apt-get update                                # pull info from ppa
+  - sudo apt-get install neko -y
+  - sudo apt-get install ocaml zlib1g-dev -y
+
+script:
+  - make
+  - make tools
+  - sudo make install
+  - cd tests/unit/
+  - mkdir ~/haxelib && haxelib setup ~/haxelib
+  - haxe -version


### PR DESCRIPTION
Here is a minimal TravisCI config, that will just compile haxe, haxelib and haxedoc.
It is working correctly on my branch, as shown at https://travis-ci.org/andyli/haxe/builds/11734295
I would like to let it run the unittests too, but there will be some modification on the test runner, so I will leave them to the later pull requests.

Before merging this pull request, please activate TravisCI first:
1. Head to https://travis-ci.org/profile
2. Select HaxeFoundation from the left hand side
3. Switch this repo on.
