### PR TITLE
[java] support static final fields for -java-lib extern interfaces (closes #3091)

### DIFF
--- a/genjava.ml
+++ b/genjava.ml
@@ -2599,7 +2599,7 @@ let convert_java_enum ctx p pe =
 			if jc.cpath <> (["java";"lang"], "CharSequence") then
 				List.iter (fun f ->
 					try
-						if !is_interface && List.mem JStatic f.jf_flags then
+						if !is_interface && List.mem JStatic f.jf_flags && not (List.mem JFinal f.jf_flags) then
 							()
 						else begin
 							fields := convert_java_field ctx p jc f :: !fields;

--- a/tests/unit/TestJava.hx
+++ b/tests/unit/TestJava.hx
@@ -81,6 +81,11 @@ class TestJava extends Test
 
 	}
 
+	function testInterfaceStaticField()
+	{
+		eq(haxe.test.StaticInterfaceField.test, 10);
+	}
+
 	function testOverloadOverride()
 	{
 		var c = new TestMyClass();

--- a/tests/unit/native_java/hxjava_build.txt
+++ b/tests/unit/native_java/hxjava_build.txt
@@ -16,6 +16,8 @@ M haxe.test.GenericHelper
 C haxe.test.GenericHelper
 M haxe.test.StaticAndInstanceClash
 C haxe.test.StaticAndInstanceClash
+M haxe.test.StaticInterfaceField
+C haxe.test.StaticInterfaceField
 M haxe.UpperCasePackage.SomeClass
 C haxe.UpperCasePackage.SomeClass
 M haxe.UpperCasePackage.lowercase

--- a/tests/unit/native_java/src/haxe/test/StaticInterfaceField.java
+++ b/tests/unit/native_java/src/haxe/test/StaticInterfaceField.java
@@ -1,0 +1,6 @@
+package haxe.test;
+
+public interface StaticInterfaceField
+{
+    int test = 10;
+}

--- a/typeload.ml
+++ b/typeload.ml
@@ -2130,7 +2130,8 @@ let init_class ctx c p context_init herits fields =
 		try
 			let fd , constr, f, do_add = loop_cf f in
 			let is_static = List.mem AStatic fd.cff_access in
-			if (is_static || constr) && c.cl_interface && f.cf_name <> "__init__" then error "You can't declare static fields in interfaces" p;
+			if (is_static || constr) && c.cl_interface && f.cf_name <> "__init__" && not (Meta.has Meta.JavaNative c.cl_meta) then
+				error "You can't declare static fields in interfaces" p;
 			begin try
 				let _,args,_ = Meta.get Meta.IfFeature f.cf_meta in
 				List.iter (fun e -> match fst e with


### PR DESCRIPTION
See #3091. @waneck please review if this is correct fix.

Also, what about defining externs for such interfaces by hand?
