### PR TITLE
modified StringMap implementation for PHP

### DIFF
--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -26,42 +26,38 @@ package haxe.ds;
 	private var h : ArrayAccess<T>;
 
 	public function new() : Void {
-		h = untyped __php__("new stdClass");
+		h = untyped __call__('array');
 	}
 
 	public function set( key : String, value : T ) : Void {
-		untyped __php__("$this->h->$key = $value");
+		untyped h[key] = value;
 	}
 
 	public function get( key : String ) : Null<T> {
-		if (untyped __call__("property_exists", h, key))
-			return untyped __php__("$this->h->$key");
+		if (untyped __call__("array_key_exists", key, h))
+			return untyped h[key];
 		else
 			return null;
 	}
 
 	public function exists( key : String ) : Bool {
-		return untyped __call__("property_exists", h, key);
+		return untyped __call__("array_key_exists", key, h);
 	}
 
 	public function remove( key : String ) : Bool {
-		if (untyped __call__("property_exists", h, key)) {
-			untyped __php__("unset($this->h->$key)");
+		if (untyped __call__("array_key_exists", key, h)) {
+			untyped __call__("unset", h[key]);
 			return true;
 		} else
 			return false;
 	}
 
 	public function keys() : Iterator<String> {
-		var arr = untyped __call__("array");
-		untyped __php__("foreach ($this->h as $key => $val) $arr[] = $key");
-		return untyped __call__("new _hx_array_iterator", arr);
+		return untyped __call__("new _hx_array_iterator", __call__("array_map", "strval", __call__("array_keys", h)));
 	}
 
 	public function iterator() : Iterator<T> {
-		var arr = untyped __call__("array");
-		untyped __php__("foreach ($this->h as $key => $val) $arr[] = $val");
-		return untyped __call__("new _hx_array_iterator", arr);
+		return untyped __call__("new _hx_array_iterator", __call__("array_values", h));
 	}
 
 	public function toString() : String {

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -26,38 +26,42 @@ package haxe.ds;
 	private var h : ArrayAccess<T>;
 
 	public function new() : Void {
-		h = untyped __call__('array');
+		h = untyped __php__("new stdClass");
 	}
 
 	public function set( key : String, value : T ) : Void {
-		untyped h[key] = value;
+		untyped __php__("$this->h->$key = $value");
 	}
 
 	public function get( key : String ) : Null<T> {
-		if (untyped __call__("array_key_exists", key, h))
-			return untyped h[key];
+		if (untyped __call__("property_exists", h, key))
+			return untyped __php__("$this->h->$key");
 		else
 			return null;
 	}
 
 	public function exists( key : String ) : Bool {
-		return untyped __call__("array_key_exists", key, h);
+		return untyped __call__("property_exists", h, key);
 	}
 
 	public function remove( key : String ) : Bool {
-		if (untyped __call__("array_key_exists", key, h)) {
-			untyped __call__("unset", h[key]);
+		if (untyped __call__("property_exists", h, key)) {
+			untyped __php__("unset($this->h->$key)");
 			return true;
 		} else
 			return false;
 	}
 
 	public function keys() : Iterator<String> {
-		return untyped __call__("new _hx_array_iterator", __call__("array_keys", h));
+		var arr = untyped __call__("array");
+		untyped __php__("foreach ($this->h as $key => $val) $arr[] = $key");
+		return untyped __call__("new _hx_array_iterator", arr);
 	}
 
 	public function iterator() : Iterator<T> {
-		return untyped __call__("new _hx_array_iterator", __call__("array_values", h));
+		var arr = untyped __call__("array");
+		untyped __php__("foreach ($this->h as $key => $val) $arr[] = $val");
+		return untyped __call__("new _hx_array_iterator", arr);
 	}
 
 	public function toString() : String {

--- a/tests/unit/src/unit/issues/Issue3462.hx
+++ b/tests/unit/src/unit/issues/Issue3462.hx
@@ -27,9 +27,7 @@ class Issue3462 extends Test
 
 		var keyCount:Int = 0;
 		for (k in d.keys()) {
-			#if !php // https://github.com/HaxeFoundation/haxe/issues/3898
 			f( keys.indexOf(k) == -1 ); // key missing from keys iterator
-			#end
 			keyCount++;
 		}
 		f(keyCount != keys.length); // keys missing
@@ -62,9 +60,7 @@ class Issue3462 extends Test
 		}
 		var keyCount:Int = 0;
 		for (k in d.keys()) {
-			#if !php // https://github.com/HaxeFoundation/haxe/issues/3898
 			f( keys.indexOf(k) == -1 ); // key missing from keys iterator
-			#end
 			keyCount++;
 		}
 		f( keyCount != keys.length ); // keys missing


### PR DESCRIPTION
As promised in #3898
Uses a `stdClass` as underlying data structure. This should keep the keys as strings.