### PR TITLE
Avoid underscore variable name

### DIFF
--- a/std/Lambda.hx
+++ b/std/Lambda.hx
@@ -215,7 +215,7 @@ class Lambda {
 	public static function count<A>( it : Iterable<A>, ?pred : A -> Bool ) {
 		var n = 0;
 		if( pred == null )
-			for( _ in it )
+			for( x in it )
 				n++;
 		else
 			for( x in it )


### PR DESCRIPTION
The original name will cause javac warning:

```
/home/travis/build/ThoughtWorksInc/auto-parser/target/src_managed/main/haxe/root/Lambda.java:290:  '_' used as an identifier
					A _ = ((A) (haxe.lang.Runtime.callField(__temp_iterator1, "next", null)) );
```