### PR TITLE
Suport 3d profile for targets before flash 11.4

### DIFF
--- a/std/flash/display/Stage3D.hx
+++ b/std/flash/display/Stage3D.hx
@@ -5,6 +5,6 @@ package flash.display;
 	var visible : Bool;
 	var x : Float;
 	var y : Float;
-	function requestContext3D(?context3DRenderMode : String, ?profile : flash.display3D.Context3DProfile) : Void;
+	function requestContext3D(?context3DRenderMode : String, ?profile : String) : Void;
 	@:require(flash12) function requestContext3DMatchingProfiles(profiles : flash.Vector<String>) : Void;
 }

--- a/std/flash/display3D/Context3DProfile.hx
+++ b/std/flash/display3D/Context3DProfile.hx
@@ -1,8 +1,8 @@
 package flash.display3D;
 
-@:fakeEnum(String) extern enum Context3DProfile {
-	BASELINE;
-	BASELINE_CONSTRAINED;
-	BASELINE_EXTENDED;
-	STANDARD;
+class Context3DProfile
+{
+	inline public static var BASELINE:String = "baseline";
+	inline public static var BASELINE_CONSTRAINED:String = "baselineConstrained";
+	inline public static var BASELINE_EXTENDED:String="baselineExtended";
 }


### PR DESCRIPTION
Flash GetContext3D is written in such a way that it has no dependencies and doesn’t even need you to compile your SWF for Flash Player 11.8 (extended profile support) or Flash Player 11.4 (constrained profile support). You can compile for any version of Flash Player starting at the first one to support Stage3D and Context3D at all: 11.0.

The change makes possible to target 11.0 and pass the Context3DProfile as just the string without getting an error. If we have Constext3DProfile as a enum we need to target at least 11.4.

Enums in general are better options but in this case, they are creating an undesirable constraint. 
