### PR TITLE
[cs] Remove unnecessary GC allocation inside Null.

### DIFF
--- a/std/cs/internal/Null.hx
+++ b/std/cs/internal/Null.hx
@@ -47,7 +47,7 @@ package cs.internal;
 	@:readOnly public var hasValue(default,never):Bool;
 
 	@:functionCode('
-			if ( !(v is System.ValueType) && System.Object.ReferenceEquals(v, default(T)))
+			if (!typeof(T).IsValueType && System.Object.ReferenceEquals(v, default(T)))
 			{
 				hasValue = false;
 			}


### PR DESCRIPTION
Calling "v is ValueType" on a value type requires boxing it, whereas typeof(T).IsValueType does not require boxing.

@waneck 