### PR TITLE
"error_reporting" in in Boot was set to not catch E_STRICT, but the h…

### DIFF
--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -837,7 +837,7 @@ class Enum {
 }
 
 error_reporting(E_ALL & ~E_STRICT);
-set_error_handler('_hx_error_handler', E_ALL);
+set_error_handler('_hx_error_handler', E_ALL & ~E_STRICT);
 set_exception_handler('_hx_exception_handler');
 
 php_Boot::$qtypes = array();


### PR DESCRIPTION
"error_reporting" in in Boot was set to not catch E_STRICT, but the handler was catching E_STRICT. This caused problems when moving from PHP 4.3 to PHP 4.4 and above as E_ALL now includes E_STRICT.

[Yes Franco, we're still using PHP, and it's handling 9mil requests a day fine - yay]