### PR TITLE
[js] Prevents StringMap's toString() appending an extra ", "

### DIFF
--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -134,7 +134,7 @@ private class StringMapIterator<T> {
 			s.add(k);
 			s.add(" => ");
 			s.add(Std.string(get(k)));
-			if( i < keys.length )
+			if( i < keys.length-1 )
 				s.add(", ");
 		}
 		s.add("}");

--- a/tests/unit/src/unit/issues/Issue4579.hx
+++ b/tests/unit/src/unit/issues/Issue4579.hx
@@ -1,0 +1,20 @@
+package unit.issues;
+
+class Issue4579 extends Test {
+	#if js
+	function test() {
+		var stringMap1:Map<String, Dynamic> = [
+	        'string-key-1'=> 42
+	    ];
+
+		var stringMap2:Map<String, Dynamic> = [
+            'string-key-1'=> 42,
+            'string-key-2'=> {a:1}
+        ];
+        
+        //count commas in toString()
+        eq(stringMap1.toString().split(',').length - 1, 0);
+        eq(stringMap2.toString().split(',').length - 1, 1);
+	}
+	#end
+}


### PR DESCRIPTION
The toString method in js StringMap was adding an extra ", " to the end of the list

Demo of issue http://try.haxe.org/#9A58e