### PR TITLE
Fixed `make ADD_REVISION=1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,6 @@ else
 	export HAXE_STD_PATH=$(CURDIR)/std
 endif
 
-ifneq ($(ADD_REVISION),0)
-	VERSION_EXTRA="let version_extra = Some \"(git build $(shell git rev-parse --abbrev-ref HEAD) @ $(shell git rev-parse --short HEAD))\""
-else
-	VERSION_EXTRA="let version_extra = None"
-endif
-
 all: libs haxe
 
 libs:
@@ -176,7 +170,7 @@ lexer.$(MODULE_EXT): ast.$(MODULE_EXT)
 ast.$(MODULE_EXT):
 
 version.$(MODULE_EXT):
-	echo $(VERSION_EXTRA) > version.ml
+	$(MAKE) -f Makefile.version_extra -s ADD_REVISION=$(ADD_REVISION) > version.ml
 	$(COMPILER) $(CFLAGS) -c version.ml
 
 # Clean

--- a/Makefile.version_extra
+++ b/Makefile.version_extra
@@ -1,0 +1,11 @@
+# A hack to print the content of version.ml consistently across Windows (cygwin / command prompt) and Unix.
+# The hack: http://stackoverflow.com/a/7284135/267998
+# The issue: https://github.com/HaxeFoundation/haxe/commit/4f8f6a99ddf810ea045492cdd6d40c55abc03e15#commitcomment-10660400
+
+all: ;
+
+ifneq ($(ADD_REVISION),0)
+	$(info let version_extra = Some "(git build $(shell git rev-parse --abbrev-ref HEAD) @ $(shell git rev-parse --short HEAD))")
+else
+	$(info let version_extra = None)
+endif

--- a/Makefile.win
+++ b/Makefile.win
@@ -5,12 +5,6 @@ EXTENSION=.exe
 
 OCAMLOPT=ocamlopt.opt
 
-ifneq ($(ADD_REVISION),0)
-	VERSION_EXTRA=let version_extra = Some " (git build $(shell git rev-parse --abbrev-ref HEAD) @ $(shell git describe --always)) "
-else
-	VERSION_EXTRA=let version_extra = None
-endif
-
 kill:
 	-@taskkill /F /IM haxe.exe
 


### PR DESCRIPTION
I tested in my machines, including Windows (cygwin and command prompt) and Mac.
@Simn would you check whether it works for you?