### PR TITLE
Fix js parseint

### DIFF
--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -43,7 +43,7 @@ import js.Boot;
 	public static function parseInt( x : String ) : Null<Int> {
 		var v = untyped __js__("parseInt")(x, 10);
 		// parse again if hexadecimal
-		if( v == 0 && (x.charCodeAt(1) == 'x'.code || x.charCodeAt(1) == 'X'.code) )
+		if( v == 0 && x.length > 1 && (x.charCodeAt(1) == 'x'.code || x.charCodeAt(1) == 'X'.code) )
 			v = untyped __js__("parseInt")(x);
 		if( untyped __js__("isNaN")(v) )
 			return null;


### PR DESCRIPTION
Fixes a bug where if a string is of length 1 and contains 'x' as its first character, charCodeAt of an invalid index would be called.
