### PR TITLE
Clearer description for Context.unify()

### DIFF
--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -378,7 +378,7 @@ class Context {
 	}
 
 	/**
-		Returns true if `t1` and `t2` unify, false otherwise.
+		Tries to unify `t1` and `t2` and returns `true` if successful.
 	**/
 	public static function unify( t1 : Type, t2 : Type) : Bool {
 		return load("unify", 2)(t1, t2);


### PR DESCRIPTION
The previous wording didn't make it clear enough that the function actually tries to unify the types. It could be mistaken as just performing a check without side-effects.