### PR TITLE
implement Unicode code point escapes

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -617,6 +617,20 @@ let unescape s =
 					let c = (try char_of_int (int_of_string ("0x" ^ String.sub s (i+1) 2)) with _ -> raise Exit) in
 					Buffer.add_char b c;
 					inext := !inext + 2;
+				| 'u' ->
+					let (u, a) =
+					  (try
+					      (int_of_string ("0x" ^ String.sub s (i+1) 4), 4)
+					    with
+					      _ -> try
+						assert (s.[i+1] = '{');
+						let l = String.index_from s (i+3) '}' - (i+2) in
+						(int_of_string ("0x" ^ String.sub s (i+2) l), l+2)
+					      with _ -> raise Exit) in
+					let ub = UTF8.Buf.create 0 in
+					UTF8.Buf.add_char ub (UChar.uchar_of_int u);
+					Buffer.add_string b (UTF8.Buf.contents ub);
+					inext := !inext + a;
 				| _ ->
 					raise Exit);
 				loop false !inext;

--- a/ast.ml
+++ b/ast.ml
@@ -625,7 +625,9 @@ let unescape s =
 					      _ -> try
 						assert (s.[i+1] = '{');
 						let l = String.index_from s (i+3) '}' - (i+2) in
-						(int_of_string ("0x" ^ String.sub s (i+2) l), l+2)
+						let u = int_of_string ("0x" ^ String.sub s (i+2) l) in
+						assert (u <= 0x10FFFF);
+						(u, l+2)
 					      with _ -> raise Exit) in
 					let ub = UTF8.Buf.create 0 in
 					UTF8.Buf.add_char ub (UChar.uchar_of_int u);


### PR DESCRIPTION
issue #2115

This is implementation of Unicode code point escapes.

For example:

```haxe
class Main {
        public static function main() {
                trace("\u2603"); // ==> ☃
                trace("\u{1F37A}"); // ==> 🍺
        }
}
```
