### PR TITLE
Fix a shutdown bug in the haxe C++ target

### DIFF
--- a/std/cpp/_std/Sys.hx
+++ b/std/cpp/_std/Sys.hx
@@ -106,6 +106,7 @@
 	}
 
 	public static function exit( code : Int ) : Void {
+		unloadAllLibraries();
 		untyped __global__.__hxcpp_exit(code);
 	}
 


### PR DESCRIPTION
shutdown logic was unloading all loaded C++ functions, then attempting to call a previously loaded
function to actually do the shut down. The result was a seg fault when
a C++ target haxe program shut down.