### PR TITLE
Fix java runtime (long + inherited methods)

### DIFF
--- a/std/java/internal/Runtime.hx
+++ b/std/java/internal/Runtime.hx
@@ -373,7 +373,7 @@ package java.internal;
 		java.lang.Class[] cls = new java.lang.Class[len];
 		java.lang.Object[] objs = new java.lang.Object[len];
 
-		java.lang.reflect.Method[] ms = cl.getDeclaredMethods();
+		java.lang.reflect.Method[] ms = cl.getMethods();
 		int msl = ms.length;
 		int realMsl = 0;
 		for(int i =0; i < msl; i++)


### PR DESCRIPTION
this pull request is intended to fox two problems with java Runtime class's slowCallField method
- if a java function has an argument with long or java.lang.Long type, runtime was not able to discover it
- if a java function is inherited on an object runtime was not able to discover it
