### PR TITLE
Added $expr to print and debug generated expressions during compilation time

### DIFF
--- a/typer.ml
+++ b/typer.ml
@@ -3242,10 +3242,10 @@ and type_call ctx e el (with_type:with_type) p =
 		let e = type_expr ctx e Value in
 		ctx.com.warning (s_type (print_context()) e.etype) e.epos;
 		e
-	| (EConst (Ident "$expr"),_) , [e] ->
+	| (EConst (Ident "$expr"),p) , [e] ->
 		let e = type_expr ctx e Value in
 		let s = s_expr_pretty "\t" (s_type (print_context())) e in 
-		ctx.com.warning s e.epos;
+		ctx.com.warning s p;
 		e
 	| (EField(e,"match"),p), [epat] ->
 		let et = type_expr ctx e Value in


### PR DESCRIPTION
you can wrap every call with $expr and it prints the resulting expression as a warning during compilation time. It works just like $type only at compilation time. It helps to debug and understand macros, function inlining etc.
