### PR TITLE
Resource name base 64

### DIFF
--- a/genas3.ml
+++ b/genas3.ml
@@ -330,6 +330,7 @@ let generate_resources infos =
 		let dir = (infos.com.file :: ["__res"]) in
 		create_dir [] dir;
 		let add_resource name data =
+			let name = Base64.str_encode name in
 			let ch = open_out_bin (String.concat "/" (dir @ [name])) in
 			output_string ch data;
 			close_out ch
@@ -344,9 +345,9 @@ let generate_resources infos =
 		Hashtbl.iter (fun name _ ->
 			let varname = ("v" ^ (string_of_int !k)) in
 			k := !k + 1;
-			print ctx "\t\t[Embed(source = \"__res/%s\", mimeType = \"application/octet-stream\")]\n" name;
+			print ctx "\t\t[Embed(source = \"__res/%s\", mimeType = \"application/octet-stream\")]\n" (Base64.str_encode name);
 			print ctx "\t\tpublic static var %s:Class;\n" varname;
-			inits := ("list[\"" ^name^ "\"] = " ^ varname ^ ";") :: !inits;
+			inits := ("list[\"" ^ Ast.s_escape name ^ "\"] = " ^ varname ^ ";") :: !inits;
 		) infos.com.resources;
 		spr ctx "\t\tstatic public function __init__():void {\n";
 		spr ctx "\t\t\tlist = new Dictionary();\n";

--- a/gencs.ml
+++ b/gencs.ml
@@ -40,7 +40,7 @@ let rec is_cs_basic_type t =
 		| TInst( { cl_path = (["haxe"], "Int32") }, [] )
 		| TInst( { cl_path = (["haxe"], "Int64") }, [] )
 		| TAbstract ({ a_path = (["cs"], "Int64") },[])
-		| TAbstract ({ a_path = (["cs"], "UInt64") },[]) 
+		| TAbstract ({ a_path = (["cs"], "UInt64") },[])
 		| TAbstract ({ a_path = ([], "Int") },[])
 		| TAbstract ({ a_path = ([], "Float") },[])
 		| TAbstract ({ a_path = ([], "Bool") },[]) ->
