### PR TITLE
Better support for BaseCode on the interpreter

### DIFF
--- a/std/haxe/crypto/BaseCode.hx
+++ b/std/haxe/crypto/BaseCode.hx
@@ -42,7 +42,7 @@ class BaseCode {
 	}
 
 	public function encodeBytes( b : haxe.io.Bytes ) : haxe.io.Bytes {
-		#if neko
+		#if (neko && !interp)
 		return haxe.io.Bytes.ofData( base_encode(b.getData(),base.getData()) );
 		#else
 		var nbits = this.nbits;
@@ -79,7 +79,7 @@ class BaseCode {
 	}
 
 	public function decodeBytes( b : haxe.io.Bytes ) : haxe.io.Bytes {
-		#if neko
+		#if (neko && !interp)
 		return haxe.io.Bytes.ofData( base_decode(b.getData(),base.getData()) );
 		#else
 		var nbits = this.nbits;
@@ -109,7 +109,7 @@ class BaseCode {
 	}
 
 	public function encodeString( s : String ) {
-		#if neko
+		#if (neko && !interp)
 		return neko.NativeString.toString( base_encode(neko.NativeString.ofString(s),base.getData()) );
 		#else
 		return encodeBytes(haxe.io.Bytes.ofString(s)).toString();
@@ -117,7 +117,7 @@ class BaseCode {
 	}
 
 	public function decodeString( s : String ) {
-		#if neko
+		#if (neko && !interp)
 		return neko.NativeString.toString( base_decode(neko.NativeString.ofString(s),base.getData()) );
 		#else
 		return decodeBytes(haxe.io.Bytes.ofString(s)).toString();

--- a/tests/unit/src/unit/TestMisc.hx
+++ b/tests/unit/src/unit/TestMisc.hx
@@ -309,9 +309,15 @@ class TestMisc extends Test {
 	}
 
 	function testBaseCode() {
+		// alternative base64
 		var b = new haxe.crypto.BaseCode(haxe.io.Bytes.ofString("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_-"));
 		eq( b.encodeString("Héllow"), "iceFr6NLtM" );
 		eq( b.decodeString("iceFr6NLtM"), "Héllow" );
+
+		// base32-hex
+		var b = new haxe.crypto.BaseCode(haxe.io.Bytes.ofString("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
+		eq( b.encodeString("foo"), "CPNMU" );
+		eq( b.decodeString("CPNMU"), "foo" );
 	}
 
 	function testUrlEncode() {


### PR DESCRIPTION
For now, don't use the base_encode and base_decode primitives in interp;
they have only been implemented to handle hex and base64 variants.

Instead, use the cross-platform encoding/decoding methods written in
Haxe.