### PR TITLE
Added GraphicsPathCommand.CUBIC_CURVE_TO

### DIFF
--- a/std/flash/display/GraphicsPathCommand.hx
+++ b/std/flash/display/GraphicsPathCommand.hx
@@ -4,7 +4,7 @@ extern class GraphicsPathCommand {
 	public static inline var LINE_TO = 2;
 	public static inline var MOVE_TO = 1;
 	public static inline var CURVE_TO = 3;
-	public static inline var CUBIC_CURVE_TO = 6;
+	@:require(flash11) public static inline var CUBIC_CURVE_TO = 6;
 	public static inline var WIDE_LINE_TO = 5;
 	public static inline var WIDE_MOVE_TO = 4;
 	public static inline var NO_OP = 0;

--- a/std/flash/display/GraphicsPathCommand.hx
+++ b/std/flash/display/GraphicsPathCommand.hx
@@ -4,6 +4,7 @@ extern class GraphicsPathCommand {
 	public static inline var LINE_TO = 2;
 	public static inline var MOVE_TO = 1;
 	public static inline var CURVE_TO = 3;
+	public static inline var CUBIC_CURVE_TO = 6;
 	public static inline var WIDE_LINE_TO = 5;
 	public static inline var WIDE_MOVE_TO = 4;
 	public static inline var NO_OP = 0;


### PR DESCRIPTION
The command `GraphicsPath.Command.CUBIC_CURVE_TO` wasn't in the flash externs.

~~While everywhere else the `cubicCurveTo()` is a flash11 feature, in the [Adobe documentation](http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/display/GraphicsPathCommand.html#CUBIC_CURVE_TO) this particular field says that it works on a flash 10 runtime so I simply added it without `@:require(flash11)`~~ The docs were wrong