### PR TITLE
jsThis

### DIFF
--- a/std/js/JQuery.hx
+++ b/std/js/JQuery.hx
@@ -74,7 +74,7 @@ extern class JQueryHelper {
 	public static var JTHIS(get, null) : JQuery;
 
 	static inline function get_JTHIS() : JQuery {
-		return untyped __js__("$(this)");
+		return new JQuery(js.Lib.jsThis);
 	}
 
 }
@@ -391,7 +391,7 @@ extern class JQuery implements ArrayAccess<Element> {
 	//static function is*, makeArray, map, merge, noop, now, param, proxy, sub, trim, type, unique
 
 	private static inline function get_cur() : JQuery {
-		return untyped js.JQuery(__js__("this"));
+		return new js.JQuery(js.Lib.jsThis);
 	}
 
 	private static function __init__() : Void untyped {

--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -65,4 +65,19 @@ class Lib {
 	static inline function get_undefined() : Dynamic {
 		return untyped __js__("undefined");
 	}
+
+	/**
+		`jsThis` is the JavaScript `this`, which is semantically different from the Haxe `this`.
+		Use `jsThis` only when working with external JavaScript code.
+
+		In Haxe, `this` is always bound to a class instance.
+		In JavaScript, `this` in a function can be bound to an arbitrary variable when 
+		the function is called using `func.call(thisObj, ...)` or `func.apply(thisObj, [...])`.
+
+		Read more at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this
+	**/
+	public static var jsThis(get,never) : Dynamic;
+	@:extern static inline function get_jsThis() : Dynamic {
+		return untyped __js__("this");
+	}
 }


### PR DESCRIPTION
This adds `js.Lib.jsThis` to output plain `this` in JS.
It is useful when using some JS libs, e.g. jQuery:

```haxe
import js.JQuery;
class Test {
	static function main () {
		new JQuery("div").each(function(){
			trace(js.Lib.jsThis); //a DivElement
		});
	}
}
```

`js.JQuery.cur` provides the js `this` wrapped in jQuery, but someone may only need the contained element.
Also someone may need to use the js `this` when using other JS libs. 