### PR TITLE
Java library and compiler bug fixes

### DIFF
--- a/genjava.ml
+++ b/genjava.ml
@@ -1525,8 +1525,9 @@ let configure gen =
 							write w "case ";
 							in_value := true;
 							(match e.eexpr with
-								| TField(_,FEnum(e,ef)) ->
-									write w ef.ef_name
+								| TField(_, FEnum(e, ef)) ->
+                           let changed_name = change_id ef.ef_name in
+									write w changed_name
 								| _ ->
 									expr_s w e);
 							write w ":";

--- a/std/java/_std/sys/net/Socket.hx
+++ b/std/java/_std/sys/net/Socket.hx
@@ -137,6 +137,11 @@ class Socket {
 		var local = sock.getLocalAddress();
 		var host = new Host(null);
 		host.wrapped = local;
+ 
+		if (boundAddr != null)
+		{
+			return { host: host, port: server.getLocalPort() };
+		}
 
 		return { host: host, port: sock.getLocalPort() };
 	}


### PR DESCRIPTION
 - Rewrite enumeration member name when it is a Java reserved keyword and is used as a case in a switch.
 - For Java, handle host() call where socket is a ServerSocket.