### PR TITLE
Added support for abstract types in SPOD

### DIFF
--- a/std/sys/db/RecordMacros.hx
+++ b/std/sys/db/RecordMacros.hx
@@ -199,7 +199,7 @@ class RecordMacros {
 			case "Int": DInt;
 			case "Float": DFloat;
 			case "Bool": DBool;
-			default: throw "Unsupported Record Type " + name;
+			default: makeType(a.get().type);
 			}
 		case TEnum(e, _):
 			var name = e.toString();


### PR DESCRIPTION
Uses the underlying type as the actual storage mechanism.

I've found having this functionality is nice for more domain specific problems such as storing Strings that should be escaped before being displayed.
