### PR TITLE
TravisCI: tmp fix of broken TRAVIS_BUILD_DIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
     - env: TARGET=cs
 
 before_install:
+  - export TRAVIS_BUILD_DIR=$(pwd) #tmp fix, see https://github.com/travis-ci/travis-build/pull/182
   - sudo apt-get update
   - sudo apt-get install ocaml zlib1g-dev libgc-dev -y
   - git clone https://github.com/HaxeFoundation/neko.git ~/neko && cd ~/neko && make && sudo make install && cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Turn out there is a recent change at Travis's end that broke the var TRAVIS_BUILD_DIR: https://github.com/travis-ci/travis-build/pull/182
Here is a tmp fix for that.
