### PR TITLE
Add filename & line # to HX_STACK_FRAME's fullName

### DIFF
--- a/gencpp.ml
+++ b/gencpp.ml
@@ -1470,13 +1470,17 @@ let strip_file ctx file = (match Common.defined ctx Common.Define.AbsolutePath w
 let hx_stack_push ctx output clazz func_name pos =
    if ctx.ctx_debug_level > 0 then begin
       let stripped_file = strip_file ctx.ctx_common pos.pfile in
-      let qfile = "\"" ^ (Ast.s_escape stripped_file) ^ "\"" in
+      let esc_file = (Ast.s_escape stripped_file) in
       ctx.ctx_file_info := PMap.add stripped_file pos.pfile !(ctx.ctx_file_info);
       if (ctx.ctx_debug_level>0) then begin
+         let full_name = clazz ^ "." ^ func_name ^ (
+           if (clazz="*") then
+             (" (" ^ esc_file ^ ":" ^ (string_of_int (Lexer.get_error_line pos) ) ^ ")")
+           else "") in
          let hash_class_func = gen_hash 0 (clazz^"."^func_name) in
          let hash_file = gen_hash 0 stripped_file in
          output ("HX_STACK_FRAME(\"" ^ clazz ^ "\",\"" ^ func_name ^ "\"," ^ hash_class_func ^ ",\"" ^
-               clazz ^ "." ^ func_name ^ "\"," ^ qfile ^ "," ^
+               full_name ^ "\",\"" ^ esc_file ^ "\"," ^
                (string_of_int (Lexer.get_error_line pos) ) ^  "," ^ hash_file ^ ")\n")
       end
    end


### PR DESCRIPTION
hxcpp's `HX_STACK_FRAME` takes a `const char* fullName` that are used in Debug.h's stack class. It looks like the only thing using these (in hxcpp) is the `Profiler` and `Telemetry` classes.

In the case of lambdas, the class seems to always be `*` while the function name is of the form `_Function_#_#`, creating a fullName, e.g. `*._Function_1_2`

This is unfriendly for debugging, locating these lambdas is difficult.

This commit adds a `(filename:line#)` suffix to the fullName when class is `*` (this should only be lambdas), so that the fullName becomes e.g. `*._Function_1_2 (openfl/_internal/text/TextEngine.hx:634)`

Again, this is used in HX_STACK_FRAME calls, e.g.:

```
			HX_STACK_FRAME("*","_Function_1_2",0x5200ed38,"*._Function_1_2 (openfl/_internal/text/TextEngine.hx:634)","openfl/_internal/text/TextEngine.hx",634,0xdff93b7f)
```

This results in easier profiling from Profiler or Telemetry.

Possible modifications to this PR:
- The syntax of the addition is not important, as long as it conveys filename and line number.
- Absolute path name isn't necessarily important (could just be `TextEngine.hx`, but full path was already available).
- I have no idea if `haxe-3.2.1` is the proper target for this merge, sorry!

@hughsando - thoughts? Does this cause problems for any tools you know of? Does anything use stack.fullName outside Profiler and Telemetry?