### PR TITLE
haxe.Serializer has been updated so that haxe.ds.Vector is properly serialized when the target is Flash10.

### DIFF
--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -190,14 +190,23 @@ class Serializer {
 	// only the instance variables
 
 	function serializeClassFields(v,c) {
-		var xml : flash.xml.XML = untyped __global__["flash.utils.describeType"](c);
-		var vars = xml.factory[0].child("variable");
-		for( i in 0...vars.length() ) {
-			var f = vars[i].attribute("name").toString();
-			if( !v.hasOwnProperty(f) )
-				continue;
-			serializeString(f);
-			serialize(Reflect.field(v,f));
+		if (StringTools.startsWith(Type.getClassName(c), "__AS3__.vec.Vector")) {
+			for (i in 0...v.length) {
+				serializeString(Std.string(i));
+				serialize(untyped v[i]);
+			}
+			serializeString("fixed");
+			serialize(v.fixed);
+		} else {
+			var xml : flash.xml.XML = untyped __global__["flash.utils.describeType"](c);
+			var vars = xml.factory[0].child("variable");
+			for( i in 0...vars.length() ) {
+				var f = vars[i].attribute("name").toString();
+				if( !v.hasOwnProperty(f) )
+					continue;
+				serializeString(f);
+				serialize(Reflect.field(v,f));
+			}
 		}
 		buf.add("g");
 	}


### PR DESCRIPTION
haxe.ds.Vector can be used on the Flash platform to improve speed. However, haxe.Serializer is not compatible with the Flash platform's haxe.ds.Vector. 

This update allows the following code to be run.

``` haxe
#if flash10
var vector = new haxe.ds.Vector<Int>(3);
vector[0] = 0;
vector[1] = 10;
vector[2] = 40;
var s = Serializer.run(vector);
var v:haxe.ds.Vector<Int> = Unserializer.run(s);
trace(s); // cy28:__AS3__.vec.Vector.%3Cint%3Ey1:0zy1:1i10y1:2i40y5:fixedtg
trace(v); // 0,10,40
#end
```

In this example, haxe.ds.Vector is serialized as class "c" when the target is Flash.

I did attempt to make haxe.ds.Vector compatible with the entire platform by defining TVector as Type.ValueType, but I was unable to find a means to dynamically set TypeParameter when a NativeArray(Vector) is being generated in the Unserializer. As such, I did not make this change.
