### PR TITLE
[std] Fix position setter in BytesInput

### DIFF
--- a/std/haxe/io/BytesInput.hx
+++ b/std/haxe/io/BytesInput.hx
@@ -74,9 +74,12 @@ class BytesInput extends Input {
 	}
 	
 	function set_position( p : Int ) : Int {
+		if( p < 0 ) p = 0;
+		else if( p > length ) p = length;
 		#if flash9
 		return b.position = p;
 		#else
+		len = totlen - p;
 		return pos = p;
 		#end
 	}

--- a/tests/unit/TestIO.hx
+++ b/tests/unit/TestIO.hx
@@ -136,4 +136,23 @@ class TestIO extends Test {
 		exc( function() i.readBytes(tmp,0,7) );
 	}
 
+	function testBytesInputSeek() {
+		var b = haxe.io.Bytes.ofString("0123456789abcdef");
+		var i = new haxe.io.BytesInput( b );
+		i.position = 15;
+		eq( i.readByte(), "f".code );
+		exc( i.readByte );
+		i.position = 1;
+		eq( i.readByte(), "1".code );
+		eq( i.readByte(), "2".code );
+		var tmp = haxe.io.Bytes.alloc(14);
+		eq( i.readBytes(tmp,0,13), 13 );
+		exc( i.readByte );
+		i.position = -10;
+		eq( i.position, 0 );
+		eq( i.readByte(), "0".code );
+		i.position = 999;
+		eq( i.position, i.length );
+		exc( i.readByte );
+	}
 }


### PR DESCRIPTION
Setting `position` wasn't resetting the bytes remaining in `totlen`, causing further reads to incorrectly throw or be truncated.
