### PR TITLE
Added yield to reserved php keywords

### DIFF
--- a/genphp.ml
+++ b/genphp.ml
@@ -307,7 +307,7 @@ let is_keyword n =
 	| "clone" | "instanceof" | "break" | "case" | "class" | "continue" | "default"
 	| "do" | "else" | "extends" | "for" | "function" | "if" | "new" | "return"
 	| "static" | "switch" | "var" | "while" | "interface" | "implements" | "public"
-	| "private" | "try" | "catch" | "throw" | "goto"
+	| "private" | "try" | "catch" | "throw" | "goto" | "yield"
 		-> true
 	| _ -> false
 


### PR DESCRIPTION
The `yield` keyword should be avoided in php output:
http://php.net/manual/en/language.generators.syntax.php#control-structures.yield