### PR TITLE
use windows paths under cygwin

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -10,12 +10,6 @@ ifneq (,$(findstring /cygdrive/,$(CURDIR)))
     CURDIR := $(shell cygpath -m ${CURDIR})
 endif
 
-ifneq ($(ADD_REVISION),0)
-	VERSION_EXTRA=let version_extra = Some " (git build $(shell git rev-parse --abbrev-ref HEAD) @ $(shell git describe --always)) "
-else
-	VERSION_EXTRA=let version_extra = None
-endif
-
 kill:
 	-@taskkill /F /IM haxe.exe 2>/dev/null
 


### PR DESCRIPTION
this makes haxe --cwd work from cygwin's make
