### PR TITLE
Added support for conditionals to getValue()

### DIFF
--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -243,6 +243,9 @@ class ExprTools {
 				}
 				obj;
 			case EArrayDecl(el): el.map(getValue);
+			case EIf(econd, eif, eelse) | ETernary(econd, eif, eelse):
+				var econd:Dynamic = getValue(econd);
+				econd ? getValue(eif) : getValue(eelse);
 			case EUnop(op, false, e1):
 				var e1:Dynamic = getValue(e1);
 				switch (op) {

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -244,8 +244,12 @@ class ExprTools {
 				obj;
 			case EArrayDecl(el): el.map(getValue);
 			case EIf(econd, eif, eelse) | ETernary(econd, eif, eelse):
-				var econd:Dynamic = getValue(econd);
-				econd ? getValue(eif) : getValue(eelse);
+				if (eelse == null) {
+					throw "If statements only have a value if the else clause is defined";
+				} else {
+					var econd:Dynamic = getValue(econd);
+					econd ? getValue(eif) : getValue(eelse);
+				}
 			case EUnop(op, false, e1):
 				var e1:Dynamic = getValue(e1);
 				switch (op) {


### PR DESCRIPTION
This may seem unnecessary, because why would someone hard-code `true ? 413 : 612` when they could just write `413`? But consider conditional compilation. For example:

    moveSpeed = #if alwaysRun true #else shiftHeld() #end ? 50 : 25;

If the `alwaysRun` flag is set, then `moveSpeed` will always be 50. And this can be determined at compile time. However, the expression cannot be hard-coded as "`moveSpeed = 50;`".