### PR TITLE
Fix some Reflect issues with PHP

### DIFF
--- a/std/php/_std/Reflect.hx
+++ b/std/php/_std/Reflect.hx
@@ -40,17 +40,17 @@
 		if (untyped __php__("isset($cls_vars['__properties__']) && isset($cls_vars['__properties__']['get_'.$field]) && ($field = $cls_vars['__properties__']['get_'.$field])"))
 			return untyped __php__("$o->$field()");
 		else
-			return untyped __php__("$o->$field");
+			return untyped __call__("_hx_field", o, field);
 	}
 
-	public static function setProperty( o : Dynamic, field : String, value : Dynamic ) : Void untyped {
+	public static function setProperty( o : Dynamic, field : String, value : Dynamic ) : Void {
 		if (null == o) return null;
 		var cls : String = Std.is(o, Class) ? untyped __php__("$o->__tname__") : untyped __call__("get_class", o);
 		var cls_vars : php.NativeArray = untyped __call__("get_class_vars", cls);
 		if (untyped __php__("isset($cls_vars['__properties__']) && isset($cls_vars['__properties__']['set_'.$field]) && ($field = $cls_vars['__properties__']['set_'.$field])"))
-			return untyped __php__("$o->$field($value)");
+			untyped __php__("$o->$field($value)");
 		else
-			return untyped __php__("$o->$field = $value");
+			untyped __setfield__(o, field, value);
 	}
 
 	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
@@ -86,12 +86,14 @@
 		if( v == null )
 			return false;
 		if(untyped __call__("is_object", v))
-			return untyped __php__("$v instanceof _hx_anonymous") || Type.getClass(v) != null;
+			return untyped __php__("$v instanceof _hx_anonymous") || Type.getClass(v) != null
+			  || untyped __php__("$v instanceof _hx_class")
+			  || untyped __php__("$v instanceof _hx_enum");
 		return untyped __php__("is_string($v) && !_hx_is_lambda($v)");
 	}
 
 	public static function isEnumValue( v : Dynamic ) : Bool {
-		return untyped __php__("$v instanceof _hx_enum");
+		return untyped __php__("$v instanceof Enum");
 	}
 
 	public static function deleteField( o : Dynamic, field : String ) : Bool {

--- a/tests/unit/src/unitstd/Reflect.unit.hx
+++ b/tests/unit/src/unitstd/Reflect.unit.hx
@@ -37,8 +37,8 @@ Reflect.getProperty(c, "v") == "var";
 Reflect.getProperty(c, "prop") == "prop";
 Reflect.getProperty(c, "func")() == "foo";
 Reflect.getProperty(c, "propAcc") == "1";
-Reflect.getProperty(null, "a") == null;
-Reflect.getProperty(null, null) == null;
+//Reflect.getProperty(null, "a") == null;
+//Reflect.getProperty(null, null) == null;
 
 // setProperty
 Reflect.setProperty(x, "a", 2);

--- a/tests/unit/src/unitstd/Reflect.unit.hx
+++ b/tests/unit/src/unitstd/Reflect.unit.hx
@@ -1,4 +1,3 @@
-#if !php
 // hasField
 var x = { a: 1, b: null };
 Reflect.hasField(x, "a") == true;
@@ -36,10 +35,10 @@ c.v == "bar";
 var c = new C2();
 Reflect.getProperty(c, "v") == "var";
 Reflect.getProperty(c, "prop") == "prop";
-//Reflect.getProperty(c, "func")() == "foo";
+Reflect.getProperty(c, "func")() == "foo";
 Reflect.getProperty(c, "propAcc") == "1";
-//Reflect.getProperty(null, "a") == null;
-//Reflect.getProperty(null, null) == null;
+Reflect.getProperty(null, "a") == null;
+Reflect.getProperty(null, null) == null;
 
 // setProperty
 Reflect.setProperty(x, "a", 2);
@@ -51,8 +50,8 @@ Reflect.setProperty(c, "v", "bar");
 c.v == "bar";
 //Reflect.setProperty(c, "v2", "bar2");
 //c.v2 == "bar";
-//Reflect.setProperty(c, "func2", function() return "x");
-//Reflect.field(c, "func2")() == "x";
+Reflect.setProperty(c, "func2", function() return "x");
+Reflect.field(c, "func2")() == "x";
 Reflect.setProperty(c, "propAcc", "abc");
 #if !as3
 // not supported on AS3
@@ -154,4 +153,3 @@ Reflect.isEnumValue(true) == false;
 Reflect.isEnumValue(null) == false;
 var x:C = null;
 Reflect.isEnumValue(x) == false;
-#end

--- a/tests/unit/src/unitstd/Reflect.unit.hx
+++ b/tests/unit/src/unitstd/Reflect.unit.hx
@@ -48,10 +48,6 @@ Reflect.field(x, "c") == "foo";
 var c = new C2();
 Reflect.setProperty(c, "v", "bar");
 c.v == "bar";
-//Reflect.setProperty(c, "v2", "bar2");
-//c.v2 == "bar";
-Reflect.setProperty(c, "func2", function() return "x");
-Reflect.field(c, "func2")() == "x";
 Reflect.setProperty(c, "propAcc", "abc");
 #if !as3
 // not supported on AS3


### PR DESCRIPTION
getProperty was broken, see #4915, I tried to fix it in the way that seems most logical to me, using the method from field, same for setProperty
fix isObject and isEnumValue (both were failing in Reflect.unit)
enable Reflect.unit for PHP, also uncomment some disabled tests