### PR TITLE
Http multipart + remoting multipart + neko/php web multipart params support

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -361,7 +361,7 @@ let parse_hxml_data data =
 	) lines)
 
 let parse_hxml file =
-	let ch = IO.input_channel (try open_in_bin file with _ -> failwith ("File not found " ^ file)) in
+	let ch = IO.input_channel (try open_in_bin file with _ -> raise Not_found) in
 	let data = IO.read_all ch in
 	IO.close_in ch;
 	parse_hxml_data data
@@ -663,7 +663,9 @@ let rec process_params create pl =
 			ctx.flush()
 		| arg :: l ->
 			match List.rev (ExtString.String.nsplit arg ".") with
-			| "hxml" :: _ when (match acc with "-cmd" :: _ -> false | _ -> true) -> loop acc (parse_hxml arg @ l)
+			| "hxml" :: _ when (match acc with "-cmd" :: _ -> false | _ -> true) ->
+				let acc, l = (try acc, parse_hxml arg @ l with Not_found -> (arg ^ " (file not found)") :: acc, l) in
+				loop acc l
 			| _ -> loop (arg :: acc) l
 	in
 	(* put --display in front if it was last parameter *)

--- a/std/haxe/remoting/HttpConnection.hx
+++ b/std/haxe/remoting/HttpConnection.hx
@@ -38,7 +38,7 @@ class HttpConnection implements Connection implements Dynamic<Connection> {
 		c.__path.push(name);
 		return c;
 	}
