### PR TITLE
Explicitly use InvariantCulture when parsing floats in C# to avoid sy…

### DIFF
--- a/std/cs/_std/Std.hx
+++ b/std/cs/_std/Std.hx
@@ -173,7 +173,7 @@ import cs.internal.Exceptions;
 			x = x.substr(0,i);
 		}
 		return try
-			cs.system.Double.Parse(x, (null : cs.system.IFormatProvider))
+			cs.system.Double.Parse(x, cs.system.globalization.CultureInfo.InvariantCulture)
 		catch(e:Dynamic)
 			Math.NaN;
 	}


### PR DESCRIPTION
…stem/language specific parsing.