### PR TITLE
TravisCI: init SauceLabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: node_js
 
 env:
-  - TARGET=macro
-  - TARGET=neko
-  - TARGET=js
-  - TARGET=php
-  - TARGET=cpp
-  - TARGET=flash9
-  - TARGET=flash8
-  - TARGET=as3
-  - TARGET=java
-  - TARGET=cs
+  global:
+    # SAUCE_USERNAME
+    - secure: SjyKefmjUEXi0IKHGGpcbLAajU0mLHONg8aA8LoY7Q9nAkSN6Aql+fzS38Boq7w1jWn+2FOpr+4jy0l6wVd/bftsF+huFfYpFJmdh8BlKmE0K71zZAral0H1c7YxkuQpPiJCIFGXqtkvev7SWTy0z31u7kuuQeEyW27boXe5cDA=
+    # SAUCE_ACCESS_KEY
+    - secure: sUvWUjCyPuWht4seNa4f2VG9DkvXkhZyLZfjJO9TUAHB2JndS16E2j/qrvKEjycyH6w8tU/B9vnjDRvvGrYXxEXcBEwsJVfkorFnRl9uwGCGIYrzjMhssEl3fMYZK7P304f+gAp5ULrDBX2gIaKeSa8lUNRtz2PsZOieE4kMdhk=
+  matrix:
+    - TARGET=macro
+    - TARGET=neko
+    - TARGET=js
+    - TARGET=php
+    - TARGET=cpp
+    - TARGET=flash9
+    - TARGET=flash8
+    - TARGET=as3
+    - TARGET=java
+    - TARGET=cs
 
 matrix:
   allow_failures:

