### PR TITLE
Use StringTools.hex for Sha1 and Sha256

### DIFF
--- a/std/haxe/crypto/Sha1.hx
+++ b/std/haxe/crypto/Sha1.hx
@@ -167,15 +167,10 @@ class Sha1 {
 
 	function hex( a : Array<Int> ){
 		var str = "";
-		var hex_chr = "0123456789abcdef";
 		for( num in a ) {
-			var j = 7;
-			while( j >= 0 ) {
-				str += hex_chr.charAt( (num >>> (j<<2)) & 0xF );
-				j--;
-			}
+			str += StringTools.hex(num, 8);
 		}
-		return str;
+		return str.toLowerCase();
 	}
 
 	#end

--- a/std/haxe/crypto/Sha256.hx
+++ b/std/haxe/crypto/Sha256.hx
@@ -183,15 +183,10 @@ class Sha256 {
 	
 	function hex( a : Array<Int> ){
 		var str = "";
-		var hex_chr = "0123456789abcdef";
 		for( num in a ) {
-			var j = 7;
-			while( j >= 0 ) {
-				str += hex_chr.charAt( (num >>> (j<<2)) & 0xF );
-				j--;
-			}
+			str += StringTools.hex(num, 8);
 		}
-		return str;
+		return str.toLowerCase();
 	}
 
 }


### PR DESCRIPTION
Md5's hex representation is little-endian, so cannot use the big-endian StringTools.hex for it; but this should simplify these two classes a little bit.