### PR TITLE
TravisCI: run apt-get update before installing anything via apt-get.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     - env: TARGET=cs
 
 before_install:
+  - sudo apt-get update
   - sudo apt-get install ocaml zlib1g-dev libgc-dev -y
   - git clone https://github.com/HaxeFoundation/neko.git ~/neko && cd ~/neko && make && sudo make install && cd $TRAVIS_BUILD_DIR
 

--- a/tests/unit/RunTravis.hx
+++ b/tests/unit/RunTravis.hx
@@ -15,7 +15,7 @@ class RunTravis {
 		Sys.putEnv("DISPLAY", ":99.0");
 		runCommand("sh", ["-e", "/etc/init.d/xvfb", "start"]);
 		Sys.putEnv("AUDIODEV", "null");
-		runCommand("sudo", ["apt-get", "install", "-qq", "libgd2-xpm", "ia32-libs", "ia32-libs-multiarch", "flashplugin-installer", "-y"]);
+		runCommand("sudo", ["apt-get", "install", "-qq", "libgd2-xpm", "ia32-libs", "ia32-libs-multiarch", "-y"]);
 		runCommand("wget", ["-nv", "http://fpdownload.macromedia.com/pub/flashplayer/updaters/11/flashplayer_11_sa_debug.i386.tar.gz"]);
 		runCommand("tar", ["-xf", "flashplayer_11_sa_debug.i386.tar.gz"]);
 		File.saveContent(Sys.getEnv("HOME") + "/mm.cfg", "ErrorReportingEnable=1\nTraceOutputFileEnable=1");


### PR DESCRIPTION
As title, and btw, “flashplugin-installer" is not used but forgot to remove...

And when there is any failure due to network error, you can try to restart the build by clicking the restart button on the top right corner of the build page. Note that it can only be done by someone that has push access.
![travis-rebuild](https://f.cloud.github.com/assets/103977/1699979/0f5b03f2-5fe2-11e3-823c-c5297ecc676f.png)
