### PR TITLE
Support quality argument in CanvasElement.toDataURL method.

### DIFF
--- a/std/js/html/CanvasElement.hx
+++ b/std/js/html/CanvasElement.hx
@@ -43,7 +43,7 @@ extern class CanvasElement extends Element
 
 	function getContext( contextId : String ) : Dynamic;
 
-	function toDataURL( ?type : String ) : String;
+	function toDataURL( ?type : String, ?quality: Float ) : String;
 
 	/** A typed shortcut for <code>getContext("2d")</code>. */
 	public inline function getContext2d() : CanvasRenderingContext2D { return cast getContext("2d"); }


### PR DESCRIPTION
For certain image types (like image/jpeg) user can specify a number between 0.0 and 1.0 as a second argument, which indicates an image quality.