@@ -3018,6 +3018,7 @@ let configure gen =
 				gen.gcon.file ^ "/src/Resources"
 		in
 		Hashtbl.iter (fun name v ->
+			let name = Base64.str_encode name in
 			let full_path = src ^ "/" ^ name in
 			mkdir_from_path full_path;
 

--- a/genjava.ml
+++ b/genjava.ml
@@ -2256,7 +2256,7 @@ let configure gen =
 	let res = ref [] in
 	Hashtbl.iter (fun name v ->
 		res := { eexpr = TConst(TString name); etype = gen.gcon.basic.tstring; epos = Ast.null_pos } :: !res;
-
+		let name = Base64.str_encode name in
 		let full_path = gen.gcon.file ^ "/src/" ^ name in
 		mkdir_from_path full_path;
 

--- a/genphp.ml
+++ b/genphp.ml
@@ -332,14 +332,10 @@ let create_directory com ldir =
  	(List.iter (fun p -> atm_path := !atm_path ^ "/" ^ p; if not (Sys.file_exists !atm_path) then (Unix.mkdir !atm_path 0o755);) ldir)
 
 let write_resource dir name data =
-	let i = ref 0 in
-	String.iter (fun c ->
-		if c = '\\' || c = '/' || c = ':' || c = '*' || c = '?' || c = '"' || c = '<' || c = '>' || c = '|' then String.blit "_" 0 name !i 1;
-		incr i
-	) name;
 	let rdir = dir ^ "/res" in
 	if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
 	if not (Sys.file_exists rdir) then Unix.mkdir rdir 0o755;
+	let name = Base64.str_encode name in
 	let ch = open_out_bin (rdir ^ "/" ^ name) in
 	output_string ch data;
 	close_out ch

--- a/genpy.ml
+++ b/genpy.ml
@@ -2137,8 +2137,9 @@ module Generator = struct
 				end else
 					","
 				in
-				print ctx "%s'%s': open('%%s.%%s'%%(__file__,'%s'),'rb').read()" prefix k k;
-				Std.output_file (ctx.com.file ^ "." ^ k) v
+				let k_enc = Base64.str_encode k in
+				print ctx "%s\"%s\": open('%%s.%%s'%%(__file__,'%s'),'rb').read()" prefix (Ast.s_escape k) k_enc;
+				Std.output_file (ctx.com.file ^ "." ^ k_enc) v
 			) ctx.com.resources;
 			spr ctx "}"
 		end

--- a/std/cs/_std/haxe/Resource.hx
+++ b/std/cs/_std/haxe/Resource.hx
@@ -45,6 +45,7 @@ package haxe;
 	}
 
 	public static function getString( name : String ) : String {
+		name = haxe.crypto.Base64.encode(haxe.io.Bytes.ofString(name));
 		var path = getPaths().get(name);
 		var str = cs.Lib.toNativeType(haxe.Resource).Assembly.GetManifestResourceStream(path);
 		if (str != null)
@@ -53,6 +54,7 @@ package haxe;
 	}
 
 	public static function getBytes( name : String ) : haxe.io.Bytes {
+		name = haxe.crypto.Base64.encode(haxe.io.Bytes.ofString(name));
 		var path = getPaths().get(name);
 		var str = cs.Lib.toNativeType(haxe.Resource).Assembly.GetManifestResourceStream(path);
 		if (str != null)

--- a/std/java/_std/haxe/Resource.hx
+++ b/std/java/_std/haxe/Resource.hx
@@ -30,6 +30,7 @@ package haxe;
 	}
 
 	public static function getString( name : String ) : String {
+		name = haxe.crypto.Base64.encode(haxe.io.Bytes.ofString(name));
 		var stream = cast(Resource, java.lang.Class<Dynamic>).getResourceAsStream("/" + name);
 		if (stream == null)
 			return null;
@@ -38,6 +39,7 @@ package haxe;
 	}
 
 	public static function getBytes( name : String ) : haxe.io.Bytes {
+		name = haxe.crypto.Base64.encode(haxe.io.Bytes.ofString(name));
 		var stream = cast(Resource, java.lang.Class<Dynamic>).getResourceAsStream("/" + name);
 		if (stream == null)
 			return null;

--- a/std/php/_std/haxe/Resource.hx
+++ b/std/php/_std/haxe/Resource.hx
@@ -21,6 +21,9 @@
  */
 package haxe;
 
+import haxe.io.Bytes;
+import haxe.crypto.Base64;
+
 @:coreApi
 class Resource {
 
@@ -33,14 +36,14 @@ class Resource {
 	}
 
 	static function getPath(name : String) : String {
-		return getDir()+'/'+cleanName(name);
+		return getDir()+'/'+Base64.encode(Bytes.ofString(name));
 	}
 
 	public static function listNames() : Array<String> {
 		var a = sys.FileSystem.readDirectory(getDir());
 		if(a[0] == '.') a.shift();
 		if(a[0] == '..') a.shift();
-		return a;
+		return a.map(function(s) return Base64.decode(s).toString());
 	}
 
 	public static function getString( name : String ) : String {

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -2,7 +2,7 @@
 -debug
 -cp src
 -cp "C:\Program Files\The Haxe Effect\src/dev/null"
--resource res1.txt
--resource res2.bin
+-resource res1.txt@res?!%[]))("'£1.txt
+-resource res2.bin@res?!%[]))("'£1.bin
 -dce full
 -D analyzer

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -2,7 +2,7 @@
 -debug
 -cp src
 -cp "C:\Program Files\The Haxe Effect\src/dev/null"
--resource res1.txt@res?!%[]))("'£1.txt
--resource res2.bin@res?!%[]))("'£1.bin
+-resource res1.txt@res?!%[]))("'1.txt
+-resource res2.bin@res?!%[]))("'1.bin
 -dce full
 -D analyzer

--- a/tests/unit/src/unit/TestResource.hx
+++ b/tests/unit/src/unit/TestResource.hx
@@ -7,22 +7,22 @@ class TestResource extends Test {
 	function testResources() {
 		var names = haxe.Resource.listNames();
 		eq( names.length, 2 );
-		if( names[0] == "res1.txt" )
-			eq( names[1], "res2.bin" );
+		if( names[0] == "res?!%[]))(\"'£1.txt" )
+			eq( names[1], "res?!%[]))(\"'£1.bin" );
 		else {
-			eq( names[0], "res2.bin" );
-			eq( names[1], "res1.txt" );
+			eq( names[0], "res?!%[]))(\"'£1.bin" );
+			eq( names[1], "res?!%[]))(\"'£1.txt" );
 		}
-		eq( haxe.Resource.getString("res1.txt"), STR );
+		eq( haxe.Resource.getString("res?!%[]))(\"'£1.txt"), STR );
 		#if (neko || php)
 		// allow binary strings
-		eq( haxe.Resource.getBytes("res2.bin").sub(0,9).toString(), "MZ\x90\x00\x03\x00\x00\x00\x04" );
+		eq( haxe.Resource.getBytes("res?!%[]))(\"'£1.bin").sub(0,9).toString(), "MZ\x90\x00\x03\x00\x00\x00\x04" );
 		#else
 		// cut until first \0
-		eq( haxe.Resource.getString("res2.bin").substr(0,2), "MZ" );
+		eq( haxe.Resource.getString("res?!%[]))(\"'£1.bin").substr(0,2), "MZ" );
 		#end
-		eq( haxe.Resource.getBytes("res1.txt").compare(haxe.io.Bytes.ofString(STR)), 0 );
-		var b = haxe.Resource.getBytes("res2.bin");
+		eq( haxe.Resource.getBytes("res?!%[]))(\"'£1.txt").compare(haxe.io.Bytes.ofString(STR)), 0 );
+		var b = haxe.Resource.getBytes("res?!%[]))(\"'£1.bin");
 		var firsts = [0x4D,0x5A,0x90,0x00,0x03,0x00,0x00,0x00,0x04,0x00,0x00,0x00,0xFF,0xFF,0x00,0x00,0xB8];
 		var lasts = [0xD6,0x52,0x03,0x1A,0x2C,0x4E,0x45,0x4B,0x4F,0x00,0x1C,0x00,0x00];
 		for( i in 0...firsts.length )
@@ -33,10 +33,10 @@ class TestResource extends Test {
 
 	#if neko
 	static function main() {
-		var ch = sys.io.File.write("res1.txt",true);
+		var ch = sys.io.File.write("res?!%[]))(\"'£1.txt",true);
 		ch.writeString(STR);
 		ch.close();
-		var ch = sys.io.File.write("res2.bin",true);
+		var ch = sys.io.File.write("res?!%[]))(\"'£1.bin",true);
 		ch.writeString("Héllo");
 		ch.writeByte(0);
 		ch.writeString("World");

--- a/tests/unit/src/unit/TestResource.hx
+++ b/tests/unit/src/unit/TestResource.hx
@@ -7,22 +7,22 @@ class TestResource extends Test {
 	function testResources() {
 		var names = haxe.Resource.listNames();
 		eq( names.length, 2 );
-		if( names[0] == "res?!%[]))(\"'£1.txt" )
-			eq( names[1], "res?!%[]))(\"'£1.bin" );
+		if( names[0] == "res?!%[]))(\"'1.txt" )
+			eq( names[1], "res?!%[]))(\"'1.bin" );
 		else {
-			eq( names[0], "res?!%[]))(\"'£1.bin" );
-			eq( names[1], "res?!%[]))(\"'£1.txt" );
+			eq( names[0], "res?!%[]))(\"'1.bin" );
+			eq( names[1], "res?!%[]))(\"'1.txt" );
 		}
-		eq( haxe.Resource.getString("res?!%[]))(\"'£1.txt"), STR );
+		eq( haxe.Resource.getString("res?!%[]))(\"'1.txt"), STR );
 		#if (neko || php)
 		// allow binary strings
-		eq( haxe.Resource.getBytes("res?!%[]))(\"'£1.bin").sub(0,9).toString(), "MZ\x90\x00\x03\x00\x00\x00\x04" );
+		eq( haxe.Resource.getBytes("res?!%[]))(\"'1.bin").sub(0,9).toString(), "MZ\x90\x00\x03\x00\x00\x00\x04" );
 		#else
 		// cut until first \0
-		eq( haxe.Resource.getString("res?!%[]))(\"'£1.bin").substr(0,2), "MZ" );
+		eq( haxe.Resource.getString("res?!%[]))(\"'1.bin").substr(0,2), "MZ" );
 		#end
-		eq( haxe.Resource.getBytes("res?!%[]))(\"'£1.txt").compare(haxe.io.Bytes.ofString(STR)), 0 );
-		var b = haxe.Resource.getBytes("res?!%[]))(\"'£1.bin");
+		eq( haxe.Resource.getBytes("res?!%[]))(\"'1.txt").compare(haxe.io.Bytes.ofString(STR)), 0 );
+		var b = haxe.Resource.getBytes("res?!%[]))(\"'1.bin");
 		var firsts = [0x4D,0x5A,0x90,0x00,0x03,0x00,0x00,0x00,0x04,0x00,0x00,0x00,0xFF,0xFF,0x00,0x00,0xB8];
 		var lasts = [0xD6,0x52,0x03,0x1A,0x2C,0x4E,0x45,0x4B,0x4F,0x00,0x1C,0x00,0x00];
 		for( i in 0...firsts.length )
@@ -33,10 +33,10 @@ class TestResource extends Test {
 
 	#if neko
 	static function main() {
-		var ch = sys.io.File.write("res?!%[]))(\"'£1.txt",true);
+		var ch = sys.io.File.write("res?!%[]))(\"'1.txt",true);
 		ch.writeString(STR);
 		ch.close();
-		var ch = sys.io.File.write("res?!%[]))(\"'£1.bin",true);
+		var ch = sys.io.File.write("res?!%[]))(\"'1.bin",true);
 		ch.writeString("Héllo");
 		ch.writeByte(0);
 		ch.writeString("World");


### PR DESCRIPTION
This applies base64 encoding on all targets that write resources by-name to the file system. There are two complementary PRs for hxjava and hxcs:

https://github.com/HaxeFoundation/hxcs/pull/16
https://github.com/HaxeFoundation/hxjava/pull/13

(closes #3760)