### PR TITLE
fix syntax of generated php

### DIFF
--- a/genphp.ml
+++ b/genphp.ml
@@ -1377,9 +1377,9 @@ and gen_expr ctx e =
 		| _ ->
 			gen_call ctx ec el);
 	| TArrayDecl el ->
-		spr ctx "new _hx_array(array(";
+		spr ctx "(new _hx_array(array(";
 		concat ctx ", " (gen_value ctx) el;
-		spr ctx "))";
+		spr ctx ")))";
 	| TThrow e ->
 		spr ctx "throw new HException(";
 		gen_value ctx e;


### PR DESCRIPTION
This patch fixes an issue genphp generates invalid php code such that

```
new _hx_array(array())->toString();
```

corresponding to the haxe's code

```
(cast [] : Array<Int>).toString();
```
