### PR TITLE
In sys.db.Manager.doUpdate(), if cache is null, update all fields

### DIFF
--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -208,7 +208,7 @@ class Manager<T : Object> {
 			if( cache == null || v != vc ) {
 				switch( f.t ) {
 				case DSmallBinary, DNekoSerialized, DLongBinary, DBytes(_), DBinary: 
-					if ( hasBinaryChanged(v,vc) )
+					if ( !hasBinaryChanged(v,vc) )
 						continue;
 				case DData:
 					v = doUpdateCache(x, name, v);

--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -205,8 +205,11 @@ class Manager<T : Object> {
 			var name = f.name;
 			var v : Dynamic = Reflect.field(x,name);
 			var vc : Dynamic = Reflect.field(cache,name);
-			if( v != vc && (!isBinary(f.t) || hasBinaryChanged(v,vc)) ) {
+			if( cache == null || v != vc ) {
 				switch( f.t ) {
+				case DSmallBinary, DNekoSerialized, DLongBinary, DBytes(_), DBinary: 
+					if ( hasBinaryChanged(v,vc) )
+						continue;
 				case DData:
 					v = doUpdateCache(x, name, v);
 					if( !hasBinaryChanged(v,vc) )
@@ -220,7 +223,8 @@ class Manager<T : Object> {
 				s.add(quoteField(name));
 				s.add(" = ");
 				getCnx().addValue(s,v);
-				Reflect.setField(cache,name,v);
+				if ( cache != null )
+					Reflect.setField(cache,name,v);
 			}
 		}
 		if( !mod )


### PR DESCRIPTION
Fixes glitch where:

- existing record has non-null value
- you have a sys.db.Object with no cache (created manually, via remoting etc)
- set the value to null, try to update
- previous value remains.

Please note the private method isBinary() is now no longer used and could
be removed, though it may be useful in future.
