### PR TITLE
Do not infer Float in JsonParser.parseNumber as it's supposed to return Int for parsed int values.

### DIFF
--- a/std/haxe/format/JsonParser.hx
+++ b/std/haxe/format/JsonParser.hx
@@ -157,7 +157,7 @@ class JsonParser {
 		return buf.toString();
 	}
 
-	inline function parseNumber( c : Int ) {
+	inline function parseNumber( c : Int ) : Dynamic {
 		var start = pos - 1;
 		var minus = c == '-'.code, digit = !minus, zero = c == '0'.code;
 		var point = false, e = false, pm = false, end = false;


### PR DESCRIPTION
Subj. Without the `Dynamic` hint, parseNumber function always returns inferred Float and that is actually adding an extra cast on static platforms such as C#, however it seems like this function is supposed to return either Int (if parsed with parseInt) or Float, so it should be returned as Dynamic. This of course boxes the returned value (i.e. object is returned on C#), but that's okay because it will be boxed in parseRec anyway.
