### PR TITLE
Allow to specify includeFile position.

### DIFF
--- a/common.ml
+++ b/common.ml
@@ -144,6 +144,7 @@ type context = {
 	mutable types : Type.module_type list;
 	mutable resources : (string,string) Hashtbl.t;
 	mutable neko_libs : string list;
+	mutable include_files : (string * string) list;
 	mutable php_front : string option;
 	mutable php_lib : string option;
 	mutable php_prefix : string option;
@@ -740,6 +741,7 @@ let create v args =
 		net_path_map = Hashtbl.create 0;
 		c_args = [];
 		neko_libs = [];
+		include_files = [];
 		php_prefix = None;
 		js_gen = None;
 		load_extern_type = [];

--- a/genjs.ml
+++ b/genjs.ml
@@ -1287,6 +1287,16 @@ let generate com =
 		in loop parts "";
 	)) exposed;
 
+	let include_files = List.rev com.include_files in
+
+	List.iter (fun file ->
+		match file with
+		| path, "top" ->
+			let file_content = Std.input_file ~bin:true (fst file) in
+			print ctx "%s\n" file_content;
+			()
+		| _ -> ()
+	) include_files;
 
 	let closureArgs = [] in
 	let closureArgs = if (anyExposed && not (Common.defined com Define.ShallowExpose)) then
@@ -1334,6 +1344,15 @@ let generate com =
 		in
 		List.iter (fun f -> print_obj f "$hx_exports") exposedObject.os_fields;
 	end;
+
+	List.iter (fun file ->
+		match file with
+		| path, "closure" ->
+			let file_content = Std.input_file ~bin:true (fst file) in
+			print ctx "%s\n" file_content;
+			()
+		| _ -> ()
+	) include_files;
 
 	(* If ctx.js_modern, console is defined in closureArgs. *)
 	if (not ctx.js_modern) && (not (Common.defined com Define.JsEs5)) then

--- a/interp.ml
+++ b/interp.ml
@@ -2713,6 +2713,20 @@ let macro_lib =
 			| Some v -> v
 			| None -> VNull
 		);
