### PR TITLE
Allow UInt to convert to Float

### DIFF
--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -29,7 +29,7 @@
 @:notNull
 @:runtimeValue
 @:analyzer(no_const_propagation)
-abstract UInt to Int from Int
+abstract UInt to Int from Int to Float
 {
 	@:commutative @:op(A+B) private static function addI(lhs:UInt, rhs:Int):UInt;
 	@:commutative @:op(A+B) private static function addF(lhs:UInt, rhs:Float):Float;
@@ -95,7 +95,7 @@ abstract UInt to Int from Int
 	The unsigned Int type is only defined for Flash and C#.
 	Simulate it for other platforms.
 **/
-abstract UInt(Int) from Int to Int {
+abstract UInt(Int) from Int to Int to Float {
 
 	@:op(A + B) private static inline function add(a:UInt, b:UInt):UInt {
 		return a.toInt() + b.toInt();


### PR DESCRIPTION
This is related to https://github.com/HaxeFoundation/haxe/issues/4039

On Neko (if not other targets) there are some issues with UInt, I believe it is because some platforms allow conversion between Int and Float, implicitly, while others might not.

Due to this issue, I needed to change tests in OpenFL to use Int instead of UInt to prevent value wrapping, though that may be an expected/desired behavior

https://github.com/openfl/openfl/commit/7201f37e03f7df7995a68227d5dfaf35579b10ac?w=1