### PR TITLE
Reflect.callMethod should accept Function only.

### DIFF
--- a/std/Reflect.hx
+++ b/std/Reflect.hx
@@ -89,7 +89,7 @@ extern class Reflect {
 	/**
 		Call a method with the given object and arguments.
 	**/
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic;
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic;
 
 	/**
 		Returns the fields of structure `o`.

--- a/std/cpp/_std/Reflect.hx
+++ b/std/cpp/_std/Reflect.hx
@@ -43,7 +43,7 @@
 			o.__SetField(field,value,true);
 	}
 
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic untyped {
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
 			if (func!=null && func.__GetType()==__global__.vtString)
 				func = o.__Field(func,true);
 			untyped func.__SetThis(o);

--- a/std/cs/_std/Reflect.hx
+++ b/std/cs/_std/Reflect.hx
@@ -110,7 +110,7 @@ import cs.internal.Function;
 	@:functionCode('
 		return ((haxe.lang.Function) func).__hx_invokeDynamic(args);
 	')
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic
 	{
 		return null;
 	}

--- a/std/flash/_std/Reflect.hx
+++ b/std/flash/_std/Reflect.hx
@@ -52,7 +52,7 @@
 		}
 	}
 
-	public inline static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic untyped {
+	public inline static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
 		return func.apply(o,args);
 	}
 

--- a/std/flash/_std/Type.hx
+++ b/std/flash/_std/Type.hx
@@ -162,7 +162,7 @@ enum ValueType {
 	}
 
 	public static function createEnum<T>( e : Enum<T>, constr : String, ?params : Array<Dynamic> ) : T {
-		var f = untyped e[constr];
+		var f:Dynamic = untyped e[constr];
 		if( f == null ) throw "No such constructor "+constr;
 		if( Reflect.isFunction(f) ) {
 			if( params == null ) throw "Constructor "+constr+" need parameters";

--- a/std/flash8/_std/Reflect.hx
+++ b/std/flash8/_std/Reflect.hx
@@ -59,7 +59,7 @@
 			Reflect.setField(o, field, value);
 	}
 
-	public inline static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic untyped {
+	public inline static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
 		return func["apply"](o,args);
 	}
 

--- a/std/flash8/_std/Type.hx
+++ b/std/flash8/_std/Type.hx
@@ -92,7 +92,7 @@ enum ValueType {
 	}
 
 	public static function createEnum<T>( e : Enum<T>, constr : String, ?params : Array<Dynamic> ) : T {
-		var f = Reflect.field(e,constr);
+		var f:Dynamic = Reflect.field(e,constr);
 		if( f == null ) throw "No such constructor "+constr;
 		if( Reflect.isFunction(f) ) {
 			if( params == null ) throw "Constructor "+constr+" need parameters";

--- a/std/java/_std/Reflect.hx
+++ b/std/java/_std/Reflect.hx
@@ -88,7 +88,7 @@ import java.Boot;
 	@:functionCode('
 		return ((haxe.lang.Function) func).__hx_invokeDynamic(args);
 	')
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic
 	{
 		return null;
 	}

--- a/std/js/_std/Reflect.hx
+++ b/std/js/_std/Reflect.hx
@@ -43,7 +43,7 @@
 		if( o.__properties__ && (tmp=o.__properties__["set_"+field]) ) o[tmp](value) else o[field] = __define_feature__("Reflect.setProperty",value);
 	}
 
-	public inline static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic untyped {
+	public inline static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
 		return func.apply(o,args);
 	}
 

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -110,7 +110,7 @@ enum ValueType {
 	}
 
 	public static function createEnum<T>( e : Enum<T>, constr : String, ?params : Array<Dynamic> ) : T {
-		var f = Reflect.field(e,constr);
+		var f:Dynamic = Reflect.field(e,constr);
 		if( f == null ) throw "No such constructor "+constr;
 		if( Reflect.isFunction(f) ) {
 			if( params == null ) throw "Constructor "+constr+" need parameters";

--- a/std/neko/_std/Reflect.hx
+++ b/std/neko/_std/Reflect.hx
@@ -46,7 +46,7 @@
 		}
 	}
 
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic untyped {
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
 		var a = args.__neko();
 		// pad missing args with null's
 		var n = $nargs(func);

--- a/std/neko/_std/Type.hx
+++ b/std/neko/_std/Type.hx
@@ -115,7 +115,7 @@ enum ValueType {
 	}
 
 	public static function createEnum<T>( e : Enum<T>, constr : String, ?params : Array<Dynamic> ) : T {
-		var f = Reflect.field(e,constr);
+		var f:Dynamic = Reflect.field(e,constr);
 		if( f == null ) throw "No such constructor "+constr;
 		if( Reflect.isFunction(f) ) {
 			if( params == null ) throw "Constructor "+constr+" need parameters";

--- a/std/php/_std/Reflect.hx
+++ b/std/php/_std/Reflect.hx
@@ -53,10 +53,7 @@
 			return untyped __php__("$o->$field = $value");
 	}
 
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic untyped {
-		if (__call__("is_string", o) && !__call__("is_array", func)) {
-			return __call__("call_user_func_array", field(o, func), __field__(args, "a"));
-		}
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
 		return __call__("call_user_func_array", __call__("is_callable", func) ? func : __call__("array", o, func), (null == args ? __call__("array") : __field__(args, "a")));
 	}
 

--- a/std/php/_std/Type.hx
+++ b/std/php/_std/Type.hx
@@ -128,7 +128,7 @@ enum ValueType {
 	}
 
 	public static function createEnum<T>( e : Enum<T>, constr : String, ?params : Array<Dynamic> ) : T {
-		var f = Reflect.field(e,constr);
+		var f:Dynamic = Reflect.field(e,constr);
 		if( f == null ) throw "No such constructor "+constr;
 		if( Reflect.isFunction(f) ) {
 			if( params == null ) throw "Constructor "+constr+" need parameters";

--- a/std/python/_std/Reflect.hx
+++ b/std/python/_std/Reflect.hx
@@ -93,7 +93,7 @@ class Reflect {
 		else Builtin.setattr(o,field, value);
 	}
 
-	public static function callMethod( o : Dynamic, func : Dynamic, args : Array<Dynamic> ) : Dynamic
+	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic
 	{
 		var args:VarArgs = args;
 		return if (Builtin.callable(func)) func(python.Syntax.varArgs(args)) else null;

--- a/std/python/_std/Type.hx
+++ b/std/python/_std/Type.hx
@@ -160,7 +160,7 @@ enum ValueType {
 
 	public static function createEnum<T>( e : Enum<T>, constr : String, ?params : Array<Dynamic> ) : T
 	{
-		var f = Reflect.field(e,constr);
+		var f:Dynamic = Reflect.field(e,constr);
 		if( f == null ) throw "No such constructor "+constr;
 		if( Reflect.isFunction(f) ) {
 			if( params == null ) throw "Constructor "+constr+" need parameters";


### PR DESCRIPTION
Modified `Reflect.callMethod` to accept `haxe.Constraints.Function` instead of `Dynamic`, to avoid common mistake of passing the method name as `String` to the function.
