### PR TITLE
[js] [WIP] FastIteratingStringMap

### DIFF
--- a/std/haxe/ds/FastIteratingStringMap.hx
+++ b/std/haxe/ds/FastIteratingStringMap.hx
@@ -1,0 +1,264 @@
+package haxe.ds;
+
+#if js
+
+class FastIteratingStringMap<T> implements haxe.Constraints.IMap<String,T> {
+    private static var emptyIterator = {
+        hasNext: function() {
+            return false;
+        },
+
+        next: function() {
+            return null;
+        }
+    };
+
+    private var data:Dynamic;
+    private var dataReserved:Dynamic;
+    private var head:Dynamic;
+    private var tail:Dynamic;
+
+    static function __init__():Void {
+        untyped __js__("var __map_reserved = {}");
+    }
+
+    public function new():Void {
+        data = {};
+        dataReserved = {};
+        head = null;
+        tail = null;
+    }
+
+    public function set(key:String, value:T):Void {
+        if (untyped __js__("__map_reserved")[key] != null) {
+            var _key = "$" + key;
+
+            if (untyped dataReserved.hasOwnProperty(_key)) {
+                untyped dataReserved[_key].value = value;
+            } else {
+                var item = {
+                    prev: tail,
+                    key: key,
+                    value: value,
+                    next: null
+                };
+
+                untyped dataReserved[_key] = item;
+
+                if (tail != null) {
+                    untyped tail.next = item;
+                }
+
+                tail = item;
+
+                if (head == null) {
+                    head = item;
+                }
+            }
+        } else {
+            if (untyped data.hasOwnProperty(key)) {
+                untyped data[key].value = value;
+            } else {
+                var item = {
+                    prev: tail,
+                    key: key,
+                    value: value,
+                    next: null
+                };
+
+                untyped data[key] = item;
+
+                if (tail != null) {
+                    untyped tail.next = item;
+                }
+
+                tail = item;
+
+                if (head == null) {
+                    head = item;
+                }
+            }
+        }
+    }
+
+    public function get(key:String):Null<T> {
+        if (untyped __js__("__map_reserved")[key] != null) {
+            key = "$" + key;
+
+            if (untyped dataReserved.hasOwnProperty(key)) {
+                return untyped dataReserved[key].value;
+            } else {
+                return null;
+            }
+        } else {
+            if (untyped data.hasOwnProperty(key)) {
+                return untyped data[key].value;
+            } else {
+                return null;
+            }
+        }
+    }
+
+    public inline function exists(key:String):Bool {
+        if (untyped __js__("__map_reserved")[key] != null) {
+            return untyped dataReserved.hasOwnProperty("$" + key);
+        } else {
+            return untyped data.hasOwnProperty(key);
+        }
+    }
+
+    public function remove(key:String):Bool {
+        if (untyped __js__("__map_reserved")[key] != null) {
+            key = "$" + key;
+
+            if (untyped !dataReserved.hasOwnProperty(key)) {
+                return false;
+            }
+
+            var item = untyped dataReserved[key];
+            var prev:Dynamic = item.prev;
+            var next:Dynamic = item.next;
+
+            untyped __js__("delete")(dataReserved[key]);
+
+            if (prev != null) {
+                untyped prev.next = next;
+            }
+
+            if (next != null) {
+                untyped next.prev = prev;
+            }
+
+            if (head == item) {
+                head = next;
+            }
+
+            if (tail == item) {
+                tail = prev;
+            }
+
+            item.prev = null;
+            item.next = null;
+
+            return true;
+        } else {
+            if (untyped !data.hasOwnProperty(key)) {
+                return false;
+            }
+
+            var item = untyped data[key];
+            var prev:Dynamic = item.prev;
+            var next:Dynamic = item.next;
+
+            untyped __js__("delete")(data[key]);
+
+            if (prev != null) {
+                untyped prev.next = next;
+            }
+
+            if (next != null) {
+                untyped next.prev = prev;
+            }
+
+            if (head == item) {
+                head = next;
+            }
+
+            if (tail == item) {
+                tail = prev;
+            }
+
+            item.prev = null;
+            item.next = null;
+
+            return true;
+        }
+    }
+
+    public function keys():Iterator<String> {
+        if (head == null) {
+            return untyped emptyIterator;
+        }
+
+        return untyped {
+            _item: head,
+
+            hasNext: function() {
+                return (__this__._item != null);
+            },
+
+            next: function() {
+                var result = __this__._item.key;
+                __this__._item = __this__._item.next;
+                return result;
+            }
+        };
+    }
+
+    public function iterator():Iterator<T> {
+        if (head == null) {
+            return untyped emptyIterator;
+        }
+
+        return untyped {
+            _item: head,
+
+            hasNext: function() {
+                return (__this__._item != null);
+            },
+
+            next: function() {
+                var result = __this__._item.value;
+                __this__._item = __this__._item.next;
+                return result;
+            }
+        };
+    }
+
+    public function toString():String {
+        var s = new StringBuf();
+        s.add("{");
+
+        untyped {
+            var item = head;
+
+            while (item != null) {
+                s.add(item.key);
+                s.add(" => ");
+                s.add(Std.string(item.value));
+
+                item = item.next;
+
+                if (item != null) {
+                    s.add(", ");
+                }
+            }
+        }
+
+        s.add("}");
+        return s.toString();
+    }
+
+    /*
+    public function toDebugString():String {
+        var s = new StringBuf();
+        s.add("{");
+        s.add(" head: ");
+        s.add(head);
+        s.add(", tail: ");
+        s.add(tail);
+        s.add(", data: ");
+        s.add(data);
+        s.add(", dataReserved: ");
+        s.add(dataReserved);
+        s.add(" }");
+        return s.toString();
+    }
+    */
+}
+
+#else
+
+typedef FastIteratingStringMap<T> = haxe.ds.StringMap<T>;
+
+#end


