### PR TITLE
fix typo in Http.fileTransfer method name

### DIFF
--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -349,7 +349,7 @@ class Http {
 
 #if sys
 
-	public function fileTransfert( argname : String, filename : String, file : haxe.io.Input, size : Int ) {
+	public function fileTransfer( argname : String, filename : String, file : haxe.io.Input, size : Int ) {
 		this.file = { param : argname, filename : filename, io : file, size : size };
 	}
 


### PR DESCRIPTION
I'm guessing this is a typo... but it could break some code since it is changing the signature.
