### PR TITLE
Guard against calling haxe.zip.Compress or Uncompress methods after close()

### DIFF
--- a/std/cpp/_std/haxe/zip/Compress.hx
+++ b/std/cpp/_std/haxe/zip/Compress.hx
@@ -31,15 +31,21 @@ class Compress {
 	}
 
 	public function execute( src : haxe.io.Bytes, srcPos : Int, dst : haxe.io.Bytes, dstPos : Int ) : { done : Bool, read : Int, write : Int } {
-		return _deflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		if( s != null ) {
+			return _deflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		}
+		return { done : true, read : 0, write : 0 };
 	}
 
 	public function setFlushMode( f : FlushMode ) : Void {
-		_set_flush_mode(s,Std.string(f));
+		if( s != null ) {
+			_set_flush_mode(s,Std.string(f));
+		}
 	}
 
 	public function close() : Void {
 		_deflate_end(s);
+		s = null;
 	}
 
 	public static function run( s : haxe.io.Bytes, level : Int ) : haxe.io.Bytes {

--- a/std/cpp/_std/haxe/zip/Uncompress.hx
+++ b/std/cpp/_std/haxe/zip/Uncompress.hx
@@ -30,15 +30,21 @@ class Uncompress {
 	}
 
 	public function execute( src : haxe.io.Bytes, srcPos : Int, dst : haxe.io.Bytes, dstPos : Int ) : { done : Bool, read : Int, write : Int } {
-		return _inflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		if( s != null ) {
+			return _inflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		}
+		return { done : true, read : 0, write : 0 };
 	}
 
 	public function setFlushMode( f : FlushMode ) : Void {
-		_set_flush_mode(s,untyped f.__Tag());
+		if( s != null ) {
+			_set_flush_mode(s,untyped f.__Tag());
+		}
 	}
 
 	public function close() : Void {
 		_inflate_end(s);
+		s = null;
 	}
 
 	public static function run( src : haxe.io.Bytes, ?bufsize : Int ) : haxe.io.Bytes {

--- a/std/neko/_std/haxe/zip/Compress.hx
+++ b/std/neko/_std/haxe/zip/Compress.hx
@@ -31,15 +31,21 @@ class Compress {
 	}
 
 	public function execute( src : haxe.io.Bytes, srcPos : Int, dst : haxe.io.Bytes, dstPos : Int ) : { done : Bool, read : Int, write : Int } {
-		return _deflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		if( s != null ) {
+			return _deflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		}
 	}
 
 	public function setFlushMode( f : FlushMode ) : Void {
-		_set_flush_mode(s,untyped Std.string(f).__s);
+		if( s != null ) {
+			_set_flush_mode(s,untyped Std.string(f).__s);
+		}
+		return { done : true, read : 0, write : 0 };
 	}
 
 	public function close() : Void {
 		_deflate_end(s);
+		s = null;
 	}
 
 	public static function run( s : haxe.io.Bytes, level : Int ) : haxe.io.Bytes {

--- a/std/neko/_std/haxe/zip/Uncompress.hx
+++ b/std/neko/_std/haxe/zip/Uncompress.hx
@@ -31,15 +31,21 @@ class Uncompress {
 	}
 
 	public function execute( src : haxe.io.Bytes, srcPos : Int, dst : haxe.io.Bytes, dstPos : Int ) : { done : Bool, read : Int, write : Int } {
-		return _inflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		if( s != null ) {
+			return _inflate_buffer(s,src.getData(),srcPos,dst.getData(),dstPos);
+		}
+		return { done : true, read : 0, write : 0 };
 	}
 
 	public function setFlushMode( f : FlushMode ) : Void {
-		_set_flush_mode(s,untyped Std.string(f).__s);
+		if( s != null ) {
+			_set_flush_mode(s,untyped Std.string(f).__s);
+		}
 	}
 
 	public function close() : Void {
 		_inflate_end(s);
+		s = null;
 	}
 
 	public static function run( src : haxe.io.Bytes, ?bufsize : Int ) : haxe.io.Bytes {


### PR DESCRIPTION
In the event that close() is called on Compress or Uncompress, the application will crash when calling a second time or calling other methods of the classes. Obviously these should not be used after a close, but it makes sense to be safe.

<!---
@huboard:{"order":2263.000057220459}
-->
