### PR TITLE
[js] support haxe.CallStack.exceptionStack by saving error stack on throw (closes #2854)

### DIFF
--- a/genjs.ml
+++ b/genjs.ml
@@ -560,7 +560,10 @@ and gen_expr ctx e =
 		spr ctx "]"
 	| TThrow e ->
 		spr ctx "throw ";
+		let save_stack = has_feature ctx "haxe.CallStack.exceptionStack" in
+		if save_stack then print ctx "%s.saveStack(" (ctx.type_accessor (TClassDecl { null_class with cl_path = ["haxe"],"CallStack" }));
 		gen_value ctx e;
+		if save_stack then spr ctx ")";
 	| TVar (v,eo) ->
 		spr ctx "var ";
 		check_var_declaration v;


### PR DESCRIPTION
See #2854. I think it's better to just save call stack when throwing error instead of wrapping/unwrapping errors on JS. And it's backward-compatible. So I implemented stack saving, but only if `haxe.CallStack.exceptionStack` is actually used (with `__feature__` stuff).

As I mentioned in the original issue, I think we should refactor `haxe.CallStack` by breaking it into several platform-dependent override modules. I could do that after merging this one (if it's okay, of course).
