### PR TITLE
Fix HXCPP api level lowercase bug in Build.xml

### DIFF
--- a/gencpp.ml
+++ b/gencpp.ml
@@ -3714,7 +3714,7 @@ let write_build_data common_ctx filename classes main_deps build_extra exe_name 
    in
 
    output_string buildfile "<xml>\n";
-   output_string buildfile ("<set name=\"HXCPP_API_LEVEL\" value=\"" ^
+   output_string buildfile ("<set name=\"hxcpp_api_level\" value=\"" ^
             (Common.defined_value common_ctx Define.HxcppApiLevel) ^ "\" />\n");
    output_string buildfile "<files id=\"haxe\">\n";
    output_string buildfile "<compilerflag value=\"-Iinclude\"/>\n";


### PR DESCRIPTION
This fix changes the API level define to the case that HXCPP is expecting.
When defined as upper case like it is, the value is ignored by HXCPP. 

To build from Build.xml directly with `haxelib run hxcpp`, `-DHXCPP_API_LEVEL=0` is used instead. The lower case fixes this, and the result is as expected, `-DHXCPP_API_LEVEL=313` again.

Additionally,
HXCPP_API_LEVEL could be defined in upper case, as well, if there was backward compatibility/assumptions.
Or, HXCPP could look for both upper and lower case, but this seems to be the point of entry to the problems.