### PR TITLE
TravisCI: take php off the allow_failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   # - TARGET=java
   # - TARGET=cs
 
-matrix:
-  allow_failures:
-    - env: TARGET=php
+# matrix:
+#   allow_failures:
+#     - env: TARGET=php
 
 before_install:
   - sudo apt-get install ocaml zlib1g-dev libgc-dev -y


### PR DESCRIPTION
The php target was fixed in 5a0e237f7a6241481a5068ef9726efcb5a1c9022.
