### PR TITLE
hashes can use StringTools.hex

### DIFF
--- a/std/haxe/crypto/Md5.hx
+++ b/std/haxe/crypto/Md5.hx
@@ -99,12 +99,10 @@ class Md5 {
 
 	function hex( a : Array<Int> ){
 		var str = "";
-		var hex_chr = "0123456789abcdef";
-		for( num in a )
-			for( j in 0...4 )
-				str += hex_chr.charAt((num >> (j * 8 + 4)) & 0x0F) +
-							 hex_chr.charAt((num >> (j * 8)) & 0x0F);
-		return str;
+		for( num in a ) {
+			str += StringTools.hex(num);
+		}
+		return str.toLowerCase();
 	}
 
 	static function bytes2blks( b : haxe.io.Bytes ){

--- a/std/haxe/crypto/Sha1.hx
+++ b/std/haxe/crypto/Sha1.hx
@@ -167,15 +167,10 @@ class Sha1 {
 
 	function hex( a : Array<Int> ){
 		var str = "";
-		var hex_chr = "0123456789abcdef";
 		for( num in a ) {
-			var j = 7;
-			while( j >= 0 ) {
-				str += hex_chr.charAt( (num >>> (j<<2)) & 0xF );
-				j--;
-			}
+			str += StringTools.hex(num);
 		}
-		return str;
+		return str.toLowerCase();
 	}
 
 	#end

--- a/std/haxe/crypto/Sha256.hx
+++ b/std/haxe/crypto/Sha256.hx
@@ -183,15 +183,10 @@ class Sha256 {
 	
 	function hex( a : Array<Int> ){
 		var str = "";
-		var hex_chr = "0123456789abcdef";
 		for( num in a ) {
-			var j = 7;
-			while( j >= 0 ) {
-				str += hex_chr.charAt( (num >>> (j<<2)) & 0xF );
-				j--;
-			}
+			str += StringTools.hex(num);
 		}
-		return str;
+		return str.toLowerCase();
 	}
 
 }

--- a/type.ml
+++ b/type.ml
@@ -780,6 +780,23 @@ let rec get_constructor build_type c =
 
 let print_context() = ref []
 
+let rec s_type_kind t =
+	let map tl = String.concat ", " (List.map s_type_kind tl) in
+	match t with
+	| TMono r ->
+		begin match !r with
+			| None -> "TMono (None)"
+			| Some t -> "TMono (Some (" ^ (s_type_kind t) ^ "))"
+		end
+	| TEnum(en,tl) -> Printf.sprintf "TEnum(%s, [%s])" (s_type_path en.e_path) (map tl)
+	| TInst(c,tl) -> Printf.sprintf "TInst(%s, [%s])" (s_type_path c.cl_path) (map tl)
+	| TType(t,tl) -> Printf.sprintf "TType(%s, [%s])" (s_type_path t.t_path) (map tl)
+	| TAbstract(a,tl) -> Printf.sprintf "TAbstract(%s, [%s])" (s_type_path a.a_path) (map tl)
+	| TFun(tl,r) -> Printf.sprintf "TFun([%s], %s)" (String.concat ", " (List.map (fun (n,b,t) -> Printf.sprintf "%s%s:%s" (if b then "?" else "") n (s_type_kind t)) tl)) (s_type_kind r)
+	| TAnon an -> "TAnon"
+	| TDynamic t2 -> "TDynamic"
+	| TLazy _ -> "TLazy"
+
 let rec s_type ctx t =
 	match t with
 	| TMono r ->


### PR DESCRIPTION
Replace the custom-rolled 'hex' function in Md5, Sha1, and Sha256 with StringTools.hex (and String.toLowerCase).