### PR TITLE
under cygwin make, translate CURDIR to windows format

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -11,7 +11,7 @@ ifeq ($(shell uname -o), Cygwin)
 endif
 
 ifneq ($(ADD_REVISION),0)
-	VERSION_EXTRA=let version_extra = Some " (git build $(shell git rev-parse --abbrev-ref HEAD) @ $(shell git describe --always)) "
+	VERSION_EXTRA=let version_extra = Some '" (git build $(shell git rev-parse --abbrev-ref HEAD) @ $(shell git describe --always)) "'
 else
 	VERSION_EXTRA=let version_extra = None
 endif


### PR DESCRIPTION
this is fix for cygwin make that translates paths like /cygdrive/d/Code/haxe to D:/Code/haxe, so "haxe.exe --cwd $CURDIR" child process doesn't fail for tasks like "make haxelib"
