### PR TITLE
Support type hints in @:enum abstract fields if they unify with the abstract (to support GADT-like behaviour)

### DIFF
--- a/tests/unit/src/unit/MyAbstract.hx
+++ b/tests/unit/src/unit/MyAbstract.hx
@@ -321,3 +321,8 @@ abstract ExposingAbstract<S>(Array<S>) {
 	}
 }
 #end
+
+@:enum abstract GADTEnumAbstract<T:haxe.Constraints.Function>(Int) {
+	var A:GADTEnumAbstract<Void->Void> = 1;
+	var B:GADTEnumAbstract<Int->Void> = 2;
+}

--- a/tests/unit/src/unit/TestType.hx
+++ b/tests/unit/src/unit/TestType.hx
@@ -862,4 +862,11 @@ class TestType extends Test {
 		eq(12, ea.pop());
 		#end
 	}
+
+	function testGADTEnumAbstract() {
+		var expectedA:unit.MyAbstract.GADTEnumAbstract<Void->Void>;
+		var expectedB:unit.MyAbstract.GADTEnumAbstract<Int->Void>;
+		typedAs(unit.MyAbstract.GADTEnumAbstract.A, expectedA);
+		typedAs(unit.MyAbstract.GADTEnumAbstract.B, expectedB);
+	}
 }

--- a/typeload.ml
+++ b/typeload.ml
@@ -1557,7 +1557,10 @@ let build_enum_abstract ctx c a fields p =
 		match field.cff_kind with
 		| FVar(ct,eo) when not (List.mem AStatic field.cff_access) ->
 			begin match ct with
-				| Some _ -> error "Type hints on enum abstract fields are not allowed" field.cff_pos
+				| Some t ->
+					let t = load_complex_type ctx field.cff_pos t in
+					let t2 = TAbstract(a, List.map (fun _ -> mk_mono()) a.a_params) in
+					unify ctx t t2 field.cff_pos
 				| None -> ()
 			end;
 			field.cff_access <- [AStatic;APublic;AInline];


### PR DESCRIPTION
Subj. This would allos us to define things like:

``` haxe
@:enum abstract SocketEvent<T:Function>(String) {

    var Connect : SocketEvent<Socket -> Void> = "connect";

    var Close : SocketEvent<Void -> Void> = "close";

}
```