+		"include_file", Fun2 (fun file position ->
+			match file, position with
+			| VString file, VString position ->
+				let file = if Sys.file_exists file then
+					file
+				else try Common.find_file (ccom()) file with
+					| Not_found ->
+						failwith ("unable to find file for inclusion: " ^ file)
+				in
+				(ccom()).include_files <- (file, position) :: (ccom()).include_files;
+				VNull
+			| _ ->
+				error()
+		);
 	]
 
 (* ---------------------------------------------------------------------- *)

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -331,22 +331,41 @@ class Compiler {
 
 	#if (js || macro)
 	/**
-		Embed an on-disk javascript file (can be called into an __init__ method)
+		Embed a JavaScript file at compile time (can be called by `--macro` or within an `__init__` method).
 	**/
-	public static macro function includeFile( fileName : Expr ) {
-		var str = switch( fileName.expr ) {
-		case EConst(c):
-			switch( c ) {
-			case CString(str): str;
-			default: null;
-			}
-		default: null;
+	public static macro function includeFile( file : String, position:IncludePosition = Top ) {
+		return switch ((position:String).toLowerCase()) {
+			case Inline:
+				if (Context.getLocalModule() == "")
+					Context.error("Cannot use inline mode when includeFile is called by `--macro`", Context.currentPos());
+
+				var f = try sys.io.File.getContent(Context.resolvePath(file)) catch( e : Dynamic ) Context.error(Std.string(e), Context.currentPos());
+				var p = Context.currentPos();
+				{ expr : EUntyped( { expr : ECall( { expr : EConst(CIdent("__js__")), pos : p }, [ { expr : EConst(CString(f)), pos : p } ]), pos : p } ), pos : p };
+			case Top | Closure:
+				load("include_file", 2)(untyped file.__s, untyped position.__s);
+				macro {};
+			case _:
+				Context.error("unknown includeFile position: " + position, Context.currentPos());
 		}
-		if( str == null ) Context.error("Should be a constant string", fileName.pos);
-		var f = try sys.io.File.getContent(Context.resolvePath(str)) catch( e : Dynamic ) Context.error(Std.string(e), fileName.pos);
-		var p = Context.currentPos();
-		return { expr : EUntyped( { expr : ECall( { expr : EConst(CIdent("__js__")), pos : p }, [ { expr : EConst(CString(f)), pos : p } ]), pos : p } ), pos : p };
 	}
 	#end
 
+}
+
+@:enum abstract IncludePosition(String) from String to String {
+	/** 
+		Prepend the file content to the output file.
+	*/
+	var Top = "top";
+	/** 
+		Prepend the file content to the body of the top-level closure.
+
+		Since the closure is in strict-mode, there may be run-time error if the input is not strict-mode-compatible.
+	*/
+	var Closure = "closure";
+	/**
+		Directly inject the file content at the call site.
+	*/
+	var Inline = "inline";
 }

--- a/tests/unit/src/unit/issues/Issue4419.hx
+++ b/tests/unit/src/unit/issues/Issue4419.hx
@@ -1,0 +1,23 @@
+package unit.issues;
+
+#if js
+@:native("Issue4419External")
+private extern class External {
+    static function __init__():Void {
+        haxe.macro.Compiler.includeFile("unit/issues/misc/Issue4419External.js");
+    }
+}
+
+private class SubExt extends External {
+	public function new():Void {}
+	public function hello() return "hello";
+}
+#end
+
+class Issue4419 extends Test {
+	#if js
+	function test() {
+		eq("hello", new SubExt().hello());
+	}
+	#end
+}

--- a/tests/unit/src/unit/issues/misc/Issue4419External.js
+++ b/tests/unit/src/unit/issues/misc/Issue4419External.js
@@ -1,0 +1,1 @@
+var Issue4419External = function() { };


### PR DESCRIPTION
Currently `haxe.macro.Compiler.includeFile()` includes the input file into the call site, where is usually inside `__init__`. It is problematic:

### Problem 1. unable to include strict-mode incompatible file

Haxe by default generate JS output in strict mode. But the input file (e.g. [jQuery](https://github.com/jquery/jquery/issues/1779)!) may not be strict mode compatible, thus there will be run-time error being thrown.

### Promlem 2. unable to extend classes from the included file

Since the haxe class members are defined before `__init__`s, we cannot extend an external class. Example:
```js
// external.js
var External = function() { };
```
```haxe
extern class External {
	static function __init__():Void {
		haxe.macro.Compiler.includeFile("external.js");
	}
}

class Test extends External {
	static function main():Void {
		trace("ok");
	}
}
```
JS output:
```js
// Generated by Haxe
(function (console) { "use strict";
function $extend(from, fields) {
	function Inherit() {} Inherit.prototype = from; var proto = new Inherit();
	for (var name in fields) proto[name] = fields[name];
	if( fields.toString !== Object.prototype.toString ) proto.toString = fields.toString;
	return proto;
}
var Test = function() { };
Test.main = function() {
	console.log("ok");
};
Test.__super__ = External;
Test.prototype = $extend(External.prototype,{
});
// external.js
var External = function() { };
Test.main();
})(typeof console != "undefined" ? console : {log:function(){}});

```
run-time error:
```
/Users/andy/Documents/workspace/TestHaxe/Test.js:14
Test.prototype = $extend(External.prototype,{
                                 ^
TypeError: Cannot read property 'prototype' of undefined
    at console.undefined.log (/Users/andy/Documents/workspace/TestHaxe/Test.js:14:34)
    at Object.<anonymous> (/Users/andy/Documents/workspace/TestHaxe/Test.js:19:3)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:929:3
Error: Command failed with error 8
```

### This PR

This PR adds an argument `position` to `includeFile`. It is defaulted to `Top`, which is the top of the output, outside our top-level closure. The JS output of the above example will become:

```js
// Generated by Haxe
// external.js
var External = function() { };
(function (console) { "use strict";
function $extend(from, fields) {
	function Inherit() {} Inherit.prototype = from; var proto = new Inherit();
	for (var name in fields) proto[name] = fields[name];
	if( fields.toString !== Object.prototype.toString ) proto.toString = fields.toString;
	return proto;
}
var Test = function() { };
Test.main = function() {
	console.log("ok");
};
Test.__super__ = External;
Test.prototype = $extend(External.prototype,{
});
Test.main();
})(typeof console != "undefined" ? console : {log:function(){}});

```