### PR TITLE
Remove line from HX_STACK_FRAME hash

### DIFF
--- a/gencpp.ml
+++ b/gencpp.ml
@@ -1169,7 +1169,7 @@ let hx_stack_push ctx output clazz func_name pos =
 	ctx.ctx_file_info := PMap.add qfile qfile !(ctx.ctx_file_info);
 	if (ctx.ctx_dump_stack_line) then begin
       let hash_class_func = gen_hash 0 (clazz^"."^func_name) in
-      let hash_file_line = gen_hash (Lexer.get_error_line pos) stripped_file in
+      let hash_file_line = gen_hash 0 stripped_file in
 		output ("HX_STACK_FRAME(\"" ^ clazz ^ "\",\"" ^ func_name ^ "\"," ^ hash_class_func ^ ",\"" ^
                 clazz ^ "." ^ func_name ^ "\"," ^ qfile ^ "," ^
 			    (string_of_int (Lexer.get_error_line pos) ) ^  "," ^ hash_file_line ^ ")\n")


### PR DESCRIPTION
HX_STACK_FRAME file line hash should not include line, because we need to compare it to breakpoints that aren't on the same line as the function definition. We need to compare them to the current executing file and line. For reference see https://code.google.com/p/hxcpp/issues/detail?id=259 and https://groups.google.com/d/msg/haxedev/i-DDPnJfdGM/ppknx6tKXbcJ
