### PR TITLE
[java/cs] Added @:strict metadata that performs type checking on C#/Java

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -148,6 +148,7 @@ module Meta = struct
 		| SkipReflection
 		| Sound
 		| StoredTypedExpr
+		| Strict
 		| Struct
 		| StructAccess
 		| SuppressWarnings

--- a/common.ml
+++ b/common.ml
@@ -475,6 +475,7 @@ module MetaInfo = struct
 		| SkipCtor -> ":skipCtor",("Used internally to generate a constructor as if it were a native type (no __hx_ctor)",[Platforms [Java;Cs]; Internal])
 		| SkipReflection -> ":skipReflection",("Used internally to annotate a field that shouldn't have its reflection data generated",[Platforms [Java;Cs]; UsedOn TClassField; Internal])
 		| Sound -> ":sound",( "Includes a given .wav or .mp3 file into the target Swf and associates it with the class (must extend flash.media.Sound)",[HasParam "File path";UsedOn TClass;Platform Flash])
+		| Strict -> ":strict",("Used to declare a native C# attribute or a native Java metadata. Is type checked",[Platforms [Java;Cs]])
 		| Struct -> ":struct",("Marks a class definition as a struct.",[Platform Cs; UsedOn TClass])
 		| StructAccess -> ":structAccess",("Marks an extern class as using struct access('.') not pointer('->').",[Platform Cpp; UsedOn TClass])
 		| SuppressWarnings -> ":suppressWarnings",("Adds a SuppressWarnings annotation for the generated Java class",[Platform Java; UsedOn TClass])

--- a/tests/unit/native_java/src/haxe/test/MyClass.java
+++ b/tests/unit/native_java/src/haxe/test/MyClass.java
@@ -1,4 +1,5 @@
 package haxe.test;
+import java.lang.annotation.*;
 
 public class MyClass
 {
@@ -105,4 +106,17 @@ public class MyClass
 			}
 		}
 	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface MyAnnotation {
+		String author();
+		int currentRevision() default 1;
+		String lastModified() default "N/A";
+		TEnum someEnum() default TEnum.TC;
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface ParameterLessAnnotation {
+	}
 }
+

--- a/tests/unit/src/unit/TestCSharp.hx
+++ b/tests/unit/src/unit/TestCSharp.hx
@@ -11,6 +11,7 @@ import haxe.test.IEditableTextBuffer;
 import haxe.test.LowerCaseClass;
 
 import cs.Flags;
+import cs.system.componentmodel.DescriptionAttribute;
 
 import NoPackage;
 #if unsafe
@@ -663,7 +664,7 @@ class TestCSharp extends Test
 	}
 }
 
-@:meta(System.ComponentModel.Description("Type description test"))
+@:strict(DescriptionAttribute("Type description test"))
 typedef StringWithDescription = String;
 
 private class HxClass extends NativeClass
@@ -687,7 +688,7 @@ private class HxClass extends NativeClass
 	}
 }
 
-@:meta(System.ComponentModel.Description("MyClass Description"))
+@:strict(cs.system.componentmodel.DescriptionAttribute("MyClass Description"))
 private class TestMyClass extends haxe.test.MyClass
 {
 	@:overload public function new()
@@ -709,7 +710,7 @@ private class TestMyClass extends haxe.test.MyClass
 	public var dynamicCalled:Bool;
 	public var getCalled:Bool;
 
-	@:meta(System.ComponentModel.Description("Argument description"))
+	@:strict(DescriptionAttribute("Argument description"))
 	@:keep public function argumentDescription(arg:StringWithDescription)
 	{
 	}

--- a/tests/unit/src/unit/TestJava.hx
+++ b/tests/unit/src/unit/TestJava.hx
@@ -1,6 +1,7 @@
 package unit;
 import haxe.io.Bytes;
 import haxe.test.Base;
+import haxe.test.MyClass;
 import haxe.test.Base.Base_InnerClass;
 import haxe.test.Base.Base___InnerClass3__;
 import haxe.test.Base.Base___InnerClass3___InnerClass4__;
@@ -10,6 +11,8 @@ import java.util.EnumSet;
 import java.vm.*;
 
 #if java
+@:strict(haxe.test.MyClass.MyClass_MyAnnotation({ author:"John Doe", someEnum: TB }))
+@:strict(MyClass_ParameterLessAnnotation)
 class TestJava extends Test
 {
   function testException()
@@ -25,6 +28,24 @@ class TestJava extends Test
       hx.excTest()
     catch(e:Dynamic) throw e; //shouldn't throw any exception
   }
+
+	@:strict(MyClass_MyAnnotation({ author:"author", currentRevision: 2 }))
+	public function testAnnotations()
+	{
+		var cl = java.Lib.toNativeType(TestJava);
+		var a = cl.getAnnotation(java.Lib.toNativeType(MyClass_MyAnnotation));
+		t(a != null);
+		eq(a.author(), "John Doe");
+		eq(a.someEnum(), TB);
+		eq(a.currentRevision(), 1);
+		t(cl.getAnnotation(java.Lib.toNativeType(MyClass_ParameterLessAnnotation)) != null);
+		var m = cl.getMethod("testAnnotations", new java.NativeArray(0));
+		a = m.getAnnotation(java.Lib.toNativeType(MyClass_MyAnnotation));
+		t(a != null);
+		eq(a.author(), "author");
+		eq(a.someEnum(), TC);
+		eq(a.currentRevision(), 2);
+	}
 
 	function testLowerCase()
 	{


### PR DESCRIPTION
Added @:meta implementation for Java. Closes #2065 

Please review - I've added some platform-specific code to typeload.ml, and I don't think this can be avoided, sadly