### PR TITLE
Lambda indexOf() and has() were stricter than their function taking equi...

### DIFF
--- a/std/Lambda.hx
+++ b/std/Lambda.hx
@@ -95,7 +95,7 @@ class Lambda {
 
 		If no such element is found, the result is false.
 	**/
-	public static function has<A>( it : Iterable<A>, elt : A ) : Bool {
+	public static function has<A:B,B>( it : Iterable<A>, elt : B ) : Bool {
 		for( x in it )
 			if( x == elt )
 				return true;
@@ -214,7 +214,7 @@ class Lambda {
 
 		If `v` does not exist in `it`, the result is -1.
 	**/
-	public static function indexOf<T>( it : Iterable<T>, v : T ) : Int {
+	public static function indexOf<T:V,V>( it : Iterable<T>, v : V ) : Int {
 		var i = 0;
 		for( v2 in it ) {
 			if( v == v2 )


### PR DESCRIPTION
Lambda indexOf() and has() were stricter than their function taking equivalents like find(), which allow a superclass of T to be passed as the function parameter type and not just the exact class T or a subclass thereof. This relaxes that restriction to be the same.
