### PR TITLE
Fixed a bug in the processing of HTTP response headers

### DIFF
--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -602,6 +602,7 @@ class Http {
 			var a = hline.split(": ");
 			var hname = a.shift();
 			var hval = if( a.length == 1 ) a[0] else a.join(": ");
+			hval = StringTools.ltrim( StringTools.rtrim( hval ) );
 			responseHeaders.set(hname, hval);
 			switch(hname.toLowerCase())
 			{


### PR DESCRIPTION
Response header values with leading or trailing whitespace were parsed incorrectly, even though the HTTP standard specifies that such whitespace should be ignored (http://www.ietf.org/rfc/rfc2616.txt - Section 4.2).
This change trims said whitespace from all HTTP reponse header values.

<!---
@huboard:{"order":2545.25}
-->
