### PR TITLE
Added jQuery approach (hack) to enable local HTTP requests with JavaScript.

### DIFF
--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -166,6 +166,15 @@ class Http {
 			if( r.readyState != 4 )
 				return;
 			var s = try r.status catch( e : Dynamic ) null;
+			if ( s != null ) {
+			    // If the request is local and we have data: assume a success (jQuery approach):
+                var protocol = js.Browser.location.protocol.toLowerCase();
+                var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;
+                var isLocal = rlocalProtocol.match( protocol );
+                if ( isLocal ) {
+                    s = r.responseText != null ? 200 : 404;
+                }
+            }
 			if( s == untyped __js__("undefined") )
 				s = null;
 			if( s != null )


### PR DESCRIPTION
Browsers usually return HTTP status 0 for requests using a local protocol like file, app...
For local development it's nice to use simulated HTTP status 200 or 404 if responseText ist available or not.

<!---
@huboard:{"order":2547.75}
-->
