### PR TITLE
DOMStringMap should be Dynamic

### DIFF
--- a/std/js/html/DOMStringMap.hx
+++ b/std/js/html/DOMStringMap.hx
@@ -24,6 +24,6 @@
 package js.html;
 
 @:native("DOMStringMap")
-extern class DOMStringMap
+extern class DOMStringMap implements Dynamic
 {
 }


### PR DESCRIPTION
I've modified js.html.DOMStringMap to be a dynamic object because that is how it is used in JS. Throwing around untyped is the only other solution right now.
