### PR TITLE
[swf9] Fix UInt shift behavior

### DIFF
--- a/genswf9.ml
+++ b/genswf9.ml
@@ -1633,10 +1633,15 @@ and gen_binop ctx retval op e1 e2 t p =
 		gen_expr ctx true e2;
 		write_op op;
 		setvar ctx wacc (if retval then Some (classify ctx e1.etype) else None)
-	| OpAdd | OpMult | OpDiv | OpSub | OpAnd | OpOr | OpXor | OpShl | OpShr | OpUShr | OpMod ->
+	| OpAdd | OpMult | OpDiv | OpSub | OpAnd | OpOr | OpXor | OpMod ->
 		gen_expr ctx true e1;
 		gen_expr ctx true e2;
 		write_op op
+	| OpShl | OpShr	| OpUShr ->
+		gen_expr ctx true e1;
+		gen_expr ctx true e2;
+		write_op op;
+		coerce ctx (classify ctx e1.etype)
 	| OpEq ->
 		gen_eq()
 	| OpNotEq ->

--- a/tests/unit/src/unit/issues/Issue2736.hx
+++ b/tests/unit/src/unit/issues/Issue2736.hx
@@ -22,6 +22,9 @@ class Issue2736 extends Test {
         t( a > 1.0 ); t( a >= 1.0 );
         f( a < -1.0 ); f( a <= 1.0 );
 
+        // Shift behavior
+        eq( '${a >> 1}', "3397483648" );
+
         /* These are currently broken but should be fixed in the future:
 		 * Currently we don't allow UInt vs Int comparisons.
          * trace(a == -1794967296);


### PR DESCRIPTION
AVM2 shift op always returns an int, even for e.g. UInt << Int. This change coerces them to the type of the first operand. Fixes #2736.