### PR TITLE
Remove annoying output from @:generic

### DIFF
--- a/std/haxe/ds/GenericStack.hx
+++ b/std/haxe/ds/GenericStack.hx
@@ -54,7 +54,7 @@ private class GenericStackIterator<T> extends cpp.FastIterator<T> {
 	The generated name is an implementation detail and should not be relied
 	upon.
 **/
-#if (flash || cpp)
+#if (!display && (flash || cpp))
 @:generic
 #end
 class GenericStack<T> {


### PR DESCRIPTION
Workaround for annoying `@:generic` typing order issue. I get 24 lines of useless debug output in FD coming from here. It happens when I attempt to autocomplete on incorrect syntax and have hscript imported (I guess hscript uses GenericStack?). **Note**: this happens with any class that uses `@:generic`.
```
import hscript.Parser;
import hscript.Interp;

default.
// autocomplete fails, get the output
```
https://github.com/HaxeFlixel/flixel/issues/1430 <- original issue
https://github.com/HaxeFlixel/flixel/commit/5b08e08901628e63c1cb4ae647f95fd0ad7127f8
https://github.com/HaxeFlixel/flixel/commit/1808cae059c67fd10c70dde9d60ae0b4ffce2c20 <- workaround in flixel

This was supposedly fixed a while ago, but I checked on dev maybe a month ago.