### PR TITLE
Incorrect cast in haxe.Int64.getLow() (java target)

### DIFF
--- a/std/java/_std/haxe/Int64.hx
+++ b/std/java/_std/haxe/Int64.hx
@@ -37,7 +37,7 @@ private typedef NativeInt64 = Int;
 
 	public static inline function getLow( x : Int64 ) : Int
 	{
-		return cast (x.asNative() & untyped __java__("0xFFFFFFFFL"));
+		return cast (x.asNative() & untyped __java__("0xFFFFFFFFL"), Int);
 	}
 
 	public static inline function getHigh( x : Int64 ) : Int


### PR DESCRIPTION
Incorrect code on java target:

Haxe input:
var x = Int64.make(0,0);
var low:Int = x.getLow();

Java output:
int low = ( ((long) (x) ) & 0xFFFFFFFFL );

javac "-sourcepath" "src" "-d" "obj" "-g" "@cmd"
src/haxe/root/TestInt64_testInt64_180__Fun.java:29: possible loss of precision
found   : long
required: int

Problem line is  https://github.com/HaxeFoundation/haxe/blob/development/std/java/_std/haxe/Int64.hx#L40
        public static inline function getLow( x : Int64 ) : Int
        {
                return cast (x.asNative() & untyped **java**("0xFFFFFFFFL"));
        }

Must be:
        public static inline function getLow( x : Int64 ) : Int
        {
                return cast (x.asNative() & untyped **java**("0xFFFFFFFFL"), Int);
        }
