### PR TITLE
Color traces in Flash Develop for Flash target (for log levels)

### DIFF
--- a/std/haxe/Log.hx
+++ b/std/haxe/Log.hx
@@ -46,7 +46,14 @@ class Log {
 		#if flash
 			#if (fdb || native_trace)
 				var pstr = infos == null ? "(null)" : infos.fileName + ":" + infos.lineNumber;
-				var str = flash.Boot.__string_rec(v, "");
+				var vs:String = v;
+				if( vs.length >= 2 && vs.charCodeAt(1)==0x3A && vs.charCodeAt(0)>=0x30 && vs.charCodeAt(0)<=0x39 ){
+					#if fdb
+					pstr = vs.substr(0,2)+pstr;
+					#end
+					vs = vs.substr(2);
+				}
+				var str = flash.Boot.__string_rec(vs, "");
 				if( infos != null && infos.customParams != null ) for( v in infos.customParams ) str += "," + flash.Boot.__string_rec(v, "");
 				untyped #if flash9 __global__["trace"] #else __trace__ #end(pstr+": "+str);
 			#else


### PR DESCRIPTION
Get different colors when tracing a string with  "n:" at the beggining, where n is a decimal number.
Example:
        trace("0:TEST"); //gray
        trace("1:TEST"); //balck
        trace("2:TEST"); //orange
        trace("3:TEST"); //red
        trace("4:TEST"); //magenta
This is the standard behavior in Flash target. Does not work in other targets.
Reference: https://github.com/fdorg/flashdevelop/issues/530#issuecomment-73069858