### PR TITLE
Added jQuery approach to enabled local HTTP requests with JavaScript

### DIFF
--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -173,7 +173,6 @@ class Http {
 				var isLocal = rlocalProtocol.match( protocol );
 				if ( isLocal ) {
 					s = r.responseText != null ? 200 : 404;
-					
 				}
 			}
 			if( s == untyped __js__("undefined") )


### PR DESCRIPTION
Browsers usually return HTTP status 0 for requests using a local protocol like file, app...
For local development it's nice to use simulated HTTP status 200 or 404 if responseText ist available or not. I created a pull request month ago but it failed with the cpp target (which I don't touch at all). So hopefully this will make in into Haxe 3.1.4. 
