### PR TITLE
StringMap<T> => Map<String,T>

### DIFF
--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -53,7 +53,7 @@ extern class Sys {
 	/**
 		Returns the whole environement variables.
 	**/
-	static function environment() : haxe.ds.StringMap<String>;
+	static function environment() : Map<String,String>;
 
 	/**
 		Suspend the current execution for the given time (in seconds).

--- a/std/cpp/_std/Sys.hx
+++ b/std/cpp/_std/Sys.hx
@@ -120,7 +120,7 @@
 		return new String(sys_exe_path());
 	}
 
-	public static function environment() : haxe.ds.StringMap<String> {
+	public static function environment() : Map<String,String> {
 		var vars:Array<String> = sys_env();
 		var result = new haxe.ds.StringMap<String>();
 		var i = 0;

--- a/std/cs/_std/Sys.hx
+++ b/std/cs/_std/Sys.hx
@@ -85,7 +85,7 @@ class Sys {
 			_env.set(s, v);
 	}
 
-	public static function environment() : haxe.ds.StringMap<String>
+	public static function environment() : Map<String,String>
 	{
 		if (_env == null)
 		{

--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -59,7 +59,7 @@ class Http {
 #if sys
 	public var noShutdown : Bool;
 	public var cnxTimeout : Float;
-	public var responseHeaders : haxe.ds.StringMap<String>;
+	public var responseHeaders : Map<String,String>;
 	var chunk_size : Null<Int>;
 	var chunk_buf : haxe.io.Bytes;
 	var file : { param : String, filename : String, io : haxe.io.Input, size : Int, mimeType : String };

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -188,7 +188,7 @@ class Context {
 		Modifying the returned map has no effect on the compiler.
 	**/
 	@:deprecated("Use Context.getLocalTVars() instead")
-	public static function getLocalVars() : haxe.ds.StringMap<Type> {
+	public static function getLocalVars() : Map<String,Type> {
 		return load("local_vars", 1)(false);
 	}
 
@@ -197,7 +197,7 @@ class Context {
 		of `Type`.
 	**/
 	@:require(haxe_ver >= 3.102)
-	public static function getLocalTVars() : haxe.ds.StringMap<Type.TVar> {
+	public static function getLocalTVars() : Map<String,Type.TVar> {
 		return load("local_vars", 1)(true);
 	}
 
@@ -234,7 +234,7 @@ class Context {
 		
 		Modifying the returned map has no effect on the compiler.
 	 */
-	public static function getDefines() : haxe.ds.StringMap<String> {
+	public static function getDefines() : Map<String,String> {
 		return load("get_defines", 0)();
 	}
 	
@@ -407,7 +407,7 @@ class Context {
 		Modifying the returned map has no effect on the compilation, use
 		`haxe.macro.Context.addResource` to add new resources to the compilation unit.
 	**/
-	public static function getResources():haxe.ds.StringMap<haxe.io.Bytes> {
+	public static function getResources():Map<String,haxe.io.Bytes> {
 		var x:haxe.ds.StringMap<neko.NativeString> = load("get_resources",0)();
 		var r = new haxe.ds.StringMap();
 		for (k in x.keys()) {

--- a/std/haxe/macro/Type.hx
+++ b/std/haxe/macro/Type.hx
@@ -120,7 +120,7 @@ typedef EnumField = {
 }
 
 typedef EnumType = {> BaseType,
-	var constructs : haxe.ds.StringMap<EnumField>;
+	var constructs : Map<String,EnumField>;
 	var names : Array<String>;
 }
 

--- a/std/haxe/rtti/CType.hx
+++ b/std/haxe/rtti/CType.hx
@@ -107,7 +107,7 @@ typedef Enumdef = {> TypeInfos,
 
 typedef Typedef = {> TypeInfos,
 	var type : CType;
-	var types : haxe.ds.StringMap<CType>; // by platform
+	var types : Map<String,CType>; // by platform
 }
 
 typedef Abstractdef = {> TypeInfos,

--- a/std/haxe/web/Dispatch.hx
+++ b/std/haxe/web/Dispatch.hx
@@ -69,7 +69,7 @@ class Redirect {
 class Dispatch {
 
 	public var parts : Array<String>;
-	public var params : haxe.ds.StringMap<String>;
+	public var params : Map<String,String>;
 	public var name : String;
 	public var cfg : DispatchConfig;
 	var subDispatch : Bool;
@@ -135,7 +135,7 @@ class Dispatch {
 		}
 	}
 
-	public function redirect( url : String, ?params : haxe.ds.StringMap<String> ) {
+	public function redirect( url : String, ?params : Map<String,String> ) {
 		parts = url.split("/");
 		if( parts[0] == "" ) parts.shift();
 		if( params != null ) this.params = params;
@@ -459,7 +459,7 @@ class Dispatch {
 		return makeConfig(obj);
 	}
 
-	public static macro function run( url : ExprOf<String>, params : ExprOf<haxe.ds.StringMap<String>>, obj : ExprOf<{}> ) : ExprOf<Void> {
+	public static macro function run( url : ExprOf<String>, params : ExprOf<Map<String,String>>, obj : ExprOf<{}> ) : ExprOf<Void> {
 		var p = Context.currentPos();
 		var cfg = makeConfig(obj);
 		return { expr : ECall({ expr : EField({ expr : ENew({ name : "Dispatch", pack : ["haxe","web"], params : [], sub : null },[url,params]), pos : p },"runtimeDispatch"), pos : p },[cfg]), pos : p };

--- a/std/haxe/web/Request.hx
+++ b/std/haxe/web/Request.hx
@@ -26,7 +26,7 @@ class Request {
 	/**
 		Returns the current page GET and POST parameters (only GET parameters for Javascript)
 	**/
-	public static function getParams() : haxe.ds.StringMap<String> {
+	public static function getParams() : Map<String,String> {
 		#if neko
 		return neko.Web.getParams();
 		#elseif php

--- a/std/java/_std/Sys.hx
+++ b/std/java/_std/Sys.hx
@@ -56,7 +56,7 @@ import sys.io.Process;
 		throw "Not implemented in this platform";
 	}
 
-	public static function environment() : haxe.ds.StringMap<String>
+	public static function environment() : Map<String,String>
 	{
 		if (_env != null)
 			return _env;

--- a/std/neko/Web.hx
+++ b/std/neko/Web.hx
@@ -164,7 +164,7 @@ class Web {
 		Returns an hashtable of all Cookies sent by the client.
 		Modifying the hashtable will not modify the cookie, use setCookie instead.
 	**/
-	public static function getCookies():haxe.ds.StringMap<String> {
+	public static function getCookies():Map<String,String> {
 		var p = _get_cookies();
 		var h = new haxe.ds.StringMap<String>();
 		var k = "";
@@ -236,7 +236,7 @@ class Web {
 		Get the multipart parameters as an hashtable. The data
 		cannot exceed the maximum size specified.
 	**/
-	public static function getMultipart( maxSize : Int ) : haxe.ds.StringMap<String> {
+	public static function getMultipart( maxSize : Int ) : Map<String,String> {
 		var h = new haxe.ds.StringMap();
 		var buf : haxe.io.BytesBuffer = null;
 		var curname = null;

--- a/std/neko/_std/Sys.hx
+++ b/std/neko/_std/Sys.hx
@@ -130,7 +130,7 @@
 		return new String(sys_exe_path());
 	}
 
-	public static function environment() : haxe.ds.StringMap<String> {
+	public static function environment() : Map<String,String> {
 		var l : Array<Dynamic> = sys_env();
 		var h = new haxe.ds.StringMap();
 		while( l != null ) {

--- a/std/neko/vm/Loader.hx
+++ b/std/neko/vm/Loader.hx
@@ -82,7 +82,7 @@ class Loader {
 		but with different names, for example with two relatives paths reprensenting
 		the same file, since the cache is done on a by-name basic.
 	**/
-	public function getCache() : haxe.ds.StringMap<Module> {
+	public function getCache() : Map<String,Module> {
 		var h = new haxe.ds.StringMap<Module>();
 		var cache = untyped l.cache;
 		for( f in Reflect.fields(cache) )

--- a/std/neko/vm/Module.hx
+++ b/std/neko/vm/Module.hx
@@ -105,7 +105,7 @@ class Module {
 		Each Module has an export table which can be useful to transfert
 		values between modules.
 	**/
-	public function getExports() : haxe.ds.StringMap<Dynamic> {
+	public function getExports() : Map<String,Dynamic> {
 		var h = new haxe.ds.StringMap();
 		var exp = _module_exports(m);
 		for( f in Reflect.fields(exp) )

--- a/std/php/Lib.hx
+++ b/std/php/Lib.hx
@@ -76,7 +76,7 @@ class Lib {
 		return untyped __call__("new _hx_array", a);
 	}
 
-	public static function hashOfAssociativeArray<T>(arr : NativeArray) : haxe.ds.StringMap<T> {
+	public static function hashOfAssociativeArray<T>(arr : NativeArray) : Map<String,T> {
 		var h = new haxe.ds.StringMap<T>();
 		untyped h.h = arr;
 		return h;

--- a/std/php/Web.hx
+++ b/std/php/Web.hx
@@ -255,7 +255,7 @@ class Web {
 		Returns an hashtable of all Cookies sent by the client.
 		Modifying the hashtable will not modify the cookie, use setCookie instead.
 	**/
-	public static function getCookies():haxe.ds.StringMap<String> {
+	public static function getCookies():Map<String,String> {
 		return Lib.hashOfAssociativeArray(untyped __php__("$_COOKIE"));
 	}
 
@@ -292,7 +292,7 @@ class Web {
 		Get the multipart parameters as an hashtable. The data
 		cannot exceed the maximum size specified.
 	**/
-	public static function getMultipart( maxSize : Int ) : haxe.ds.StringMap<String> {
+	public static function getMultipart( maxSize : Int ) : Map<String,String> {
 		var h = new haxe.ds.StringMap();
 		var buf : StringBuf = null;
 		var curname = null;

--- a/std/php/_std/Sys.hx
+++ b/std/php/_std/Sys.hx
@@ -110,7 +110,7 @@
 		return untyped __php__("$_SERVER['SCRIPT_FILENAME']");
 	}
 
-	public static function environment() : haxe.ds.StringMap<String> {
+	public static function environment() : Map<String,String> {
 		return php.Lib.hashOfAssociativeArray(untyped __php__("$_SERVER"));
 	}
 

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -47,7 +47,7 @@ class Sys {
 		environ.set(s, v);
 	}
 
-	public static function environment() : haxe.ds.StringMap<String> {
+	public static function environment() : Map<String,String> {
 		return environ;
 	}
 

--- a/std/sys/db/RecordInfos.hx
+++ b/std/sys/db/RecordInfos.hx
@@ -78,7 +78,7 @@ typedef RecordInfos = {
 	var name : String;
 	var key : Array<String>;
 	var fields : Array<RecordField>;
-	var hfields : haxe.ds.StringMap<RecordField>;
+	var hfields : Map<String,RecordField>;
 	var relations : Array<RecordRelation>;
 	var indexes : Array<{ keys : Array<String>, unique : Bool }>;
 }


### PR DESCRIPTION
I found it a bit weird to use `StringMap<T>` instead of `Map<String,T>` in the std lib.
Since `Map<String,T>` allows ppl to use `map[key]` syntax, which `StringMap<T>` doesn't, `Map<String,T>` is more flexible to ppl.

Here I replaced all `StringMap<T>` presented in the public API in the std lib with `Map<String,T>`.
I also searched for `IntMap`, `EnumValueMap`, and `ObjectMap`, but they simply do not appear in the API.
