### PR TITLE
add Context.storeTypedExpr

### DIFF
--- a/analyzer.ml
+++ b/analyzer.ml
@@ -695,7 +695,7 @@ module Ssa = struct
 			IntMap.find v.v_id ctx.cur_data.nd_var_map
 		with Not_found ->
 			if not (has_meta Meta.Unbound v.v_meta) then
-				ctx.com.warning (Printf.sprintf "Unbound variable %s" v.v_name) p;
+				error (Printf.sprintf "Unbound variable %s" v.v_name) p;
 			v
 
 	let close_join_node ctx node p =

--- a/ast.ml
+++ b/ast.ml
@@ -144,6 +144,7 @@ module Meta = struct
 		| SkipCtor
 		| SkipReflection
 		| Sound
+		| StoredTypedExpr
 		| Struct
 		| StructAccess
 		| SuppressWarnings

--- a/codegen.ml
+++ b/codegen.ml
@@ -928,7 +928,7 @@ module PatternMatchConversion = struct
 	let is_declared cctx v =
 		let rec loop sl = match sl with
 			| stack :: sl ->
-				List.exists (fun ((v2,_),_) -> v == v2) stack || loop sl
+				List.exists (fun ((v2,_),_) -> v.v_id = v2.v_id) stack || loop sl
 			| [] ->
 				false
 		in
@@ -980,7 +980,7 @@ module PatternMatchConversion = struct
 				) catches in
 				{e with eexpr = TTry(e1,catches)}
 			| TLocal v ->
-				let v' = try List.assq v !v_known with Not_found -> v in
+				let v' = try snd (List.find (fun (v2,_) -> v2.v_id = v.v_id) !v_known) with Not_found -> v in
 				{e with eexpr = TLocal v'}
 			| _ ->
 				Type.map_expr loop e

--- a/common.ml
+++ b/common.ml
@@ -133,6 +133,7 @@ type context = {
 	mutable get_macros : unit -> context option;
 	mutable run_command : string -> int;
 	file_lookup_cache : (string,string option) Hashtbl.t;
+	mutable stored_typed_exprs : (int, texpr) PMap.t;
 	(* output *)
 	mutable file : string;
 	mutable flash_version : float;
@@ -463,6 +464,7 @@ module MetaInfo = struct
 		| RuntimeValue -> ":runtimeValue",("Marks an abstract as being a runtime value",[UsedOn TAbstract])
 		| SelfCall -> ":selfCall",("Translates method calls into calling object directly",[UsedOn TClassField; Platform Js])
 		| Setter -> ":setter",("Generates a native getter function on the given field",[HasParam "Class field name";UsedOn TClassField;Platform Flash])
+		| StoredTypedExpr -> ":storedTypedExpr",("Used internally to reference a typed expression returned from a macro",[Internal])
 		| SkipCtor -> ":skipCtor",("Used internally to generate a constructor as if it were a native type (no __hx_ctor)",[Platforms [Java;Cs]; Internal])
 		| SkipReflection -> ":skipReflection",("Used internally to annotate a field that shouldn't have its reflection data generated",[Platforms [Java;Cs]; UsedOn TClassField; Internal])
 		| Sound -> ":sound",( "Includes a given .wav or .mp3 file into the target Swf and associates it with the class (must extend flash.media.Sound)",[HasParam "File path";UsedOn TClass;Platform Flash])
@@ -735,6 +737,7 @@ let create v args =
 			tarray = (fun _ -> assert false);
 		};
 		file_lookup_cache = Hashtbl.create 0;
+		stored_typed_exprs = PMap.empty;
 		memory_marker = memory_marker;
 	}
 

--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -72,6 +72,7 @@
 	macro : [breaking] extended TAnonymous structures now have AExtend status instead of AClosed
 	macro : added Context.getDefines
 	macro : fixed file_seek from end (position was inversed)
+	macro : added Context.storeTypedExpr
 
 	Deprecations:
 

--- a/filters.ml
+++ b/filters.ml
@@ -583,7 +583,7 @@ let rename_local_vars ctx e =
 				the same variable twice. In that case do not perform a rename since
 				we are sure it's actually the same variable
 			*)
-			if v == v2 then raise Not_found;
+			if v.v_id = v2.v_id then raise Not_found;
 			rename look_vars v;
 		with Not_found ->
 			());
