### PR TITLE
RequestAnimationFrameCallback signature fix

### DIFF
--- a/std/js/html/RequestAnimationFrameCallback.hx
+++ b/std/js/html/RequestAnimationFrameCallback.hx
@@ -23,4 +23,4 @@
 // This file is generated, do not edit!
 package js.html;
 
-typedef RequestAnimationFrameCallback = Float -> Bool;
+typedef RequestAnimationFrameCallback = Float -> Void;


### PR DESCRIPTION
The W3C specification defines this callback as:
callback FrameRequestCallback = void (DOMHighResTimeStamp time);

See:
http://www.w3.org/TR/animation-timing/#framerequestcallback
