### PR TITLE
Allow JavaScript error message and name

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -28,7 +28,8 @@ private class HaxeError extends js.Error {
 	public function new(val:Dynamic) untyped {
 		super();
 		this.val = __define_feature__("js.Boot.HaxeError", val);
-		this.message = String(val);
+		if (Reflect.hasField(val, "name")) this.name = Reflect.field(val, "name");
+		this.message = Reflect.hasField(val, "message") ? Reflect.field(val, "message") : String(val);
 		if (js.Error.captureStackTrace) js.Error.captureStackTrace(this, HaxeError);
 	}
 


### PR DESCRIPTION
The JavaScript `Error` type has a name and a message property.

After throwing an error, you can catch it and read both of these values to determine the type of error, and in a JavaScript debug console, you will usually get nice output differentiating them, such as "Uncaught Error: This is not okay" or "Uncaught ArgumentError: Argument count mismatch on hello()"

As it would happen, the ActionScript 3 API follows a similar pattern. The `Event` class has both `name` and `message` properties, and when thrown, display differently in debugger versions of Flash Player.

If we would allow for an optional `name` and `message` property, it would allow for direct use of OpenFL events:

```haxe
throw new ReferenceError ("Cannot create property foo on HelloWorld");
```

(resulting in `Uncaught ReferenceError: Cannot create property foo on HelloWorld` in Chrome)

It would allow for more robust event objects in other projects as well, if they decide to throw both a `name` and `message` similar to JavaScript. We do not need to set `name` for simple errors, because JavaScript implies a default value of "Error"

Thank you!