### PR TITLE
[sys][sql] Replaced "1"/"0" query comparison values with "TRUE"/"FALSE"

### DIFF
--- a/std/sys/db/Manager.hx
+++ b/std/sys/db/Manager.hx
@@ -457,7 +457,7 @@ class Manager<T : Object> {
 				}
 			}
 		if( first )
-			s.add("1");
+			s.add("TRUE");
 	}
 
 	/* --------------------------- MISC API  ------------------------------ */

--- a/std/sys/db/RecordMacros.hx
+++ b/std/sys/db/RecordMacros.hx
@@ -439,8 +439,8 @@ class RecordMacros {
 			case CIdent(n):
 				switch( n ) {
 				case "null": return { expr : EConst(CString("NULL")), pos : v.pos };
-				case "true": return { expr : EConst(CInt("1")), pos : v.pos };
-				case "false": return { expr : EConst(CInt("0")), pos : v.pos };
+				case "true": return { expr : EConst(CInt("TRUE")), pos : v.pos };
+				case "false": return { expr : EConst(CInt("FALSE")), pos : v.pos };
 				}
 			default:
 			}
@@ -756,9 +756,9 @@ class RecordMacros {
 				case "null":
 					return { sql : makeString("NULL", p), t : DNull, n : true };
 				case "true":
-					return { sql : makeString("1", p), t : DBool, n : false };
+					return { sql : makeString("TRUE", p), t : DBool, n : false };
 				case "false":
-					return { sql : makeString("0", p), t : DBool, n : false };
+					return { sql : makeString("FALSE", p), t : DBool, n : false };
 				}
 				return buildDefault(cond);
 			}


### PR DESCRIPTION
This allows generated SQL to be compatible with Postgres
while still keeping compatibility with MySQL

PostgreHX link: https://github.com/jdonaldson/postgrehx
SQL Fiddle links showing that "1" does not work in PostgreSQL
and "TRUE" works for both PostgreSQL and MySQL:
MYSQL 5.5.32 http://sqlfiddle.com/#!2/78ef27/4
PostgreSQL 9.3.1 http://sqlfiddle.com/#!15/efc23/2
