### PR TITLE
Display TFloat without an "f" in genxml

### DIFF
--- a/type.ml
+++ b/type.ml
@@ -860,7 +860,7 @@ let s_expr_kind e =
 
 let s_const = function
 	| TInt i -> Int32.to_string i
-	| TFloat s -> s ^ "f"
+	| TFloat s -> s
 	| TString s -> Printf.sprintf "\"%s\"" (Ast.s_escape s)
 	| TBool b -> if b then "true" else "false"
 	| TNull -> "null"


### PR DESCRIPTION
Otherwise it looks like this in dox:

![](http://i.imgur.com/kYml1gU.png)

It seems misleading to add an `f` considering it's not valid syntax (unlike in Java for example).
