### PR TITLE
Remove the range of values in docs of -swf-version

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -1047,7 +1047,7 @@ try
 		("-swf-version",Arg.Float (fun v ->
 			if not !swf_version || com.flash_version < v then com.flash_version <- v;
 			swf_version := true;
-		),"<version> : change the SWF version (6 to 10)");
+		),"<version> : change the SWF version");
 		("-swf-header",Arg.String (fun h ->
 			try
 				swf_header := Some (match ExtString.String.nsplit h ":" with


### PR DESCRIPTION
Apart from the fact that this info is outdated - considering the [currently possible swf-versions](https://github.com/HaxeFoundation/haxe/blob/55701455963cfe3ecd6938023339980d35fe20f2/common.ml#L809), giving a range like this doesn't seem too useful anymore as there's no real consistency (10.2, 10.3, but no 10.4 for example). Or in other words, all possible versions would need to be listed here, which is probably not a good idea.
