### PR TITLE
Update Printer.hx

### DIFF
--- a/std/haxe/xml/Printer.hx
+++ b/std/haxe/xml/Printer.hx
@@ -103,7 +103,7 @@ class Printer {
 
 	inline function newline() {
 		if (pretty) {
-			output.add("");
+			output.add("\n");
 		}
 	}
 


### PR DESCRIPTION
The newline() function in xml printer wasn't actually adding any newlines. Without this, Printer.print(someXml,true) inserts tabs, but not newlines. This makes the output correct.