### PR TITLE
Https support for cpp

### DIFF
--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -412,7 +412,11 @@ class Http {
 				#elseif java
 				sock = new java.net.SslSocket();
 				#elseif hxssl
+				#if neko
 				sock = new neko.tls.Socket();
+				#else
+				sock = new sys.ssl.Socket();
+				#end
 				#else
 				throw "Https is only supported with -lib hxssl";
 				#end


### PR DESCRIPTION
New hxssl format for tls socket. Neko stays the same for backwards compatibility, but should eventually move to sys.ssl.Socket as well.