### PR TITLE
hide the __meta__ field returned from Type.getClassFields in JS target

### DIFF
--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -141,6 +141,7 @@ enum ValueType {
 		a.remove("__interfaces__");
 		a.remove("__properties__");
 		a.remove("__super__");
+		a.remove("__meta__");
 		a.remove("prototype");
 		return a;
 	}


### PR DESCRIPTION
close #3672 