--- a/tests/RunTravis.hx
+++ b/tests/RunTravis.hx
@@ -88,6 +88,16 @@ class RunTravis {
 				runCommand("haxe", ["compile-js.hxml"]);
 				runCommand("node", ["-e", "var unit = require('./unit.js').unit; unit.Test.main(); process.exit(unit.Test.success ? 0 : 1);"]);
 
+				if (Sys.getEnv("TRAVIS_SECURE_ENV_VARS") == "true") {
+					//https://saucelabs.com/opensource/travis
+					runCommand("npm", ["install", "wd"]);
+					runCommand("curl", ["https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh", "|", "bash"]);
+					runCommand("haxelib", ["install", "nodejs"]);
+					runCommand("haxe", ["compile-saucelabs-runner.hxml"]);
+					runCommand("nekotools", ["server", "&"]);
+					runCommand("node", ["RunSauceLabs.js"]);
+				}
+
 				Sys.println("Test optimization:");
 				Sys.setCwd(optDir);
 				runCommand("haxe", ["run.hxml"]);

--- a/tests/unit/RunSauceLabs.hx
+++ b/tests/unit/RunSauceLabs.hx
@@ -1,0 +1,131 @@
+import js.Node.*;
+using Reflect;
+
+class RunSauceLabs {
+	static function main():Void {
+		var success = true;
+		var webdriver:Dynamic = require("wd");
+		var browser:Dynamic = webdriver.remote(
+			"localhost",
+			4445,
+			Sys.getEnv("SAUCE_USERNAME"), 
+			Sys.getEnv("SAUCE_ACCESS_KEY")
+		);
+
+		var tags = [];
+		if (Sys.getEnv("TRAVIS") != null) tags.push("TravisCI");
+
+		//https://saucelabs.com/platforms
+		var browsers = [
+			// {
+			// 	"browserName": "internet explorer",
+			// 	"platform": "Windows XP",
+			// 	"version": "6"
+			// },
+			// {
+			// 	"browserName": "internet explorer",
+			// 	"platform": "Windows XP",
+			// 	"version": "7"
+			// },
+			// {
+			// 	"browserName": "internet explorer",
+			// 	"platform": "Windows XP",
+			// 	"version": "8"
+			// },
+			{
+				"browserName": "internet explorer",
+				"platform": "Windows 7",
+				"version": "9"
+			},
+			{
+				"browserName": "internet explorer",
+				"platform": "Windows 7",
+				"version": "10"
+			},
+			{
+				"browserName": "internet explorer",
+				"platform": "Windows 8.1",
+				"version": "11"
+			},
+			{
+				"browserName": "chrome",
+				"platform": "Windows XP",
+				"version": "31"
+			},
+			{
+				"browserName": "firefox",
+				"platform": "Windows XP",
+				"version": "26"
+			},
+			{
+				"browserName": "safari",
+				"platform": "OS X 10.6",
+				"version": "5"
+			},
+			{
+				"browserName": "safari",
+				"platform": "OS X 10.8",
+				"version": "6"
+			},
+			{
+				"browserName": "safari",
+				"platform": "OS X 10.9",
+				"version": "7"
+			},
+			{
+				"browserName": "iphone",
+				"platform": "OS X 10.8",
+				"version": "6.1",
+				"device-orientation": "portrait"
+			},
+			{
+				"browserName": "iphone",
+				"platform": "OS X 10.9",
+				"version": "7",
+				"device-orientation": "portrait"
+			},
+			{
+				"browserName": "android",
+				"platform": "Linux",
+				"version": "4.0",
+				"device-orientation": "portrait"
+			}
+		];
+
+		function testBrowsers(browsers:Array<Dynamic>) {
+			if (browsers.length == 0) {
+				Sys.exit(success ? 0 : 1);
+			} else {
+				var caps = browsers.shift();
+				caps.setField("name", "haxe");
+				caps.setField("tags", tags);
+				if (Sys.getEnv("TRAVIS") != null) {
+					caps.setField("tunnel-identifier", Sys.getEnv("TRAVIS_JOB_NUMBER"));
+					caps.setField("build", Sys.getEnv("TRAVIS_BUILD_NUMBER"));
+				}
+
+				console.log('========================================================');
+				console.log('${caps.browserName} ${caps.version} on ${caps.platform}:');
+				browser.init(caps, function() {
+					browser.get("http://localhost:2000/unit-js.html", function() {
+						browser.text("body", function(err, re) {
+							if (err != null) throw err;
+							console.log(re);
+							browser.eval("unit.Test.success", function(err, re) {
+								if (err != null) throw err;
+								success = success && re;
+								browser.sauceJobUpdate({ passed: re },function(err) {
+									browser.quit(function(err) {
+										if (err != null) throw err;
+										testBrowsers(browsers);
+									});
+								});
+							});
+						});
+					});
+				});
+			}
+		}
+		testBrowsers(browsers);
+	}
+}

--- a/tests/unit/compile-saucelabs-runner.hxml
+++ b/tests/unit/compile-saucelabs-runner.hxml
@@ -1,0 +1,4 @@
+-js RunSauceLabs.js
+-main RunSauceLabs
+-lib nodejs
+-debug

--- a/tests/unit/unit-js.html
+++ b/tests/unit/unit-js.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Haxe Tests (JS)</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body id="haxe:trace">
+        <script src="unit.js"></script>
+        <script>unit.Test.main();</script>
+    </body>
+</html>

--- a/tests/unit/unit.html
+++ b/tests/unit/unit.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
@@ -35,13 +36,12 @@ iframe {
   white-space: pre;
 }
 	</style>
-	<script type="text/javascript" src="unit.js"></script>
 </head>
 <body>
 <p>Note : These tests need to be run from a local domain called <code>dev.unit-tests</code> which is running mod_neko in this directory.</p>
 <div class="window">
   <div class="label">JavaScript</div>
-  <div id="haxe:trace" class="cont"></div>
+  <div id="js_container" class="cont"><iframe src="unit-js.html"></iframe></div>
 </div>
 <div class="window">
   <div class="label">Neko</div>
@@ -143,10 +143,7 @@ iframe {
 </div>
 <div class="window">
   <div class="label">C#-unsafe</div>
-  <div id="csharp_container" class="cont"><iframe src="runexe.n?cs_unsafe/bin/cs_unsafe"></iframe></div>
+  <div id="csharp_unsafe_container" class="cont"><iframe src="runexe.n?cs_unsafe/bin/cs_unsafe"></iframe></div>
 </div>
-<script type="text/javascript">
-setTimeout('unit.Test.main()', 1000)
-</script>
 </body>
 </html>


### PR DESCRIPTION
Here I hook TravisCI with [SauceLabs](https://saucelabs.com/), which test against nearly every browser.
You may check **tests/unit/RunSauceLabs.hx** for the list of browsers I enabled for testing. 

SauceLabs kind of encourage each project to have its own SauceLabs account.
I opened a sub-account for haxe under my own account. Let me know if you wanna change it or something.

Also keep in mind that since it is using TravisCI's [secure environment variables](http://docs.travis-ci.com/user/build-configuration/#Secure-environment-variables), which is not available for pull requests, so SauceLabs testing will not be run for pull requests. Our original testing using nodejs would still be run for such cases. And once a pull request is merged into **HaxeFoundation/haxe**, TravisCI will run the test once more which SauceLabs will be available. Well, better late than never.

Note that the unit test is currently failing on IE 6/7/8, so I didn't enable them.

IE6:

```
Test.hx:240: Generated at: 2014-01-26 20:35:07
Test.hx:242: START
TestEReg.hx:24: should be null
TestEReg.hx:32: should be null
Test.hx:224: ABORTED : [object Error] in unit.TestMisc.testJSon
Test.hx:227: STACK : undefined
Test.hx:224: ABORTED : [object Error] in unit.TestSpecification.testInt32_unit_hx
Test.hx:227: STACK : undefined
TestDCE.hx:157: unit.ThrownWithToString should have member field toString
Test.hx:187: DONE [4217 tests]
Test.hx:329: SUCCESS: false
```

IE7:

```
Test.hx:240: Generated at: 2014-01-26 20:35:07
Test.hx:242: START
TestEReg.hx:24: should be null
TestEReg.hx:32: should be null
Test.hx:224: ABORTED : [object Error] in unit.TestMisc.testJSon
Test.hx:227: STACK : undefined
Test.hx:224: ABORTED : [object Error] in unit.TestSpecification.testInt32_unit_hx
Test.hx:227: STACK : undefined
TestDCE.hx:157: unit.ThrownWithToString should have member field toString
Test.hx:187: DONE [4217 tests]
Test.hx:329: SUCCESS: false
```

IE8:

```
Test.hx:240: Generated at: 2014-01-26 20:35:07
Test.hx:242: START
TestEReg.hx:24: should be null
TestEReg.hx:32: should be null
TestDCE.hx:157: unit.ThrownWithToString should have member field toString
Test.hx:187: DONE [4258 tests]
Test.hx:329: SUCCESS: false
```
