### PR TITLE
Remove python/_std documentation

### DIFF
--- a/std/python/_std/EReg.hx
+++ b/std/python/_std/EReg.hx
@@ -26,15 +26,6 @@ import python.lib.Re.Pattern;
 
 @:coreApi
 class EReg {
-
-	/**
-		Creates a new regular expression with pattern `r` and modifiers `opt`.
-
-		This is equivalent to the shorthand syntax `~/r/opt`
-
-		If `r` or `opt` are null, the result is unspecified.
-	**/
-
 	var pattern:Regex;
 	var matchObj:MatchObject;
 	var global:Bool;
@@ -53,89 +44,27 @@ class EReg {
 		pattern = Re.compile(r, options);
 	}
 
-	/**
-		Tells if `this` regular expression matches String `s`.
-
-		This method modifies the internal state.
-
-		If `s` is `null`, the result is unspecified.
-	**/
 	public inline function match( s : String ) : Bool {
 		matchObj = Re.search(pattern, s);
 		return matchObj != null;
 	}
 
-	/**
-		Returns the matched sub-group `n` of `this` EReg.
-
-		This method should only be called after `this.match` or
-		`this.matchSub`, and then operates on the String of that operation.
-
-		The index `n` corresponds to the n-th set of parentheses in the pattern
-		of `this` EReg. If no such sub-group exists, an exception is thrown.
-
-		If `n` equals 0, the whole matched substring is returned.
-	**/
 	public inline function matched( n : Int ) : String {
 		return matchObj.group(n);
 	}
 
-	/**
-		Returns the part to the left of the last matched substring.
-
-		If the most recent call to `this.match` or `this.matchSub` did not
-		match anything, the result is unspecified.
-
-		If the global g modifier was in place for the matching, only the
-		substring to the left of the leftmost match is returned.
-
-		The result does not include the matched part.
-	**/
 	public inline function matchedLeft() : String {
 		return matchObj.string.substr(0, matchObj.start());
 	}
 
-	/**
-		Returns the part to the right of the last matched substring.
-
-		If the most recent call to `this.match` or `this.matchSub` did not
-		match anything, the result is unspecified.
-
-		If the global g modifier was in place for the matching, only the
-		substring to the right of the leftmost match is returned.
-
-		The result does not include the matched part.
-	**/
 	public inline function matchedRight() : String {
 		return matchObj.string.substr(matchObj.end());
 	}
 
-	/**
-		Returns the position and length of the last matched substring, within
-		the String which was last used as argument to `this.match` or
-		`this.matchSub`.
-
-		If the most recent call to `this.match` or `this.matchSub` did not
-		match anything, the result is unspecified.
-
-		If the global g modifier was in place for the matching, the position and
-		length of the leftmost substring is returned.
-	**/
 	public inline function matchedPos() : { pos : Int, len : Int } {
 		return { pos : matchObj.start(), len : matchObj.end() - matchObj.start() };
 	}
 
-	/**
-		Tells if `this` regular expression matches a substring of String `s`.
-
-		This function expects `pos` and `len` to describe a valid substring of
-		`s`, or else the result is unspecified. To get more robust behavior,
-		`this.matchSub(s.substr(pos,len))` can be used instead.
-
-		This method modifies the internal state.
-
-		If `s` is null, the result is unspecified.
-	**/
 	public function matchSub( s : String, pos : Int, len : Int = -1):Bool {
 		if (len != -1) {
 			matchObj = pattern.search(s, pos, pos+len);
@@ -147,24 +76,6 @@ class EReg {
 
 	}
 
-	/**
-		Splits String `s` at all substrings `this` EReg matches.
-
-		If a match is found at the start of `s`, the result contains a leading
-		empty String "" entry.
-
-		If a match is found at the end of `s`, the result contains a trailing
-		empty String "" entry.
-
-		If two matching substrings appear next to each other, the result
-		contains the empty String "" between them.
-
-		By default, this method splits `s` into two parts at the first matched
-		substring. If the global g modifier is in place, `s` is split at each
-		matched substring.
-
-		If `s` is null, the result is unspecified.
-	**/
 	public function split( s : String ) : Array<String> {
 		return if (global) {
 			var ret = [];
@@ -188,20 +99,6 @@ class EReg {
 		}
 	}
 
-	/**
-		Replaces the first substring of `s` which `this` EReg matches with `by`.
-
-		If `this` EReg does not match any substring, the result is `s`.
-
-		By default, this method replaces only the first matched substring. If
-		the global g modifier is in place, all matched substrings are replaced.
-
-		If `by` contains `$1` to `$9`, the digit corresponds to number of a
-		matched sub-group and its value is used instead. If no such sub-group
-		exists, the replacement is unspecified. The string `$$` becomes `$`.
-
-		If `s` or `by` are null, the result is unspecified.
-	**/
 	public function replace( s : String, by : String ) : String
 	{
 		var by = by.split("$$").join("_hx_#repl#__");
@@ -218,11 +115,6 @@ class EReg {
 		return Re.sub(pattern, replace, s, global ? 0 : 1 );
 	}
 
-	/**
-		For each occurence of the pattern in the string `s`, the function `f` is called and
-		can return the string that needs to be replaced. All occurences are matched anyway,
-		and setting the `g` flag might cause some incorrect behavior on some platforms.
-	**/
 	public function map( s : String, f : EReg -> String ) : String {
 
 		var buf = new StringBuf();

--- a/std/python/_std/String.hx
+++ b/std/python/_std/String.hx
@@ -19,175 +19,57 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-/**
-	The basic String class.
-
-	A haxe String is immutable, it is not possible to modify individual
-	characters. No method of this class changes the state of [this] String.
-
-	Strings can be constructed using the string literal syntax "string value".
-
-	String can be concatenated by using the + operator. If an operand is not a
-	String, it is passed through Std.string() first.
-**/
 #if !macro
 import python.internal.StringImpl;
 #end
 @:coreApi
 @:native("str")
 extern class String {
-	/**
-		The number of characters in [this] String.
-	**/
 	var length(default,null) : Int;
-
-	/**
-		Creates a copy from a given String.
-	**/
+	
 	function new(string:String) : Void;
-
-	/**
-		Returns a String where all characters of [this] String are upper case.
-
-		Affects the characters [a-z]. Other characters remain unchanged.
-	**/
+	
 	@:runtime public inline function toUpperCase() : String {
 		return StringImpl.toUpperCase(this);
 	}
 
-	/**
-		Returns a String where all characters of [this] String are lower case.
-
-		Affects the characters [A-Z]. Other characters remain unchanged.
-	**/
 	@:runtime public inline function toLowerCase() : String {
 		return StringImpl.toLowerCase(this);
 	}
 
-	/**
-		Returns the character at position [index] of [this] String.
-
-		If [index] is negative or exceeds [this].length, the empty String ""
-		is returned.
-	**/
 	inline public function charAt(index : Int) : String
 	{
 		return StringImpl.charAt(this, index);
 	}
 
-	/**
-		Returns the character code at position [index] of [this] String.
-
-		If [index] is negative or exceeds [this].length, null is returned.
-
-		To obtain the character code of a single character, "x".code can be used
-		instead to inline the character code at compile time. Note that this
-		only works on String literals of length 1.
-	**/
 	inline public function charCodeAt( index : Int) : Null<Int>
 	{
 		return StringImpl.charCodeAt(this, index);
 	}
 
-	/**
-		Returns the position of the leftmost occurence of [str] within [this]
-		String.
-
-		If [startIndex] is given, the search is performed within the substring
-		of [this] String starting from [startIndex]. Otherwise the search is
-		performed within [this] String. In either case, the returned position
-		is relative to the beginning of [this] String.
-
-		If [str] cannot be found, -1 is returned.
-	**/
 	inline function indexOf( str : String, ?startIndex : Int ) : Int {
 		return StringImpl.indexOf(this, str, startIndex);
 	}
 
-	/**
-		Returns the position of the rightmost occurence of [str] within [this]
-		String.
-
-		If [startIndex] is given, the search is performed within the substring
-		of [this] String from 0 to [startIndex]. Otherwise the search is
-		performed within [this] String. In either case, the returned position
-		is relative to the beginning of [this] String.
-
-		If [str] cannot be found, -1 is returned.
-	**/
 	inline function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		return StringImpl.lastIndexOf(this, str, startIndex);
 	}
 
-	/**
-		Splits [this] String at each occurence of [delimiter].
-
-		If [delimiter] is the empty String "", [this] String is split into an
-		Array of [this].length elements, where the elements correspond to the
-		characters of [this] String.
-
-		If [delimiter] is not found within [this] String, the result is an Array
-		with one element, which equals [this] String.
-
-		If [delimiter] is null, the result is unspecified.
-
-		Otherwise, [this] String is split into parts at each occurence of
-		[delimiter]. If [this] String starts (or ends) with [delimiter}, the
-		result Array contains a leading (or trailing) empty String "" element.
-		Two subsequent delimiters also result in an empty String "" element.
-	**/
 	inline function split( delimiter : String ) : Array<String> {
 		return StringImpl.split(this, delimiter);
 	}
 
-	/**
-		Returns [len] characters of [this] String, starting at position [pos].
-
-		If [len] is omitted, all characters from position [pos] to the end of
-		[this] String are included.
-
-		If [pos] is negative, its value is calculated from the end of [this]
-		String by [this].length + [pos]. If this yields a negative value, 0 is
-		used instead.
-
-		If the calculated position + [len] exceeds [this].length, the characters
-		from that position to the end of [this] String are returned.
-
-		If [len] is negative, the result is unspecified.
-	**/
 	inline public function substr( pos : Int, ?len : Int ) : String
 	{
 		return StringImpl.substr(this, pos, len);
 	}
 
-	/**
-		Returns the part of [this] String from [startIndex] to [endIndex].
-
-		If [startIndex] or [endIndex] are negative, 0 is used instead.
-
-		If [startIndex] exceeds [endIndex], they are swapped.
-
-		If the (possibly swapped) [endIndex] is omitted or exceeds
-		[this].length, [this].length is used instead.
-
-		If the (possibly swapped) [startIndex] exceeds [this].length, the empty
-		String "" is returned.
-	**/
 	inline function substring( startIndex : Int, ?endIndex : Int ) : String {
 		return StringImpl.substring(this, startIndex, endIndex);
 	}
 
-	/**
-		Returns the String itself.
-	**/
 	inline function toString() : String return StringImpl.toString(this);
 
-	/**
-		Returns the String corresponding to the character code [code].
-
-		If [code] is negative or has another invalid value, the result is
-		unspecified.
-	**/
 	public static inline function fromCharCode( code : Int ) : String {
 		return StringImpl.fromCharCode(code);
 	}

--- a/std/python/_std/StringBuf.hx
+++ b/std/python/_std/StringBuf.hx
@@ -23,27 +23,8 @@
 import python.lib.io.IOBase.SeekSet;
 import python.lib.io.StringIO;
 
-
-/**
-	A String buffer is an efficient way to build a big string by appending small
-	elements together.
-
-	Its cross-platform implementation uses String concatenation internally, but
-	StringBuf may be optimized for different targets.
-
-	Unlike String, an instance of StringBuf is not immutable in the sense that
-	it can be passed as argument to functions which modify it by appending more
-	values. However, the internal buffer cannot be modified.
-**/
-
 @:coreApi
 class StringBuf {
-
-	/**
-		Creates a new StringBuf instance.
-
-		This may involve initialization of the internal buffer.
-	**/
 
 	private var b : StringIO;
 
@@ -61,15 +42,6 @@ class StringBuf {
 		return len;
 	}
 
-	/**
-		Appends the representation of [x] to [this] StringBuf.
-
-		The exact representation of [x] may vary per platform. To get more
-		consistent behavior, this function should be called with
-		Std.string(x).
-
-		If [x] is null, the String "null" is appended.
-	**/
 	public inline function add<T>( x : T ) : Void {
 		add1(Std.string(x));
 	}
@@ -78,37 +50,14 @@ class StringBuf {
 		b.write(s);
 	}
 
-	/**
-		Appends the character identified by [c] to [this] StringBuf.
-
-		If [c] is negative or has another invalid value, the result is
-		unspecified.
-	**/
 	public inline function addChar( c : Int ) : Void {
 		add1(String.fromCharCode(c));
 	}
 
-	/**
-		Appends a substring of [s] to [this] StringBuf.
-
-		This function expects [pos] and [len] to describe a valid substring of
-		[s], or else the result is unspecified. To get more robust behavior,
-		[this].add(s.substr(pos,len)) can be used instead.
-
-		If [s] or [pos] are null, the result is unspecified.
-
-		If [len] is omitted or null, the substring ranges from [pos] to the end
-		of [s].
-	**/
 	public inline function addSub( s : String, pos : Int, ?len : Int) : Void {
 		add1((len == null ? s.substr(pos) : s.substr(pos, len)));
 	}
 
-	/**
-		Returns the content of [this] StringBuf as String.
-
-		The buffer is not emptied by this operation.
-	**/
 	public inline function toString() : String {
 		return b.getvalue();
 	}

--- a/std/python/_std/sys/io/File.hx
+++ b/std/python/_std/sys/io/File.hx
@@ -24,11 +24,6 @@ package sys.io;
 import python.io.IoTools;
 import sys.io.FileInput;
 
-/**
-	API for reading and writing to files.
-
-	See `sys.FileSystem` for the complementary file system API.
-**/
 @:coreApi
 class File {
 

--- a/std/python/_std/sys/net/Host.hx
+++ b/std/python/_std/sys/net/Host.hx
@@ -21,44 +21,24 @@
  */
 package sys.net;
 
-/**
-	A given IP host name.
-**/
 class Host {
-
-	/**
-		The actual IP corresponding to the host.
-	**/
 	public var ip(default,null) : Int;
 
-	/**
-		Creates a new Host : the name can be an IP in the form "127.0.0.1" or an host name such as "google.com", in which case
-		the corresponding IP address is resolved using DNS. An exception occur if the host name could not be found.
-	**/
-    var name:String;
+	var name:String;
+	
 	public function new( name : String ) : Void {
-        this.name = name;
-    }
+		this.name = name;
+    	}
 
-	/**
-		Returns the IP representation of the host
-	**/
 	public function toString() : String {
-        return name;
-    }
-
-	/**
-		Perform a reverse-DNS query to resolve a host name from an IP.
-	**/
+		return name;
+	}
+    
 	public function reverse() : String {
-        return "";
-    }
-
-	/**
-		Returns the local computer host name
-	**/
+        	return "";
+    	}
+    
 	public static function localhost() : String {
-        return "";
-    }
-
+        	return "";
+    	}
 }


### PR DESCRIPTION
None of these target-specific classes should have documentation.

It adds double fields to the API documentation, see for example http://api.haxe.org/String.html#split