### PR TITLE
Use flash.Vector.ofArray in haxe.ds.Vector only for flash10.

### DIFF
--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -205,7 +205,7 @@ abstract Vector<T>(VectorData<T>) {
 	static public inline function fromArrayCopy<T>(array:Array<T>):Vector<T> {
 		#if python
 		return cast array.copy();
-		#elseif flash
+		#elseif flash10
 		return fromData(flash.Vector.ofArray(array));
 		#elseif java
 		return fromData(java.Lib.nativeArray(array,false));


### PR DESCRIPTION
As it is, it causes a compiler error for flash9