### PR TITLE
Avoid IOException

### DIFF
--- a/std/java/_std/sys/FileSystem.hx
+++ b/std/java/_std/sys/FileSystem.hx
@@ -61,7 +61,12 @@ class FileSystem {
 
 	public static function fullPath( relPath : String ) : String
 	{
-		return new File(relPath).getCanonicalPath();
+		try {
+			return new File(relPath).getCanonicalPath();
+		} catch (e: java.io.IOException) {
+			throw new java.lang.RuntimeException(e);
+			return null;
+		}
 	}
 
 	public static function absPath ( relPath : String ) : String {


### PR DESCRIPTION
This patch suppresses the following error:

```
$ haxe sys.FileSystem -java j -dce no
haxelib run hxjava hxjava_build.txt --haxe-version 3200
D:\Program Files (x86)\Java\jdk1.7.0_55/bin/javac.exe "-sourcepath" "src" "-d" "obj" "-g:none" "@cmd"
src\sys\FileSystem.java:66: 错误: 未报告的异常错误IOException; 必须对其进行捕获或声明以便抛出
                return new java.io.File(haxe.lang.Runtime.toString(relPath)).getCanonicalPath();
                                                                                             ^
注: src\haxe\root\Date.java使用或覆盖了已过时的 API。
注: 有关详细信息, 请使用 -Xlint:deprecation 重新编译。
1 个错误
Compilation error
Native compilation failed
D:\HaxeToolkit\haxe\std/java/_std/haxe/ds/WeakMap.hx:525: lines 525-540 : Warning : No overload found for this constructor call
Error: Build failed
```
