### PR TITLE
Staged installs support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #
 .SUFFIXES : .ml .mli .cmo .cmi .cmx .mll .mly
 
-INSTALL_DIR=/usr
+INSTALL_DIR=$(DESTDIR)/usr
 INSTALL_BIN_DIR=$(INSTALL_DIR)/bin
 INSTALL_LIB_DIR=$(INSTALL_DIR)/lib/haxe
 
@@ -79,20 +79,19 @@ haxelib:
 tools: haxelib
 
 install:
-	-rm -f $(INSTALL_LIB_DIR)
-	-mkdir -p $(INSTALL_LIB_DIR)
+	rm -rf $(INSTALL_LIB_DIR)
+	mkdir -p $(INSTALL_BIN_DIR)
+	mkdir -p $(INSTALL_LIB_DIR)/lib
 	rm -rf $(INSTALL_LIB_DIR)/std
 	cp -rf std $(INSTALL_LIB_DIR)/std
 	cp -rf extra $(INSTALL_LIB_DIR)
-	-mkdir -p $(INSTALL_LIB_DIR)/lib
 	rm -f $(INSTALL_BIN_DIR)/haxe
 	cp haxe $(INSTALL_LIB_DIR)
 	ln -s $(INSTALL_LIB_DIR)/haxe $(INSTALL_BIN_DIR)/haxe
 	chmod -R a+rx $(INSTALL_LIB_DIR)
 	chmod 777 $(INSTALL_LIB_DIR)/lib
-	# cp extra/haxelib_src/haxelib_script.sh $(INSTALL_DIR)/bin/haxelib
-	echo "#!/bin/sh" > $(INSTALL_BIN_DIR)/haxelib
-	echo "exec haxe -cp $(INSTALL_LIB_DIR)/extra/haxelib_src/src --run tools.haxelib.Main \"\$$@\"" >> $(INSTALL_BIN_DIR)/haxelib
+	ln -s $(INSTALL_LIB_DIR)/extra/haxelib_src/haxelib_script.sh \
+	      $(INSTALL_BIN_DIR)/haxelib
 	chmod a+rx $(INSTALL_BIN_DIR)/haxe $(INSTALL_BIN_DIR)/haxelib
 
 # will install native version of the tools instead of script ones


### PR DESCRIPTION
Some package managers (f.e., gentoo portage) require staged install support:
i.e. installation of files into some temporary location (prefix).
This changeset adds support of that feature via DESTDIR variable.
Also see https://www.gnu.org/prep/standards/html_node/DESTDIR.html .

Related haxelib commit: https://github.com/HaxeFoundation/haxelib/pull/128