### PR TITLE
Fixed php.Boot._hx_string_call error.

### DIFF
--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -565,7 +565,7 @@ function _hx_string_call($s, $method, $params) {
 		case 'charAt'     : return substr($s, $params[0], 1);
 		case 'charCodeAt' : return _hx_char_code_at($s, $params[0]);
 		case 'indexOf'    : return _hx_index_of($s, $params[0], (count($params) > 1 ? $params[1] : null));
-		case 'lastIndexOf': return _hx_last_index_of($s, (count($params) > 1 ? $params[1] : null), null);
+		case 'lastIndexOf': return _hx_last_index_of($s, $params[0], (count($params) > 1 ? $params[1] : null));
 		case 'split'      : return _hx_explode($params[0], $s);
 		case 'substr'     : return _hx_substr($s, $params[0], (count($params) > 1 ? $params[1] : null));
 		case 'toString'   : return $s;


### PR DESCRIPTION
- Fixed passing arguments in wrong order calling `_hx_last_index_of`
  in `php.Boot._hx_string_call`.

This code can be used to test the error:

``` haxe

package test;

import haxe.unit.TestCase;

class TestString extends TestCase {

    public function testString():Void {

        var str:String = 'Hello World!!';
        assertEquals(7, str.lastIndexOf('o')); // Works.

    }

    public function testDynamicString():Void {

        var str:Dynamic = 'Hello World!!';
        assertEquals(7, str.lastIndexOf('o')); // Fails.

    }

}

```
