### PR TITLE
Update CallStack.hx to allow Generation of stack traces on iOS

### DIFF
--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -76,9 +76,15 @@ class CallStack {
 				}
 				return stack;
 			}
-			var a = makeStack(untyped __new__("Error").stack);
-			a.shift(); // remove Stack.callStack()
-			(untyped Error).prepareStackTrace = oldValue;
+			var a = null;
+			try{
+				throw untyped __new__("Error");
+			}
+			catch(error:Dynamic){
+				a = makeStack(error.stack);
+				a.shift(); // remove Stack.callStack()
+				(untyped Error).prepareStackTrace = oldValue;
+			}
 			return a;
 		#else
 			return []; // Unsupported


### PR DESCRIPTION
On iOS the error object's stack property was null, throwing an Error rather than instantiating it fixed this problem.

<!---
@huboard:{"order":0.0301513671875}
-->
