### PR TITLE
added check for native js objects to __instanceof

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -222,8 +222,10 @@ class Boot {
 	
 	// resolve native JS class (with window or global):
 	static function __resolveNativeClass(name:String) untyped {
-		var g = __js__("typeof window") != "undefined" ? window : global;
-		return g[name];
+		if (__js__("typeof window") != "undefined")
+			return window[name];
+		else
+			return global[name];
 	}
 
 }

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -217,7 +217,6 @@ class Boot {
 	// get native JS [[Class]]
 	static function __nativeClassName(o:Dynamic):String {
 		var name = untyped __toStr.call(o).slice(8, -1);
-		trace(name);
 		// exclude general Object and Function
 		// also exclude Math and JSON, because instanceof cannot be called on them
 		if (name == "Object" || name == "Function" || name == "Math" || name == "JSON")

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -222,7 +222,7 @@ class Boot {
 	
 	// resolve native JS class (with window or global):
 	static function __resolveNativeClass(name:String) untyped {
-		var g = __js__("typeof")(window) != "undefined" ? window : global;
+		var g = __js__("typeof window") != "undefined" ? window : global;
 		return g[name];
 	}
 

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -66,7 +66,7 @@ enum ValueType {
 		var cl : Class<Dynamic> = $hxClasses[name];
 		// ensure that this is a class
 		if( cl == null || !js.Boot.isClass(cl) )
-			return js.Boot.__resolveNativeClass(name);
+			return null;
 		return cl;
 	}
 

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -52,6 +52,8 @@ enum ValueType {
 
 	public static function getClassName( c : Class<Dynamic> ) : String {
 		var a : Array<String> = untyped c.__name__;
+		if (a == null)
+			return null;
 		return a.join(".");
 	}
 
@@ -64,7 +66,7 @@ enum ValueType {
 		var cl : Class<Dynamic> = $hxClasses[name];
 		// ensure that this is a class
 		if( cl == null || !js.Boot.isClass(cl) )
-			return null;
+			return js.Boot.__resolveNativeClass(name);
 		return cl;
 	}
 

--- a/tests/unit/issues/Issue2857.hx
+++ b/tests/unit/issues/Issue2857.hx
@@ -1,0 +1,14 @@
+package unit.issues;
+
+class Issue2857 extends unit.Test {
+#if js
+	function testElement() {
+		var vid = js.Browser.document.createVideoElement();
+		t(Std.is(vid, js.html.VideoElement));
+		t(Std.is(vid, js.html.Element));
+		f(Std.is(vid, haxe.Http));
+		f(Std.is(vid, js.html.ArrayBuffer));
+		eq(Type.getClass(vid), js.html.VideoElement);
+	}
+#end
+}

--- a/tests/unit/issues/Issue2857.hx
+++ b/tests/unit/issues/Issue2857.hx
@@ -8,7 +8,7 @@ class Issue2857 extends unit.Test {
 		t(Std.is(vid, js.html.Element));
 		f(Std.is(vid, haxe.Http));
 		f(Std.is(vid, js.html.ArrayBuffer));
-		eq(Type.getClass(vid), js.html.VideoElement);
+		//eq(Type.getClass(vid), js.html.VideoElement);
 	}
 #end
 }

--- a/tests/unit/issues/Issue2857.hx
+++ b/tests/unit/issues/Issue2857.hx
@@ -3,12 +3,14 @@ package unit.issues;
 class Issue2857 extends unit.Test {
 #if js
 	function testElement() {
-		var vid = js.Browser.document.createVideoElement();
-		t(Std.is(vid, js.html.VideoElement));
-		t(Std.is(vid, js.html.Element));
-		f(Std.is(vid, haxe.Http));
-		f(Std.is(vid, js.html.ArrayBuffer));
-		//eq(Type.getClass(vid), js.html.VideoElement);
+		if (js.Browser.supported) {
+			var vid = js.Browser.document.createVideoElement();
+			t(Std.is(vid, js.html.VideoElement));
+			t(Std.is(vid, js.html.Element));
+			f(Std.is(vid, haxe.Http));
+			f(Std.is(vid, js.html.ArrayBuffer));
+			eq(Type.getClass(vid), js.html.VideoElement);
+		}
 	}
 #end
 }


### PR DESCRIPTION
Std.is should work with native objects where typeof returns "object" now
added function for getting js [[Class]]
added function for resolving native classes
added handling of native objects to getClass
added null-check to Type.getClassName to avoid error when a native class is used
added resolving of native classes to Type.resolveClass
