### PR TITLE
[cs] Added @:padded to null padded arguments; Properly convert -net-lib optional arguments

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -120,6 +120,7 @@ module Meta = struct
 		| Op
 		| Optional
 		| Overload
+		| Padded
 		| PrivateAccess
 		| Property
 		| Protected

--- a/common.ml
+++ b/common.ml
@@ -442,6 +442,7 @@ module MetaInfo = struct
 		| Overload -> ":overload",("Allows the field to be called with different argument types",[HasParam "Function specification (no expression)";UsedOn TClassField])
 		| Public -> ":public",("Marks a class field as being public",[UsedOn TClassField])
 		| PublicFields -> ":publicFields",("Forces all class fields of inheriting classes to be public",[UsedOn TClass])
+		| Padded -> ":padded",("Annotates a padded null on the AST",[Internal])
 		| PrivateAccess -> ":privateAccess",("Allow private access to anything for the annotated expression",[UsedOn TExpr])
 		| Protected -> ":protected",("Marks a class field as being protected",[UsedOn TClassField])
 		| Property -> ":property",("Marks a property field to be compiled as a native C# property",[UsedOn TClassField;Platform Cs])

--- a/gencommon.ml
+++ b/gencommon.ml
@@ -9703,6 +9703,20 @@ struct
 					gen.ghandle_cast to_t e_null_t (unwrap_null e)
 		in
 
+		let extract_meta e =
+			let meta = ref None in
+			let rec loop e = match e.eexpr with
+				| TParenthesis(_) | TCast(_) ->
+					Type.map_expr loop e
+				| TMeta(m,e) ->
+					meta := Some m;
+					e
+				| _ -> e
+			in
+			let ret = loop e in
+			!meta, ret
+		in
+
 		let handle_wrap e t =
 			match e.eexpr with
 				| TConst(TNull) ->
@@ -9776,6 +9790,18 @@ struct
 				| TCall(ecall, params) when is_some (is_null_t ecall.etype) ->
 					let to_t = get (is_null_t ecall.etype) in
 					{ e with eexpr = TCall(handle_unwrap to_t (run ecall), List.map run params) }
+				| TCall(ec, args) ->
+					(* this will only happen on CsNative classes, which never return a Null<T> *)
+					let ec = run ec in
+					let args = List.map (fun arg ->
+						let meta, arg = extract_meta arg in
+						match meta with
+							| None ->
+								run arg
+							| Some meta ->
+								{ arg with eexpr = TMeta(meta, run arg) }
+					) args in
+					{ e with eexpr = TCall(ec,args) }
 				| TArray(earray, p) when is_some (is_null_t earray.etype) ->
 					let to_t = get (is_null_t earray.etype) in
 					{ e with eexpr = TArray(handle_unwrap to_t (run earray), p) }
@@ -10413,6 +10439,8 @@ struct
 						} ); etype = TFun(!args, ret) } );
 						cf.cf_type <- TFun(!args, ret)
 
+					| true, None when Meta.has Meta.CsNative cf.cf_meta ->
+							args := List.map (fun (n,o,t) -> if o then (n,o,follow t) else (n,o,t) ) !args
 					| _ -> ()
 				);
 				(if !found then cf.cf_type <- TFun(!args, ret))
@@ -11060,8 +11088,11 @@ struct
 	let default_implementation gen ~metas =
 		let rec run e =
 			match e.eexpr with
-			| TMeta(entry, e) when not (Hashtbl.mem metas entry) ->
+			| TMeta((entry,_,_), e) when not (Hashtbl.mem metas entry) ->
 				run e
+			| TMeta(entry,e) ->
+				let e = run e in
+				{ e with eexpr = TMeta(entry,e); }
 			| _ ->
 				map_expr_type (fun e -> run e) filter_param (fun v -> v.v_type <- filter_param v.v_type; v) e
 		in

--- a/tests/unit/src/unit/TestCSharp.hx
+++ b/tests/unit/src/unit/TestCSharp.hx
@@ -69,11 +69,11 @@ class TestCSharp extends Test
 		eq(dyn.get_Item(2,3), 6);
 	}
 
-	// function testOptional()
-	// {
-	// 	eq(new Base().optional(), 420);
-	// 	eq(new Base().optional(10), 100);
-	// }
+	function testOptional()
+	{
+		eq(new Base().optional(), 420);
+		eq(new Base().optional(10), 100);
+	}
 
 	function testProp()
 	{

--- a/typer.ml
+++ b/typer.ml
@@ -688,7 +688,7 @@ let rec unify_call_args' ctx el args r callp inline force_inline =
 		if is_pos_infos t then
 			mk_pos_infos t
 		else
-			null (ctx.t.tnull t) callp
+			{ eexpr = TMeta( (Meta.Padded,[],callp), null (ctx.t.tnull t) callp ); etype = t; epos = callp }
 	in
 	let skipped = ref [] in
 	let skip name ul t =
@@ -4678,7 +4678,7 @@ let type_macro ctx mode cpath f (el:Ast.expr list) p =
 				(* get back our index and real expression *)
 				| TArray ({ eexpr = TArrayDecl [e] }, { eexpr = TConst (TInt index) }) -> List.nth el (Int32.to_int index), e
 				(* added by unify_call_args *)
-				| TConst TNull -> (EConst (Ident "null"),e.epos), e
+				| TMeta( (Meta.Padded,_,_), { eexpr = TConst TNull } ) -> (EConst (Ident "null"),e.epos), e
 				| _ -> assert false
 			) in
 			if ise then


### PR DESCRIPTION
I'm adding this to review since it's changing how the null padded arguments are generated. I'm not sure if there's any special handling of null padded arguments on any target - I've added a `Meta.Padded` to be able to identify them.