### PR TITLE
TravisCI: test js/java/cs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,15 @@ env:
   - TARGET=cpp
   - TARGET=js
   - TARGET=java
+  - TARGET=cs
   # - TARGET=flash8
   # - TARGET=flash9
   # - TARGET=as3
-  # - TARGET=cs
 
 matrix:
   allow_failures:
     - env: TARGET=java
+    - env: TARGET=cs
 
 before_install:
   - sudo apt-get install ocaml zlib1g-dev libgc-dev -y

--- a/tests/unit/RunTravis.hx
+++ b/tests/unit/RunTravis.hx
@@ -45,6 +45,15 @@ class RunTravis {
 				runProcess("haxelib", ["git", "hxjava", "https://github.com/HaxeFoundation/hxjava.git"]);
 				runProcess("haxe", ["compile-java.hxml"]);
 				runProcess("java", ["-jar", "java/java.jar"]);
+			case "cs":
+				runProcess("sudo", ["apt-get", "install", "mono-devel", "mono-mcs", "-y"]);
+				runProcess("haxelib", ["git", "hxcs", "https://github.com/HaxeFoundation/hxcs.git"]);
+				
+				runProcess("haxe", ["compile-cs.hxml"]);
+				runProcess("mono", ["cs/bin/Test-Debug.exe"]);
+
+				runProcess("haxe", ["compile-cs-unsafe.hxml"]);
+				runProcess("mono", ["cs_unsafe/bin/Test-Debug.exe"]);
 			case target:
 				throw "unknown target: " + target;
 		}


### PR DESCRIPTION
Run unit tests of another 3 targets: js/java/cs.
Currently java and cs are broken, so they're in `allow_failures` of `.travis.yml`.

The remaining flash8/flash9/as3 targets look a bit tricky. I will try enabling them a bit later.