### PR DESCRIPTION
This pull request is not finished, I open it because I want to discuss.

## Short summary

haxe.ds.StringMap for javascript target is really optimized very well. But there is one thing that is inefficient - iterating over keys or values, because it create a new array, push all the keys into it and return an iterator over this array. This means that every call of keys() or iterator() has O(n) complexity (where n is keys count) plus allocates additional memory.

I tested various ideas, but the most efficient was following: keep doubly linked list along with hashmap, where hashmap entries are pointers to objects in linked list. Something like java.util.LinkedHashMap.

## StringMap vs FastIteratingStringMap for js target

 | StringMap | FastIteratingStringMap
----|----|----
set | fast, O(1) | pretty slow, but still O(1)
get | fast, O(1) | slower, O(1)
exists | fast, O(1) | fast, O(1)
remove | fast, O(1) | pretty slow, but still O(1)
keys | very slow, O(n) | fast, O(1)
iterator | very slow, O(n) | fast, O(1)

## Posts with more details

 - part 1: http://blog.zame-dev.org/fast-iterators-for-stringmap/
 - part 2: http://blog.zame-dev.org/fastiteratingstringmap-part-2/
 - latest benchmark: http://blog.zame-dev.org/wp-content/uploads/2015/03/benchmark-v2-full.png

## TODO

 - [ ] Same approach for IntMap
 - [ ] Same approach for ObjectMap

## Discuss

 1. Should it be included in Haxe core, or it should be in external library, and not in core?
 2. Should it replace current StringMap implementation, or it should be in separate class?
 3. FastIteratingStringMap is good name, or rename it to LinkedStringMap or something else?
 4. Should it be in `std/haxe/ds/...` with `#if js` or it should be in `std/js/_std/haxe/...`? Any other placement?
 5. Will flash implementation have some benefits of this approach or not (I already see that flash version are using special SWF opcodes)?