### PR TITLE
Enable SocketConnection.create on platforms other than neko/flash/js.

### DIFF
--- a/std/haxe/remoting/SocketConnection.hx
+++ b/std/haxe/remoting/SocketConnection.hx
@@ -110,8 +110,6 @@ class SocketConnection implements AsyncConnection implements Dynamic<AsyncConnec
 		if( f.onResult != null ) f.onResult(ret);
 	}
 
-	#if (flash || js || neko)
-
 	function defaultLog(path,args,e) {
 		// exception inside the called method
 		var astr, estr;
@@ -177,7 +175,5 @@ class SocketConnection implements AsyncConnection implements Dynamic<AsyncConnec
 		#end
 		return sc;
 	}
-
-	#end
 
 }


### PR DESCRIPTION
Currently, ThreadRemotingServer is not usable on clients for targets other than neko, flash, and js. This is because SocketConnection's create method is hidden behind conditional compilation, so it's impossible to create SocketConnection objects. Is there a reason for this?

After removing the conditional block, I was able to build a desktop app using C++ and OpenFL on Linux, with openfl-native's version of flash.net.XMLSocket. It compiled successfully and a connection was established with no problem.
