### PR TITLE
PHP externs in the global namespace

### DIFF
--- a/ast.ml
+++ b/ast.ml
@@ -134,6 +134,7 @@ module Meta = struct
 		| Op
 		| Optional
 		| Overload
+		| PhpConstants
 		| PrivateAccess
 		| Property
 		| Protected

--- a/common.ml
+++ b/common.ml
@@ -465,6 +465,7 @@ module MetaInfo = struct
 		| Op -> ":op",("Declares an abstract field as being an operator overload",[HasParam "The operation";UsedOn TAbstractField])
 		| Optional -> ":optional",("Marks the field of a structure as optional",[UsedOn TClassField])
 		| Overload -> ":overload",("Allows the field to be called with different argument types",[HasParam "Function specification (no expression)";UsedOn TClassField])
+		| PhpConstants -> ":phpConstants",("Marks the fields of an TAbstract as php constants, without $",[Platform Php;UsedOn TClass])
 		| Public -> ":public",("Marks a class field as being public",[UsedOn TClassField])
 		| PublicFields -> ":publicFields",("Forces all class fields of inheriting classes to be public",[UsedOn TClass])
 		| QuotedField -> ":quotedField",("Used internally to mark structure fields which are quoted in syntax",[Internal])

--- a/genphp.ml
+++ b/genphp.ml
@@ -782,10 +782,10 @@ and gen_member_access ctx isvar e s =
 		| EnumStatics _ ->
 			print ctx "::%s%s" (if isvar then "$" else "") (s_ident s)
 		| Statics sta ->
-		  let sep = match sta.cl_path with
-		  | ([], "") | ([], "\\") -> ""
-		  | _ -> "::" in
-		  let isconst = Meta.has Meta.PhpConstants sta.cl_meta in
+			let sep = match sta.cl_path with
+			| ([], "") | ([], "\\") -> ""
+			| _ -> "::" in
+			let isconst = Meta.has Meta.PhpConstants sta.cl_meta in
 			print ctx "%s%s%s" sep (if isvar && not isconst then "$" else "") (s_ident s)
 		| _ -> print ctx "->%s" (if isvar then s_ident_field s else s_ident s))
 	| _ -> print ctx "->%s" (if isvar then s_ident_field s else s_ident s)

--- a/genphp.ml
+++ b/genphp.ml
@@ -781,8 +781,12 @@ and gen_member_access ctx isvar e s =
 		(match !(a.a_status) with
 		| EnumStatics _ ->
 			print ctx "::%s%s" (if isvar then "$" else "") (s_ident s)
-		| Statics _ ->
-			print ctx "::%s%s" (if isvar then "$" else "") (s_ident s)
+		| Statics sta ->
+		  let sep = match sta.cl_path with
+		  | ([], "") | ([], "\\") -> ""
+		  | _ -> "::" in
+		  let isconst = Meta.has Meta.PhpConstants sta.cl_meta in
+			print ctx "%s%s%s" sep (if isvar && not isconst then "$" else "") (s_ident s)
 		| _ -> print ctx "->%s" (if isvar then s_ident_field s else s_ident s))
 	| _ -> print ctx "->%s" (if isvar then s_ident_field s else s_ident s)
 

--- a/typeload.ml
+++ b/typeload.ml
@@ -198,7 +198,7 @@ let module_pass_1 com m tdecls loadp =
 				(match !decls with
 				| (TClassDecl c,_) :: _ ->
 					List.iter (fun m -> match m with
-						| ((Meta.Build | Meta.CoreApi | Meta.Allow | Meta.Access | Meta.Enum | Meta.Dce | Meta.Native | Meta.JsRequire | Meta.PythonImport | Meta.Expose | Meta.Deprecated),_,_) ->
+						| ((Meta.Build | Meta.CoreApi | Meta.Allow | Meta.Access | Meta.Enum | Meta.Dce | Meta.Native | Meta.JsRequire | Meta.PythonImport | Meta.Expose | Meta.Deprecated | Meta.PhpConstants),_,_) ->
 							c.cl_meta <- m :: c.cl_meta;
 						| _ ->
 							()


### PR DESCRIPTION
Some attempts in ocaml hackery, not ready yet:
Modify gen_member_access in genphp to deal with global namespace
Add metadata @:phpConstants for dealing with constants