### PR TITLE
[php] modified generated comparison function

### DIFF
--- a/genphp.ml
+++ b/genphp.ml
@@ -1225,9 +1225,9 @@ and gen_expr ctx e =
 				let tmp = define_local ctx "_t" in
 				print ctx "(is_object($%s = " tmp;
 				gen_field_op ctx e1;
-				print ctx ") && !($%s instanceof Enum) ? $%s%s" tmp tmp s_phop;
+				print ctx ") && ($%s instanceof Enum) ? $%s%s" tmp tmp s_op;
 				gen_field_op ctx e2;
-				print ctx " : $%s%s" tmp s_op;
+				print ctx " : $%s%s" tmp s_phop;
 				gen_field_op ctx e2;
 				spr ctx ")";
 			end

--- a/genphp.ml
+++ b/genphp.ml
@@ -1227,9 +1227,11 @@ and gen_expr ctx e =
 				gen_field_op ctx e1;
 				print ctx ") && ($%s instanceof Enum) ? $%s%s" tmp tmp s_op;
 				gen_field_op ctx e2;
-				print ctx " : $%s%s" tmp s_phop;
+				print ctx " : ";
+				if op = Ast.OpNotEq then spr ctx "!";
+				print ctx "_hx_equal($%s, " tmp;
 				gen_field_op ctx e2;
-				spr ctx ")";
+				spr ctx "))";
 			end
 		| Ast.OpGt | Ast.OpGte | Ast.OpLt | Ast.OpLte when is_string_expr e1 ->
 			spr ctx "(strcmp(";

--- a/std/php/_std/Sys.hx
+++ b/std/php/_std/Sys.hx
@@ -35,7 +35,8 @@
 	}
 
 	public static function getEnv( s : String ) : String {
-		return untyped __call__("getenv", s);
+		var ret:Dynamic = untyped __call__("getenv", s);
+		return ret == false ? null : ret;
 	}
 
 	public static function putEnv( s : String, v : String ) : Void {

--- a/tests/unit/src/unit/issues/Issue4695.hx
+++ b/tests/unit/src/unit/issues/Issue4695.hx
@@ -1,0 +1,25 @@
+package unit.issues;
+
+class Issue4695 extends unit.Test {
+
+	function eqCheck<T>(v1:T, v2:T) {
+		return v1 == v2;
+	}
+	
+	public function testNull() {
+		f("" == null);
+		f(eqCheck("", null));
+		f(false == null);
+		f(eqCheck(false, null));
+	}
+	
+	#if php
+	public function testNativeArray() {
+		var a1 = (untyped __php__)('array("f1" => 1, "f2" => 2, "f3" => 3)');
+		var a2 = (untyped __php__)('array("f1" => true, "f2" => "2", "f3" => 3)');
+		f(a1 == a2);
+		f(eqCheck(a1, a2));
+	}
+	#end
+	
+}

--- a/tests/unit/src/unit/issues/Issue4695.hx
+++ b/tests/unit/src/unit/issues/Issue4695.hx
@@ -9,8 +9,10 @@ class Issue4695 extends unit.Test {
 	public function testNull() {
 		f("" == null);
 		f(eqCheck("", null));
+		#if !(cpp || flash9 || as3 || java || cs)
 		f(false == null);
 		f(eqCheck(false, null));
+		#end
 	}
 	
 	#if php


### PR DESCRIPTION
The original function generates a comparison between objects `$a` and `$b` in the form of:
`if((is_object($_t = $a) && !($_t instanceof Enum) ? $_t === $b : $_t == $b))`
So all objects except Enums are compared with `===`, the rest (including Enums) with `==`.
I would prefer:
`if((is_object($_t = $a) && ($_t instanceof Enum) ? $_t == $b : $_t === $b))`
So only Enums are compared with `==` and all the rest (not only objects) is compared with `===`.
This has the advantage, that e.g. PHP native arrays are compared with `===`.
Hope I got the OCaml right.