### PR TITLE
[js] Fixed an issue with a trailing ", "

### DIFF
--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -128,13 +128,12 @@ private class StringMapIterator<T> {
 	public function toString() : String {
 		var s = new StringBuf();
 		s.add("{");
-		var keys = arrayKeys();
-		for( i in 0...keys.length ) {
-			var k = keys[i];
-			s.add(k);
+		var it = keys();
+		for( i in it ) {
+			s.add(i);
 			s.add(" => ");
-			s.add(Std.string(get(k)));
-			if( i < keys.length )
+			s.add(Std.string(get(i)));
+			if( it.hasNext() )
 				s.add(", ");
 		}
 		s.add("}");


### PR DESCRIPTION
Altered the toString method in StringMap to use the same pattern as the toString methods in the other Map classes. The previous version had an issue where an extra ", " would be printed at the end

Demo of issue http://try.haxe.org/#9A58e