### PR TITLE
Resolving inconsistent FileSystem.fullPath behavior on different targets.

### DIFF
--- a/std/cpp/_std/sys/FileSystem.hx
+++ b/std/cpp/_std/sys/FileSystem.hx
@@ -53,6 +53,11 @@ class FileSystem {
 		return new String(file_full_path(relPath));
 	}
 
+	public static function absPath ( relPath : String ) : String {
+		if (haxe.io.Path.isAbsolute(relPath)) return relPath;
+		return haxe.io.Path.join([Sys.getCwd(), relPath]);
+	}
+
 	static function kind( path : String ) : FileKind {
 		var k:String = sys_file_type(haxe.io.Path.removeTrailingSlashes(path));
 		return switch(k) {

--- a/std/cs/_std/sys/FileSystem.hx
+++ b/std/cs/_std/sys/FileSystem.hx
@@ -82,6 +82,11 @@ class FileSystem {
 		return new FileInfo(relPath).FullName;
 	}
 
+	public static function absPath ( relPath : String ) : String {
+		if (haxe.io.Path.isAbsolute(relPath)) return relPath;
+		return haxe.io.Path.join([Sys.getCwd(), relPath]);
+	}
+
 	public static function isDirectory( path : String ) : Bool
 	{
 		var isdir = Directory.Exists(path);

--- a/std/haxe/io/Path.hx
+++ b/std/haxe/io/Path.hx
@@ -299,4 +299,13 @@ class Path {
 		}
 		return path;
 	}
+
+	/**
+		Returns true if the path is an absolute path, and false otherwise.
+	**/
+	public static function isAbsolute ( path : String ) : Bool {
+		if (StringTools.startsWith(path, '/')) return true;
+		if (path.charAt(2) == ':') return true;
+		return false;
+	}
 }

--- a/std/java/_std/sys/FileSystem.hx
+++ b/std/java/_std/sys/FileSystem.hx
@@ -61,7 +61,12 @@ class FileSystem {
 
 	public static function fullPath( relPath : String ) : String
 	{
-		return new File(relPath).getAbsolutePath();
+		return new File(relPath).getCanonicalPath();
+	}
+
+	public static function absPath ( relPath : String ) : String {
+		if (haxe.io.Path.isAbsolute(relPath)) return relPath;
+		return haxe.io.Path.join([Sys.getCwd(), relPath]);
 	}
 
 	public static function isDirectory( path : String ) : Bool

--- a/std/neko/_std/sys/FileSystem.hx
+++ b/std/neko/_std/sys/FileSystem.hx
@@ -50,6 +50,11 @@ class FileSystem {
 		return new String(file_full_path(untyped relPath.__s));
 	}
 
+	public static function absPath ( relPath : String ) : String {
+		if (haxe.io.Path.isAbsolute(relPath)) return relPath;
+		return haxe.io.Path.join([Sys.getCwd(), relPath]);
+	}
+
 	static function kind( path : String ) : FileKind {
 		var k = new String(sys_file_type(untyped (haxe.io.Path.removeTrailingSlashes(path)).__s));
 		return switch(k) {

--- a/std/php/_std/sys/FileSystem.hx
+++ b/std/php/_std/sys/FileSystem.hx
@@ -63,6 +63,11 @@ class FileSystem {
 			return p;
 	}
 
+	public static function absPath ( relPath : String ) : String {
+		if (haxe.io.Path.isAbsolute(relPath)) return relPath;
+		return haxe.io.Path.join([Sys.getCwd(), relPath]);
+	}
+
 	static function kind( path : String ) : FileKind {
 		var k = untyped __call__("filetype", path);
 		switch(k) {

--- a/std/python/_std/sys/FileSystem.hx
+++ b/std/python/_std/sys/FileSystem.hx
@@ -53,7 +53,12 @@ class FileSystem {
 	}
 
 	public static function fullPath( relPath : String ) : String {
-		return Path.abspath(relPath);
+		return Path.realpath(relPath);
+	}
+
+	public static function absPath ( relPath : String ) : String {
+		if (haxe.io.Path.isAbsolute(relPath)) return relPath;
+		return haxe.io.Path.join([Sys.getCwd(), relPath]);
 	}
 
 	public static function isDirectory( path : String ) : Bool

--- a/std/sys/FileSystem.hx
+++ b/std/sys/FileSystem.hx
@@ -55,11 +55,21 @@ extern class FileSystem {
 
 	/**
 		Returns the full path of the file or directory specified by `relPath`,
-		which is relative to the current working directory.
+		which is relative to the current working directory. Symlinks will be 
+		followed and the path will be normalized.
 
 		If `relPath` is null, the result is unspecified.
 	**/
 	static function fullPath( relPath : String ) : String;
+
+	/**
+		Returns the full path of the file or directory specified by `relPath`,
+		which is relative to the current working directory. The path doesn't 
+		have to exist.
+
+		If `relPath` is null, the result is unspecified.
+	**/
+	static function absPath( relPath : String ) : String;
 
 	/**
 		Tells if the file or directory specified by `path` is a directory.


### PR DESCRIPTION
Current implementations of sys.FileSystem.fullPath differ in behavior on different targets. For example, PHP and Neko follow symlinks, while Python and Java don't. Python doesn't require the path to actually exist on the local filesystem, while other platforms do.

This pull request creates an additional function, sys.FileSystem.absPath. fullPath will find only real paths and eliminate symbolic links (as currently in PHP); absPath simply joins the path to the current working directory if it isn't already an absolute path, and the path doesn't have to exist (as currently in Python.)

There's also a new function haxe.io.Path.isAbsolute for checking whether a path is absolute.
