### PR TITLE
add `haxe.ArrayTools` with `contains` method, add `haxe.ArrayTools` to global usings (closes #3323)

### DIFF
--- a/std/haxe/ArrayTools.hx
+++ b/std/haxe/ArrayTools.hx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C)2005-2015 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package haxe;
+
+class ArrayTools {
+	/**
+		Returns whether array `a` contains `value`.
+
+		If `value` is found by checking standard equality, the
+		function returns `true`.
+
+		If `value` is not found, the function returns `false`.
+	**/
+	static public inline function contains<T>(a:Array<T>, value:T):Bool {
+		return a.indexOf(value) != -1;
+	}
+}

--- a/tests/unit/src/unitstd/Array.unit.hx
+++ b/tests/unit/src/unitstd/Array.unit.hx
@@ -234,6 +234,12 @@ a == [i0, i1];
 [1, 10, 10, 1].lastIndexOf(10, -4) == -1;
 [1, 10, 10, 1].lastIndexOf(10, -5) == -1;
 
+// contains
+[].contains(1) == false;
+[1,2,3].contains(2) == true;
+[1,2,2].contains(2) == true;
+[1,2,3].contains(4) == false;
+
 // copy
 var i0 = new IntWrap(1);
 var i1 = new IntWrap(1);

--- a/typer.ml
+++ b/typer.ml
@@ -4915,6 +4915,12 @@ let rec create com =
 		)) m.m_types;
 		assert false
 	with Exit -> ());
+
+	let m = Typeload.load_module ctx (["haxe"],"ArrayTools") null_pos in
+	(match m.m_types with
+	| [TClassDecl c1] -> ctx.g.global_using <- c1 :: ctx.g.global_using
+	| _ -> assert false);
+
 	let m = Typeload.load_module ctx (["haxe"],"EnumTools") null_pos in
 	(match m.m_types with
 	| [TClassDecl c1;TClassDecl c2] -> ctx.g.global_using <- c1 :: c2 :: ctx.g.global_using


### PR DESCRIPTION
See #3323. I decided to leave the name `contains`, because if we name it `has`, the version from `Lambda` will take priority (because local module usings have more priority than global usings). I wonder if that's okay.

Also, should we move `remove` method to static extension?