### PR TITLE
[js] don't add __class__ to Array.prototype (closes #2060, closes #1909)

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -68,7 +68,10 @@ class Boot {
 	}
 
 	static inline function getClass(o:Dynamic) : Dynamic {
-		return untyped __define_feature__("js.Boot.getClass", o.__class__);
+		if (Std.is(o, Array))
+			return Array;
+		else
+			return untyped __define_feature__("js.Boot.getClass", o.__class__);
 	}
 
 	@:ifFeature("has_enum")
@@ -171,6 +174,8 @@ class Boot {
 			return (untyped __js__("typeof"))(o) == "boolean";
 		case String:
 			return (untyped __js__("typeof"))(o) == "string";
+		case Array:
+			return (untyped __js__("(o instanceof Array)")) && o.__enum__ == null;
 		case Dynamic:
 			return true;
 		default:
@@ -178,8 +183,6 @@ class Boot {
 				// Check if o is an instance of a Haxe class
 				if( (untyped __js__("typeof"))(cl) == "function" ) {
 					if( untyped __js__("o instanceof cl") ) {
-						if( cl == Array )
-							return (o.__enum__ == null);
 						return true;
 					}
 					if( __interfLoop(getClass(o),cl) )

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -61,7 +61,7 @@ import js.Boot;
 	static function __init__() : Void untyped {
 		__feature__("js.Boot.getClass",String.prototype.__class__ = __feature__("Type.resolveClass",$hxClasses["String"] = String,String));
 		__feature__("js.Boot.isClass",String.__name__ = __feature__("Type.getClassName",["String"],true));
-		__feature__("js.Boot.getClass",Array.prototype.__class__ = __feature__("Type.resolveClass",$hxClasses["Array"] = Array,Array));
+		__feature__("Type.resolveClass",$hxClasses["Array"] = Array);
 		__feature__("js.Boot.isClass",Array.__name__ = __feature__("Type.getClassName",["Array"],true));
 		__feature__("Date.*", {
 			__feature__("js.Boot.getClass",__js__('Date').prototype.__class__ = __feature__("Type.resolveClass",$hxClasses["Date"] = __js__('Date'),__js__('Date')));


### PR DESCRIPTION
See related issues (#2060, #1909). This fix will make haxe not add `__class__` to `Array.prototype` and check for Array case as it were special in the reflection api. It should impove interoperability with buggy(?) extern js libraries that use `for (var index in array)` for array iteration. It should work even better when/if #2543 is merged.

``` haxe
class Main
{
    static function main()
    {
        var a = [1, 2, 3];

        Std.is(a, Array);

        untyped __js__("for (var i in a) {
            console.log(i);
        }");
    }
}
```

Before

```
0
1
2
__class__
```

After

```
0
1
2
```
