### PR TITLE
[js] don't generate constructor function for KAbstractImpl

### DIFF
--- a/genjs.ml
+++ b/genjs.ml
@@ -978,10 +978,18 @@ let generate_class ctx c =
 	else
 		print ctx "%s = $hxClasses[\"%s\"] = " p (dot_path c.cl_path);
 	(match (get_exposed ctx p c.cl_meta) with [s] -> print ctx "$hx_exports.%s = " s | _ -> ());
-	(match c.cl_constructor with
-	| Some { cf_expr = Some e } -> gen_expr ctx e
-	| _ -> (print ctx "function() { }"); ctx.separator <- true);
+
+	(match c.cl_kind with
+	| KAbstractImpl _ -> 
+		(* abstract implementations only contain static members and don't need to have constructor functions *)
+		print ctx "{}"; ctx.separator <- true
+	| _ ->
+		(match c.cl_constructor with
+		| Some { cf_expr = Some e } -> gen_expr ctx e
+		| _ -> (print ctx "function() {}"); ctx.separator <- true)
+	);
 	newline ctx;
+
 	if ctx.js_modern && hxClasses then begin
 		print ctx "$hxClasses[\"%s\"] = %s" (dot_path c.cl_path) p;
 		newline ctx;


### PR DESCRIPTION
Despite being classes under the hood, abstract implementations is just a collections of static methods and can't be constructed, so generating constructor function in JS doesn't make sense.

We did this cleanup for C# (now KAbstractImpl are just sealed classes with nothing but static methods) and for JS I think they should be generated as simple objects for the sake of cleanliness of generated JS. It also makes the distinction between regular classes and abstract implementations more clear to a person reading the generated code (most of people do that when they start with haxe).

This may or may not (probably not) have some positive impact on performance, depending on how modern js engines work with regard to an object being a constructor function or simple hash.

Before:

``` js
_Main.A_Impl_ = function() { };
_Main.A_Impl_.doStuff = function(this1) {
```

After:

``` js
_Main.A_Impl_ = { };
_Main.A_Impl_.doStuff = function(this1) {
```

I thought about generating it even simplier, like this:

``` js
_Main.A_Impl_ = {
    doStuff: function(this1) {
    }
};
```

But then it's not clear how to deal with `__init__` that is supposed to run before static var initialization.
