### PR TITLE
Fix for updating DB object property to null when cache==null

### DIFF
--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -197,7 +197,7 @@ class Manager<T : Object> {
 			var vc : Dynamic = Reflect.field(cache,name);
 			if( cache == null || v != vc ) {
 				switch( f.t ) {
-				case DSmallBinary, DNekoSerialized, DLongBinary, DBytes(_), DBinary: true;
+				case DSmallBinary, DNekoSerialized, DLongBinary, DBytes(_), DBinary:
 					if ( !hasBinaryChanged(v,vc) )
 						continue;
 				case DData:


### PR DESCRIPTION
The bug:
- Create an object, where one of the "SNULL<T>" values is set to a non-null value.  Save to DB.
- Create a new object, with the same values, same ID, but set the `SNULL<T>` value to null.
- Call `update()`.  Your property will keep it's old value, it will not be set to null in the db.

The issue:
- There are circumstances where an object that already exists in the
  database has no cache.  eg. If you create it, but set an id, or if
  you transfer it over remoting, but your serialization ignores the
  cache.
- When you call update() it only includes properties in the SQL "UPDATE"
  query when the new value `v` is different from the cached value `vc`.
- The cached value is retrieved with "Reflect.field", so if there is no
  cache, `vc == null`.
- If your existing object had a property which previously was set to a 
  non-null value, but now you want to change it to null, it will not be
  included in the "UPDATE" query, because `vc==null` and `v==null`, therefore
  `vc==v`, we assume the value has not changed and don't include it in the query.

The resolution:
- If the cache==null, ensure all fields are set during your "UPDATE" 
  query, because you cannot be sure which properties have changed.
