### PR TITLE
Add -D js-es5.

### DIFF
--- a/common.ml
+++ b/common.ml
@@ -187,6 +187,7 @@ module Define = struct
 		| Interp
 		| JavaVer
 		| JsClassic
+		| JsEs5
 		| JsFlatten
 		| Macro
 		| MacroTimes
@@ -256,6 +257,7 @@ module Define = struct
 		| Interp -> ("interp","The code is compiled to be run with --interp")
 		| JavaVer -> ("java_ver", "<version:5-7> Sets the Java version to be targeted")
 		| JsClassic -> ("js_classic","Don't use a function wrapper and strict mode in JS output")
+		| JsEs5 -> ("js_es5","Generate JS for ES5-compliant runtimes")
 		| JsFlatten -> ("js_flatten","Generate classes to use fewer object property lookups")
 		| Macro -> ("macro","Defined when we compile code in the macro context")
 		| MacroTimes -> ("macro_times","Display per-macro timing when used with --times")

--- a/std/js/_std/Array.hx
+++ b/std/js/_std/Array.hx
@@ -45,6 +45,11 @@ extern class Array<T> {
 		return @:privateAccess HxOverrides.remove(this,x);
 	}
 
+#if js_es5
+	function indexOf( x : T, ?fromIndex:Int ) : Int;
+	function lastIndexOf( x : T, ?fromIndex:Int ) : Int;
+
+#else
 	inline function indexOf( x : T, ?fromIndex:Int ) : Int {
 		return @:privateAccess HxOverrides.indexOf(this,x,(fromIndex!=null)?fromIndex:0);
 	}
@@ -52,6 +57,7 @@ extern class Array<T> {
 	inline function lastIndexOf( x : T, ?fromIndex:Int ) : Int {
 		return @:privateAccess HxOverrides.lastIndexOf(this,x,(fromIndex!=null)?fromIndex:length-1);
 	}
+#end
 
 	inline function copy() : Array<T> {
 		return (untyped this).slice();

--- a/std/js/_std/HxOverrides.hx
+++ b/std/js/_std/HxOverrides.hx
@@ -114,7 +114,7 @@ class HxOverrides {
 	}
 
 	static function remove<T>( a : Array<T>, obj : T ) {
-		var i = indexOf(a, obj, 0);
+		var i = a.indexOf(obj);
 		if( i == -1 ) return false;
 		a.splice(i,1);
 		return true;
@@ -134,11 +134,14 @@ class HxOverrides {
 	}
 
 	static function __init__() untyped {
+#if !js_es5
 		__feature__('HxOverrides.indexOf', if( Array.prototype.indexOf ) __js__("HxOverrides").indexOf = function(a,o,i) return Array.prototype.indexOf.call(a, o, i));
 		__feature__('HxOverrides.lastIndexOf', if( Array.prototype.lastIndexOf ) __js__("HxOverrides").lastIndexOf = function(a,o,i) return Array.prototype.lastIndexOf.call(a, o, i));
-		#if mt
+#end
+
+#if mt
 		if( String.prototype.cca == null ) String.prototype.cca = String.prototype.charCodeAt;
-		#end
+#end
 	}
 
 }

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -90,6 +90,8 @@ import js.Boot;
 		__feature__("Void.*",{
 			var Void = __feature__("Type.resolveEnum", $hxClasses["Void"] = { __ename__ : ["Void"] }, { __ename__ : ["Void"] });
 		});
+
+#if !js_es5
 		__feature__("Array.map",
 			if( Array.prototype.map == null )
 				Array.prototype.map = function(f) {
@@ -110,6 +112,7 @@ import js.Boot;
 					return a;
 				}
 		);
+#end
 	}
 
 }


### PR DESCRIPTION
We can generate smaller and faster JS if we don't care about IE8.

Here's the compatibility table:
http://kangax.github.io/es5-compat-table

Might add more features behind this flag later.
