### PR TITLE
[cpp] fix zero-argument functions in CFFIPrime

### DIFF
--- a/std/cpp/Prime.hx
+++ b/std/cpp/Prime.hx
@@ -99,7 +99,7 @@ class Prime {
 
       var cppMode = Context.defined("cpp");
 
-      var typeString = parts.length==1 ? codeToType("v",cppMode) : codeToType(parts.shift(),cppMode);
+      var typeString = parts.length==1 ? "Void" : codeToType(parts.shift(),cppMode);
       for(p in parts)
          typeString += "->" + codeToType(p,cppMode);
 


### PR DESCRIPTION
It was generating `Callable<cpp.Void->Int>` for `Prime.load("some", "func", "i")` which could not be simply called with `.call()`.