### PR TITLE
[php] Fix readInt32 in haxe.io.Input for php

### DIFF
--- a/std/haxe/io/Input.hx
+++ b/std/haxe/io/Input.hx
@@ -312,7 +312,15 @@ class Input {
 		var ch2 = readByte();
 		var ch3 = readByte();
 		var ch4 = readByte();
+#if php
+        // php will overflow integers.  Convert them back to signed 32-bit ints.
+        var n = bigEndian ? ch4 | (ch3 << 8) | (ch2 << 16) | (ch1 << 24) : ch1 | (ch2 << 8) | (ch3 << 16) | (ch4 << 24);
+        if (n & 0x80000000 != 0)
+            return ( n | 0x80000000);
+        else return n;
+#else
 		return bigEndian ? ch4 | (ch3 << 8) | (ch2 << 16) | (ch1 << 24) : ch1 | (ch2 << 8) | (ch3 << 16) | (ch4 << 24);
+#end
 	}
 
 	public function readString( len : Int ) : String {


### PR DESCRIPTION
This updates php so that it always returns a signed int32 from this command.
