### PR TITLE
[as3] Generate operator overloads as public

### DIFF
--- a/genas3.ml
+++ b/genas3.ml
@@ -930,7 +930,7 @@ let generate_field ctx static f =
 			print ctx "]";
 		| _ -> ()
 	) f.cf_meta;
-	let public = f.cf_public || Hashtbl.mem ctx.get_sets (f.cf_name,static) || (f.cf_name = "main" && static) || f.cf_name = "resolve" || Ast.Meta.has Ast.Meta.Public f.cf_meta in
+	let public = f.cf_public || Hashtbl.mem ctx.get_sets (f.cf_name,static) || (f.cf_name = "main" && static) || f.cf_name = "resolve" || Ast.Meta.has Ast.Meta.Public f.cf_meta || Ast.Meta.has Ast.Meta.Op f.cf_meta in
 	let rights = (if static then "static " else "") ^ (if public then "public" else "protected") in
 	let p = ctx.curclass.cl_pos in
 	match f.cf_expr, f.cf_kind with


### PR DESCRIPTION
Fixes #2596. Maybe instead push Meta.Public in https://github.com/HaxeFoundation/haxe/blob/development/typeload.ml#L1815 but wanted to avoid dirtying up typeload with more target specific hacks.
