### PR TITLE
[js] Fix exposing for integrated runtimes

### DIFF
--- a/genjs.ml
+++ b/genjs.ml
@@ -1345,7 +1345,7 @@ let generate com =
 		print ctx "})(";
 		if (anyExposed && not (Common.defined com Define.ShallowExpose)) then (
 			(* TODO(bruno): Remove runtime branching when standard node haxelib is available *)
-			print ctx "typeof window != \"undefined\" ? window : exports"
+			print ctx "typeof window != \"undefined\" ? window : typeof exports != \"undefined\" ? exports : this"
 		);
 		print ctx ")";
 		newline ctx;


### PR DESCRIPTION
Integrated JavaScript runtimes oftent don't (and probably don't need to) have such things like "window", "exports", "console" etc. So this fix is intented to use "this" object whenever other options are not available. "this" will always be defined and will refer to the parent scope, since we use a self calling function here to expose haxe classes.
