### PR TITLE
Allow access to the provided named host in sys.net.Host 

### DIFF
--- a/std/cpp/_std/sys/net/Host.hx
+++ b/std/cpp/_std/sys/net/Host.hx
@@ -24,9 +24,12 @@ package sys.net;
 @:coreApi
 class Host {
 
+	public var host(default,null) : String;
+
 	public var ip(default,null) : Int;
 
 	public function new( name : String ) : Void {
+		host = name;
 		ip = host_resolve(name);
 	}
 

--- a/std/cs/_std/sys/net/Host.hx
+++ b/std/cs/_std/sys/net/Host.hx
@@ -18,6 +18,11 @@ class Host {
 	public var ipAddress(default, null) : IPAddress;
 
 	/**
+		The provided host string.
+	**/
+	var host(default,null) : String;
+
+	/**
 		The actual IP corresponding to the host.
 	**/
 	public var ip(get, null) : Int;
@@ -30,6 +35,7 @@ class Host {
 		the corresponding IP address is resolved using DNS. An exception occur if the host name could not be found.
 	**/
 	public function new( name : String ) : Void {
+		host = name;
 		hostEntry = Dns.GetHostEntry(name);
 		for (i in 0...hostEntry.AddressList.Length) {
 			if (hostEntry.AddressList[i].AddressFamily == InterNetwork) {

--- a/std/java/_std/sys/net/Host.hx
+++ b/std/java/_std/sys/net/Host.hx
@@ -23,12 +23,14 @@ package sys.net;
 import java.net.InetAddress;
 
 class Host {
+	public var host(default,null) : String;
 	public var ip(default,null) : Int;
 
 	@:allow(sys.net) private var wrapped:InetAddress;
 
 	public function new( name : String ) : Void
 	{
+		host = name;
 		try
 			this.wrapped = InetAddress.getByName(name)
 		catch(e:Dynamic) throw e;

--- a/std/neko/_std/sys/net/Host.hx
+++ b/std/neko/_std/sys/net/Host.hx
@@ -25,9 +25,12 @@ package sys.net;
 @:keepInit
 class Host {
 
+	public var host(default,null) : String;
+
 	public var ip(default,null) : Int;
 
 	public function new( name : String ) : Void {
+		host = name;
 		ip = host_resolve(untyped name.__s);
 	}
 

--- a/std/php/_std/sys/net/Host.hx
+++ b/std/php/_std/sys/net/Host.hx
@@ -24,10 +24,13 @@ package sys.net;
 @:coreApi
 class Host {
 
+	public var host(default,null) : String;
+
 	private var _ip : String;
 	public var ip(default,null) : Int;
 
 	public function new( name : String ) : Void {
+		host = name;
 		if(~/^(\d{1,3}\.){3}\d{1,3}$/.match(name)) {
 		  _ip = name;
 		} else {

--- a/std/python/_std/sys/net/Host.hx
+++ b/std/python/_std/sys/net/Host.hx
@@ -22,11 +22,13 @@
 package sys.net;
 
 class Host {
+	public var host(default,null) : String;
 	public var ip(default,null) : Int;
 
 	var name:String;
 	
 	public function new( name : String ) : Void {
+		host = name;
 		this.name = name;
     	}
 

--- a/std/sys/net/Host.hx
+++ b/std/sys/net/Host.hx
@@ -27,6 +27,11 @@ package sys.net;
 extern class Host {
 
 	/**
+		The provided host string.
+	**/
+	var host(default,null) : String;
+
+	/**
 		The actual IP corresponding to the host.
 	**/
 	var ip(default,null) : Int;


### PR DESCRIPTION
Makes a `host` property available in `sys.net.Host`. The original named host is needed for certificate verification in hxssl.