### PR TITLE
Usability improvements for haxe.ds.vector

### DIFF
--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -220,7 +220,7 @@ abstract Vector<T>(VectorData<T>) {
 		#end
 	}
 	
-	/**
+/**
 		make a shallow copy of requested vector
 	**/
 	public inline function copy<T>() : Vector<T> {
@@ -233,8 +233,9 @@ abstract Vector<T>(VectorData<T>) {
 		iterates other the elements of `v` applying the function `f`.
 	**/
 	public inline function iter<T>(f:T->Void ) : Void {
-		for( vs in this)
-			f(vs);
+		var len = length;
+		for( i in 0...len)
+			f(get(i));
 	}
 	
 	/**
@@ -246,11 +247,11 @@ abstract Vector<T>(VectorData<T>) {
 		#else
 		var b = new StringBuf();
 		var i = 0;
-		for( vs in this) {
-			b.add( Std.string(vs) );
-			if( i < this.length-1)
+		var len = length;
+		for( i in 0...len) {
+			b.add( Std.string(get(i)) );
+			if( i < len-1)
 				b.add(sep);
-			i++;
 		}
 		return b.toString();
 		#end
@@ -263,10 +264,9 @@ abstract Vector<T>(VectorData<T>) {
 	public inline function map<T>(f:T->T) : Vector<T> {
 		var r = new Vector(length);
 		var i = 0;
-		for( vs in this){
-			r[i] = f( vs );
-			i++;
-		}
+		var len = length;
+		for( i in 0...len) 
+			r[i] = f( get(i) );
 		return r;
 	}
 	

--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -219,4 +219,69 @@ abstract Vector<T>(VectorData<T>) {
 		return vec;
 		#end
 	}
+	
+	/**
+		make a shallow copy of requested vector
+	**/
+	public inline function copy<T>() : Vector<T> {
+		var r = new Vector<T>(length);
+		Vector.blit(cast this, 0, r, 0, length);
+		return r;
+	}
+	
+	/**
+		iterates other the elements of `v` applying the function `f`.
+	**/
+	public inline function iter<T>(f:T->Void ) : Void {
+		for( vs in this)
+			f(vs);
+	}
+	
+	/**
+		joins the string representation of `v` applying the separator `sep`.
+	**/
+	public inline function join<T>( sep:String ) : String {
+		#if (flash||cpp)
+		return this.join(sep);
+		#else
+		var b = new StringBuf();
+		var i = 0;
+		for( vs in this) {
+			b.add( Std.string(vs) );
+			if( i < this.length-1)
+				b.add(sep);
+			i++;
+		}
+		return b.toString();
+		#end
+	}
+	
+	/**
+		Creates a new Vector by using the elements of `v` through the application of function `f`.
+		This always creates a copy.
+	**/
+	public inline function map<T>(f:T->T) : Vector<T> {
+		var r = new Vector(length);
+		var i = 0;
+		for( vs in this){
+			r[i] = f( vs );
+			i++;
+		}
+		return r;
+	}
+	
+	/**
+		Sorts the vector using provided callback
+		example:
+			var a = new Vector(10);
+			...
+			a.sort( Reflect.compare );
+	**/
+	public inline function sort<T>(f:T->T->Int) : Void{
+	#if(neko||cs||java)
+		throw "not yet supported";
+	#else
+		this.sort(f);
+	#end
+	}
 }


### PR DESCRIPTION
Adds :

join
iter
map
copy

Fully tested on flash and windows targets.

PR for issue : #3887

Tested on flash/cpp using 
```
trace("copy");
		//copy
		{
			var v = haxe.ds.Vector.fromArrayCopy([0, 1, 2, 3]);
			var v0 = v.copy();
			v0[0] = 66;
			trace(v);
			trace(v0);
		}
		
		trace("**iter**");
		//iter
		{
			var v = haxe.ds.Vector.fromArrayCopy([ {val:0} , {val:1} ]);
			trace(v.join(" "));
			v.iter(function(e) e.val++);
			trace(v.join(" "));
		}
		
		trace("**map**");
		//map
		{
			var v0 = haxe.ds.Vector.fromArrayCopy([ {val:0} , {val:1} ]);
			var v1 = v0.map(function(e) {
				var c = Reflect.copy(e);
				c.val++;
				return c;
			});
			trace(v0.join(" "));
			trace(v1.join(" "));
		}
		
		trace("**sort**");
		//sort
		{
			var v = haxe.ds.Vector.fromArrayCopy([ 0, 1, 2 ]);
			v.sort( Reflect.compare );
			trace( v.join(" ") );
			
			var v = haxe.ds.Vector.fromArrayCopy([ 2, 3, 4 ]);
			v.sort( function(e0, e1) return -Reflect.compare(e0, e1) );
			trace( v.join(" ") );
		}
```