### PR TITLE
Add TestCase.assertMatch

### DIFF
--- a/std/haxe/unit/TestCase.hx
+++ b/std/haxe/unit/TestCase.hx
@@ -21,6 +21,9 @@
  */
 package haxe.unit;
 import haxe.PosInfos;
+#if macro
+import haxe.macro.*;
+#end
 
 @:keepSub
 @:publicFields


### PR DESCRIPTION
This patch allows pattern match test in a TestCase:

```
class MyTest extends TestCase {
  function testMatch() {
    var json = { foo: [ 1, 2, 3 ], bar: "xxx" };
    assertMatch( { foo: [ 1, 2, 3 ], bar: "xxx" }, json);
  }
}
```
