### PR TITLE
Don't replace '$' at last position in class names

### DIFF
--- a/genjava.ml
+++ b/genjava.ml
@@ -832,9 +832,8 @@ let configure gen =
 
 	let change_clname name =
 		let r = String.copy name in
-		for i = 0 to String.length r - 1 do
+		for i = 0 to String.length r - 2 do
 			match r.[i] with
-				| '$' when i + 1 == String.length r -> ()
 				| '$' -> r.[i] <- '.'
 				| _ -> ()
 		done;


### PR DESCRIPTION
Alone with dacb8631d3095416ea0b9d332f9a6f11ffb6d62a, this patch enables Haxe to access Scala singleton.

``` haxe
@:native("scala.collection.mutable.Set$")
extern class SetSingleton
{

  @:native("MODULE$")
  public static var singletonInstance(default, null):SetSingleton;

}
```
