### PR TITLE
Documentation typo fix

### DIFF
--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -442,8 +442,8 @@ class Context {
 		
 		Compilation server : when using the compilation server, the resource is bound
 		to the Haxe module which calls the macro, so it will be included again if
-		that module is reused. If this resource concerns several modules, prefix your
-		ressource name with a $ sign, this will bind it to the macro module instead.
+		that module is reused. If this resource concerns several modules, prefix its
+		name with a $ sign, this will bind it to the macro module instead.
 	**/
 	public static function addResource( name : String, data : haxe.io.Bytes ) {
 		load("add_resource",2)(untyped name.__s,data.getData());


### PR DESCRIPTION
Decided to remove the incorrectly spelled version of `resource` since it's already mentioned (and spelled correctly) in the previous part of the sentence.