@@ -600,7 +600,7 @@ let rename_local_vars ctx e =
 			let vars = if cfg.pf_locals_scope then vars else all_vars in
 			(try
 				let v = PMap.find name !vars in
-				if v == vtemp then raise Not_found; (* ignore *)
+				if v.v_id = vtemp.v_id then raise Not_found; (* ignore *)
 				rename (!vars) v;
 				rebuild_vars := true;
 				vars := PMap.add v.v_name v !vars

--- a/interp.ml
+++ b/interp.ml
@@ -106,6 +106,7 @@ type extern_api = {
 	on_type_not_found : (string -> value) -> unit;
 	parse_string : string -> Ast.pos -> bool -> Ast.expr;
 	type_expr : Ast.expr -> Type.texpr;
+	store_typed_expr : Type.texpr -> Ast.expr;
 	get_display : string -> string;
 	allow_package : string -> unit;
 	type_patch : string -> string -> bool -> string option -> unit;
@@ -2627,6 +2628,10 @@ let macro_lib =
 		"get_typed_expr", Fun1 (fun e ->
 			let e = decode_texpr e in
 			encode_expr (make_ast e)
+		);
+		"store_typed_expr", Fun1 (fun e ->
+			let e = try decode_texpr e with Invalid_expr -> error() in
+			encode_expr ((get_ctx()).curapi.store_typed_expr e)
 		);
 		"get_output", Fun0 (fun() ->
 			VString (ccom()).file

--- a/matcher.ml
+++ b/matcher.ml
@@ -770,7 +770,7 @@ let column_sigma mctx st pmat =
 		if not g then Hashtbl.replace unguarded c.c_def true;
 	in
 	let bind_st out st v =
-		if not (List.exists (fun ((v2,p),_) -> v2.v_id == (fst v).v_id) !bindings) then bindings := (v,st) :: !bindings
+		if not (List.exists (fun ((v2,p),_) -> v2.v_id = (fst v).v_id) !bindings) then bindings := (v,st) :: !bindings
 	in
 	let rec loop pmat = match pmat with
 		| (pv,out) :: pr ->

--- a/optimizer.ml
+++ b/optimizer.ml
@@ -1315,7 +1315,7 @@ let inline_constructors ctx e =
 								match e.eexpr with
 								| TBlock el ->
 									List.iter get_assigns el
-								| TBinop (OpAssign, { eexpr = TField ({ eexpr = TLocal vv },FInstance(_,_,cf)); etype = t }, e) when v == vv ->
+								| TBinop (OpAssign, { eexpr = TField ({ eexpr = TLocal vv },FInstance(_,_,cf)); etype = t }, e) when v.v_id = vv.v_id ->
 									assigns := (cf.cf_name,e,t) :: !assigns
 								| _ ->
 									raise Exit

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -465,6 +465,24 @@ class Context {
 		return load("get_typed_expr",1)(t);
 	}
 
+
+	/**
+		Store typed expression `t` internally and give a syntax-level expression
+		that can be returned from a macro and will be replaced by the stored
+		typed expression.
+
+		If `t` is null or invalid, an exception is thrown.
+
+		NOTE: the returned value references an internally stored typed expression
+		that is reset between compilations, so care should be taken when storing
+		the expression returned by this method in a static variable and using the
+		compilation server.
+	**/
+	@:require(haxe_ver >= 3.2)
+	public static function storeTypedExpr( t : Type.TypedExpr ) : Expr {
+		return load("store_typed_expr",1)(t);
+	}
+
 	/**
 		Manually adds a dependency between module `modulePath` and an external
 		file `externFile`.

--- a/tests/unit/src/unit/issues/Issue3914.hx
+++ b/tests/unit/src/unit/issues/Issue3914.hx
@@ -1,0 +1,61 @@
+package unit.issues;
+
+class Issue3914 extends Test {
+    #if macro
+    static var storedExpr:haxe.macro.Expr;
+    #end
+
+    function test() {
+        storeExpr(function(a:Array<Int>) {
+            for (i in a) {
+                try throw i catch (v:Dynamic) {
+                    var v2 = v;
+                    return v2;
+                }
+            }
+            throw false;
+        });
+        eq(getStoredExpr()([3,2,1]), 3);
+    }
+
+    function test2() {
+        storeExpr(function(a:Array<Int>) {
+            for (i in a) {
+                try throw i catch (v:Dynamic) {
+                    var v2 = v;
+                    return v2;
+                }
+            }
+            throw false;
+        });
+        check2();
+    }
+
+    function check2() {
+        eq(getStoredExpr()([3,2,1]), 3);
+    }
+
+    function test3() {
+        store3();
+        eq(getStoredExpr()([3,2,1]), 3);
+    }
+
+    function store3() {
+        storeExpr(function(a:Array<Int>) {
+            for (i in a) {
+                try throw i catch (v:Dynamic) {
+                    var v2 = v;
+                    return v2;
+                }
+            }
+            throw false;
+        });
+    }
+
+    static macro function storeExpr(e) {
+        storedExpr = haxe.macro.Context.storeTypedExpr(haxe.macro.Context.typeExpr(e));
+        return macro {};
+    }
+
+    static macro function getStoredExpr() return storedExpr;
+}

--- a/typeload.ml
+++ b/typeload.ml
@@ -1868,7 +1868,7 @@ let init_class ctx c p context_init herits fields =
 								let rec has_this e = match e.eexpr with
 									| TConst TThis ->
 										display_error ctx "Cannot access this or other member field in variable initialization" e.epos;
-									| TLocal v when (match ctx.vthis with Some v2 -> v == v2 | None -> false) ->
+									| TLocal v when (match ctx.vthis with Some v2 -> v.v_id = v2.v_id | None -> false) ->
 										display_error ctx "Cannot access this or other member field in variable initialization" e.epos;
 									| _ ->
 									Type.iter has_this e


### PR DESCRIPTION
This adds new `Context.storeTypedExpr` method that allows one to store a typed expression in the context and return a syntax-level expression to be returned from a macro that will be replaced by the stored expression when typing.

This allows to "properly" deal with issues like the one described in #3906, when we want to return a (part of) typed expression from a macro.

I would like this to be included in 3.2 because otherwise I would have to find some ugly workarounds for "regressions" in my project code, like this one https://gist.github.com/nadako/54f9cac9de1515746950