### PR TITLE
Be able to output "::" on a template file

### DIFF
--- a/std/haxe/Template.hx
+++ b/std/haxe/Template.hx
@@ -112,6 +112,8 @@ class Template {
 	}
 
 	function resolve( v : String ) : Dynamic {
+		if( v == "_")
+			return "::";
 		if( Reflect.hasField(context,v) )
 			return Reflect.field(context,v);
 		for( ctx in stack )


### PR DESCRIPTION
Use ::_:: to output "::"
For example, when including a C++ template file that has to use namespaces