### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ clean_libs:
 	make -C libs/ttflib clean
 
 clean_haxe:
-	rm -f $(MODULES:=.obj) $(MODULES:=.o) $(MODULES:=.cmx) $(MODULES:=.cmi) lexer.ml haxe.exe
+	rm -f $(MODULES:=.obj) $(MODULES:=.o) $(MODULES:=.cmx) $(MODULES:=.cmi) lexer.ml $(OUTPUT)
 
 clean_tools:
 	rm -f $(OUTPUT) haxelib


### PR DESCRIPTION
- Separated bin/lib install path. It is mainly done for homebrew, which requires placing bin/lib into different directories. (See the discussion at Homebrew/homebrew#27152)
- Minor change of using `$(OUTPUT)` instead of `haxe.exe` in clean_haxe

It works for me, but since I'm not fluent in Makefile, so it would be great if you can take a look before merging.
