### PR TITLE
[cpp] haxe.io.Bytes.alloc use exact size

### DIFF
--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -463,7 +463,7 @@ class Bytes {
 		return new Bytes(length, BytesData.alloc(length));
 		#elseif cpp
 		var a = new BytesData();
-		if (length>0) a[length-1] = untyped 0;
+		if (length>0) cpp.NativeArray.setSize(a, length);
 		return new Bytes(length, a);
 		#elseif cs
 		return new Bytes(length, new cs.NativeArray(length));


### PR DESCRIPTION
Previously, Bytes.alloc's underlying array would use non-exact sizing designed to prepare for array growth, allocating 1.5x the memory it needs. Use cpp.NativeArray.setSize to allocate with an exact size.

This reaches parity with other platforms that allocate exact-sized arrays.