### PR TITLE
[all] Make all inline functions in abstract @:extern also

### DIFF
--- a/std/cs/_std/haxe/Int64.hx
+++ b/std/cs/_std/haxe/Int64.hx
@@ -28,188 +28,188 @@ private typedef __Int64 = cs.StdTypes.Int64;
 abstract Int64(__Int64) from __Int64 to __Int64
 {
 
-	public static inline function make( high : Int32, low : Int32 ) : Int64
+	@:extern public static inline function make( high : Int32, low : Int32 ) : Int64
 		return new Int64( (cast(high, __Int64) << 32) | (cast(low, __Int64)& untyped __cs__('0xffffffffL')) );
 
-	private inline function new(x : __Int64)
+	@:extern private inline function new(x : __Int64)
 		this = x;
 
 	private var val( get, set ) : __Int64;
-	inline function get_val() : __Int64 return this;
-	inline function set_val( x : __Int64 ) : __Int64 return this = x;
+	@:extern inline function get_val() : __Int64 return this;
+	@:extern inline function set_val( x : __Int64 ) : __Int64 return this = x;
 
 	public var high( get, never ):Int32;
-	public inline function get_high():Int32 return cast(this >> 32);
+	@:extern public inline function get_high():Int32 return cast(this >> 32);
 
 	public var low( get, never ):Int32;
-	public inline function get_low():Int32 return cast this;
+	@:extern public inline function get_low():Int32 return cast this;
 
-	public inline function copy():Int64
+	@:extern public inline function copy():Int64
 		return new Int64( this );
 
-	@:from public static inline function ofInt( x : Int ) : Int64
+	@:extern @:from public static inline function ofInt( x : Int ) : Int64
 		return cast x;
 
-	public static inline function toInt( x : Int64 ) : Int {
+	@:extern public static inline function toInt( x : Int64 ) : Int {
 		if( x.val < 0x80000000 || x.val > 0x7FFFFFFF )
 			throw "Overflow";
 		return cast x.val;
 	}
 
-	public static inline function getHigh( x : Int64 ) : Int32
+	@:extern public static inline function getHigh( x : Int64 ) : Int32
 		return cast( x.val >> 32 );
 
-	public static inline function getLow( x : Int64 ) : Int32
+	@:extern public static inline function getLow( x : Int64 ) : Int32
 		return cast( x.val );
 
-	public static inline function isNeg( x : Int64 ) : Bool
+	@:extern public static inline function isNeg( x : Int64 ) : Bool
 		return x.val < 0;
 
-	public static inline function isZero( x : Int64 ) : Bool
+	@:extern public static inline function isZero( x : Int64 ) : Bool
 		return x.val == 0;
 
-	public static inline function compare( a : Int64, b : Int64 ) : Int
+	@:extern public static inline function compare( a : Int64, b : Int64 ) : Int
 	{
 		if( a.val < b.val ) return -1;
 		if( a.val > b.val ) return 1;
 		return 0;
 	}
 
-	public static inline function ucompare( a : Int64, b : Int64 ) : Int {
+	@:extern public static inline function ucompare( a : Int64, b : Int64 ) : Int {
 		if( a.val < 0 )
 			return ( b.val < 0 ) ? compare( a, b ) : 1;
 		return ( b.val < 0 ) ? -1 : compare( a, b );
 	}
 
-	public static inline function toStr( x : Int64 ) : String
+	@:extern public static inline function toStr( x : Int64 ) : String
 		return '${x.val}';
 
-	public static inline function divMod( dividend : Int64, divisor : Int64 ) : { quotient : Int64, modulus : Int64 }
+	@:extern public static inline function divMod( dividend : Int64, divisor : Int64 ) : { quotient : Int64, modulus : Int64 }
 		return { quotient: dividend / divisor, modulus: dividend % divisor };
 
-	private inline function toString() : String
+	@:extern private inline function toString() : String
 		return '$this';
 
-	@:op(-A) public static function neg( x : Int64 ) : Int64
+	@:extern @:op(-A) public inline static function neg( x : Int64 ) : Int64
 		return -x.val;
 
-	@:op(++A) private inline function preIncrement() : Int64
+	@:extern @:op(++A) private inline function preIncrement() : Int64
 		return ++this;
 
-	@:op(A++) private inline function postIncrement() : Int64
+	@:extern @:op(A++) private inline function postIncrement() : Int64
 		return this++;
 
-	@:op(--A) private inline function preDecrement() : Int64
+	@:extern @:op(--A) private inline function preDecrement() : Int64
 		return --this;
 
-	@:op(A--) private inline function postDecrement() : Int64
+	@:extern @:op(A--) private inline function postDecrement() : Int64
 		return this--;
 
-	@:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64
 		return a.val + b.val;
 
-	@:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
 		return a.val + b;
 
-	@:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64
 		return a.val - b.val;
 
-	@:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
 		return a.val - b;
 
-	@:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
 		return a - b.val;
 
-	@:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64
 		return a.val * b.val;
 
-	@:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
 		return a.val * b;
 
-	@:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
 		return a.val / b.val;
 
-	@:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
 		return a.val / b;
 
-	@:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
 		return a / b.val;
 
-	@:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
 		return a.val % b.val;
 
-	@:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
 		return a.val % b;
 
-	@:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
 		return a % b.val;
 
-	@:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
 		return a.val == b.val;
 
-	@:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
 		return a.val == b;
 
-	@:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
 		return a.val != b.val;
 
-	@:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
 		return a.val != b;
 
-	@:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
 		return a.val < b.val;
 
-	@:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
 		return a.val < b;
 
-	@:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
 		return a < b.val;
 
-	@:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
 		return a.val <= b.val;
 
-	@:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
 		return a.val <= b;
 
-	@:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
 		return a <= b.val;
 
-	@:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
 		return a.val > b.val;
 
-	@:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
 		return a.val > b;
 
-	@:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
 		return a > b.val;
 
-	@:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
 		return a.val >= b.val;
 
-	@:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
 		return a.val >= b;
 
-	@:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
 		return a >= b.val;
 
-	@:op(~A) private static inline function complement( x : Int64 ) : Int64
+	@:extern @:op(~A) private static inline function complement( x : Int64 ) : Int64
 		return ~x.val;
 
-	@:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
 		return a.val & b.val;
 
-	@:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
 		return a.val | b.val;
 
-	@:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
 		return a.val ^ b.val;
 
-	@:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64
+	@:extern @:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64
 		return a.val << b;
 
-	@:op(A >> B) public static inline function shr( a : Int64, b : Int ) : Int64
+	@:extern @:op(A >> B) public static inline function shr( a : Int64, b : Int ) : Int64
 		return a.val >> b;
 
-	@:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64
+	@:extern @:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64
 		return cast ( (a.val : cs.StdTypes.UInt64) >> b );
 }

--- a/std/haxe/Int32.hx
+++ b/std/haxe/Int32.hx
@@ -28,39 +28,39 @@
 abstract Int32(Int) from Int to Int {
 	@:op(-A) private function negate():Int32;
 
-	@:op(++A) private inline function preIncrement():Int32
+	@:extern @:op(++A) private inline function preIncrement():Int32
 		return this = clamp(++this);
 
-	@:op(A++) private inline function postIncrement():Int32 {
+	@:extern @:op(A++) private inline function postIncrement():Int32 {
 		var ret = this++;
 		this = clamp(this);
 		return ret;
 	}
 
-	@:op(--A) private inline function preDecrement():Int32
+	@:extern @:op(--A) private inline function preDecrement():Int32
 		return this = clamp(--this);
 
-	@:op(A--) private inline function postDecrement():Int32 {
+	@:extern @:op(A--) private inline function postDecrement():Int32 {
 		var ret = this--;
 		this = clamp(this);
 		return ret;
 	}
 
-	@:op(A + B) private static inline function add(a:Int32, b:Int32):Int32
+	@:extern @:op(A + B) private static inline function add(a:Int32, b:Int32):Int32
 		return clamp( (a : Int) + (b : Int) );
 
-	@:op(A + B) @:commutative private static inline function addInt(a:Int32, b:Int):Int32
+	@:extern @:op(A + B) @:commutative private static inline function addInt(a:Int32, b:Int):Int32
 		return clamp( (a : Int) + (b : Int) );
 
 	@:op(A + B) @:commutative private static function addFloat(a:Int32, b:Float):Float;
 
-	@:op(A - B) private static inline function sub(a:Int32, b:Int32):Int32
+	@:extern @:op(A - B) private static inline function sub(a:Int32, b:Int32):Int32
 		return clamp( (a : Int) - (b : Int) );
 
-	@:op(A - B) private static inline function subInt(a:Int32, b:Int):Int32
+	@:extern @:op(A - B) private static inline function subInt(a:Int32, b:Int):Int32
 		return clamp( (a : Int) - (b : Int) );
 
-	@:op(A - B) private static inline function intSub(a:Int, b:Int32):Int32
+	@:extern @:op(A - B) private static inline function intSub(a:Int, b:Int32):Int32
 		return clamp( (a : Int) - (b : Int) );
 
 	@:op(A - B) private static function subFloat(a:Int32, b:Float):Float;
@@ -72,7 +72,7 @@ abstract Int32(Int) from Int to Int {
 	@:op(A * B) private static function mul(a:Int32, b:Int32):Int32
 		return clamp( (a : Int) * ((b : Int) & 0xFFFF) + clamp( (a : Int) * ((b : Int) >>> 16) << 16 ) );
 
-	@:op(A * B) @:commutative private static inline function mulInt(a:Int32, b:Int):Int32
+	@:extern @:op(A * B) @:commutative private static inline function mulInt(a:Int32, b:Int):Int32
 		return mul(a, b);
 
 	#else
@@ -151,13 +151,13 @@ abstract Int32(Int) from Int to Int {
 	#if (php || python)
 
 	// PHP may be 64-bit, so shifts must be clamped
-	@:op(A << B) private static inline function shl(a:Int32, b:Int32):Int32
+	@:extern @:op(A << B) private static inline function shl(a:Int32, b:Int32):Int32
 		return clamp( (a : Int) << (b : Int) );
 
-	@:op(A << B) private static inline function shlInt(a:Int32, b:Int):Int32
+	@:extern @:op(A << B) private static inline function shlInt(a:Int32, b:Int):Int32
 		return clamp( (a : Int) << b );
 
-	@:op(A << B) private static inline function intShl(a:Int, b:Int32):Int32
+	@:extern @:op(A << B) private static inline function intShl(a:Int, b:Int32):Int32
 		return clamp( a << (b : Int) );
 
 	#else
@@ -168,7 +168,7 @@ abstract Int32(Int) from Int to Int {
 
 	#end
 
-	@:to private inline function toFloat():Float
+	@:extern @:to private inline function toFloat():Float
 		return this;
 
 	/**
@@ -184,7 +184,7 @@ abstract Int32(Int) from Int to Int {
 	static var extraBits : Int = untyped __php__("PHP_INT_SIZE") * 8 - 32;
 	#end
 
-	static inline function clamp( x : Int ) : Int {
+	@:extern static inline function clamp( x : Int ) : Int {
 		// force to-int conversion on platforms that require it
 		#if (as3 || flash8 || js)
 		return x | 0;

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -32,33 +32,33 @@ using haxe.Int64;
 #end
 abstract Int64(__Int64) from __Int64 to __Int64
 {
-	private inline function new( x : __Int64 )
+	@:extern private inline function new( x : __Int64 )
 		this = x;
 
 	/**
 		Makes a copy of `this` Int64.
 	**/
-	public inline function copy():Int64
+	@:extern public inline function copy():Int64
 		return make( high, low );
 
 	/**
 		Construct an Int64 from two 32-bit words `high` and `low`.
 	**/
-	public static inline function make( high:Int32, low:Int32 ) : Int64
+	@:extern public static inline function make( high:Int32, low:Int32 ) : Int64
 		return new Int64( new __Int64(high, low) );
 
 	/**
 		Returns an Int64 with the value of the Int `x`.
 		`x` is sign-extended to fill 64 bits.
 	**/
-	@:from public static inline function ofInt( x : Int ) : Int64
+	@:extern @:from public static inline function ofInt( x : Int ) : Int64
 		return make( x >> 31, x );
 
 	/**
 		Returns an Int with the value of the Int64 `x`.
 		Throws an exception  if `x` cannot be represented in 32 bits.
 	**/
-	public static inline function toInt( x : Int64 ) : Int {
+	@:extern public static inline function toInt( x : Int64 ) : Int {
 		if( x.high != x.low >> 31 )
 			throw "Overflow";
 
@@ -69,26 +69,26 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		Returns the high 32-bit word of `x`.
 	**/
 	@:deprecated("Use high instead")
-	public static inline function getHigh( x : Int64 ) : Int32
+	@:extern public static inline function getHigh( x : Int64 ) : Int32
 		return x.high;
 
 	/**
 		Returns the low 32-bit word of `x`.
 	**/
 	@:deprecated("Use low instead")
-	public static inline function getLow( x : Int64 ) : Int32
+	@:extern public static inline function getLow( x : Int64 ) : Int32
 		return x.low;
 
 	/**
 		Returns `true` if `x` is less than zero.
 	**/
-	public static inline function isNeg( x : Int64) : Bool
+	@:extern public static inline function isNeg( x : Int64) : Bool
 		return x.high < 0;
 
 	/**
 		Returns `true` if `x` is exactly zero.
 	**/
-	public static inline function isZero( x : Int64 ) : Bool
+	@:extern public static inline function isZero( x : Int64 ) : Bool
 		return x == 0;
 
 	/**
@@ -96,7 +96,7 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		Returns a negative value if `a < b`, positive if `a > b`,
 		or 0 if `a == b`.
 	**/
-	public static inline function compare( a : Int64, b : Int64 ) : Int {
+	@:extern public static inline function compare( a : Int64, b : Int64 ) : Int {
 		var v = a.high - b.high;
 		v = if( v != 0 ) v else Int32.ucompare(a.low, b.low);
 		return a.high < 0 ? (b.high < 0 ? v : -1) : (b.high >= 0 ? v : 1);
@@ -107,7 +107,7 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		Returns a negative value if `a < b`, positive if `a > b`,
 		or 0 if `a == b`.
 	**/
-	public static inline function ucompare( a : Int64, b : Int64 ) : Int {
+	@:extern public static inline function ucompare( a : Int64, b : Int64 ) : Int {
 		var v = Int32.ucompare(a.high, b.high);
 		return if( v != 0 ) v else Int32.ucompare(a.low, b.low);
 	}
@@ -115,7 +115,7 @@ abstract Int64(__Int64) from __Int64 to __Int64
 	/**
 		Returns a signed decimal `String` representation of `x`.
 	**/
-	public static inline function toStr(x:Int64) : String
+	@:extern public static inline function toStr(x:Int64) : String
 		return x.toString();
 
 	#if as3 public #else private #end function toString() : String
@@ -190,7 +190,7 @@ abstract Int64(__Int64) from __Int64 to __Int64
 	/**
 		Returns the negative of `x`.
 	**/
-	@:op(-A) public static inline function neg( x : Int64 ) : Int64 {
+	@:extern @:op(-A) public static inline function neg( x : Int64 ) : Int64 {
 		var high = ~x.high;
 		var low = -x.low;
 		if( low == 0 )
@@ -198,25 +198,25 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		return make( high, low );
 	}
 
-	@:op(++A) private inline function preIncrement() : Int64 {
+	@:extern @:op(++A) private inline function preIncrement() : Int64 {
 		this.low++;
 		if( this.low == 0 ) this.high++;
 		return cast this;
 	}
 
-	@:op(A++) private inline function postIncrement() : Int64 {
+	@:extern @:op(A++) private inline function postIncrement() : Int64 {
 		var ret = copy();
 		preIncrement();
 		return ret;
 	}
 
-	@:op(--A) private inline function preDecrement() : Int64 {
+	@:extern @:op(--A) private inline function preDecrement() : Int64 {
 		if( this.low == 0 ) this.high--;
 		this.low--;
 		return cast this;
 	}
 
-	@:op(A--) private inline function postDecrement() : Int64 {
+	@:extern @:op(A--) private inline function postDecrement() : Int64 {
 		var ret = copy();
 		preDecrement();
 		return ret;
@@ -225,36 +225,36 @@ abstract Int64(__Int64) from __Int64 to __Int64
 	/**
 		Returns the sum of `a` and `b`.
 	**/
-	@:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64 {
+	@:extern @:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64 {
 		var high = a.high + b.high;
 		var low = a.low + b.low;
 		if( Int32.ucompare( low, a.low ) < 0 ) high++;
 		return make( high, low );
 	}
 
-	@:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
 		return add( a, b );
 
 	/**
 		Returns `a` minus `b`.
 	**/
-	@:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64 {
+	@:extern @:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64 {
 		var high = a.high - b.high;
 		var low = a.low - b.low;
 		if( Int32.ucompare( a.low, b.low ) < 0 ) high--;
         return make( high, low );
 	}
 
-	@:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
 		return sub( a, b );
 
-	@:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
 		return sub( a, b );
 
 	/**
 		Returns the product of `a` and `b`.
 	**/
-	@:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64 {
+	@:extern @:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64 {
 		var mask = 0xFFFF;
 		var al = a.low & mask, ah = a.low >>> 16;
 		var bl = b.low & mask, bh = b.low >>> 16;
@@ -274,115 +274,115 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		return make( high, low );
 	}
 
-	@:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
 		return mul( a, b );
 
 	/**
 		Returns the quotient of `a` divided by `b`.
 	**/
-	@:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
 		return divMod(a, b).quotient;
 
-	@:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
 		return div( a, b );
 
-	@:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
 		return div( a, b ).toInt();
 
 	/**
 		Returns the modulus of `a` divided by `b`.
 	**/
-	@:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
 		return divMod(a, b).modulus;
 
-	@:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
 		return mod( a, b ).toInt();
 
-	@:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
 		return mod( a, b ).toInt();
 
 	/**
 		Returns `true` if `a` is equal to `b`.
 	**/
-	@:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
 		return a.high == b.high && a.low == b.low;
 
-	@:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
 		return eq( a, b );
 
 	/**
 		Returns `true` if `a` is not equal to `b`.
 	**/
-	@:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
 		return a.high != b.high || a.low != b.low;
 
-	@:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
 		return neq(a, b);
 
-	@:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
 		return compare(a, b) < 0;
 
-	@:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
 		return lt(a, b);
 
-	@:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
 		return lt(a, b);
 
-	@:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
 		return compare(a, b) <= 0;
 
-	@:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
 		return lte(a, b);
 
-	@:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
 		return lte(a, b);
 
-	@:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
 		return compare(a, b) > 0;
 
-	@:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
 		return gt(a, b);
 
-	@:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
 		return gt( a, b );
 
-	@:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
 		return compare(a, b) >= 0;
 
-	@:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
 		return gte(a, b);
 
-	@:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
 		return gte(a, b);
 
 	/**
 		Returns the bitwise NOT of `a`.
 	**/
-	@:op(~A) private static inline function complement( a : Int64 ) : Int64
+	@:extern @:op(~A) private static inline function complement( a : Int64 ) : Int64
 		return make( ~a.high, ~a.low );
 
 	/**
 		Returns the bitwise AND of `a` and `b`.
 	**/
-	@:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
 		return make( a.high & b.high, a.low & b.low );
 
 	/**
 		Returns the bitwise OR of `a` and `b`.
 	**/
-	@:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
 		return make( a.high | b.high, a.low | b.low );
 
 	/**
 		Returns the bitwise XOR of `a` and `b`.
 	**/
-	@:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
 		return make( a.high ^ b.high, a.low ^ b.low );
 
 	/**
 		Returns `a` left-shifted by `b` bits.
 	**/
-	@:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64 {
+	@:extern @:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64 {
 		b &= 63;
 		return if( b == 0 ) a.copy()
 			else if( b < 32 ) make( (a.high << b) | (a.low >>> (32-b)), a.low << b)
@@ -393,7 +393,7 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		Returns `a` right-shifted by `b` bits in signed mode.
 		`a` is sign-extended.
 	**/
-	@:op(A >> B) public static inline function shr( a : Int64, b : Int) : Int64 {
+	@:extern @:op(A >> B) public static inline function shr( a : Int64, b : Int) : Int64 {
 		b &= 63;
 		return if( b == 0 ) a.copy()
 			else if( b < 32 ) make( a.high >> b, (a.high << (32-b)) | (a.low >>> b) )
@@ -404,7 +404,7 @@ abstract Int64(__Int64) from __Int64 to __Int64
 		Returns `a` right-shifted by `b` bits in unsigned mode.
 		`a` is padded with zeroes.
 	**/
-	@:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64 {
+	@:extern @:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64 {
 		b &= 63;
 		return if( b == 0 ) a.copy()
 			else if( b < 32 ) make( a.high >>> b, (a.high << (32-b)) | (a.low >>> b) )
@@ -412,12 +412,12 @@ abstract Int64(__Int64) from __Int64 to __Int64
 	}
 
 	public var high(get, never) : Int32;
-	private inline function get_high() return this.high;
-	private inline function set_high(x) return this.high = x;
+	@:extern private inline function get_high() return this.high;
+	@:extern private inline function set_high(x) return this.high = x;
 
 	public var low(get, never) : Int32;
-	private inline function get_low() return this.low;
-	private inline function set_low(x) return this.low = x;
+	@:extern private inline function get_low() return this.low;
+	@:extern private inline function set_low(x) return this.low = x;
 }
 
 /**
@@ -431,7 +431,7 @@ private class ___Int64 {
 	public var high : Int32;
 	public var low : Int32;
 
-	public inline function new( high, low ) {
+	@:extern public inline function new( high, low ) {
 		this.high = high;
 		this.low = low;
 	}

--- a/std/java/_std/haxe/Int64.hx
+++ b/std/java/_std/haxe/Int64.hx
@@ -28,188 +28,188 @@ private typedef __Int64 = java.StdTypes.Int64;
 abstract Int64(__Int64) from __Int64 to __Int64
 {
 
-	public static inline function make( high : Int32, low : Int32 ) : Int64
+	@:extern public static inline function make( high : Int32, low : Int32 ) : Int64
 		return new Int64( (cast(high, __Int64) << 32) | (cast(low, __Int64)& untyped __java__('0xffffffffL')) );
 
-	private inline function new(x : __Int64)
+	@:extern private inline function new(x : __Int64)
 		this = x;
 
 	private var val( get, set ) : __Int64;
-	inline function get_val() : __Int64 return this;
-	inline function set_val( x : __Int64 ) : __Int64 return this = x;
+	@:extern inline function get_val() : __Int64 return this;
+	@:extern inline function set_val( x : __Int64 ) : __Int64 return this = x;
 
 	public var high( get, never ):Int32;
-	public inline function get_high():Int32 return cast(this >> 32);
+	@:extern public inline function get_high():Int32 return cast(this >> 32);
 
 	public var low( get, never ):Int32;
-	public inline function get_low():Int32 return cast this;
+	@:extern public inline function get_low():Int32 return cast this;
 
-	public inline function copy():Int64
+	@:extern public inline function copy():Int64
 		return new Int64( this );
 
-	@:from public static inline function ofInt( x : Int ) : Int64
+	@:extern @:from public static inline function ofInt( x : Int ) : Int64
 		return cast x;
 
-	public static inline function toInt( x : Int64 ) : Int {
+	@:extern public static inline function toInt( x : Int64 ) : Int {
 		if( x.val < 0x80000000 || x.val > 0x7FFFFFFF )
 			throw "Overflow";
 		return cast x.val;
 	}
 
-	public static inline function getHigh( x : Int64 ) : Int32
+	@:extern public static inline function getHigh( x : Int64 ) : Int32
 		return cast( x.val >> 32 );
 
-	public static inline function getLow( x : Int64 ) : Int32
+	@:extern public static inline function getLow( x : Int64 ) : Int32
 		return cast( x.val );
 
-	public static inline function isNeg( x : Int64 ) : Bool
+	@:extern public static inline function isNeg( x : Int64 ) : Bool
 		return x.val < 0;
 
-	public static inline function isZero( x : Int64 ) : Bool
+	@:extern public static inline function isZero( x : Int64 ) : Bool
 		return x.val == 0;
 
-	public static inline function compare( a : Int64, b : Int64 ) : Int
+	@:extern public static inline function compare( a : Int64, b : Int64 ) : Int
 	{
 		if( a.val < b.val ) return -1;
 		if( a.val > b.val ) return 1;
 		return 0;
 	}
 
-	public static inline function ucompare( a : Int64, b : Int64 ) : Int {
+	@:extern public static inline function ucompare( a : Int64, b : Int64 ) : Int {
 		if( a.val < 0 )
 			return ( b.val < 0 ) ? compare( a, b ) : 1;
 		return ( b.val < 0 ) ? -1 : compare( a, b );
 	}
 
-	public static inline function toStr( x : Int64 ) : String
+	@:extern public static inline function toStr( x : Int64 ) : String
 		return '${x.val}';
 
-	public static inline function divMod( dividend : Int64, divisor : Int64 ) : { quotient : Int64, modulus : Int64 }
+	@:extern public static inline function divMod( dividend : Int64, divisor : Int64 ) : { quotient : Int64, modulus : Int64 }
 		return { quotient: dividend / divisor, modulus: dividend % divisor };
 
-	private inline function toString() : String
+	@:extern private inline function toString() : String
 		return '$this';
 
-	@:op(-A) public static function neg( x : Int64 ) : Int64
+	@:extern @:op(-A) public inline static function neg( x : Int64 ) : Int64
 		return -x.val;
 
-	@:op(++A) private inline function preIncrement() : Int64
+	@:extern @:op(++A) private inline function preIncrement() : Int64
 		return ++this;
 
-	@:op(A++) private inline function postIncrement() : Int64
+	@:extern @:op(A++) private inline function postIncrement() : Int64
 		return this++;
 
-	@:op(--A) private inline function preDecrement() : Int64
+	@:extern @:op(--A) private inline function preDecrement() : Int64
 		return --this;
 
-	@:op(A--) private inline function postDecrement() : Int64
+	@:extern @:op(A--) private inline function postDecrement() : Int64
 		return this--;
 
-	@:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A + B) public static inline function add( a : Int64, b : Int64 ) : Int64
 		return a.val + b.val;
 
-	@:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A + B) @:commutative private static inline function addInt( a : Int64, b : Int ) : Int64
 		return a.val + b;
 
-	@:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A - B) public static inline function sub( a : Int64, b : Int64 ) : Int64
 		return a.val - b.val;
 
-	@:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A - B) private static inline function subInt( a : Int64, b : Int ) : Int64
 		return a.val - b;
 
-	@:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A - B) private static inline function intSub( a : Int, b : Int64 ) : Int64
 		return a - b.val;
 
-	@:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A * B) public static inline function mul( a : Int64, b : Int64 ) : Int64
 		return a.val * b.val;
 
-	@:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A * B) @:commutative private static inline function mulInt( a : Int64, b : Int ) : Int64
 		return a.val * b;
 
-	@:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A / B) public static inline function div( a : Int64, b : Int64 ) : Int64
 		return a.val / b.val;
 
-	@:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A / B) private static inline function divInt( a : Int64, b : Int ) : Int64
 		return a.val / b;
 
-	@:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A / B) private static inline function intDiv( a : Int, b : Int64 ) : Int64
 		return a / b.val;
 
-	@:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A % B) public static inline function mod( a : Int64, b : Int64 ) : Int64
 		return a.val % b.val;
 
-	@:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
+	@:extern @:op(A % B) private static inline function modInt( a : Int64, b : Int ) : Int64
 		return a.val % b;
 
-	@:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
+	@:extern @:op(A % B) private static inline function intMod( a : Int, b : Int64 ) : Int64
 		return a % b.val;
 
-	@:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A == B) public static inline function eq( a : Int64, b : Int64 ) : Bool
 		return a.val == b.val;
 
-	@:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A == B) @:commutative private static inline function eqInt( a : Int64, b : Int ) : Bool
 		return a.val == b;
 
-	@:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A != B) public static inline function neq( a : Int64, b : Int64 ) : Bool
 		return a.val != b.val;
 
-	@:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A != B) @:commutative private static inline function neqInt( a : Int64, b : Int ) : Bool
 		return a.val != b;
 
-	@:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A < B) private static inline function lt( a : Int64, b : Int64 ) : Bool
 		return a.val < b.val;
 
-	@:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A < B) private static inline function ltInt( a : Int64, b : Int ) : Bool
 		return a.val < b;
 
-	@:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A < B) private static inline function intLt( a : Int, b : Int64 ) : Bool
 		return a < b.val;
 
-	@:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A <= B) private static inline function lte( a : Int64, b : Int64 ) : Bool
 		return a.val <= b.val;
 
-	@:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A <= B) private static inline function lteInt( a : Int64, b : Int ) : Bool
 		return a.val <= b;
 
-	@:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A <= B) private static inline function intLte( a : Int, b : Int64 ) : Bool
 		return a <= b.val;
 
-	@:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A > B) private static inline function gt( a : Int64, b : Int64 ) : Bool
 		return a.val > b.val;
 
-	@:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A > B) private static inline function gtInt( a : Int64, b : Int ) : Bool
 		return a.val > b;
 
-	@:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A > B) private static inline function intGt( a : Int, b : Int64 ) : Bool
 		return a > b.val;
 
-	@:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
+	@:extern @:op(A >= B) private static inline function gte( a : Int64, b : Int64 ) : Bool
 		return a.val >= b.val;
 
-	@:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
+	@:extern @:op(A >= B) private static inline function gteInt( a : Int64, b : Int ) : Bool
 		return a.val >= b;
 
-	@:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
+	@:extern @:op(A >= B) private static inline function intGte( a : Int, b : Int64 ) : Bool
 		return a >= b.val;
 
-	@:op(~A) private static inline function complement( x : Int64 ) : Int64
+	@:extern @:op(~A) private static inline function complement( x : Int64 ) : Int64
 		return ~x.val;
 
-	@:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A & B) public static inline function and( a : Int64, b : Int64 ) : Int64
 		return a.val & b.val;
 
-	@:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A | B) public static inline function or( a : Int64, b : Int64 ) : Int64
 		return a.val | b.val;
 
-	@:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
+	@:extern @:op(A ^ B) public static inline function xor( a : Int64, b : Int64 ) : Int64
 		return a.val ^ b.val;
 
-	@:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64
+	@:extern @:op(A << B) public static inline function shl( a : Int64, b : Int ) : Int64
 		return a.val << b;
 
-	@:op(A >> B) public static inline function shr( a : Int64, b : Int ) : Int64
+	@:extern @:op(A >> B) public static inline function shr( a : Int64, b : Int ) : Int64
 		return a.val >> b;
 
-	@:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64
+	@:extern @:op(A >>> B) public static inline function ushr( a : Int64, b : Int ) : Int64
 		return a.val >>> b;
 }


### PR DESCRIPTION
This makes a prettier output when running with `-dce no`. And since there is no way to access those methods via reflection, I don't see why not add this.