### PR TITLE
[cs/java] generate specific getTag methods for enum classes to avoid using reflection

### DIFF
--- a/gencommon.ml
+++ b/gencommon.ml
@@ -9059,6 +9059,37 @@ struct
 			cl.cl_ordered_statics <- constructs_cf :: cfs @ cl.cl_ordered_statics ;
 			cl.cl_statics <- PMap.add "constructs" constructs_cf cl.cl_statics;
 
+			let getTag_cf_type = tfun [] basic.tstring in
+			let getTag_cf = mk_class_field "getTag" getTag_cf_type true pos (Method MethNormal) [] in
+			getTag_cf.cf_meta <- [(Meta.Final, [], pos)];
+			getTag_cf.cf_expr <- Some {
+				eexpr = TFunction {
+					tf_args = [];
+					tf_type = basic.tstring;
+					tf_expr = {
+						eexpr = TReturn (Some (
+							let e_constructs = mk_static_field_access_infer cl "constructs" pos [] in
+							let e_this = mk (TConst TThis) (TInst (cl,[])) pos in
+							let e_index = mk_field_access gen e_this "index" pos in
+							let e_unsafe_get = mk_field_access gen e_constructs "__unsafe_get" pos in
+							{
+								eexpr = TCall (e_unsafe_get, [e_index]);
+								etype = basic.tstring;
+								epos = pos;
+							}
+						));
+						epos = pos;
+						etype = basic.tvoid;
+					}
+				};
+				etype = getTag_cf_type;
+				epos = pos;
+			};
+
+			cl.cl_ordered_fields <- getTag_cf :: cl.cl_ordered_fields ;
+			cl.cl_fields <- PMap.add "getTag" getTag_cf cl.cl_fields;
+			cl.cl_overrides <- getTag_cf :: cl.cl_overrides;
+
 			(if should_be_hxgen then
 				cl.cl_meta <- (Meta.HxGen,[],cl.cl_pos) :: cl.cl_meta
 			else begin

--- a/std/cs/internal/HxObject.hx
+++ b/std/cs/internal/HxObject.hx
@@ -82,7 +82,7 @@ private class Enum
 		untyped this.index = index;
 		untyped this.params = params;
 	}
-	@:final public function getTag():String
+	public function getTag():String
 	{
 		var cl:Dynamic = StdType.getClass(this);
 		return cl.constructs[index];

--- a/std/java/internal/HxObject.hx
+++ b/std/java/internal/HxObject.hx
@@ -78,7 +78,7 @@ private class Enum
 		untyped this.index = index;
 		untyped this.params = params;
 	}
-	@:final public function getTag():String
+	public function getTag():String
 	{
 		var cl:Dynamic = StdType.getEnum(cast this);
 		return cl.constructs[index];


### PR DESCRIPTION
I'm trying to make people use haxe enums, but we need interop with native C# code, so we need to use `getTag` method a lot. It was generating a bunch of ugly reflection calls which are VERY slow (77ms). I tried to make it use concrete target-specific reflection for enums, but that didn't help much (54ms), so I went another way and just made haxe generate overriden `getTag` method for every concrete `Enum` subclass which does simply access its static `constructs` array, which works a lot faster (2ms).

For example, `haxe.ds.Option` now generates the following C# code:
```cs
public override string getTag() {
	return global::haxe.lang.Runtime.toString(global::haxe.ds.Option.constructs.__unsafe_get(this.index));
}
```

Now, the 2 ms overhead is caused by `Runtime.toString` call which I don't yet know how to avoid (any suggestion welcome!).

@waneck are there any potential problems with this approach? and please help me with that unncecesary `toString` call. is it coming from `CastDetect`?