### PR TITLE
add a new display mode to get argument index and function signature

### DIFF
--- a/common.ml
+++ b/common.ml
@@ -104,6 +104,7 @@ type display_mode =
 	| DMToplevel
 	| DMResolve of string
 	| DMType
+	| DMFunArgs of int
 
 type context = {
 	(* config *)

--- a/main.ml
+++ b/main.ml
@@ -1241,6 +1241,9 @@ try
 					| "toplevel" ->
 						activate_special_display_mode();
 						DMToplevel
+					| "funargs" ->
+						Parser.use_parser_resume := true;
+						DMFunArgs (-1)	
 					| "" ->
 						Parser.use_parser_resume := true;
 						DMDefault
@@ -1642,8 +1645,13 @@ with
 	| Typecore.DisplayTypes tl ->
 		let ctx = print_context() in
 		let b = Buffer.create 0 in
+		let i = match com.display with
+			| DMFunArgs i -> i
+			| _ -> -1
+		in
 		List.iter (fun t ->
 			Buffer.add_string b "<type>\n";
+			if (i >= 0) then Buffer.add_string b (Printf.sprintf "%d@" i);
 			Buffer.add_string b (htmlescape (s_type ctx t));
 			Buffer.add_string b "\n</type>\n";
 		) tl;

--- a/parser.ml
+++ b/parser.ml
@@ -74,6 +74,7 @@ let use_doc = ref false
 let use_parser_resume = ref true
 let resume_display = ref null_pos
 let in_macro = ref false
+let fun_arg_display_index = ref (-1)
 
 let last_token s =
 	let n = Stream.count s in
@@ -1239,7 +1240,7 @@ and expr = parser
 	| [< '(Kwd New,p1); t = parse_type_path; '(POpen,p); s >] ->
 		if is_resuming p then display (EDisplayNew t,punion p1 p);
 		(match s with parser
-		| [< al = psep Comma expr; '(PClose,p2); s >] -> expr_next (ENew (t,al),punion p1 p2) s
+		| [< al = parse_new_params t p; '(PClose,p2); s >] -> expr_next (ENew (t,al),punion p1 p2) s
 		| [< >] -> serror())
 	| [< '(POpen,p1); e = expr; s >] -> (match s with parser
 		| [< '(PClose,p2); s >] -> expr_next (EParenthesis e, punion p1 p2) s
@@ -1397,21 +1398,44 @@ and parse_catch etry = parser
 				Display e -> display (ETry (etry,[name,t,e]),punion (pos etry) (pos e)))
 		| [< '(_,p) >] -> error Missing_type p
 
+and parse_new_params t p s = match s with parser
+	| [< v = expr; s >] ->
+		let rec loop acc = match s with parser
+			| [< '(Comma, pc) >] ->
+				if is_resuming pc then begin
+					fun_arg_display_index := List.length acc;
+					display (EDisplayNew t,punion pc p)
+				end;
+				(match s with parser [< v = expr >] -> loop (v::acc))
+			| [< >] -> List.rev acc
+		in
+		loop [v]
+	| [< >] -> []
+
 and parse_call_params ec s =
 	let e = (try
 		match s with parser
 		| [< e = expr >] -> Some e
 		| [< >] -> None
-	with Display e ->
-		display (ECall (ec,[e]),punion (pos ec) (pos e))
-	) in
+	with (Display e) as ex ->
+		match e with
+		| EDisplay _, _ -> raise ex
+		| _ -> display (ECall (ec,[e]),punion (pos ec) (pos e))
+ 	) in
 	let rec loop acc =
 		try
 			match s with parser
-			| [< '(Comma,_); e = expr >] -> loop (e::acc)
+			| [< '(Comma, pc) >] ->
+				if is_resuming pc then begin
+					fun_arg_display_index := List.length acc;
+					display (EDisplay (ec, true), pc)
+				end;
+				(match s with parser [< e = expr >] -> loop (e::acc))
 			| [< >] -> List.rev acc
-		with Display e ->
-			display (ECall (ec,List.rev (e::acc)),punion (pos ec) (pos e))
+		with (Display e) as ex ->
+			match e with
+			| EDisplay _,_ -> raise ex
+			| _ -> display (ECall (ec,List.rev (e::acc)),punion (pos ec) (pos e))
 	in
 	match e with
 	| None -> []
@@ -1522,6 +1546,7 @@ let parse ctx code =
 	let old = Lexer.save() in
 	let old_cache = !cache in
 	let mstack = ref [] in
+	let old_fadi = !fun_arg_display_index in
 	cache := DynArray.create();
 	last_doc := None;
 	in_macro := Common.defined ctx Common.Define.Macro;
@@ -1599,6 +1624,16 @@ let parse ctx code =
 	and skip_tokens p test = skip_tokens_loop p test (Lexer.token code)
 
 	in
+	let restore() =
+		cache := old_cache;
+		Lexer.restore old;
+		let i = !fun_arg_display_index in
+		begin match ctx.display with
+			| DMFunArgs j when j < 0 ->  ctx.display <- DMFunArgs i 
+			| _ -> ()
+		end;
+		fun_arg_display_index := old_fadi
+	in
 	let s = Stream.from (fun _ ->
 		let t = next_token() in
 		DynArray.add (!cache) t;
@@ -1607,17 +1642,14 @@ let parse ctx code =
 	try
 		let l = parse_file s in
 		(match !mstack with p :: _ when not (do_resume()) -> error Unclosed_macro p | _ -> ());
-		cache := old_cache;
-		Lexer.restore old;
+		restore();
 		l
 	with
 		| Stream.Error _
 		| Stream.Failure ->
 			let last = (match Stream.peek s with None -> last_token s | Some t -> t) in
-			Lexer.restore old;
-			cache := old_cache;
+			restore();
 			error (Unexpected (fst last)) (pos last)
 		| e ->
-			Lexer.restore old;
-			cache := old_cache;
+			restore();
 			raise e

--- a/tests/misc/projects/display-funargs/Main.hx
+++ b/tests/misc/projects/display-funargs/Main.hx
@@ -1,0 +1,1 @@
+class Main { static function main() { var a = ""; a.substr(0, 1); } }

--- a/tests/misc/projects/display-funargs/compile.hxml
+++ b/tests/misc/projects/display-funargs/compile.hxml
@@ -1,0 +1,2 @@
+-main Main
+--display Main.hx@61@funargs

--- a/tests/misc/projects/display-funargs/compile.hxml.stderr
+++ b/tests/misc/projects/display-funargs/compile.hxml.stderr
@@ -1,0 +1,4 @@
+<type>
+1@pos : Int -&gt; ?len : Null&lt;Int&gt; -&gt; String
+</type>
+

--- a/typer.ml
+++ b/typer.ml
@@ -3827,7 +3827,7 @@ and handle_display ctx e_ast iscall with_type p =
 		e
 	| DMToplevel ->
 		collect_toplevel_identifiers ctx;
-	| DMDefault | DMNone ->
+	| DMDefault | DMNone | DMFunArgs _ ->
 		let opt_args args ret = TFun(List.map(fun (n,o,t) -> n,true,t) args,ret) in
 		let e = match e.eexpr with
 			| TField (e1,fa) ->


### PR DESCRIPTION
Hello,

Can we have in the compiler a new display mode (or enhanced an old one) that will get the argument index of a function along with it's signature so an IDE can use it.

As a result for example:
https://twitter.com/pleclech/status/682300151738675200
https://pbs.twimg.com/tweet_video/CXgECJ9WkAInx8p.mp4

I don't know if it s the right way to do it, but there is an implementation with a new display mode...

-----

- add a new displaymode @funargs to get in return the index of the
argument at ',' position along with the function signature.

The format returned is <type>int_index@function_signature</type>

Ex.:
```haxe
class Main { static function main() { var a = ""; a.substr(0, 1); } }
```

calling with --display Main.hx@61@funargs will return 

```xml
<type>1@pos : Int -> ?len : Null<Int> -> String</type>
```