### PR TITLE
Remove haxe.exe whence cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ clean_libs:
 	make -C libs/ttflib clean
 
 clean_haxe:
-	rm -f $(MODULES:=.obj) $(MODULES:=.o) $(MODULES:=.cmx) $(MODULES:=.cmi) lexer.ml
+	rm -f $(MODULES:=.obj) $(MODULES:=.o) $(MODULES:=.cmx) $(MODULES:=.cmi) lexer.ml haxe.exe
 
 clean_tools:
 	rm -f $(OUTPUT) haxelib haxedoc


### PR DESCRIPTION
would be cool so that users don't mistakenly use obsolete builds :)
