### PR TITLE
Made flash8.Boot.__string_rec public

### DIFF
--- a/std/flash8/Boot.hx
+++ b/std/flash8/Boot.hx
@@ -27,7 +27,7 @@ class Boot {
 	private static var def_color = 0;
 	private static var exception = null;
 
-	private static function __string_rec(o : Dynamic,s : String) {
+	public static function __string_rec(o : Dynamic,s : String) {
 		untyped {
 			if( s.length >= 20 )
 				return "<...>"; // too much deep recursion


### PR DESCRIPTION
Currently when targeting flash8, with `-D fdb`, there will be compilation error:

```
C:\HaxeToolkit\haxe\std/haxe/Log.hx:49: characters 14-37 : Cannot access private field __string_rec
C:\HaxeToolkit\haxe\std/haxe/Log.hx:50: characters 98-121 : Cannot access private field __string_rec
```

Since `Boot.__string_rec` is already public for flash9, here I also made the flash8 one public to fix the above issue.
