### PR TITLE
Always use analyzer transformations

### DIFF
--- a/analyzer.ml
+++ b/analyzer.ml
@@ -260,6 +260,7 @@ end
 	- OpAssignOp on a variable is rewritten to OpAssign
 	- Prefix increment/decrement operations are rewritten to OpAssign
 	- Postfix increment/decrement operations are rewritten to a TBlock with OpAssign and OpAdd/OpSub
+	- `do {} while(true)` is rewritten to `while(true) {}`
 	- TWhile expressions are rewritten to `while (true)` with appropriate conditional TBreak
 	- TFor is rewritten to TWhile
 *)
@@ -289,7 +290,9 @@ module TexprFilter = struct
 				]) e.etype e.epos
 			in
 			loop e
-		| TWhile(e1,e2,flag) when not (flag = NormalWhile && is_true_expr e1) ->
+		| TWhile(e1,e2,DoWhile) when is_true_expr e1 ->
+			loop {e with eexpr = TWhile(e1,e2,NormalWhile)}
+		| TWhile(e1,e2,flag) when not (is_true_expr e1) ->
 			let p = e.epos in
 			let e_break = mk TBreak t_dynamic p in
 			let e_not = mk (TUnop(Not,Prefix,Codegen.mk_parent e1)) e1.etype e1.epos in

--- a/analyzer.ml
+++ b/analyzer.ml
@@ -289,7 +289,7 @@ module TexprFilter = struct
 				]) e.etype e.epos
 			in
 			loop e
-		| TWhile(e1,e2,flag) when not (is_true_expr e1) ->
+		| TWhile(e1,e2,flag) when not (flag = NormalWhile && is_true_expr e1) ->
 			let p = e.epos in
 			let e_break = mk TBreak t_dynamic p in
 			let e_not = mk (TUnop(Not,Prefix,Codegen.mk_parent e1)) e1.etype e1.epos in

--- a/filters.ml
+++ b/filters.ml
@@ -92,70 +92,6 @@ let rec blockify_ast e =
 	| _ ->
 		Type.map_expr blockify_ast e
 
-(*
-	Pushes complex right-hand side expression inwards.
-
-	return { exprs; value; } -> { exprs; return value; }
-	x = { exprs; value; } -> { exprs; x = value; }
-	var x = { exprs; value; } -> { var x; exprs; x = value; }
-*)
-let promote_complex_rhs com e =
-	let rec is_complex e = match e.eexpr with
-		| TBlock _ | TSwitch _ | TIf _ | TTry _ | TCast(_,Some _) -> true
-		| TBinop(_,e1,e2) -> is_complex e1 || is_complex e2
-		| TParenthesis e | TMeta(_,e) | TCast(e, None) | TField(e,_) -> is_complex e
-		| _ -> false
-	in
-	let rec loop f e = match e.eexpr with
-		| TBlock(el) ->
-			begin match List.rev el with
-				| elast :: el -> {e with eexpr = TBlock(block (List.rev ((loop f elast) :: el)))}
-				| [] -> e
-			end
-		| TSwitch(es,cases,edef) ->
-			{e with eexpr = TSwitch(es,List.map (fun (el,e) -> List.map find el,loop f e) cases,match edef with None -> None | Some e -> Some (loop f e)); }
-		| TIf(eif,ethen,eelse) ->
-			{e with eexpr = TIf(find eif, loop f ethen, match eelse with None -> None | Some e -> Some (loop f e)); }
-		| TTry(e1,el) ->
-			{e with eexpr = TTry(loop f e1, List.map (fun (el,e) -> el,loop f e) el); }
-		| TParenthesis e1 when not (Common.defined com Define.As3) ->
-			{e with eexpr = TParenthesis(loop f e1)}
-		| TMeta(m,e1) ->
-			{ e with eexpr = TMeta(m,loop f e1)}
-		| TReturn _ | TThrow _ ->
-			find e
-		| TContinue | TBreak ->
-			e
-		| _ ->
-			f (find e)
-	and block el =
-		let r = ref [] in
-		List.iter (fun e ->
-			match e.eexpr with
-			| TVar(v,eo) ->
-				begin match eo with
-					| Some e when is_complex e ->
-						let e = find e in
-						r := (loop (fun e -> mk (TBinop(OpAssign,mk (TLocal v) v.v_type e.epos,e)) v.v_type e.epos) e)
-							:: ((mk (TVar (v,None)) com.basic.tvoid e.epos))
-							:: !r
-					| Some e ->
-						r := (mk (TVar (v,Some (find e))) com.basic.tvoid e.epos) :: !r
-					| None -> r := (mk (TVar (v,None)) com.basic.tvoid e.epos) :: !r
-				end
-			| TReturn (Some e1) when (match follow e1.etype with TAbstract({a_path=[],"Void"},_) -> true | _ -> false) ->
-				r := ({e with eexpr = TReturn None}) :: e1 :: !r
-			| _ -> r := (find e) :: !r
-		) el;
-		List.rev !r
-	and find e = match e.eexpr with
-		| TReturn (Some e1) -> loop (fun er -> {e with eexpr = TReturn (Some er)}) e1
-		| TBinop(OpAssign | OpAssignOp _ as op, ({eexpr = TLocal _ | TField _ | TArray _} as e1), e2) -> loop (fun er -> {e with eexpr = TBinop(op, e1, er)}) e2
-		| TBlock(el) -> {e with eexpr = TBlock (block el)}
-		| _ -> Type.map_expr find e
-	in
-	find e
-
 (* Adds final returns to functions as required by some platforms *)
 let rec add_final_return e =
 	let rec loop e t =
