### PR TITLE
Math.random on neko

### DIFF
--- a/std/neko/_std/Math.hx
+++ b/std/neko/_std/Math.hx
@@ -59,6 +59,7 @@ private class MathImpl {
 		M.fceil = try Lib.load("std", "math_fceil", 1) catch( e : Dynamic ) M.ceil;
 		M.ffloor = try Lib.load("std", "math_ffloor", 1) catch( e : Dynamic ) M.floor;
 		M.fround = try Lib.load("std", "math_fround", 1) catch( e : Dynamic ) M.round;
+		M.random = random;
 	}
 }
 


### PR DESCRIPTION
On haxe 3.2 Reflect.getProperty(Math, "random") return null if I dont have:
M.random = random; line
P.S. not sure if it still the problem on latest github version of haxe