### PR TITLE
Compiler.hx keep macro fix for case (some more)

### DIFF
--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -275,7 +275,24 @@ class Compiler {
 				var fullPath = classPath + path.split(".").join("/");
 				var isValidModule:Bool = startsWithUpperCase && sys.FileSystem.exists(fullPath + ".hx");
 				var isValidSubType:Bool = !isValidModule && moduleRootPath != "" && rootStartsWithUpperCase && sys.FileSystem.exists(moduleRootPath);
-				var isValidDirectory:Bool = !isValidSubType && sys.FileSystem.exists(fullPath) && sys.FileSystem.isDirectory(fullPath);
+
+				var doesExist : Bool = sys.FileSystem.exists(fullPath);
+				var isDirectory : Bool = doesExist && sys.FileSystem.isDirectory(fullPath);
+				var canBeValidDirectory : Bool = false;
+
+					//it can only be a valid directory if the 
+					//name exists in the parent folder under the same case,
+					//again because FileSystem is used on insensitive platforms
+				if(doesExist) {
+					var parentPath = haxe.io.Path.directory(fullPath);
+					var fileList = sys.FileSystem.readDirectory( parentPath );
+					var pathName = path.split('.').pop();
+					if(fileList.indexOf(pathName) != -1) {
+						canBeValidDirectory = true;
+					}
+				}				
+
+				var isValidDirectory:Bool = !isValidSubType && canBeValidDirectory && doesExist && isDirectory;
 				if ( !isValidDirectory && !isValidModule && !isValidSubType)
 					continue;
 				else


### PR DESCRIPTION
With :
src/Game.hx
src/game/

And
keep(“Game”)

The following error is thrown :
--macro:1: character 0 : Invalid package : Game should be game

This is because FileSystem is not case sensitive for .exists(), it
would find the package folder for Game under game/ and suggest
isValidDirectory is true. On platforms with insensitive paths, this is
an error.

This commit checks the case against the parent folder of the searched
keep in order to ensure case is respected before it tries to set
isValidDirectory.
