### PR TITLE
[JS] Fixed instanceof for native functions

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -186,7 +186,7 @@ class Boot {
 						return true;
 				} else if( 	(untyped __js__("typeof"))(cl) == "object" &&
 							(untyped __js__("typeof"))(o) != "string" &&
-							(untyped __js__("(/^\\[object .*?Constructor\\]$/).test(cl)")) ) {
+							(untyped __js__("(/^\\[object .*?Element.*?\\]$/).test(cl)")) ) {
 					return untyped __js__("o instanceof cl");
 				}
 			} else {


### PR DESCRIPTION
As part of the ES5 spec (http://ecma262-5.com/ELS5_HTML.htm#Section_11.4.3), native functions return "object" when typeof is called on them. Chrome, Firefox, Opera implement the spec incorrectly and return "function" so there are no problems, but at least iOS Safari (possibly desktop Safari) implement the spec correctly and return "object". This leads to cast throwing errors if you are working with native DOM objects.

<!---
@huboard:{"order":2263.46875}
-->
