### PR TITLE
add -D unreflective and @:reflective

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -122,6 +122,7 @@ module Meta = struct
 		| PublicFields
 		| ReadOnly
 		| RealPath
+		| Reflective
 		| Remove
 		| Require
 		| RequiresAssign

--- a/codegen.ml
+++ b/codegen.ml
@@ -1627,7 +1627,11 @@ module UnificationCallback = struct
 				let eo = Some (f e v.v_type) in
 				{ e with eexpr = TVar(v,eo) }
 			| TCall(e1,el) ->
-				let el = check_call f el e1.etype in
+				let t = match e1.eexpr with
+					| TField (_, (FStatic(_,cf) | FInstance(_,cf) | FAnon cf)) -> cf.cf_type
+					| _ -> e1.etype
+				in
+				let el = check_call f el t in
 				{e with eexpr = TCall(e1,el)}
 			| TNew(c,tl,el) ->
 				begin try

--- a/common.ml
+++ b/common.ml
@@ -230,6 +230,7 @@ module Define = struct
 		| SwfUseDoAbc
 		| Sys
 		| UnityStdTarget
+		| Unreflective
 		| Unsafe
 		| UseNekoc
 		| UseRttiDoc
@@ -306,6 +307,7 @@ module Define = struct
 		| SwfUseDoAbc -> ("swf_use_doabc", "Use DoAbc swf-tag instead of DoAbcDefine")
 		| Sys -> ("sys","Defined for all system platforms")
 		| UnityStdTarget -> ("unity_std_target", "Changes C# sources location so that each generated C# source is relative to the Haxe source location. If the location is outside the current directory, the value set here will be used")
+		| Unreflective -> ("unreflective", "Do not generate reflection code by default")
 		| Unsafe -> ("unsafe","Allow unsafe code when targeting C#")
 		| UseNekoc -> ("use_nekoc","Use nekoc compiler instead of internal one")
 		| UseRttiDoc -> ("use_rtti_doc","Allows access to documentation during compilation")
@@ -428,6 +430,7 @@ module MetaInfo = struct
 		| Property -> ":property",("Marks a property field to be compiled as a native C# property",[UsedOn TClassField;Platform Cs])
 		| ReadOnly -> ":readOnly",("Generates a field with the 'readonly' native keyword",[Platform Cs; UsedOn TClassField])
 		| RealPath -> ":realPath",("Internally used on @:native types to retain original path information",[Internal])
+		| Reflective -> ":reflective",("Keep reflection information for field or type even if -D unreflective is used",[UsedOnEither [TClass;TEnum;TAbstract]])
 		| Remove -> ":remove",("Causes an interface to be removed from all implementing classes before generation",[UsedOn TClass])
 		| Require -> ":require",("Allows access to a field only if the specified compiler flag is set",[HasParam "Compiler flag to check";UsedOn TClassField])
 		| RequiresAssign -> ":requiresAssign",("Used internally to mark certain abstract operator overloads",[Internal])

--- a/std/cpp/_std/Type.hx
+++ b/std/cpp/_std/Type.hx
@@ -31,6 +31,7 @@ enum ValueType {
 	TUnknown;
 }
 
+@:reflective
 @:coreApi class Type {
 	public static function getClass<T>( o : T ) : Class<T> untyped {
 			if (o==null || !Reflect.isObject(o))  return null;

--- a/tests/unit/Test.hx
+++ b/tests/unit/Test.hx
@@ -5,6 +5,7 @@ package unit;
 #if as3
 @:publicFields
 #end
+@:reflective
 class Test #if swf_mark implements mt.Protect #end {
 
 	public function new() {

--- a/tests/unit/TestDCE.hx
+++ b/tests/unit/TestDCE.hx
@@ -189,6 +189,7 @@ class UsedThroughInterface implements UsedInterface {
 }
 
 class UsedAsBase { }
+
 class UsedAsBaseChild extends UsedAsBase {
 	public function new() { }
 }
@@ -208,6 +209,7 @@ interface PropertyInterface {
 	public var x(get_x, set_x):String;
 }
 
+@:reflective
 class PropertyAccessorsFromBaseClass {
 	public function get_x() return throw "must not set";
 	public function set_x(x:String) return "ok";

--- a/tests/unit/compile-cpp.hxml
+++ b/tests/unit/compile-cpp.hxml
@@ -2,3 +2,4 @@ compile-each.hxml
 -main unit.Test
 -cpp cpp
 -D NO_PRECOMPILED_HEADERS
+-D unreflective


### PR DESCRIPTION
This pull request adds the -D unreflective flag which tells the CPP generator to not generate `__Field` and `__SetField` bodies by default. Individual classes and fields can be marked with `@:reflective` to keep the reflection information.

We also try to detect cases where we "probably" need the reflection information, i.e. when a TInst is assigned to TDynamic or TAnon. For the unit tests this wasn't quite enough and I had to add `@:reflective` in a few places:
- unit.Test: This is obvious, we want to keep all the test fields to call them via reflection.
- unit.PropertyAccessorsFromBaseClass: This is used only via Type.resolveClass, which makes it impossible to detect.
- Type: This one bugs me a bit. I think it comes from the Unserializer using it as a resolver, but I have to investigate this a bit more.

My main concern is that this is not so easy to debug. Maybe we can let gencpp output some print if a `__Field` call is made which has no field information.
