### PR TITLE
Inline support for __cpp__ magic

### DIFF
--- a/gencpp.ml
+++ b/gencpp.ml
@@ -1672,7 +1672,39 @@ and gen_expression ctx retval expression =
          | _ -> false) ->
       ( match arg_list with
       | [{ eexpr = TConst (TString code) }] -> output code;
-      | _ -> error "__cpp__ accepts only one string as an argument" func.epos;
+      | ({ eexpr = TConst (TString code) } as ecode) :: tl ->
+        let exprs = Array.of_list tl in
+        let i = ref 0 in
+        let err msg =
+          let pos = { ecode.epos with pmin = ecode.epos.pmin + !i } in
+          ctx.ctx_common.error msg pos
+        in
+        let regex = Str.regexp "[{}]" in
+        let rec loop m = match m with
+          | [] -> ()
+          | Str.Text txt :: tl ->
+            i := !i + String.length txt;
+            output txt;
+            loop tl
+          | Str.Delim a :: Str.Delim b :: tl when a = b ->
+            i := !i + 2;
+            output a;
+            loop tl
+          | Str.Delim "{" :: Str.Text n :: Str.Delim "}" :: tl ->
+            (try
+              let expr = Array.get exprs (int_of_string n) in
+              gen_expression ctx true expr;
+              i := !i + 2 + String.length n;
+              loop tl
+            with | Failure "int_of_string" ->
+              err ("Index expected. Got " ^ n)
+            | Invalid_argument _ ->
+              err ("Out-of-bounds __cpp__ special parameter: " ^ n))
+          | Str.Delim x :: _ ->
+            err ("Unexpected " ^ x)
+        in
+        loop (Str.full_split regex code)
+      | _ -> error "__cpp__'s first argument must be a string" func.epos;
       )
    | TCall (func, arg_list) when tcall_expand_args->
       let use_temp_func = has_side_effects func in


### PR DESCRIPTION
This request introduces the possibility of having `__cpp__` magic on inline functions. The following test case was used:

``` haxe
class Main
{
    static function main()
    {
        var bytes = haxe.io.Bytes.alloc(8).getData();
        setInt(bytes,4,0xFF0FF0F0);
        trace(getInt(bytes,4));
        trace(0xFF0FF0F0);
    }

    inline private static function setInt(bytes:haxe.io.BytesData, addr:Int, x:Int)
    {
        untyped __cpp__("*((int *) ({0}->GetBase() + {1})) = {2}",bytes,addr,x);
    }

    inline private static function getInt(bytes:haxe.io.BytesData, addr:Int):Int
    {
        return untyped __cpp__("*((int *) ({0}->GetBase() + {1}))",bytes,addr);
    }
}
```

And it works as expected.  As seen on the example above, this will add a special `{\d}` construct for the `__cpp__` magic keyword, which will be replaced by the actual expression representation. This is backwards-compatible as the behaviour will only be triggered when there is more than one argument in the `__cpp__` magic. Also invalid input is detected and there is an effort to more precisely indicate the position where the error occurs.
