### PR TITLE
Make require an external function

### DIFF
--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -50,7 +50,7 @@ class Lib {
 		This is only supported in environments where `require` function
 		is available, such as Node.js or RequireJS.
 	**/
-	public static inline function require( module:String ) : Dynamic {
+	@:extern public static inline function require( module:String ) : Dynamic {
 		return untyped __js__("require")(module);
 	}
 


### PR DESCRIPTION
This change prevent the following warning when using [webpack](https://webpack.github.io) with haxe generated JavaScript files.

```
WARNING in ./~/microbuilder-js/index.js
Critical dependencies:
6183:8-23 the request of a dependency is an expression
 @ ./~/microbuilder-js/index.js 6183:8-23
```