### PR TITLE
Forward improvements

### DIFF
--- a/std/haxe/macro/Build.hx
+++ b/std/haxe/macro/Build.hx
@@ -240,7 +240,7 @@ class Build {
 			var fieldNames = getIdentNamePair(fieldExpr);
 			var baseName = fieldNames.baseName;
 			var newName = fieldNames.newName;
-			var fieldNameFree = !curAbstractFields.exists(newName);
+			var fieldNameFree = !abstractFieldLookup.exists(newName);
 			// in case of forwardAll we ignore if the field name is free because it could be a mapping.
 			// Additionally we can provide a better error message.
 			if (!forwardAll || fieldNameFree) {

--- a/tests/unit/MyAbstract.hx
+++ b/tests/unit/MyAbstract.hx
@@ -321,4 +321,19 @@ abstract ExposingAbstract<S>(Array<S>) {
 		this = [];
 	}
 }
+
+@:forward(![push])
+abstract ExposingAbstract2<S>(Array<S>) {
+	public inline function new() {
+		this = [];
+	}
+}
+
+@:forward(length, pop)
+abstract ExposingAbstract3<S>(Array<S>) {
+	public inline function new() {
+		this = [];
+	}
+}
+
 #end


### PR DESCRIPTION
allow to forward all fields: @:forward -> without parameters …
allow to forward all with excluding list: @:forward(![foo, bar])
allow to forward properties and variables
show error if a field is forwarded and also defined in the abstract itself.

<!---
@huboard:{"order":2263.0000143051147}
-->
