### PR TITLE
fix for `Array` slipping through `__nativeClassName`

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -231,7 +231,7 @@ class Boot {
 		var name = untyped __toStr.call(o).slice(8, -1);
 		// exclude general Object and Function
 		// also exclude Math and JSON, because instanceof cannot be called on them
-		if (name == "Object" || name == "Function" || name == "Math" || name == "JSON")
+		if (name == "Object" || name == "Function" || name == "Math" || name == "JSON" || name == "Array")
 			return null;
 		return name;
 	}


### PR DESCRIPTION
should fix `EnumValue` problem in #4079.