### PR TITLE
Safeguard in reflection not to trigger magic __get in subclasses unintentionally.

### DIFF
--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -398,7 +398,7 @@ function _hx_field($o, $field) {
 							return $o->$field;
 						}
 					}
-				} else if(isset($o->__dynamics[$field])) {
+				} else if(isset($o->__dynamics) && isset($o->__dynamics[$field])) {
 					return $o->__dynamics[$field];
 				} else {
 					return array($o, $field);


### PR DESCRIPTION
The current method to check for the existence of dynamic fields:

    isset($o->__dynamics[$field])

will (unintentionally) trigger the magic __get method if it is defined on the object. Objects translated from Haxe do not currently contain this magic, but classes extending them can. I added an extra check:

    isset($o->__dynamics)

before the above to make sure magic won't be activated during this call.

Background: it might seem like an edge case, but I'm encountering this problem in a very real situation. I'm using Haxe objects as model classes in a multi-platform application. On the PHP-side Doctrine is managing these objects. Doctrine's lazy loading functionality is implemented with proxy classes, which extend the model classes (which are the ones compiled from Haxe in my case). The proxy classes use __get magic and fail on properties which are not part of the.

An other solution could be to add an empty `$__dynamics` to all PHP classes, but I believe you had a reason not having done so already.