### PR TITLE
Optimize java.internal.HaxeException

### DIFF
--- a/std/java/internal/Exceptions.hx
+++ b/std/java/internal/Exceptions.hx
@@ -61,7 +61,7 @@ class Exceptions {
 		return obj;
 	}
 
-	@:overload override function fillInStackTrace():Throwable
+	@:overload override public function fillInStackTrace():Throwable
 	{
 		return this;
 	}


### PR DESCRIPTION
This patch enhances performance of exceptions-as-control-structures style programs, e.g. `throw new haxe.io.Eof();`
