### PR TITLE
fix issue #3821

### DIFF
--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -102,11 +102,15 @@ class Compiler {
 
 		In order to include single modules, their paths can be listed directly
 		on command line: `haxe ... ModuleName pack.ModuleName`.
+		
+		By default `Compiler.include` will search for modules in the directories defined with `-cp`.
+		If you want to specify a different set of paths to search for modules, you can use the optional
+		argument `classPath`.
 
 		@param rec If true, recursively adds all sub-packages.
 		@param ignore Array of module names to ignore for inclusion.
-		@param classPaths Array of additional class paths to check. This can be
-		    used to add packages outside the usual class paths.
+		@param classPaths An alternative array of paths (directory names) to use to search for modules to include.
+		       Note that if you pass this argument, only the specified paths will be used for inclusion.  
 	**/
 	public static function include( pack : String, ?rec = true, ?ignore : Array<String>, ?classPaths : Array<String> ) {
 		var skip = if( ignore == null ) {


### PR DESCRIPTION
Updated documentation to reflect usage of optional parameter in `Compiler.include()`.