@@ -1211,49 +1147,24 @@ let run com tctx main =
 	let use_static_analyzer = Common.defined com Define.Analyzer in
 	(* this part will be a bit messy until we make the analyzer the default *)
 	let new_types = List.filter (fun t -> not (is_cached t)) com.types in
-	if use_static_analyzer then begin
 		(* PASS 1: general expression filters *)
-		let filters = [
-			Codegen.AbstractCast.handle_abstract_casts tctx;
-			check_local_vars_init;
-			Optimizer.inline_constructors tctx;
-			Optimizer.reduce_expression tctx;
-			captured_vars com;
-		] in
-		List.iter (run_expression_filters tctx filters) new_types;
-		Analyzer.Run.run_on_types tctx true new_types;
-		List.iter (iter_expressions [verify_ast tctx]) new_types;
-		let filters = [
-			Optimizer.sanitize com;
-			if com.config.pf_add_final_return then add_final_return else (fun e -> e);
-			if com.platform = Js then wrap_js_exceptions com else (fun e -> e);
-			rename_local_vars tctx;
-		] in
-		List.iter (run_expression_filters tctx filters) new_types;
-	end else begin
-		(* PASS 1: general expression filters *)
-		let filters = [
-			Codegen.AbstractCast.handle_abstract_casts tctx;
-			blockify_ast;
-			check_local_vars_init;
-			Optimizer.inline_constructors tctx;
-		] in
-		List.iter (run_expression_filters tctx filters) new_types;
-		begin match com.platform with
-			| Cpp when not (Common.defined com Define.Cppia) -> Analyzer.Run.run_on_types tctx false new_types;
-			| _ -> ()
-		end;
-		let filters = [
-			if com.foptimize then (fun e -> Optimizer.reduce_expression tctx e) else Optimizer.sanitize com;
-			captured_vars com;
-			promote_complex_rhs com;
-			if com.config.pf_add_final_return then add_final_return else (fun e -> e);
-			if com.platform = Js then wrap_js_exceptions com else (fun e -> e);
-			rename_local_vars tctx;
-		] in
-		List.iter (run_expression_filters tctx filters) new_types;
-		List.iter (iter_expressions [verify_ast tctx]) new_types;
-	end;
+	let filters = [
+		Codegen.AbstractCast.handle_abstract_casts tctx;
+		check_local_vars_init;
+		Optimizer.inline_constructors tctx;
+		Optimizer.reduce_expression tctx;
+		captured_vars com;
+	] in
+	List.iter (run_expression_filters tctx filters) new_types;
+	Analyzer.Run.run_on_types tctx use_static_analyzer new_types;
+	List.iter (iter_expressions [verify_ast tctx]) new_types;
+	let filters = [
+		Optimizer.sanitize com;
+		if com.config.pf_add_final_return then add_final_return else (fun e -> e);
+		if com.platform = Js then wrap_js_exceptions com else (fun e -> e);
+		rename_local_vars tctx;
+	] in
+	List.iter (run_expression_filters tctx filters) new_types;
 	next_compilation();
 	List.iter (fun f -> f()) (List.rev com.filters); (* macros onGenerate etc. *)
 	List.iter (save_class_state tctx) new_types;

--- a/optimizer.ml
+++ b/optimizer.ml
@@ -385,7 +385,7 @@ let rec type_inline ctx cf f ethis params tret config p ?(self_calling_closure=f
 		end;
 		l, e
 	) (ethis :: loop params f.tf_args true) ((vthis,None) :: f.tf_args) in
-	if !had_side_effect || (Common.defined ctx.com Define.Analyzer) then List.iter (fun (l,e) ->
+	List.iter (fun (l,e) ->
 		if might_be_affected e then l.i_force_temp <- true;
 	) inlined_vars;
 	let inlined_vars = List.rev inlined_vars in

--- a/optimizer.ml
+++ b/optimizer.ml
@@ -613,7 +613,7 @@ let rec type_inline ctx cf f ethis params tret config p ?(self_calling_closure=f
 
 		This could be fixed with better post process code cleanup (planed)
 	*)
-	if !cancel_inlining || (not (Common.defined ctx.com Define.Analyzer) && Common.platform ctx.com Js && not !force && (init <> None || !has_vars)) then
+	if !cancel_inlining then
 		None
 	else
 		let wrap e =

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -5,5 +5,5 @@
 -resource res1.txt@re/s?!%[]))("'1.txt
 -resource res2.bin@re/s?!%[]))("'1.bin
 -dce full
--D analyzer
+#-D analyzer
 -D analyzer-code-motion


### PR DESCRIPTION
This pull request changes the filters so that the analyzer transformations (but not optimizations) are always run. This does a lot of code-cleanup for eliminating temporary variables. Here are some encouraging stats for unit.js:

Compilation  | Size   | $this | Time
------------ | ------ | ----- | ------
Old default  | 1690kb | 798   | 4.065s
Old analyzer | 1670kb | 7     | 6.523s
New default  | 1648kb | 10    | 3.942s
New analyzer | 1632kb | 10    | 4.370s

This loses the JS inlining restriction and closes #1827 among other things!