### PR TITLE
Allow extern to have field name that is used for both static and instance

### DIFF
--- a/typeload.ml
+++ b/typeload.ml
@@ -2707,7 +2707,7 @@ module ClassInitializer = struct
 					()
 				| FKNormal ->
 					let dup = if fctx.is_static then PMap.exists cf.cf_name c.cl_fields || has_field cf.cf_name c.cl_super else PMap.exists cf.cf_name c.cl_statics in
-					if not cctx.is_native && dup then error ("Same field name can't be use for both static and instance : " ^ cf.cf_name) p;
+					if not cctx.is_native && not c.cl_extern && dup then error ("Same field name can't be use for both static and instance : " ^ cf.cf_name) p;
 					if List.mem AOverride f.cff_access then c.cl_overrides <- cf :: c.cl_overrides;
 					let is_var f = match cf.cf_kind with | Var _ -> true | _ -> false in
 					if PMap.mem cf.cf_name (if fctx.is_static then c.cl_statics else c.cl_fields) then


### PR DESCRIPTION
It would let us define JS externs easier. For example there are 8 methods in jQuery that use the same name for both static and instance.

PS. Look like it has already been allowed for java native class. So why not allow it for extern class as well? ;)