### PR TITLE
[php] right shift : return left operand if right operand is 0 in PHP

### DIFF
--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -554,7 +554,7 @@ function _hx_set_method($o, $field, $func) {
 }
 
 function _hx_shift_right($v, $n) {
-	return ($v >= 0) ? ($v >> $n) : ($v >> $n) & (0x7fffffff >> ($n-1));
+	return ($n == 0) ? $v : ($v >= 0) ? ($v >> $n) : ($v >> $n) & (0x7fffffff >> ($n-1));
 }
 
 function _hx_string_call($s, $method, $params) {

--- a/tests/unit/src/unit/issues/Issue4571.hx
+++ b/tests/unit/src/unit/issues/Issue4571.hx
@@ -1,0 +1,8 @@
+package unit.issues;
+
+class Issue4571 extends Test {
+	function test() {
+		var x = -1072787802;
+		eq(x, (x >>> 0));
+	}
+}

--- a/tests/unit/src/unit/issues/Issue4571.hx
+++ b/tests/unit/src/unit/issues/Issue4571.hx
@@ -1,8 +1,0 @@
-package unit.issues;
-
-class Issue4571 extends Test {
-	function test() {
-		var x = -1072787802;
-		eq(x, (x >>> 0));
-	}
-}


### PR DESCRIPTION
This seems to fix these issues in PHP:
https://gist.github.com/clemos/fc48d8076d936531a386#file-test-hx-L14-L18
Please review carefully, as I'm not at all an expert in bit manipulation :p 