### PR TITLE
Extend Map::set to return the value set instead of nothing.

### DIFF
--- a/std/Map.hx
+++ b/std/Map.hx
@@ -30,109 +30,108 @@ import haxe.ds.EnumValueMap;
  /**
 	Map allows key to value mapping for arbitrary value types, and many key
 	types.
-		
+
 	This is a multi-type abstract, it is instantiated as one of its
 	specialization types depending on its type parameters.
-	
+
 	A Map can be instantiated without explicit type parameters. Type inference
 	will then determine the type parameters from the usage.
-	
+
 	Maps can also be created with `key1 => value1, key2 => value2` syntax.
-	
+
 	Map is an abstract type, it is not available at runtime.
 **/
 @:multiType
 abstract Map<K,V>(IMap<K,V> ) {
-	
+
 	/**
 		Creates a new Map.
-		
+
 		This becomes a constructor call to one of the specialization types in
 		the output. The rules for that are as follows:
-		
+
 		1. if K is a `String`, `haxe.ds.StringMap` is used
 		2. if K is an `Int`, `haxe.ds.IntMap` is used
 		3. if K is an `EnumValue`, `haxe.ds.EnumValueMap` is used
 		4. if K is any other class or structure, `haxe.ds.ObjectMap` is used
 		5. if K is any other type, it causes a compile-time error
-			
+
 		(Cpp) Map does not use weak keys on ObjectMap by default.
 	**/
 	public function new();
 
 	/**
 		Maps `key` to `value`.
-		
+
 		If `key` already has a mapping, the previous value disappears.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
-	public inline function set(key:K, value:V) this.set(key, value);
-	
+	public inline function set(key:K, value:V) return this.set(key, value);
+
 	/**
 		Returns the current mapping of `key`.
-		
+
 		If no such mapping exists, null is returned.
-		
+
 		Note that a check like `map.get(key) == null` can hold for two reasons:
-		
+
 		1. the map has no mapping for `key`
 		2. the map has a mapping with a value of `null`
-		
-		If it is important to distinguish these cases, `exists()` should be 
+
+		If it is important to distinguish these cases, `exists()` should be
 		used.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
 	@:arrayAccess public inline function get(key:K) return this.get(key);
-	
+
 	/**
 		Returns true if `key` has a mapping, false otherwise.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
 	public inline function exists(key:K) return this.exists(key);
-	
+
 	/**
 		Removes the mapping of `key` and returns true if such a mapping existed,
 		false otherwise.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
 	public inline function remove(key:K) return this.remove(key);
-	
+
 	/**
 		Returns an Iterator over the keys of `this` Map.
-		
+
 		The order of keys is undefined.
 	**/
 	public inline function keys():Iterator<K> {
 		return this.keys();
 	}
-	
+
 	/**
 		Returns an Iterator over the values of `this` Map.
-		
+
 		The order of values is undefined.
 	**/
 	public inline function iterator():Iterator<V> {
 		return this.iterator();
 	}
-	
+
 	/**
 		Returns a String representation of `this` Map.
-		
+
 		The exact representation depends on the platform and key-type.
 	**/
 	public inline function toString():String {
 		return this.toString();
 	}
-	
+
 	@:arrayAccess @:noCompletion public inline function arrayWrite(k:K, v:V):V {
-		this.set(k, v);
-		return v;
+		return this.set(k, v);
 	}
-	
+
 	@:to static inline function toStringMap(t:IMap<String,V>):StringMap<V> {
 		return new StringMap<V>();
 	}
@@ -140,7 +139,7 @@ abstract Map<K,V>(IMap<K,V> ) {
 	@:to static inline function toIntMap(t:IMap<Int,V>):IntMap<V> {
 		return new IntMap<V>();
 	}
-	
+
 	@:to static inline function toEnumValueMapMap<K:EnumValue>(t:IMap<K,V>):EnumValueMap<K,V> {
 		return new EnumValueMap<K, V>();
 	}
@@ -148,11 +147,11 @@ abstract Map<K,V>(IMap<K,V> ) {
 	@:to static inline function toObjectMap<K:{ }>(t:IMap<K,V>):ObjectMap<K,V> {
 		return new ObjectMap<K, V>();
 	}
-	
+
 	@:from static inline function fromStringMap<V>(map:StringMap<V>):Map< String, V > {
 		return map;
 	}
-	
+
 	@:from static inline function fromIntMap<V>(map:IntMap<V>):Map< Int, V > {
 		return map;
 	}
@@ -164,7 +163,7 @@ abstract Map<K,V>(IMap<K,V> ) {
 
 interface IMap<K,V> {
 	public function get(k:K):Null<V>;
-	public function set(k:K, v:V):Void;
+	public function set(k:K, v:V):V;
 	public function exists(k:K):Bool;
 	public function remove(k:K):Bool;
 	public function keys():Iterator<K>;

--- a/std/cpp/_std/haxe/ds/IntMap.hx
+++ b/std/cpp/_std/haxe/ds/IntMap.hx
@@ -29,8 +29,9 @@ package haxe.ds;
 		h = untyped __global__.__int_hash_create();
 	}
 
-	public function set( key : Int, value : T ) : Void {
+	public function set( key : Int, value : T ) : T {
 		untyped __global__.__int_hash_set(h,key,value);
+		return value;
 	}
 
 	public function get( key : Int ) : Null<T> {

--- a/std/cpp/_std/haxe/ds/ObjectMap.hx
+++ b/std/cpp/_std/haxe/ds/ObjectMap.hx
@@ -31,10 +31,11 @@ class ObjectMap<K:{},V> implements Map.IMap<K,V> {
 		__KeyRefs = new IntMap<K>();
 	}
 
-	public function set( key : K, value : V ) : Void {
+	public function set( key : K, value : V ) : V {
 		var id = untyped __global__.__hxcpp_obj_id(key);
 		__Internal.set( id, value );
 		__KeyRefs.set( id, key );
+		return value;
 	}
 
 	public function get( key : K ) : Null<V> {

--- a/std/cpp/_std/haxe/ds/StringMap.hx
+++ b/std/cpp/_std/haxe/ds/StringMap.hx
@@ -28,8 +28,9 @@ package haxe.ds;
 		__Internal = {};
 	}
 
-	public function set( key : String, value : T ) : Void {
+	public function set( key : String, value : T ) : T {
 		untyped __Internal.__SetField(key,value,true);
+		return value;
 	}
 
 	public function get( key : String ) : Null<T> {

--- a/std/cs/_std/haxe/ds/IntMap.hx
+++ b/std/cs/_std/haxe/ds/IntMap.hx
@@ -54,7 +54,7 @@ import cs.NativeArray;
 		cachedIndex = -1;
 	}
 
-	public function set( key : Int, value : T ) : Void
+	public function set( key : Int, value : T ) : T
 	{
 		var x:Int;
 		if (nOccupied >= upperBound)
@@ -108,6 +108,8 @@ import cs.NativeArray;
 			assert(_keys[x] == key);
 			vals[x] = value;
 		}
+
+		return value;
 	}
 
 	@:final private function lookup( key : Int ) : Int

--- a/std/cs/_std/haxe/ds/ObjectMap.hx
+++ b/std/cs/_std/haxe/ds/ObjectMap.hx
@@ -61,7 +61,7 @@ import cs.NativeArray;
 		cachedIndex = -1;
 	}
 
-	public function set( key : K, value : V ) : Void
+	public function set( key : K, value : V ) : V
 	{
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound)
@@ -124,6 +124,8 @@ import cs.NativeArray;
 
 		cachedIndex = x;
 		cachedKey = key;
+
+		return value;
 	}
 
 	@:final private function lookup( key : K ) : Int

--- a/std/cs/_std/haxe/ds/StringMap.hx
+++ b/std/cs/_std/haxe/ds/StringMap.hx
@@ -61,7 +61,7 @@ import cs.NativeArray;
 		cachedIndex = -1;
 	}
 
-	public function set( key : String, value : T ) : Void
+	public function set( key : String, value : T ) : T
 	{
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound)
@@ -124,6 +124,8 @@ import cs.NativeArray;
 
 		cachedIndex = x;
 		cachedKey = key;
+
+		return value;
 	}
 
 	@:final private function lookup( key : String ) : Int

--- a/std/flash/_std/haxe/ds/IntMap.hx
+++ b/std/flash/_std/haxe/ds/IntMap.hx
@@ -29,8 +29,8 @@ package haxe.ds;
 		h = new flash.utils.Dictionary();
 	}
 
-	public function set( key : Int, value : T ) : Void {
-		untyped h[key] = value;
+	public function set( key : Int, value : T ) : T {
+		return untyped h[key] = value;
 	}
 
 	public function get( key : Int ) : Null<T> {

--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -6,13 +6,13 @@ class ObjectMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> 
 	public function new() {
 		super(false);
 	}
-	
+
 	public inline function get( key : K ) : Null<V> {
 		return untyped this[key];
 	}
 
-	public inline function set( key : K, value : V ):Void {
-		untyped this[key] = value;
+	public inline function set( key : K, value : V ):V{
+		return untyped this[key] = value;
 	}
 
 	public inline function exists( key : K ) : Bool {
@@ -26,7 +26,7 @@ class ObjectMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> 
 	}
 
 	#if as3
-	
+
  	public function keys() : Iterator<K> {
 		return untyped __keys__(this).iterator();
  	}
@@ -38,7 +38,7 @@ class ObjectMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> 
 		return ret.iterator();
  	}
 	#else
-	
+
 	public function keys() : Iterator<K> {
 		return NativePropertyIterator.iterator(this);
 	}
@@ -46,7 +46,7 @@ class ObjectMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> 
 	public function iterator() : Iterator<V> {
 		return NativeValueIterator.iterator(this);
 	}
-	
+
 	#end
 
 	public function toString() : String {

--- a/std/flash/_std/haxe/ds/StringMap.hx
+++ b/std/flash/_std/haxe/ds/StringMap.hx
@@ -29,8 +29,8 @@ package haxe.ds;
 		h = new flash.utils.Dictionary();
 	}
 
-	public function set( key : String, value : T ) : Void {
-		untyped h["$"+key] = value;
+	public function set( key : String, value : T ) : T {
+		return untyped h["$"+key] = value;
 	}
 
 	public function get( key : String ) : Null<T> {

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -6,13 +6,13 @@ class WeakMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> {
 	public function new() {
 		super(true);
 	}
-	
+
 	public inline function get( key : K ) : Null<V> {
 		return untyped this[key];
 	}
 
-	public inline function set( key : K, value : V ):Void {
-		untyped this[key] = value;
+	public inline function set( key : K, value : V ):V {
+		return untyped this[key] = value;
 	}
 
 	public inline function exists( key : K ) : Bool {
@@ -26,7 +26,7 @@ class WeakMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> {
 	}
 
 	#if as3
-	
+
  	public function keys() : Iterator<K> {
 		return untyped __keys__(this).iterator();
  	}
@@ -38,7 +38,7 @@ class WeakMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> {
 		return ret.iterator();
  	}
 	#else
-	
+
 	public function keys() : Iterator<K> {
 		return NativePropertyIterator.iterator(this);
 	}
@@ -46,7 +46,7 @@ class WeakMap<K:{},V> extends flash.utils.Dictionary implements Map.IMap<K,V> {
 	public function iterator() : Iterator<V> {
 		return NativeValueIterator.iterator(this);
 	}
-	
+
 	#end
 
 	public function toString() : String {

--- a/std/flash8/_std/haxe/ds/IntMap.hx
+++ b/std/flash8/_std/haxe/ds/IntMap.hx
@@ -29,8 +29,8 @@ package haxe.ds;
 		h = untyped __new__(_global["Object"]);
 	}
 
-	public function set( key : Int, value : T ) : Void {
-		h[key] = value;
+	public function set( key : Int, value : T ) : T {
+		return h[key] = value;
 	}
 
 	public function get( key : Int ) : Null<T> {

--- a/std/flash8/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash8/_std/haxe/ds/ObjectMap.hx
@@ -24,38 +24,38 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
-	
+
 	static var count = 0;
-	
+
 	static inline function assignId(obj: { } ):Int {
 		return untyped obj.__id__ = ++count;
 	}
-	
+
 	static inline function getId(obj: { } ):Int {
 		return untyped obj.__id__;
 	}
-	
+
 	var h: { };
-	
+
 	public function new():Void {
 		h = untyped __new__(_global["Object"]);
 		untyped h.__keys__ = untyped __new__(_global["Object"]);
 	}
-	
-	public function set(key:K, value:V):Void untyped {
+
+	public function set(key:K, value:V):V untyped {
 		var id = "$" + (key.__id__ != null ? key.__id__ : assignId(key));
-		h[id] = value;
 		h.__keys__[id] = key;
+		return h[id] = value;
 	}
-	
+
 	public inline function get(key:K):Null<V> {
 		return untyped h["$" +getId(key)];
 	}
-	
+
 	public inline function exists(key:K):Bool {
 		return untyped h["hasOwnProperty"]("$" +getId(key));
 	}
-	
+
 	public function remove( key : K ) : Bool {
 		var key = "$" + getId(key);
 		if( untyped !h["hasOwnProperty"](key) ) return false;
@@ -63,7 +63,7 @@ class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
 		untyped __delete__(h.__keys__,key);
 		return true;
 	}
-	
+
 	public function keys() : Iterator<K> {
 		var a = [];
 		untyped {
@@ -75,7 +75,7 @@ class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
 		}
 		return a.iterator();
 	}
-	
+
 	public function iterator() : Iterator<V> {
 		return untyped {
 			ref : h,
@@ -84,7 +84,7 @@ class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
 			next : function() { var i = __this__.it[__unprotect__("next")](); return __this__.ref["$" +i]; }
 		};
 	}
-	
+
 	public function toString() : String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/flash8/_std/haxe/ds/StringMap.hx
+++ b/std/flash8/_std/haxe/ds/StringMap.hx
@@ -29,8 +29,8 @@ package haxe.ds;
 		h = untyped __new__(_global["Object"]);
 	}
 
-	public function set( key : String, value : T ) : Void {
-		untyped h["$"+key] = value;
+	public function set( key : String, value : T ) : T {
+		return untyped h["$"+key] = value;
 	}
 
 	public function get( key : String ) : Null<T> {

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -26,36 +26,37 @@ package haxe.ds;
 	BalancedTree allows key-value mapping with arbitrary keys, as long as they
 	can be ordered. By default, `Reflect.compare` is used in the `compare`
 	method, which can be overridden in subclasses.
-	
+
 	Operations have a logarithmic average and worst-case cost.
-	
+
 	Iteration over keys and values, using `keys` and `iterator` respectively,
 	are in-order.
 **/
 class BalancedTree<K,V> {
 	var root:TreeNode<K,V>;
-	
+
 	/**
 		Creates a new BalancedTree, which is initially empty.
 	**/
 	public function new() { }
-	
+
 	/**
 		Binds `key` to `value`.
-		
+
 		If `key` is already bound to a value, that binding disappears.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
-	public function set(key:K, value:V) {
+	public function set(key:K, value:V):V {
 		root = setLoop(key, value, root);
+        return value;
 	}
-	
+
 	/**
 		Returns the value `key` is bound to.
-		
+
 		If `key` is not bound to any value, `null` is returned.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
 	public function get(key:K):Null<V> {
@@ -68,15 +69,15 @@ class BalancedTree<K,V> {
 		}
 		return null;
 	}
-	
+
 	/**
 		Removes the current binding of `key`.
-		
+
 		If `key` has no binding, `this` BalancedTree is unchanged and false is
 		returned.
-		
+
 		Otherwise the binding of `key` is removed and true is returned.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
 	public function remove(key:K) {
@@ -88,12 +89,12 @@ class BalancedTree<K,V> {
 			return false;
 		}
 	}
-	
+
 	/**
 		Tells if `key` is bound to a value.
-		
+
 		This method returns true even if `key` is bound to null.
-		
+
 		If `key` is null, the result is unspecified.
 	**/
 	public function exists(key:K) {
@@ -106,10 +107,10 @@ class BalancedTree<K,V> {
 		}
 		return false;
 	}
-	
+
 	/**
 		Iterates over the bound values of `this` BalancedTree.
-		
+
 		This operation is performed in-order.
 	**/
 	public function iterator():Iterator<V> {
@@ -117,10 +118,10 @@ class BalancedTree<K,V> {
 		iteratorLoop(root, ret);
 		return ret.iterator();
 	}
-	
+
 	/**
 		Iterates over the keys of `this` BalancedTree.
-		
+
 		This operation is performed in-order.
 	**/
 	public function keys():Iterator<K> {
@@ -128,7 +129,7 @@ class BalancedTree<K,V> {
 		keysLoop(root, ret);
 		return ret.iterator();
 	}
-	
+
 	function setLoop(k:K, v:V, node:TreeNode<K,V>) {
 		if (node == null) return new TreeNode<K,V>(null, k, v, null);
 		var c = compare(k, node.key);
@@ -141,7 +142,7 @@ class BalancedTree<K,V> {
 			balance(node.left, node.key, node.value, nr);
 		}
 	}
-		
+
 	function removeLoop(k:K, node:TreeNode<K,V>) {
 		if (node == null) throw "Not_found";
 		var c = compare(k, node.key);
@@ -149,7 +150,7 @@ class BalancedTree<K,V> {
 		else if (c < 0) balance(removeLoop(k, node.left), node.key, node.value, node.right);
 		else balance(node.left, node.key, node.value, removeLoop(k, node.right));
 	}
-	
+
 	function iteratorLoop(node:TreeNode<K,V>, acc:Array<V>) {
 		if (node != null) {
 			iteratorLoop(node.left, acc);
@@ -157,7 +158,7 @@ class BalancedTree<K,V> {
 			iteratorLoop(node.right, acc);
 		}
 	}
-	
+
 	function keysLoop(node:TreeNode<K,V>, acc:Array<K>) {
 		if (node != null) {
 			keysLoop(node.left, acc);
@@ -165,25 +166,25 @@ class BalancedTree<K,V> {
 			keysLoop(node.right, acc);
 		}
 	}
-	
+
 	function merge(t1, t2) {
 		if (t1 == null) return t2;
 		if (t2 == null) return t1;
 		var t = minBinding(t2);
 		return balance(t1, t.key, t.value, removeMinBinding(t2));
 	}
-	
+
 	function minBinding(t:TreeNode<K,V>) {
 		return if (t == null) throw "Not_found";
 		else if (t.left == null) t;
 		else minBinding(t.left);
 	}
-	
+
 	function removeMinBinding(t:TreeNode<K,V>) {
 		return if (t.left == null) t.right;
 		else balance(removeMinBinding(t.left), t.key, t.value, t.right);
 	}
-		
+
 	function balance(l:TreeNode<K,V>, k:K, v:V, r:TreeNode<K,V>):TreeNode<K,V> {
 		var hl = l.get_height();
 		var hr = r.get_height();
@@ -197,11 +198,11 @@ class BalancedTree<K,V> {
 			new TreeNode<K,V>(l, k, v, r, (hl > hr ? hl : hr) + 1);
 		}
 	}
-	
+
 	function compare(k1:K, k2:K) {
 		return Reflect.compare(k1, k2);
 	}
-	
+
 	public function toString() {
 		return '{${root.toString()}}';
 	}
@@ -216,7 +217,7 @@ class TreeNode<K,V> {
 	public
 	#end
 	var _height : Int;
-	
+
 	public function new(l, k, v, r, h = -1) {
 		left = l;
 		key = k;
@@ -227,9 +228,9 @@ class TreeNode<K,V> {
 		else
 			_height = h;
 	}
-	
+
 	@:extern public inline function get_height() return this == null ? 0 : _height;
-	
+
 	public function toString() {
 		return (left == null ? "" : left.toString() + ", ") + '$key=$value' + (right == null ? "" : ", " +right.toString());
 	}

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -23,7 +23,7 @@ package haxe.ds;
 
 /**
 	IntMap allows mapping of Int keys to arbitrary values.
-	
+
 	See `Map` for documentation details.
 **/
 extern class IntMap<T> implements Map.IMap<Int,T> {
@@ -36,8 +36,8 @@ extern class IntMap<T> implements Map.IMap<Int,T> {
 	/**
 		See `Map.set`
 	**/
-	public function set( key : Int, value : T ) : Void;
-	
+	public function set( key : Int, value : T ) : T;
+
 	/**
 		See `Map.get`
 	**/

--- a/std/haxe/ds/ObjectMap.hx
+++ b/std/haxe/ds/ObjectMap.hx
@@ -24,51 +24,51 @@ package haxe.ds;
 
 /**
 	ObjectMap allows mapping of object keys to arbitrary values.
-	
+
 	On static targets, the keys are considered to be strong references. Refer
 	to `haxe.ds.WeakMap` for a weak reference version.
-	
+
 	See `Map` for documentation details.
 **/
 extern class ObjectMap < K: { }, V > implements Map.IMap<K,V> {
-	
+
 	/**
 		Creates a new ObjectMap.
 	**/
 	public function new():Void;
-	
+
 	/**
 		See `Map.set`
 	**/
-	public function set(key:K, value:V):Void;
-	
+	public function set(key:K, value:V):V;
+
 	/**
 		See `Map.get`
-	**/	
+	**/
 	public function get(key:K):Null<V>;
-	
+
 	/**
 		See `Map.exists`
-	**/	
+	**/
 	public function exists(key:K):Bool;
-	
+
 	/**
 		See `Map.remove`
-	**/	
+	**/
 	public function remove(key:K):Bool;
-	
+
 	/**
 		See `Map.keys`
-	**/	
+	**/
 	public function keys():Iterator<K>;
-	
+
 	/**
 		See `Map.iterator`
-	**/	
+	**/
 	public function iterator():Iterator<V>;
-	
+
 	/**
 		See `Map.toString`
-	**/	
+	**/
 	public function toString():String;
 }

--- a/std/haxe/ds/StringMap.hx
+++ b/std/haxe/ds/StringMap.hx
@@ -24,7 +24,7 @@ package haxe.ds;
 
 /**
 	StringMap allows mapping of String keys to arbitrary values.
-	
+
 	See `Map` for documentation details.
 **/
 extern class StringMap<T> implements Map.IMap<String,T> {
@@ -37,7 +37,7 @@ extern class StringMap<T> implements Map.IMap<String,T> {
 	/**
 		See `Map.set`
 	**/
-	public function set( key : String, value : T ) : Void;
+	public function set( key : String, value : T ) : T;
 
 	/**
 		See `Map.get`

--- a/std/haxe/ds/WeakMap.hx
+++ b/std/haxe/ds/WeakMap.hx
@@ -24,64 +24,65 @@ package haxe.ds;
 
 /**
 	WeakMap allows mapping of object keys to arbitrary values.
-	
+
 	The keys are considered to be weak references on static targets.
-	
+
 	See `Map` for documentation details.
 **/
 class WeakMap<K: { },V> implements Map.IMap<K,V> {
-	
+
 	/**
 		Creates a new WeakMap.
-	**/	
+	**/
 	public function new():Void {
 		throw "Not implemented for this platform";
 	}
-	
+
 	/**
 		See `Map.set`
-	**/	
-	public function set(key:K, value:V):Void {
+	**/
+	public function set(key:K, value:V):V {
+		return null;
 	}
-	
+
 	/**
 		See `Map.get`
-	**/		
+	**/
 	public function get(key:K):Null<V> {
 		return null;
 	}
-	
+
 	/**
 		See `Map.exists`
-	**/		
+	**/
 	public function exists(key:K):Bool {
 		return false;
 	}
-	
+
 	/**
 		See `Map.remove`
-	**/		
+	**/
 	public function remove(key:K):Bool {
 		return false;
 	}
-	
+
 	/**
 		See `Map.keys`
-	**/		
+	**/
 	public function keys():Iterator<K> {
 		return null;
 	}
-	
+
 	/**
 		See `Map.iterator`
-	**/		
+	**/
 	public function iterator():Iterator<V> {
 		return null;
 	}
-	
+
 	/**
 		See `Map.toString`
-	**/		
+	**/
 	public function toString():String {
 		return null;
 	}

--- a/std/java/_std/haxe/ds/IntMap.hx
+++ b/std/java/_std/haxe/ds/IntMap.hx
@@ -52,7 +52,7 @@ import java.NativeArray;
 		cachedIndex = -1;
 	}
 
-	public function set( key : Int, value : T ) : Void
+	public function set( key : Int, value : T ) : T
 	{
 		var x:Int;
 		if (nOccupied >= upperBound)
@@ -106,6 +106,8 @@ import java.NativeArray;
 			assert(_keys[x] == key);
 			vals[x] = value;
 		}
+
+		return value;
 	}
 
 	@:final private function lookup( key : Int ) : Int

--- a/std/java/_std/haxe/ds/ObjectMap.hx
+++ b/std/java/_std/haxe/ds/ObjectMap.hx
@@ -61,7 +61,7 @@ import java.NativeArray;
 		cachedIndex = -1;
 	}
 
-	public function set( key : K, value : V ) : Void
+	public function set( key : K, value : V ) : V
 	{
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound)
@@ -124,6 +124,8 @@ import java.NativeArray;
 
 		cachedIndex = x;
 		cachedKey = key;
+
+		return value;
 	}
 
 	@:final private function lookup( key : K ) : Int

--- a/std/java/_std/haxe/ds/StringMap.hx
+++ b/std/java/_std/haxe/ds/StringMap.hx
@@ -61,7 +61,7 @@ import java.NativeArray;
 		cachedIndex = -1;
 	}
 
-	public function set( key : String, value : T ) : Void
+	public function set( key : String, value : T ) : T
 	{
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound)
@@ -124,6 +124,8 @@ import java.NativeArray;
 
 		cachedIndex = x;
 		cachedKey = key;
+
+		return value;
 	}
 
 	@:final private function lookup( key : String ) : Int

--- a/std/java/_std/haxe/ds/WeakMap.hx
+++ b/std/java/_std/haxe/ds/WeakMap.hx
@@ -101,7 +101,7 @@ import java.lang.ref.ReferenceQueue;
 		}
 	}
 
-	public function set( key : K, value : V ) : Void
+	public function set( key : K, value : V ) : V
 	{
 		cleanupRefs();
 		var x:Int, k:Int;
@@ -163,6 +163,8 @@ import java.lang.ref.ReferenceQueue;
 
 		cachedIndex = x;
 		cachedEntry = entry;
+
+		return value;
 	}
 
 	@:final private function lookup( key : K ) : Int

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -29,8 +29,8 @@ package haxe.ds;
 		h = {};
 	}
 
-	public function set( key : Int, value : T ) : Void {
-		untyped h[key] = value;
+	public function set( key : Int, value : T ) : T {
+		return untyped h[key] = value;
 	}
 
 	public function get( key : Int ) : Null<T> {

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -24,38 +24,38 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap<K:{ }, V> implements Map.IMap<K,V> {
-	
+
 	static var count = 0;
-	
+
 	static inline function assignId(obj: { } ):Int {
 		return untyped obj.__id__ = ++count;
 	}
-	
+
 	static inline function getId(obj: { } ):Int {
 		return untyped obj.__id__;
 	}
-	
+
 	var h : { };
-	
+
 	public function new() : Void {
 		h = { };
 		untyped h.__keys__ = { };
 	}
-	
-	public function set(key:K, value:V):Void untyped {
+
+	public function set(key:K, value:V):V untyped {
 		var id = key.__id__ != null ? key.__id__ : assignId(key);
-		h[id] = value;
 		h.__keys__[id] = key;
+		return h[id] = value;
 	}
-	
+
 	public inline function get(key:K):Null<V> {
 		return untyped h[getId(key)];
 	}
-	
+
 	public inline function exists(key:K):Bool {
 		return untyped h.hasOwnProperty(getId(key));
 	}
-	
+
 	public function remove( key : K ) : Bool {
 		var id = getId(key);
 		if ( untyped !h.hasOwnProperty(id) ) return false;
@@ -63,7 +63,7 @@ class ObjectMap<K:{ }, V> implements Map.IMap<K,V> {
 		untyped  __js__("delete")(h.__keys__[id]);
 		return true;
 	}
-	
+
 	public function keys() : Iterator<K> {
 		var a = [];
 		untyped {
@@ -74,7 +74,7 @@ class ObjectMap<K:{ }, V> implements Map.IMap<K,V> {
 		}
 		return a.iterator();
 	}
-	
+
 	public function iterator() : Iterator<V> {
 		return untyped {
 			ref : h,
@@ -83,7 +83,7 @@ class ObjectMap<K:{ }, V> implements Map.IMap<K,V> {
 			next : function() { var i = __this__.it.next(); return __this__.ref[getId(i)]; }
 		};
 	}
-	
+
 	public function toString() : String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -29,8 +29,8 @@ package haxe.ds;
 		h = {};
 	}
 
-	public function set( key : String, value : T ) : Void {
-		untyped h["$"+key] = value;
+	public function set( key : String, value : T ) : T {
+		return untyped h["$"+key] = value;
 	}
 
 	public function get( key : String ) : Null<T> {

--- a/std/neko/_std/haxe/ds/IntMap.hx
+++ b/std/neko/_std/haxe/ds/IntMap.hx
@@ -29,8 +29,9 @@ package haxe.ds;
 		h = untyped __dollar__hnew(0);
 	}
 
-	public inline function set( key : Int, value : T ) : Void {
+	public inline function set( key : Int, value : T ) : T {
 		untyped __dollar__hset(h,key,value,null);
+		return value;
 	}
 
 	public function get( key : Int ) : Null<T> {

--- a/std/neko/_std/haxe/ds/ObjectMap.hx
+++ b/std/neko/_std/haxe/ds/ObjectMap.hx
@@ -25,29 +25,30 @@ package haxe.ds;
 class ObjectMap<K:{},V> implements Map.IMap<K,V> {
 
 	static var count = 0;
-	
+
 	static inline function assignId(obj: { } ):Int {
 		var newId = count++;
 		untyped obj.__id__ = newId;
 		return newId;
 	}
-	
+
 	static inline function getId(obj: { } ):Int {
 		return untyped obj.__id__;
 	}
-	
+
 	var h : { };
 	var k : { };
-	
+
 	public function new() : Void {
 		h = untyped __dollar__hnew(0);
 		k = untyped __dollar__hnew(0);
 	}
 
-	public inline function set( key : K, value : V ) : Void untyped {
+	public inline function set( key : K, value : V ) : V untyped {
 		var id = key.__id__ != null ? key.__id__ : assignId(key);
 		untyped __dollar__hset(h,id,value,null);
 		untyped __dollar__hset(k,id,key,null);
+		return value;
 	}
 
 	public function get( key : K ) : Null<V> {

--- a/std/neko/_std/haxe/ds/StringMap.hx
+++ b/std/neko/_std/haxe/ds/StringMap.hx
@@ -29,8 +29,9 @@ package haxe.ds;
 		h = untyped __dollar__hnew(0);
 	}
 
-	public inline function set( key : String, value : T ) : Void {
+	public inline function set( key : String, value : T ) : T {
 		untyped __dollar__hset(h,key.__s,value,null);
+		return value;
 	}
 
 	public inline function get( key : String ) : Null<T> {

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -27,8 +27,8 @@ package haxe.ds;
 		h = untyped __call__('array');
 	}
 
-	public function set( key : Int, value : T ) : Void {
-		untyped h[key] = value;
+	public function set( key : Int, value : T ) : T {
+		return untyped h[key] = value;
 	}
 
 	public function get( key : Int ) : Null<T> {

--- a/std/php/_std/haxe/ds/ObjectMap.hx
+++ b/std/php/_std/haxe/ds/ObjectMap.hx
@@ -27,21 +27,21 @@ class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
 	static function getId(key: { } ):String {
 		return untyped __php__("spl_object_hash($key)");
 	}
-	
+
 	var h : ArrayAccess<V>;
 	var hk : ArrayAccess<K>;
-	
+
 	public function new():Void {
 		h = untyped __call__('array');
 		hk = untyped __call__('array');
 	}
-	
-	public function set(key:K, value:V):Void untyped {
+
+	public function set(key:K, value:V):V untyped {
 		var id = getId(key);
-		untyped h[id] = value;
 		untyped hk[id] = key;
+		return untyped h[id] = value;
 	}
-	
+
 	public function get(key:K):Null<V> {
 		var id = getId(key);
 		if (untyped __call__("array_key_exists", id, h))
@@ -49,11 +49,11 @@ class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
 		else
 			return null;
 	}
-	
+
 	public function exists(key:K):Bool {
 		return untyped __call__("array_key_exists", getId(key), h);
 	}
-	
+
 	public function remove( key : K ) : Bool {
 		var id = getId(key);
 		if (untyped __call__("array_key_exists", id, h)) {
@@ -63,15 +63,15 @@ class ObjectMap <K:{ }, V> implements Map.IMap<K,V> {
 		} else
 			return false;
 	}
-	
+
 	public inline function keys() : Iterator<K> {
 		return untyped __call__("new _hx_array_iterator", __call__("array_values", hk));
 	}
-	
+
 	public inline function iterator() : Iterator<V> {
 		return untyped __call__("new _hx_array_iterator", __call__("array_values", h));
 	}
-	
+
 	public function toString() : String {
 		var s = "{";
 		var it = keys();

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -28,8 +28,8 @@ package haxe.ds;
 		h = untyped __call__('array');
 	}
 
-	public function set( key : String, value : T ) : Void {
-		untyped h[key] = value;
+	public function set( key : String, value : T ) : T {
+		return untyped h[key] = value;
 	}
 
 	public function get( key : String ) : Null<T> {


### PR DESCRIPTION
Improves code generation when inlined for @:arrayAccess setter, and besides which it always feels strange having a setter that does not return a value, especcialy when haxe property setters return values.

Whilst this is a change to the std API, it should not be a breaking change at all (As opposed to if we did the opposite, removing a return from a function).