-
+	
 	public function call( params : Array<Dynamic> ) : Dynamic {
 		var data = null;
 		var h = new haxe.Http(__url);
@@ -51,11 +51,46 @@ class HttpConnection implements Connection implements Dynamic<Connection> {
 		#if (neko || php || cpp)
 			h.cnxTimeout = TIMEOUT;
 		#end
+		var files	= new List();
+		function isFile( p : Dynamic ) {
+			try{
+				if ( p.param != null && p.filename != null && p.bytes != null  )	return true;
+			}catch( e : Dynamic ){}
+			return false;
+		}
+		function searchFile( o : Dynamic ) {
+			if ( Std.is( o, Array ) ) {
+				var a	: Array<Dynamic>	= cast o;
+				for ( i in 0...a.length ) {
+					var p	= a [ i ];
+					if ( isFile( p ) ) {
+						files.add( cast p );
+						a[ i ]	= '__file__${ p.param }';
+					}else if ( Std.is( p, Array ) || ( Reflect.isObject( p ) ) ) {
+						searchFile( p );
+					}
+				}
+			}else if ( Reflect.isObject( o ) && !Std.is( o, String ) ) {
+				for ( k in Reflect.fields( o ) ) {
+					var p	= Reflect.getProperty( o, k );
+					if ( isFile( p ) ) {
+						files.add( cast p );
+						Reflect.setProperty( o, k ,'__file__${ p.param }' );
+					}else if ( Std.is( p, Array ) || ( Reflect.isObject( p ) ) ) {
+						searchFile( p );
+					}
+				}
+			}
+		}
+		for( p in params ){
+			searchFile( p );
+		}
 		var s = new haxe.Serializer();
 		s.serialize(__path);
 		s.serialize(params);
 		h.setHeader("X-Haxe-Remoting","1");
-		h.setParameter("__x",s.toString());
+		h.setParameter("__x", s.toString());
+		for ( file in files )	h.addFileTransfer( file.param, file.filename, file.bytes, file.mimeType );
 		h.onData = function(d) { data = d; };
 		h.onError = function(e) { throw e; };
 		h.request(true);
@@ -75,27 +110,84 @@ class HttpConnection implements Connection implements Dynamic<Connection> {
 
 	#if neko
 	public static function handleRequest( ctx : Context ) {
-		var v = neko.Web.getParams().get("__x");
-		if( neko.Web.getClientHeader("X-Haxe-Remoting") == null || v == null )
-			return false;
-		neko.Lib.print(processRequest(v,ctx));
-		return true;
+		var v	= null;	
+		var mutlipartParams	= null;
+		if ( neko.Web.getClientHeader( "X-Haxe-Remoting" ) != null ) {
+			var ct	= neko.Web.getClientHeader( "Content-Type" );
+			if ( ct != null && ct.indexOf( "multipart/form-data" ) != -1 ) {
+				mutlipartParams	= neko.Web.getMultipartParams();
+				v	= mutlipartParams.get( "__x" );
+			}else
+				v	= neko.Web.getParams().get( "__x" );
+			if ( v != null ) {
+				neko.Lib.print( processRequest( v, ctx, mutlipartParams ) );
+				return true;
+			}
+		}
+		
+		return false;
 	}
 	#elseif php
 	public static function handleRequest( ctx : Context ) {
-		var v = php.Web.getParams().get("__x");
-		if( php.Web.getClientHeader("X-Haxe-Remoting") == null || v == null )
-			return false;
-		php.Lib.print(processRequest(v,ctx));
-		return true;
+		var v	= null;		
+		var mutlipartParams	= null;
+		if ( php.Web.getClientHeader( "X-Haxe-Remoting" ) != null ) {
+			var ct	= php.Web.getClientHeader( "Content-Type" );
+			if ( ct != null && ct.indexOf( "multipart/form-data" ) != -1 ) {
+				mutlipartParams	= php.Web.getMultipartParams();
+				v	= mutlipartParams.get( "__x" );
+			}else
+				v	= php.Web.getParams().get( "__x" );
+			if ( v != null ) {
+				php.Lib.print( processRequest( v, ctx ) );
+				return true;
+			}
+		}
+		return false;
 	}
 	#end
-
-	public static function processRequest( requestData : String, ctx : Context ) : String {
+	
+	#if neko
+	public static function processRequest( requestData : String, ctx : Context, ?multipartParams : haxe.ds.StringMap<Dynamic> ) : String {
 		try {
 			var u = new haxe.Unserializer(requestData);
 			var path = u.unserialize();
-			var args = u.unserialize();
+			var args : Array<Dynamic> = cast u.unserialize();
+			
+			if ( multipartParams != null ) {
+				function isFile( arg : Dynamic ) {
+					if ( Std.is( arg, String ) && StringTools.startsWith( arg, "__file__" ) )	return true;
+					return false;
+				}
+				function searchFile( o : Dynamic ) {
+					if ( Std.is( o, Array ) ) {
+						var a	: Array<Dynamic>	= cast o;
+						for ( i in 0...a.length ) {
+							var arg	= a [ i ];
+							if ( isFile( arg ) ) {
+								var s	: String	= cast arg;
+								a[ i ]	= multipartParams.get( s.substr( 8 ) );
+							}else if ( Std.is( arg, Array ) || ( Reflect.isObject( arg ) ) ) {
+								searchFile( arg );
+							}
+						}
+					}else if ( Reflect.isObject( o ) ) {
+						for ( k in Reflect.fields( o ) ) {
+							var arg	= Reflect.getProperty( o, k );
+							if ( isFile( arg ) ) {
+								var s	: String	= cast arg;
+								Reflect.setProperty( o, k , multipartParams.get( s.substr( 8 ) ) );
+							}else if ( Std.is( arg, Array ) || ( Reflect.isObject( arg ) ) ) {
+								searchFile( arg );
+							}
+						}
+					}
+				}
+				for( arg in args ){
+					searchFile( arg );
+				}
+			}
+			
 			var data = ctx.call(path,args);
 			var s = new haxe.Serializer();
 			s.serialize(data);
@@ -106,5 +198,57 @@ class HttpConnection implements Connection implements Dynamic<Connection> {
 			return "hxr" + s.toString();
 		}
 	}
+	#elseif php
+	public static function processRequest( requestData : String, ctx : Context, ?multipartParams : haxe.ds.StringMap<Dynamic> ) : String {
+		try {
+			var u = new haxe.Unserializer(requestData);
+			var path = u.unserialize();
+			var args : Array<Dynamic> = cast u.unserialize();
+			
+			if ( multipartParams != null ) {
+				function isFile( arg : Dynamic ) {
+					if ( Std.is( arg, String ) && StringTools.startsWith( arg, "__file__" ) )	return true;
+					return false;
+				}
+				function searchFile( o : Dynamic ) {
+					if ( Std.is( o, Array ) ) {
+						var a	: Array<Dynamic>	= cast o;
+						for ( i in 0...a.length ) {
+							var arg	= a [ i ];
+							if ( isFile( arg ) ) {
+								var s	: String	= cast arg;
+								a[ i ]	= multipartParams.get( s.substr( 8 ) );
+							}else if ( Std.is( arg, Array ) || ( Reflect.isObject( arg ) ) ) {
+								searchFile( arg );
+							}
+						}
+					}else if ( Reflect.isObject( o ) ) {
+						for ( k in Reflect.fields( o ) ) {
+							var arg	= Reflect.getProperty( o, k );
+							if ( isFile( arg ) ) {
+								var s	: String	= cast arg;
+								Reflect.setProperty( o, k , multipartParams.get( s.substr( 8 ) ) );
+							}else if ( Std.is( arg, Array ) || ( Reflect.isObject( arg ) ) ) {
+								searchFile( arg );
+							}
+						}
+					}
+				}
+				for( arg in args ){
+					searchFile( arg );
+				}
+			}
+			
+			var data = ctx.call(path,args);
+			var s = new haxe.Serializer();
+			s.serialize(data);
+			return "hxr" + s.toString();
+		} catch( e : Dynamic ) {
+			var s = new haxe.Serializer();
+			s.serializeException(e);
+			return "hxr" + s.toString();
+		}
+	}
+	#end
 
 }

--- a/std/neko/Web.hx
+++ b/std/neko/Web.hx
@@ -164,7 +164,7 @@ class Web {
 		Returns an hashtable of all Cookies sent by the client.
 		Modifying the hashtable will not modify the cookie, use setCookie instead.
 	**/
-	public static function getCookies():Map<String,String> {
+	public static function getCookies():haxe.ds.StringMap<String> {
 		var p = _get_cookies();
 		var h = new haxe.ds.StringMap<String>();
 		var k = "";
@@ -236,7 +236,7 @@ class Web {
 		Get the multipart parameters as an hashtable. The data
 		cannot exceed the maximum size specified.
 	**/
-	public static function getMultipart( maxSize : Int ) : Map<String,String> {
+	public static function getMultipart( maxSize : Int ) : haxe.ds.StringMap<String> {
 		var h = new haxe.ds.StringMap();
 		var buf : haxe.io.BytesBuffer = null;
 		var curname = null;
@@ -258,6 +258,55 @@ class Web {
 			h.set(curname,neko.Lib.stringReference(buf.getBytes()));
 		return h;
 	}
+	
+	/**
+		Get the multipart parameters as an hashtable.
+		Values are String, { filename : String, bytes : haxe.io.Bytes }
+		or Array<{ filename : String, bytes : haxe.io.Bytes }> (if multiple files with same name)
+	**/
+	static var _multipartParams	: haxe.ds.StringMap<Dynamic>;	
+	public static function getMultipartParams() : haxe.ds.StringMap<Dynamic> {
+		//if( _multipartParams == null ){	// can't do that if cacheModule used...
+			_multipartParams = new haxe.ds.StringMap<Dynamic>();
+			var buf : haxe.io.BytesBuffer = null;
+			var curname 	= null;
+			var curFilename = null;
+			var curIsFile 	= false;
+			parseMultipart(function(p,filename) {
+				if ( curname != null )
+					if ( curIsFile ){
+						if ( _multipartParams.exists( curname ) ){
+							if( _multipartParams.get( curname ).push != null )
+								_multipartParams.get( curname ).push( { filename : curFilename, bytes : buf.getBytes() } );
+							else 
+								_multipartParams.set( curname, [ _multipartParams.get( curname ) ].concat( [ { filename : curFilename, bytes : buf.getBytes() } ] ) );
+						}else {
+							_multipartParams.set( curname, { filename : curFilename, bytes : buf.getBytes() } );
+						}
+					}else
+						_multipartParams.set(curname,neko.Lib.stringReference(buf.getBytes()));
+				curname 	= p;
+				curIsFile	= filename != null;
+				curFilename	= filename;
+				buf = new haxe.io.BytesBuffer();
+			},function(str,pos,len) {
+				buf.addBytes(str,pos,len);
+			});
+			if ( curname != null )
+				if ( curIsFile ){
+					if ( _multipartParams.exists( curname ) ){
+						if( _multipartParams.get( curname ).push != null )
+							_multipartParams.get( curname ).push( { filename : curFilename, bytes : buf.getBytes() } );
+						else 
+							_multipartParams.set( curname, [ _multipartParams.get( curname ) ].concat( [ { filename : curFilename, bytes : buf.getBytes() } ] ) );
+					}else {
+						_multipartParams.set( curname, { filename : curFilename, bytes : buf.getBytes() } );
+					}
+				}else
+						_multipartParams.set(curname,neko.Lib.stringReference(buf.getBytes()));
+		//}
+		return _multipartParams;
+	}
 
 	/**
 		Parse the multipart data. Call [onPart] when a new part is found
@@ -271,7 +320,7 @@ class Web {
 			function(buf,pos,len) { onData(untyped new haxe.io.Bytes(__dollar__ssize(buf),buf),pos,len); }
 		);
 	}
-
+	
 	/**
 		Flush the data sent to the client. By default on Apache, outgoing data is buffered so
 		this can be useful for displaying some long operation progress.


### PR DESCRIPTION
-haxe.Http now supports multipart encoding. addFileTransfer function added, files support on all plateforms
-neko.Web and php.Web getMultipartParams function added that is a StringMap of Strings, { filename : String, bytes : haxe.io.Bytes } or Array<{ filename : String, bytes : haxe.io.Bytes }> (if multiple file upload with same name)
-Multipart remoting supported like that : if a param is { param, filename, bytes, ?mimeType } then all the transfert is delegated to multipart/form-data (simple String params too). The requests are handled checking also against multipartParams and not only url-encoded params ( __x ). If files are found, they are transmitted as an array of files params, as function arguments. Objects and Arrays are recursively checked for files too.