### PR TITLE
Added `haxe.extern.Callback`.

### DIFF
--- a/std/haxe/CallbackBuilder.hx
+++ b/std/haxe/CallbackBuilder.hx
@@ -1,0 +1,40 @@
+package haxe;
+
+import haxe.macro.*;
+import haxe.macro.Expr;
+
+class CallbackBuilder {
+	static public function build() {
+		switch (Context.getLocalType()) {
+			case TInst(_, [Context.follow(_) => TFun(args, ret)]):
+				var argsComplexTypes = [for (a in args) {
+					if (a.opt)
+						TOptional(Context.toComplexType(a.t));
+					else
+						Context.toComplexType(a.t);
+				}];
+				var retComplexType = Context.toComplexType(ret);
+				var types = [for (len in 0...args.length) argsComplexTypes.slice(0, len+1)];
+
+				// add Void->X
+				types.unshift([macro:Void]);
+
+				return either([for (ts in types) TFunction(ts, retComplexType)]);
+			case _: throw "Type param of Callback should be a function type.";
+		}
+		return null;
+	}
+
+	static function either(types:Array<ComplexType>):ComplexType {
+		return switch (types.length) {
+			case 0: 
+				throw "There should be at least one type.";
+			case 1: 
+				types[0];
+			case len:
+				var type1 = types[0];
+				var type2 = either(types.slice(1));
+				macro:haxe.extern.EitherType<$type1, $type2>;
+		}
+	}
+}

--- a/std/haxe/extern/Callback.hx
+++ b/std/haxe/extern/Callback.hx
@@ -32,5 +32,5 @@ package haxe.extern;
 	}
 	```
 */
-@:genericBuild(haxe.CallbackBuilder.build())
+@:genericBuild(haxe.macro.CallbackBuilder.build())
 interface Callback<T:haxe.Constraints.Function> {}

--- a/std/haxe/extern/Callback.hx
+++ b/std/haxe/extern/Callback.hx
@@ -1,0 +1,36 @@
+package haxe.extern;
+
+/**
+	`Callback` is a type that unifies with functions with number of arguments less than or equals to `T`.
+	Concretely, a function that accepts `Callback<A->B->C>` can be passed with `A->B->C`, `A->C`, or `Void->C`.
+	It is implemented using `EitherType`.
+
+	Some languages (e.g. JS), allow calling a function with extra arguments.
+	When using such languages, it is a common practice to pass a callback function that
+	accepts less arguments than the expected type. A JS example:
+
+	```js
+	var Process = {
+		// `handler` will be called with a status message
+		onComplete: function(handler) {
+			handler("completed");
+		}
+	}
+
+	var myhandler = function(){ // ignore the status message being passed in
+		console.log("done");
+	}
+	Process.onComplete(myhandler);
+	```
+
+	To allow such usage in Haxe, we can create an extern class of `Process` as follows:
+
+	```haxe
+	extern class Process {
+		// handler can be either `String->Void` or `Void->Void`
+		static public function onComplete(handler:Callback<String->Void>):Void;
+	}
+	```
+*/
+@:genericBuild(haxe.CallbackBuilder.build())
+interface Callback<T:haxe.Constraints.Function> {}

--- a/std/haxe/macro/CallbackBuilder.hx
+++ b/std/haxe/macro/CallbackBuilder.hx
@@ -1,9 +1,9 @@
-package haxe;
+package haxe.macro;
 
-import haxe.macro.*;
 import haxe.macro.Expr;
 
 class CallbackBuilder {
+	#if macro
 	static public function build() {
 		switch (Context.getLocalType()) {
 			case TInst(_, [Context.follow(_) => TFun(args, ret)]):
@@ -24,6 +24,7 @@ class CallbackBuilder {
 		}
 		return null;
 	}
+	#end
 
 	static function either(types:Array<ComplexType>):ComplexType {
 		return switch (types.length) {

--- a/tests/unit/src/unitstd/haxe/extern/Callback.unit.hx
+++ b/tests/unit/src/unitstd/haxe/extern/Callback.unit.hx
@@ -1,0 +1,19 @@
+var cb:haxe.extern.Callback<String->String->Int> = null;
+TestType.typeError(cb = function(s1:String, s2:String) return 0) == false;
+TestType.typeError(cb = function(s1:String) return 0) == false;
+TestType.typeError(cb = function() return 0) == false;
+
+TestType.typeError(cb = function(s1:String, s2:String, s3:Int) return 0) == true;
+TestType.typeError(cb = function(s1:String, s2:Int) return 0) == true;
+TestType.typeError(cb = function(s1:String, s2:Int){}) == true;
+
+var cb:haxe.extern.Callback<Void->Int> = null;
+TestType.typeError(cb = function() return 0) == false;
+
+var cb:haxe.extern.Callback<Void->Void> = null;
+TestType.typeError(cb = function(){}) == false;
+
+var cb:haxe.extern.Callback<?String->?String->Int> = null;
+TestType.typeError(cb = function(?s1:String, ?s2:String) return 0) == false;
+TestType.typeError(cb = function(?s1:String) return 0) == false;
+TestType.typeError(cb = function() return 0) == false;


### PR DESCRIPTION
As discussed in https://github.com/HaxeFoundation/haxe/issues/4528#issuecomment-138558443
See the doc of `haxe.extern.Callback` for details.

I named it as `Callback` because it is intended to be used as an argument type. I don't want to prefix it with JS since it could be used for future targets that share the same behaviour of JS.

`CallbackBuilder` is placed in the `haxe.macro` package instead of `haxe.extern` due to #4535.
