### PR TITLE
add newline to test runner class notification

### DIFF
--- a/std/haxe/unit/TestRunner.hx
+++ b/std/haxe/unit/TestRunner.hx
@@ -118,7 +118,7 @@ class TestRunner {
 		var cl = Type.getClass(t);
 		var fields = Type.getInstanceFields(cl);
 
-		print( "Class: "+Type.getClassName(cl)+" ");
+		print( "Class: "+Type.getClassName(cl)+" \n");
 		for ( f in fields ){
 			var fname = f;
 			var field = Reflect.field(t, f);


### PR DESCRIPTION
This just adds a line break after the "Class <X>" preamble that precedes a test run.

Putting this on its own line enables traces, etc. from getting concatenated, and enables IDE parsers to better label the output.
