### PR TITLE
Use abstract instead of typedef for `Null<T>`

### DIFF
--- a/codegen.ml
+++ b/codegen.ml
@@ -1634,13 +1634,13 @@ struct
 			t
 		| TInst _ | TEnum _ ->
 			t
-		| TAbstract(a,tl) -> simplify_t (Abstract.get_underlying_type a tl)
-		| TType(({ t_path = [],"Null" } as t), [t2]) -> (match simplify_t t2 with
+		| TAbstract(({ a_path = [],"Null" } as t), [t2]) -> (match simplify_t t2 with
 			| (TAbstract(a,_) as t2) when Meta.has Meta.CoreType a.a_meta ->
-				TType(t, [simplify_t t2])
+				TAbstract(t, [simplify_t t2])
 			| (TEnum _ as t2) ->
-				TType(t, [simplify_t t2])
+				TAbstract(t, [simplify_t t2])
 			| t2 -> t2)
+		| TAbstract(a,tl) -> simplify_t (Abstract.get_underlying_type a tl)
 		| TType(t, tl) ->
 			simplify_t (apply_params t.t_params tl t.t_type)
 		| TMono r -> (match !r with
@@ -1708,6 +1708,12 @@ struct
 			(cacc + 2, 0) (* a dynamic to a basic type will have an "unboxing" penalty *)
 		| _, TDynamic _ ->
 			(cacc + 1, 0)
+		| TAbstract({ a_path = [], "Null" }, [tf]), TAbstract({ a_path = [], "Null" }, [ta]) ->
+			rate_conv (cacc+0) tf ta
+		| TAbstract({ a_path = [], "Null" }, [tf]), ta ->
+			rate_conv (cacc+1) tf ta
+		| tf, TAbstract({ a_path = [], "Null" }, [ta]) ->
+			rate_conv (cacc+1) tf ta
 		| TAbstract(af,tlf), TAbstract(aa,tla) ->
 			(if af == aa then
 				(cacc, rate_tp tlf tla)
@@ -1730,12 +1736,6 @@ struct
 					Option.get !ret
 			else
 				raise Not_found)
-		| TType({ t_path = [], "Null" }, [tf]), TType({ t_path = [], "Null" }, [ta]) ->
-			rate_conv (cacc+0) tf ta
-		| TType({ t_path = [], "Null" }, [tf]), ta ->
-			rate_conv (cacc+1) tf ta
-		| tf, TType({ t_path = [], "Null" }, [ta]) ->
-			rate_conv (cacc+1) tf ta
 		| TFun _, TFun _ -> (* unify will make sure they are compatible *)
 			cacc,0
 		| tfun,targ ->
@@ -1784,7 +1784,8 @@ struct
 			(* convert compatible into ( rate * compatible_type ) list *)
 			let rec mk_rate acc elist args = match elist, args with
 				| [], [] -> acc
-				| (_,true) :: elist, _ :: args -> mk_rate acc elist args
+				| (e,true) :: elist, _ :: args ->
+					mk_rate acc elist args
 				| (e,false) :: elist, (n,o,t) :: args ->
 					(* if the argument is an implicit cast, we need to start with a penalty *)
 					(* The penalty should be higher than any other implicit cast - other than Dynamic *)

--- a/gencs.ml
+++ b/gencs.ml
@@ -141,7 +141,7 @@ let is_pointer gen t =
 let rec is_null t =
 	match t with
 		| TInst( { cl_path = (["haxe"; "lang"], "Null") }, _ )
-		| TType( { t_path = ([], "Null") }, _ ) -> true
+		| TAbstract( { a_path = ([], "Null") }, _ ) -> true
 		| TType( t, tl ) -> is_null (apply_params t.t_params tl t.t_type)
 		| TMono r ->
 			(match !r with
@@ -826,8 +826,8 @@ let configure gen =
 			| TAbstract ({ a_path = ["cs"],"Out" },_)
 			| TType ({ t_path = [],"Single" },[])
 			| TAbstract ({ a_path = [],"Single" },[]) -> Some t
-			| TType (({ t_path = [],"Null" } as tdef),[t2]) ->
-					Some (TType(tdef,[follow (gen.gfollow#run_f t2)]))
+			| TAbstract (({ a_path = [],"Null" } as tdef),[t2]) ->
+					Some (TAbstract(tdef,[follow (gen.gfollow#run_f t2)]))
 			| TAbstract({ a_path = ["cs"],"PointerAccess" },[t]) ->
 					Some (TAbstract(ptr,[t]))
 			| TAbstract (a, pl) when not (Meta.has Meta.CoreType a.a_meta) ->
@@ -867,6 +867,23 @@ let configure gen =
 	let rec real_type t =
 		let t = gen.gfollow#run_f t in
 		let ret = match t with
+			| TAbstract({ a_path = ([], "Null") }, [t]) ->
+				(*
+					Null<> handling is a little tricky.
+					It will only change to haxe.lang.Null<> when the actual type is non-nullable or a type parameter
+					It works on cases such as Hash<T> returning Null<T> since cast_detect will invoke real_type at the original type,
+					Null<T>, which will then return the type haxe.lang.Null<>
+				*)
+				if erase_generics then
+					if is_cs_basic_type t then
+						t_dynamic
+					else
+						real_type t
+				else
+					(match real_type t with
+						| TInst( { cl_kind = KTypeParameter _ }, _ ) -> TInst(null_t, [t])
+						| _ when is_cs_basic_type t -> TInst(null_t, [t])
+						| _ -> real_type t)
 			| TAbstract (a, pl) when not (Meta.has Meta.CoreType a.a_meta) ->
 				real_type (Abstract.get_underlying_type a pl)
 			| TAbstract ({ a_path = (["cs";"_Flags"], "EnumUnderlying") }, [t]) ->
@@ -894,23 +911,6 @@ let configure gen =
 			| TInst(cl, params) when Meta.has Meta.Enum cl.cl_meta ->
 				TInst(cl, List.map (fun _ -> t_dynamic) params)
 			| TInst(cl, params) -> TInst(cl, change_param_type (TClassDecl cl) params)
-			| TType({ t_path = ([], "Null") }, [t]) ->
-				(*
-					Null<> handling is a little tricky.
-					It will only change to haxe.lang.Null<> when the actual type is non-nullable or a type parameter
-					It works on cases such as Hash<T> returning Null<T> since cast_detect will invoke real_type at the original type,
-					Null<T>, which will then return the type haxe.lang.Null<>
-				*)
-				if erase_generics then
-					if is_cs_basic_type t then
-						t_dynamic
-					else
-						real_type t
-				else
-					(match real_type t with
-						| TInst( { cl_kind = KTypeParameter _ }, _ ) -> TInst(null_t, [t])
-						| _ when is_cs_basic_type t -> TInst(null_t, [t])
-						| _ -> real_type t)
 			| TAbstract _
 			| TType _ -> t
 			| TAnon (anon) when (match !(anon.a_status) with | Statics _ | EnumStatics _ | AbstractStatics _ -> true | _ -> false) -> t
@@ -2969,7 +2969,7 @@ let configure gen =
 	in
 
 	let may_nullable t = match gen.gfollow#run_f t with
-		| TType({ t_path = ([], "Null") }, [t]) ->
+		| TAbstract({ a_path = ([], "Null") }, [t]) ->
 			(match follow t with
 				| TInst({ cl_path = ([], "String") }, [])
 				| TAbstract ({ a_path = ([], "Float") },[])

--- a/genphp.ml
+++ b/genphp.ml
@@ -110,18 +110,15 @@ and type_string_suff suffix haxe_type =
 	| TAbstract ({ a_path = [],"Void" },[]) -> "Void"
 	| TEnum (enum,params) ->  (join_class_path enum.e_path "::") ^ suffix
 	| TInst (klass,params) ->  (class_string klass suffix params)
+	| TAbstract ({a_path = [],"Null"},[t]) ->
+		(match follow t with
+		| TInst ({ cl_path = [],"Int" },_)
+		| TInst ({ cl_path = [],"Float" },_)
+		| TEnum ({ e_path = [],"Bool" },_) -> "Dynamic"
+		| _ -> type_string_suff suffix t)
 	| TAbstract (abs,params) ->  (join_class_path abs.a_path "::") ^ suffix
 	| TType (type_def,params) ->
 		(match type_def.t_path with
-		| [] , "Null" ->
-			(match params with
-			| [t] ->
-				(match follow t with
-				| TInst ({ cl_path = [],"Int" },_)
-				| TInst ({ cl_path = [],"Float" },_)
-				| TEnum ({ e_path = [],"Bool" },_) -> "Dynamic"
-				| _ -> type_string_suff suffix t)
-			| _ -> assert false);
 		| [] , "Array" ->
 			(match params with
 			| [t] -> "Array<" ^ (type_string (follow t) ) ^ " >"

--- a/genswf9.ml
+++ b/genswf9.ml
@@ -188,7 +188,7 @@ let rec follow_basic t =
 		| _ -> t)
 	| TLazy f ->
 		follow_basic (!f())
-	| TType ({ t_path = [],"Null" },[tp]) ->
+	| TAbstract ({ a_path = [],"Null" },[tp]) ->
 		(match follow_basic tp with
 		| TMono _
 		| TFun _
@@ -226,7 +226,7 @@ let rec type_id ctx t =
 			type_id ctx (TInst (c,params))
 		| _ ->
 			type_path ctx c.cl_path)
-	| TAbstract (a,_) ->
+	| TAbstract (a,_) when Meta.has Meta.CoreType a.a_meta ->
 		type_path ctx a.a_path
 	| TFun _ | TType ({ t_path = ["flash";"utils"],"Function" },[]) ->
 		type_path ctx ([],"Function")

--- a/genxml.ml
+++ b/genxml.ml
@@ -74,8 +74,8 @@ let rec follow_param t =
 		(match !r with
 		| Some t -> follow_param t
 		| _ -> t)
-	| TType ({ t_path = [],"Null" } as t,tl) ->
-		follow_param (apply_params t.t_params tl t.t_type)
+	| TAbstract ({ a_path = [],"Null" } as t,tl) ->
+		follow_param (apply_params t.a_params tl t.a_this)
 	| _ ->
 		t
 
@@ -355,7 +355,7 @@ let generate_type com t =
 			| Some t -> notnull t)
 		| TLazy f ->
 			notnull ((!f)())
-		| TType ({ t_path = [],"Null" },[t]) ->
+		| TAbstract ({ a_path = [],"Null" },[t]) ->
 			t
 		| _ ->
 			t

--- a/interp.ml
+++ b/interp.ml
@@ -2586,6 +2586,8 @@ let macro_lib =
 					(match !r with
 					| None -> t
 					| Some t -> t)
+				| TAbstract({a_path = [],"Null"},[t]) ->
+					t
 				| TAbstract _ | TEnum _ | TInst _ | TFun _ | TAnon _ | TDynamic _ ->
 					t
 				| TType (t,tl) ->

--- a/matcher.ml
+++ b/matcher.ml
@@ -299,7 +299,7 @@ let rec is_value_type = function
 let rec matches_null ctx t = match t with
 	| TMono r ->
 		(match !r with None -> r := Some (ctx.t.tnull (mk_mono())); true | Some t -> matches_null ctx t)
-	| TType ({ t_path = ([],"Null") },[_]) ->
+	| TAbstract ({ a_path = ([],"Null") },[_]) ->
 		true
 	| TLazy f ->
 		matches_null ctx (!f())
@@ -1072,8 +1072,8 @@ let convert_switch mctx st cases loop =
 	| None ->
 		dt
 	| Some dt_null ->
-		let t = match ctx.t.tnull ctx.t.tint with
-			| TType(t,_) ->TType(t,[st.st_type])
+		let t = match ctx.t.tnull st.st_type with
+			| TAbstract(a,_) -> TAbstract(a,[st.st_type])
 			| t -> t
 		in
 		let e_null = mk (TConst TNull) t p in

--- a/std/StdTypes.hx
+++ b/std/StdTypes.hx
@@ -52,7 +52,9 @@
 	generator to distinguish between base values that can be null and others that
 	can't.
 **/
-typedef Null<T> = T
+@:forward
+@:callable
+abstract Null<T>(T) from T to T { }
 
 /**
 	The standard Boolean type, which can either be true or false.

--- a/std/sys/db/RecordMacros.hx
+++ b/std/sys/db/RecordMacros.hx
@@ -163,7 +163,10 @@ class RecordMacros {
 					return c;
 				csup = csup.t.get().superClass;
 			}
-		case TType(t, p):
+		case TType(t,[p]) if(t.toString() == "sys.db.SNull"):
+			isNull = true;
+			return makeRecord(p);
+		case TAbstract(t, p):
 			var name = t.toString();
 			if( p.length == 1 && (name == "Null" || name == "sys.db.SNull") ) {
 				isNull = true;
@@ -211,6 +214,7 @@ class RecordMacros {
 			case "Int": DInt;
 			case "Float": DFloat;
 			case "Bool": DBool;
+			case "Null": isNull = true; return makeType(p[0]);
 			case _ if (!a.get().meta.has(':coreType')):
 				var a = a.get();
 #if macro

--- a/typeload.ml
+++ b/typeload.ml
@@ -797,8 +797,8 @@ let same_overload_args ?(get_vmtype) t1 t2 f1 f2 =
 			| _ -> t)
 		| TLazy f ->
 			follow_skip_null (!f())
-		| TType ({ t_path = [],"Null" } as t, [p]) ->
-			TType(t,[follow p])
+		| TAbstract ({ a_path = [],"Null" } as t, [p]) ->
+			TAbstract(t,[follow p])
 		| TType (t,tl) ->
 			follow_skip_null (apply_params t.t_params tl t.t_type)
 		| _ -> t


### PR DESCRIPTION
For the most part this changes some TType to TAbstract and moves match cases around where necessary. There are a few special cases in type.ml to retain the current behavior and not break anything.

The idea is this:
1. Merge this and stabilize it (now).
2. Add a compiler flag to remove the `to T` from `Null<T>` and provide some sort of `.force():T` field (for 3.3.0).
3. Get rid of the special cases that allow e.g. variance of `Array<Int>` and `Array<Null<Int>>` (for Haxe 4.0.0).

This PR might break macros that check for TType("Null") right now. However, we have plenty of time to communicate that before the next release so it shouldn't be a problem.

@ncannasse: If you have any reservations about doing this please speak up now. I would like to merge this really soon because it's quite merge-conflict-vulnerable.