### PR TITLE
haxe.CallStack.exceptionStack for js

### DIFF
--- a/genjs.ml
+++ b/genjs.ml
@@ -663,6 +663,12 @@ and gen_expr ctx e =
 		let bend = open_block ctx in
 		let last = ref false in
 		let else_block = ref false in
+
+		if (has_feature ctx "haxe.CallStack.exceptionStack") then begin
+			newline ctx;
+			print ctx "%s.lastException = %s" (ctx.type_accessor (TClassDecl { null_class with cl_path = ["haxe"],"CallStack" })) vname
+		end;
+
 		if (has_feature ctx "js.Boot.HaxeError") then begin
 			newline ctx;
 			print ctx "if (%s instanceof %s) %s = %s.val" vname (ctx.type_accessor (TClassDecl { null_class with cl_path = ["js";"_Boot"],"HaxeError" })) vname vname;

--- a/genjs.ml
+++ b/genjs.ml
@@ -663,6 +663,11 @@ and gen_expr ctx e =
 		let bend = open_block ctx in
 		let last = ref false in
 		let else_block = ref false in
+		if (has_feature ctx "js.Boot.HaxeError") then begin
+			newline ctx;
+			print ctx "if (%s instanceof %s) %s = %s.val" vname (ctx.type_accessor (TClassDecl { null_class with cl_path = ["js";"_Boot"],"HaxeError" })) vname vname;
+		end;
+
 		List.iter (fun (v,e) ->
 			if !last then () else
 			let t = (match follow v.v_type with

--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -45,6 +45,7 @@ class CallStack {
 		(untyped Error).prepareStackTrace = function (error, callsites :Array<Dynamic>) {
 			var stack = [];
 			for (site in callsites) {
+				if (wrapCallSite != null) site = wrapCallSite(site);
 				var method = null;
 				var fullName :String = site.getFunctionName();
 				if (fullName != null) {
@@ -63,6 +64,9 @@ class CallStack {
 		(untyped Error).prepareStackTrace = oldValue;
 		return a;
 	}
+
+	// support for source-map-support module
+	public static var wrapCallSite:Dynamic->Dynamic;
 	#end
 
 	/**

--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -296,7 +296,7 @@ class CallStack {
 						var line = Std.parseInt(rie10.matched(3));
 						m.push(FilePos( meth == "Anonymous function" ? LocalFunction() : meth == "Global code" ? null : Method(path.join("."),meth), file, line ));
 					} else
-						m.push(Module(line)); // A little weird, but better than nothing
+						m.push(Module(StringTools.trim(line))); // A little weird, but better than nothing
 				}
 				return m;
 			} else {

--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -293,7 +293,9 @@ class CallStack {
 			}
 			return m;
 		#elseif js
-			if ((untyped __js__("typeof"))(s) == "string") {
+			if (s == null) {
+				return [];
+			} else if ((untyped __js__("typeof"))(s) == "string") {
 				// Return the raw lines in browsers that don't support prepareStackTrace
 				var stack : Array<String> = s.split("\n");
 				if( stack[0] == "Error" ) stack.shift();

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -21,6 +21,17 @@
  */
 package js;
 
+private class HaxeError extends js.Error {
+
+	var val:Dynamic;
+
+	public function new(val:Dynamic) {
+		super();
+		this.val = untyped __define_feature__("js.Boot.HaxeError", val);
+		untyped js.Error.captureStackTrace(this, HaxeError);
+	}
+}
+
 @:dox(hide)
 class Boot {
 

--- a/tests/optimization/src/TestJs.hx
+++ b/tests/optimization/src/TestJs.hx
@@ -74,13 +74,13 @@ class TestJs {
 		forEach(function(x) trace(x + 2));
 	}
 
-	@:js('var a = "";var tmp;var __ex0 = a;var _g = __ex0.toLowerCase();switch(_g) {case "e":tmp = 0;break;default:throw false;}var e = tmp;')
+	@:js('var a = "";var tmp;var __ex0 = a;var _g = __ex0.toLowerCase();switch(_g) {case "e":tmp = 0;break;default:throw new Error();}var e = tmp;')
 	@:analyzer(no_const_propagation, no_local_dce)
 	static function testRValueSwitchWithExtractors() {
 		var a = "";
 		var e = switch (a) {
 			case _.toLowerCase() => "e": 0;
-			default: throw false;
+			default: throw new js.Error();
 		}
 	}
 

--- a/tests/unit/src/unitstd/haxe/CallStack.unit.hx
+++ b/tests/unit/src/unitstd/haxe/CallStack.unit.hx
@@ -1,0 +1,5 @@
+var stack = haxe.CallStack.callStack();
+Std.is(stack, Array) == true;
+
+var stack = haxe.CallStack.exceptionStack();
+Std.is(stack, Array) == true;


### PR DESCRIPTION
See #2854 and #3062. This wraps thrown objects that are not instances of `js.Error` in its special subclass, and saves in catch so we can get the stack trace for `haxe.CallStack.exceptionStack`.

```haxe
class Main {
    static function main() {
        try {
            throw false;
        } catch (e:Dynamic) {
            trace(e);
        }
    }
}
```
now generates
```js
Main.main = function() {
	try {
		throw new js__$Boot_HaxeError(false);
	} catch( e ) {
		if (e instanceof js__$Boot_HaxeError) e = e.val;
		console.log(e);
	}
};
```
but only if we did any wraping, so e.g.
```haxe
class Main {
    static function main() {
        try {
            throw new js.Error();
        } catch (e:Dynamic) {
            trace(e);
        }
    }
}
```
generates simple
```js
Main.main = function() {
	try {
		throw new Error();
	} catch( e ) {
		console.log(e);
	}
};
```

now if we use `haxe.Callstack.exceptionStack`
```haxe
class Main {
    static function main() {
        try {
            throw new js.Error();
        } catch (e:Dynamic) {
            var stack = haxe.CallStack.exceptionStack();
            trace(stack);
        }
    }
}
```
we get the following
```js
Main.main = function() {
	try {
		throw new Error();
	} catch( e ) {
		haxe_CallStack.lastException = e;
		var stack = haxe_CallStack.exceptionStack();
		console.log(stack);
	}
};
```

finally, if we throw non-`Error` object and use `exceptionStack`, we generate everything

```haxe
class Main {
    static function main() {
        try {
            throw false;
        } catch (e:Dynamic) {
            var stack = haxe.CallStack.exceptionStack();
            trace(stack);
        }
    }
}
```

```js
Main.main = function() {
	try {
		throw new js__$Boot_HaxeError(false);
	} catch( e ) {
		haxe_CallStack.lastException = e;
		if (e instanceof js__$Boot_HaxeError) e = e.val;
		var stack = haxe_CallStack.exceptionStack();
		console.log(stack);
	}
};
```

One potential problem with this implementation is that if we access `e.stack` before calling `CallStack.exceptionStack()`, the latter will skip custom `prepareStackTrace` function and return a simple `StackItem` array formed by fallback implementation in `CallStack,makeStack`. This may or may not be a problem, but I don't really have a solution besides generating `StackItem`s at the catch point which will hurt performance if we don't use `exceptionStack`, so I think this is not an option.