### PR TITLE
SSL for neko and cpp platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,12 +111,14 @@ install:
   # Install haxe and neko dependencies
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
     travis_retry brew update;
-    travis_retry brew install ocaml camlp4;
+    travis_retry brew install ocaml camlp4 mbedtls;
     fi
   # Install neko
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
       travis_retry git clone https://github.com/HaxeFoundation/neko.git ~/neko;
       cd ~/neko;
+      # install mbedTLS (note: wget refuse tls.mbed.org certificate on Ubuntu 12.04)
+      (cd libs/include/ssl/ && wget --no-check-certificate https://tls.mbed.org/download/mbedtls-2.2.1-apache.tgz && tar xzf mbedtls-2.2.1-apache.tgz && cd mbedtls-2.2.1 && sed -i "s/\/\/#define MBEDTLS_THREADING_PTHREAD/#define MBEDTLS_THREADING_PTHREAD/; s/\/\/#define MBEDTLS_THREADING_C/#define MBEDTLS_THREADING_C/; s/#define MBEDTLS_SSL_PROTO_SSL3/\/\/#define MBEDTLS_SSL_PROTO_SSL3/" include/mbedtls/config.h && SHARED=1 make lib && sudo make install);
       make os=${TRAVIS_OS_NAME} -s;
       export PATH="$PATH:$HOME/neko/bin";
       export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$HOME/neko/bin";

--- a/std/cpp/_std/sys/net/Socket.hx
+++ b/std/cpp/_std/sys/net/Socket.hx
@@ -117,7 +117,7 @@ private class SocketOutput extends haxe.io.Output {
 
 
 @:coreApi
-class Socket {
+class Socket implements sys.net.ISocket {
 
 	private var __s : Dynamic;
 	public var input(default,null) : haxe.io.Input;
@@ -214,7 +214,7 @@ class Socket {
 		socket_set_fast_send(__s,b);
 	}
 
-	public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float ) : {read: Array<Socket>,write: Array<Socket>,others: Array<Socket>} {
+	public static function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float ) : {read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket>} {
 		var neko_array = socket_select(read,write,others, timeout);
 		if (neko_array==null)
 			throw "Select error";

--- a/std/cpp/_std/sys/ssl/Certificate.hx
+++ b/std/cpp/_std/sys/ssl/Certificate.hx
@@ -1,0 +1,106 @@
+package sys.ssl;
+
+@:coreApi
+class Certificate {
+	
+	var __x : Dynamic;
+
+	@:allow(sys.ssl.Socket)
+	function new( x : Dynamic ){
+		__x = x;
+	}
+
+	public static function loadFile( file : String ) : Certificate {
+		return new Certificate( cert_load_file( file ) );
+	}
+	
+	public static function loadPath( path : String ) : Certificate {
+		return new Certificate( cert_load_path( path ) );
+	}
+
+	public static function loadDefaults() : Certificate {
+		var x = cert_load_defaults();
+		if ( x != null )
+			return new Certificate( x );
+		
+		var defPaths = null;
+		switch( Sys.systemName() ){
+			case "Linux":
+				defPaths = [
+					"/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu/Gentoo etc.
+					"/etc/pki/tls/certs/ca-bundle.crt",   // Fedora/RHEL
+					"/etc/ssl/ca-bundle.pem",             // OpenSUSE
+					"/etc/pki/tls/cacert.pem",            // OpenELEC
+					"/etc/ssl/certs"                      // SLES10/SLES11
+				];
+			case "BSD":
+				defPaths = [
+					"/usr/local/share/certs/ca-root-nss.crt", // FreeBSD/DragonFly
+					"/etc/ssl/cert.pem",                      // OpenBSD
+					"/etc/openssl/certs/ca-certificates.crt", // NetBSD	
+				];
+			case "Android":
+				defPaths = ["/system/etc/security/cacerts"];
+			default:
+		}
+		if( defPaths != null ){
+			for( path in defPaths )
+				if( sys.FileSystem.exists(path) )
+					return loadFile(path);
+		}
+		return null;
+	}
+
+	public var commonName(get,null) : Null<String>;
+	public var altNames(get, null) : Array<String>;
+	public var notBefore(get,null) : Date;
+	public var notAfter(get,null) : Date;
+
+	function get_commonName() : Null<String> {
+		return subject("CN");
+	}
+
+	function get_altNames() : Array<String> {
+		var l : Dynamic = cert_get_altnames(__x);
+		var a = new Array<String>();
+		while( l != null ){
+			a.push(l[0]);
+			l = l[1];
+		}
+		return a;
+	}
+	
+	public function subject( field : String ) : Null<String> {
+		return cert_get_subject(__x, field);
+	}
+	
+	public function issuer( field : String ) : Null<String> {
+		return cert_get_issuer(__x, field);
+	}
+
+	function get_notBefore() : Date {
+		var a = cert_get_notbefore( __x );
+		return new Date( a[0], a[1] - 1, a[2], a[3], a[4], a[5] );
+	}
+
+	function get_notAfter() : Date {
+		var a = cert_get_notafter( __x );
+		return new Date( a[0], a[1] - 1, a[2], a[3], a[4], a[5] );
+	}
+	
+	public function next() : Null<Certificate> {
+		var n = cert_get_next(__x);
+		return n == null ? null : new Certificate( n );
+	}
+
+	private static var cert_load_defaults = cpp.Lib.load("ssl", "cert_load_defaults",0);
+	private static var cert_load_file = cpp.Lib.load("ssl","cert_load_file",1);
+	private static var cert_load_path = cpp.Lib.load("ssl","cert_load_path",1);
+	private static var cert_get_subject = cpp.Lib.load("ssl", "cert_get_subject", 2);
+	private static var cert_get_issuer = cpp.Lib.load("ssl","cert_get_issuer",2);
+	private static var cert_get_altnames = cpp.Lib.load("ssl","cert_get_altnames",1);
+	private static var cert_get_notbefore = cpp.Lib.load("ssl","cert_get_notbefore",1);
+	private static var cert_get_notafter = cpp.Lib.load("ssl","cert_get_notafter",1);
+	private static var cert_get_next = cpp.Lib.load("ssl","cert_get_next",1);
+
+}

--- a/std/cpp/_std/sys/ssl/Digest.hx
+++ b/std/cpp/_std/sys/ssl/Digest.hx
@@ -1,0 +1,33 @@
+package sys.ssl;
+
+@:enum
+abstract DigestAlgorithm(String) {
+	var MD5 = "MD5";
+	var SHA1 = "SHA1";
+	var SHA224 = "SHA224";
+	var SHA256 = "SHA256";
+	var SHA384 = "SHA384";
+	var SHA512 = "SHA512";
+	var RIPEMD160 = "RIPEMD160";
+}
+
+@:coreApi
+class Digest {
+
+	public static function make( data : haxe.io.Bytes, alg : DigestAlgorithm ) : haxe.io.Bytes {
+		return haxe.io.Bytes.ofData( dgst_make( data.getData(), alg ) );
+	}
+	
+	public static function sign( data : haxe.io.Bytes, privKey : Key, alg : DigestAlgorithm ) : haxe.io.Bytes {
+		return haxe.io.Bytes.ofData( dgst_sign( data.getData(), @:privateAccess privKey.__k, alg ) );
+	}
+	
+	public static function verify( data : haxe.io.Bytes, signature : haxe.io.Bytes, pubKey : Key, alg : DigestAlgorithm ) : Bool{
+		return dgst_verify( data.getData(), signature.getData(), @:privateAccess pubKey.__k, alg );
+	}
+
+	private static var dgst_make = cpp.Lib.load("ssl","dgst_make",2);
+	private static var dgst_sign = cpp.Lib.load("ssl","dgst_sign",3);
+	private static var dgst_verify = cpp.Lib.load("ssl","dgst_verify",4);
+
+}

--- a/std/cpp/_std/sys/ssl/Key.hx
+++ b/std/cpp/_std/sys/ssl/Key.hx
@@ -1,0 +1,34 @@
+package sys.ssl;
+
+private typedef PKEY = Dynamic;
+
+@:coreApi
+class Key {
+	
+	private var __k : PKEY;
+
+	private function new( k : PKEY ){
+		__k = k;
+	}
+	
+	public static function loadFile( file : String, ?isPublic : Bool, ?pass : String ) : Key {
+		var data = sys.io.File.getBytes( file );
+		var str = cpp.Lib.stringReference(data);
+		if( str.indexOf("-----BEGIN ") >= 0 )
+			return readPEM( str, isPublic==true, pass );
+		else
+			return readDER( data, isPublic==true );
+	}
+	
+	public static function readPEM( data : String, isPublic : Bool, ?pass : String ) : Key {
+		return new Key( key_from_pem( data, isPublic, pass ) );
+	}
+
+	public static function readDER( data : haxe.io.Bytes, isPublic : Bool ) : Key {
+		return new Key( key_from_der( data.getData(), isPublic ) );
+	}
+
+	private static var key_from_pem = cpp.Lib.load("ssl","key_from_pem",3);
+	private static var key_from_der = cpp.Lib.load("ssl","key_from_der",2);
+
+}

--- a/std/cpp/_std/sys/ssl/Socket.hx
+++ b/std/cpp/_std/sys/ssl/Socket.hx
@@ -1,0 +1,337 @@
+package sys.ssl;
+
+private typedef SocketHandle = Dynamic;
+private typedef CTX = Dynamic;
+private typedef SSL = Dynamic;
+
+private class SocketInput extends haxe.io.Input {
+	@:allow(sys.ssl.Socket) private var __s : SocketHandle;
+	@:allow(sys.ssl.Socket) private var ssl : SSL;
+
+	public function new( s : SocketHandle, ?ssl : SSL ) {
+		this.__s = s;
+		this.ssl = ssl;
+	}
+
+	public override function readByte() {
+		return try {
+			socket_recv_char( ssl );
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else if( __s == null )
+				throw haxe.io.Error.Custom(e);
+			else
+				throw new haxe.io.Eof();
+		}
+	}
+
+	public override function readBytes( buf : haxe.io.Bytes, pos : Int, len : Int ) : Int {
+		var r : Int;
+		if( ssl == null || __s == null )
+			throw "Invalid handle";
+		try {
+			r = socket_recv(  ssl, buf.getData(), pos, len );
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				throw haxe.io.Error.Custom(e);
+		}
+		if( r == 0 )
+			throw new haxe.io.Eof();
+		return r;
+	}
+
+	public override function close() {
+		super.close();
+		if( __s != null ) socket_close( __s );
+	}
+
+	private static var socket_recv = cpp.Lib.load( "ssl", "ssl_recv", 4 );
+	private static var socket_recv_char = cpp.Lib.load( "ssl", "ssl_recv_char", 1 );
+	private static var socket_close = cpp.Lib.load( "std", "socket_close", 1 );
+
+}
+
+private class SocketOutput extends haxe.io.Output {
+	@:allow(sys.ssl.Socket) private var __s : SocketHandle;
+	@:allow(sys.ssl.Socket) private var ssl : SSL;
+
+	public function new( s : SocketHandle, ?ssl : SSL ) {
+		this.__s = s;
+		this.ssl = ssl;
+	}
+
+	public override function writeByte( c : Int ) {
+		if( __s == null )
+			throw "Invalid handle";
+		try {
+			socket_send_char( ssl, c);
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				throw haxe.io.Error.Custom(e);
+		}
+	}
+
+	public override function writeBytes( buf : haxe.io.Bytes, pos : Int, len : Int) : Int {
+		return try {
+			socket_send( ssl, buf.getData(), pos, len);
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				throw haxe.io.Error.Custom(e);
+		}
+	}
+
+	public override function close() {
+		super.close();
+		if( __s != null ) socket_close(__s);
+	}
+
+	private static var socket_close = cpp.Lib.load( "std", "socket_close", 1 );
+	private static var socket_send_char = cpp.Lib.load( "ssl", "ssl_send_char", 2 );
+	private static var socket_send = cpp.Lib.load( "ssl", "ssl_send", 4 );
+}
+
+@:coreApi
+class Socket implements sys.net.ISocket {
+	
+	public static var DEFAULT_VERIFY_CERT : Null<Bool> = true;
+
+	public static var DEFAULT_CA : Null<Certificate>;
+	
+	public var input(default,null) : haxe.io.Input;
+	public var output(default,null) : haxe.io.Output;
+	public var custom : Dynamic;
+
+	private var __s : SocketHandle;
+	private var ctx : CTX;
+	private var ssl : SSL;
+	
+	public var verifyCert : Null<Bool>;
+	private var caCert : Null<Certificate>;
+	private var hostname : String;
+
+	private var ownCert : Null<Certificate>;
+	private var ownKey : Null<Key>;
+	private var altSNIContexts : Null<Array<{match: String->Bool, key: Key, cert: Certificate}>>;
+	private var sniCallback : Dynamic;
+
+	public function new() {
+		__s = socket_new( false );
+		input = new SocketInput( __s );
+		output = new SocketOutput( __s );
+		if( DEFAULT_VERIFY_CERT && DEFAULT_CA == null ){
+			try {
+				DEFAULT_CA = Certificate.loadDefaults();
+			}catch( e : Dynamic ){}
+		}	
+		caCert = DEFAULT_CA;
+		verifyCert = DEFAULT_VERIFY_CERT;
+	}
+
+	public function connect(host : sys.net.Host, port : Int) : Void {
+		try {
+			ctx = buildSSLContext( false );
+			ssl = ssl_new( ctx );
+			ssl_set_socket( ssl, __s );
+			var input : SocketInput = cast input;
+			var output : SocketOutput = cast output;
+			input.ssl = ssl;
+			output.ssl = ssl;
+			if( hostname == null )
+				hostname = host.host;
+			if( hostname != null )
+				ssl_set_hostname( ssl, hostname );
+			socket_connect( __s, host.ip, port );
+			handshake();
+		} catch( s : String ) {
+			if( s == "std@socket_connect" )
+				throw "Failed to connect on "+host.host+":"+port;
+			else
+				cpp.Lib.rethrow(s);
+		} catch( e : Dynamic ) {
+			cpp.Lib.rethrow(e);
+		}
+	}
+
+	public function handshake() : Void {
+		try {
+			ssl_handshake( ssl );
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				cpp.Lib.rethrow( e );
+		}
+	}
+
+	public function setCA( cert : Certificate ) : Void {
+		caCert = cert;
+	}
+
+	public function setHostname( name : String ) : Void {
+		hostname = name;
+	}
+
+	public function setCertificate( cert : Certificate, key : Key ) : Void {
+		ownCert = cert;
+		ownKey = key;
+	}
+
+	public function read() : String {
+		var b = ssl_read( ssl );
+		if( b == null )
+			return "";
+		return b;
+	}
+
+	public function write( content : String ) : Void {
+		ssl_write( ssl, content );
+	}
+
+	public function close() : Void {
+		if( ssl != null ) ssl_close( ssl );
+		if( ctx != null ) conf_close( ctx );
+		if( altSNIContexts != null )
+			sniCallback = null;
+		socket_close( __s );
+		var input : SocketInput = cast input;
+		var output : SocketOutput = cast output;
+		@:privateAccess input.__s = output.__s = null;
+		@:privateAccess input.ssl = output.ssl = null;
+		input.close();
+		output.close();
+	}
+
+	public function addSNICertificate( cbServernameMatch : String->Bool, cert : Certificate, key : Key ) : Void {
+		if( altSNIContexts == null )
+			altSNIContexts = [];
+		altSNIContexts.push( {match: cbServernameMatch, cert: cert, key: key} );
+	}
+
+	public function bind( host : sys.net.Host, port : Int ) : Void {
+		ctx = buildSSLContext( true );
+
+		socket_bind( __s, host.ip, port );
+	}
+
+	public function listen( connections : Int ) : Void {
+		socket_listen( __s, connections );
+	}
+
+	public function accept() : Socket {
+		var c = socket_accept( __s );
+		var ssl = ssl_new( ctx );
+		ssl_set_socket( ssl, c );
+
+		var s = Type.createEmptyInstance( sys.ssl.Socket );
+		s.__s = c;
+		s.ssl = ssl;
+		s.input = new SocketInput(c, ssl);
+		s.output = new SocketOutput(c, ssl);
+
+		return s;
+	}
+
+	public function peer() : { host : sys.net.Host, port : Int } {
+		var a : Dynamic = socket_peer(__s);
+		var h = new sys.net.Host("127.0.0.1");
+		untyped h.ip = a[0];
+		return { host : h, port : a[1] };
+	}
+
+	public function peerCertificate() : sys.ssl.Certificate {
+		var x = ssl_get_peer_certificate( ssl );
+		return x==null ? null : new sys.ssl.Certificate( x );
+	}
+
+	public function shutdown( read : Bool, write : Bool ) : Void {
+		socket_shutdown( __s, read, write );
+	}
+
+	public function host() : { host : sys.net.Host, port : Int } {
+		var a : Dynamic = socket_host( __s );
+		var h = new sys.net.Host( "127.0.0.1" );
+		untyped h.ip = a[0];
+		return { host : h, port : a[1] };
+	}
+
+	public function setTimeout( timeout : Float ) : Void {
+		socket_set_timeout( __s, timeout );
+	}
+
+	public function waitForRead() : Void {
+		sys.net.Socket.select([__s],null,null,null);
+	}
+
+	public function setBlocking( b : Bool ) : Void {
+		socket_set_blocking(__s,b);
+	}
+
+	public function setFastSend( b : Bool ) : Void {
+		socket_set_fast_send(__s,b);
+	}
+
+	private function buildSSLContext( server : Bool ) : CTX {
+		var ctx : CTX = conf_new( server );
+
+		if( ownCert != null && ownKey != null )
+			conf_set_cert( ctx, @:privateAccess ownCert.__x, @:privateAccess ownKey.__k );
+
+		if ( altSNIContexts != null ) {
+			sniCallback = function(servername) {
+				var servername = new String(cast servername);
+				for( c in altSNIContexts ){
+					if( c.match(servername) )
+						return @:privateAccess {key: c.key.__k, cert: c.cert.__x};
+				}
+				if( ownKey != null && ownCert != null )
+					return @:privateAccess { key: ownKey.__k, cert: ownCert.__x };
+				return null;
+			}
+			conf_set_servername_callback( ctx, sniCallback );
+		}
+
+		if ( caCert != null ) 
+			conf_set_ca( ctx, caCert == null ? null : @:privateAccess caCert.__x  );
+		conf_set_verify( ctx, verifyCert );
+		
+		return ctx;
+	}
+	
+	private static var ssl_new = cpp.Lib.load( "ssl", "ssl_new", 1 );
+	private static var ssl_close = cpp.Lib.load( "ssl", "ssl_close", 1 );
+	private static var ssl_handshake = cpp.Lib.load( "ssl", "ssl_handshake", 1 );
+	private static var ssl_set_socket = cpp.Lib.load( "ssl", "ssl_set_socket", 2 );
+	private static var ssl_set_hostname = cpp.Lib.load( "ssl", "ssl_set_hostname", 2 );
+	private static var ssl_get_peer_certificate = cpp.Lib.load( "ssl", "ssl_get_peer_certificate", 1 );
+
+	private static var ssl_read = cpp.Lib.load( "ssl", "ssl_read", 1 );
+	private static var ssl_write = cpp.Lib.load( "ssl", "ssl_write", 2 );
+
+	private static var conf_new = cpp.Lib.load( "ssl", "conf_new", 1 );
+	private static var conf_close = cpp.Lib.load( "ssl", "conf_close", 1 );
+	private static var conf_set_ca = cpp.Lib.load( "ssl", "conf_set_ca", 2 );
+	private static var conf_set_verify = cpp.Lib.load( "ssl", "conf_set_verify", 2 );
+	private static var conf_set_cert = cpp.Lib.load( "ssl", "conf_set_cert", 3 );
+	private static var conf_set_servername_callback = cpp.Lib.load( "ssl", "conf_set_servername_callback", 2 );
+
+	private static var socket_new = cpp.Lib.load("std","socket_new",1);
+	private static var socket_close = cpp.Lib.load("std","socket_close",1);
+	private static var socket_connect = cpp.Lib.load("std","socket_connect",3);
+	private static var socket_listen = cpp.Lib.load("std","socket_listen",2);
+	private static var socket_bind = cpp.Lib.load("std","socket_bind",3);
+	private static var socket_accept = cpp.Lib.load("std","socket_accept",1);
+	private static var socket_peer = cpp.Lib.load("std","socket_peer",1);
+	private static var socket_host = cpp.Lib.load("std","socket_host",1);
+	private static var socket_set_timeout = cpp.Lib.load("std","socket_set_timeout",2);
+	private static var socket_shutdown = cpp.Lib.load("std","socket_shutdown",3);
+	private static var socket_set_blocking = cpp.Lib.load("std","socket_set_blocking",2);
+	private static var socket_set_fast_send = cpp.Lib.loadLazy("std","socket_set_fast_send",2);
+
+}

--- a/std/cs/_std/sys/net/Socket.hx
+++ b/std/cs/_std/sys/net/Socket.hx
@@ -39,7 +39,7 @@ import haxe.io.Output;
 	A TCP socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
 **/
 @:coreapi
-class Socket {
+class Socket implements sys.net.ISocket {
 	private var sock : cs.system.net.sockets.Socket = null;
 
 	/**
@@ -200,7 +200,7 @@ class Socket {
 		[select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
 		In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
 	**/
-	static public function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> } {
+	static public function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float) : { read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket> } {
 		throw "Not implemented yet.";
 		return null;
 	}

--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -26,16 +26,6 @@ package haxe;
 import sys.net.Host;
 import sys.net.Socket;
 
-private typedef AbstractSocket = {
-	var input(default,null) : haxe.io.Input;
-	var output(default,null) : haxe.io.Output;
-	function connect( host : Host, port : Int ) : Void;
-	function setTimeout( t : Float ) : Void;
-	function write( str : String ) : Void;
-	function close() : Void;
-	function shutdown( read : Bool, write : Bool ) : Void;
-}
-
 #end
 
 /**
@@ -371,7 +361,7 @@ class Http {
 		this.file = { param : argname, filename : filename, io : file, size : size, mimeType : mimeType };
 	}
 
-	public function customRequest( post : Bool, api : haxe.io.Output, ?sock : AbstractSocket, ?method : String  ) {
+	public function customRequest( post : Bool, api : haxe.io.Output, ?sock : sys.net.ISocket, ?method : String  ) {
 		this.responseData = null;
 		var url_regexp = ~/^(https?:\/\/)?([a-zA-Z\.0-9_-]+)(:[0-9]+)?(.*)$/;
 		if( !url_regexp.match(url) ) {
@@ -385,12 +375,8 @@ class Http {
 				sock = new php.net.SslSocket();
 				#elseif java
 				sock = new java.net.SslSocket();
-				#elseif hxssl
-				#if neko
-				sock = new neko.tls.Socket();
-				#else
+				#elseif (hxssl || cpp || (neko && !(macro || interp)))
 				sock = new sys.ssl.Socket();
-				#end
 				#else
 				throw "Https is only supported with -lib hxssl";
 				#end
@@ -534,7 +520,7 @@ class Http {
 		}
 	}
 
-	function readHttpResponse( api : haxe.io.Output, sock : AbstractSocket ) {
+	function readHttpResponse( api : haxe.io.Output, sock : sys.net.ISocket ) {
 		// READ the HTTP header (until \r\n\r\n)
 		var b = new haxe.io.BytesBuffer();
 		var k = 4;

--- a/std/java/_std/sys/net/Socket.hx
+++ b/std/java/_std/sys/net/Socket.hx
@@ -23,7 +23,7 @@ package sys.net;
 import java.net.InetSocketAddress;
 
 @:coreApi
-class Socket {
+class Socket implements sys.net.ISocket {
 
 	public var input(default,null) : haxe.io.Input;
 	public var output(default,null) : haxe.io.Output;
@@ -170,7 +170,7 @@ class Socket {
 		catch(e:Dynamic) throw e;
 	}
 
-	public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> }
+	public static function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float) : { read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket> }
 	{
 		throw "Not implemented";
 		return null;

--- a/std/neko/_std/sys/net/Socket.hx
+++ b/std/neko/_std/sys/net/Socket.hx
@@ -114,7 +114,7 @@ private class SocketInput extends haxe.io.Input {
 }
 
 @:coreApi
-class Socket {
+class Socket implements sys.net.ISocket {
 
 	private var __s : SocketHandle;
 	public var input(default,null) : haxe.io.Input;
@@ -207,9 +207,9 @@ class Socket {
 		socket_set_fast_send(__s,b);
 	}
 
-	public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : {read: Array<Socket>,write: Array<Socket>,others: Array<Socket>} {
+	public static function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float) : {read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket>} {
 		var c = untyped __dollar__hnew( 1 );
-		var f = function( a : Array<Socket> ){
+		var f = function( a : Array<ISocket> ){
 			if( a == null ) return null;
 			untyped {
 				var r = __dollar__amake(a.length);
@@ -224,7 +224,7 @@ class Socket {
 		}
 		var neko_array = socket_select(f(read),f(write),f(others), timeout);
 
-		var g = function( a ) : Array<Socket> {
+		var g = function( a ) : Array<ISocket> {
 			if( a == null ) return null;
 
 			var r = new Array();

--- a/std/neko/_std/sys/ssl/Certificate.hx
+++ b/std/neko/_std/sys/ssl/Certificate.hx
@@ -1,0 +1,109 @@
+package sys.ssl;
+
+@:coreApi
+class Certificate {
+	
+	var __x : Dynamic;
+
+	@:allow(sys.ssl.Socket)
+	function new( x : Dynamic ){
+		__x = x;
+	}
+
+	public static function loadFile( file : String ) : Certificate {
+		return new Certificate( cert_load_file( untyped file.__s ) );
+	}
+	
+	public static function loadPath( path : String ) : Certificate {
+		return new Certificate( cert_load_path( untyped path.__s ) );
+	}
+	
+	public static function loadDefaults() : Certificate {
+		var x = cert_load_defaults();
+		if ( x != null )
+			return new Certificate( x );
+		
+		var defPaths = null;
+		switch( Sys.systemName() ){
+			case "Linux":
+				defPaths = [
+					"/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu/Gentoo etc.
+					"/etc/pki/tls/certs/ca-bundle.crt",   // Fedora/RHEL
+					"/etc/ssl/ca-bundle.pem",             // OpenSUSE
+					"/etc/pki/tls/cacert.pem",            // OpenELEC
+					"/etc/ssl/certs"                      // SLES10/SLES11
+				];
+			case "BSD":
+				defPaths = [
+					"/usr/local/share/certs/ca-root-nss.crt", // FreeBSD/DragonFly
+					"/etc/ssl/cert.pem",                      // OpenBSD
+					"/etc/openssl/certs/ca-certificates.crt", // NetBSD	
+				];
+			case "Android":
+				defPaths = ["/system/etc/security/cacerts"];
+			default:
+		}
+		if( defPaths != null ){
+			for( path in defPaths )
+				if( sys.FileSystem.exists(path) )
+					return loadFile(path);
+		}
+		return null;
+	}
+
+	public var commonName(get,null) : Null<String>;
+	public var altNames(get, null) : Array<String>;
+	public var notBefore(get,null) : Date;
+	public var notAfter(get,null) : Date;
+
+	function get_commonName() : Null<String> {
+		return subject("CN");
+	}
+
+	function get_altNames() : Array<String> {
+		var l : Dynamic = cert_get_altnames(__x);
+		var a = new Array<String>();
+		while( l != null ){
+			a.push(new String(l[0]));
+			l = l[1];
+		}
+		return a;
+	}
+	
+	public function subject( field : String ) : Null<String> {
+		var s = cert_get_subject(__x, untyped field.__s);
+		return s==null ? null : new String( cast s );
+	}
+	
+	public function issuer( field : String ) : Null<String> {
+		var s = cert_get_issuer(__x, untyped field.__s);
+		return s==null ? null : new String( cast s );
+	}
+
+	function get_notBefore() : Date {
+		var a = cert_get_notbefore( __x );
+		return new Date( a[0], a[1] - 1, a[2], a[3], a[4], a[5] );
+	}
+
+	function get_notAfter() : Date {
+		var a = cert_get_notafter( __x );
+		return new Date( a[0], a[1] - 1, a[2], a[3], a[4], a[5] );
+	}
+	
+	public function next() : Null<Certificate> {
+		var n = cert_get_next(__x);
+		return n == null ? null : new Certificate( n );
+	}
+
+	private static var cert_load_defaults = neko.Lib.load("ssl", "cert_load_defaults",0);
+	private static var cert_load_file = neko.Lib.load("ssl", "cert_load_file",1);
+	private static var cert_load_path = neko.Lib.load("ssl","cert_load_path",1);
+	private static var cert_get_subject = neko.Lib.load("ssl", "cert_get_subject", 2);
+	private static var cert_get_issuer = neko.Lib.load("ssl","cert_get_issuer",2);
+	private static var cert_get_altnames = neko.Lib.load("ssl","cert_get_altnames",1);
+	private static var cert_get_notbefore = neko.Lib.load("ssl","cert_get_notbefore",1);
+	private static var cert_get_notafter = neko.Lib.load("ssl","cert_get_notafter",1);
+	private static var cert_get_next = neko.Lib.load("ssl","cert_get_next",1);
+	
+
+}

--- a/std/neko/_std/sys/ssl/Digest.hx
+++ b/std/neko/_std/sys/ssl/Digest.hx
@@ -1,0 +1,33 @@
+package sys.ssl;
+
+@:enum
+abstract DigestAlgorithm(String) {
+	var MD5 = "MD5";
+	var SHA1 = "SHA1";
+	var SHA224 = "SHA224";
+	var SHA256 = "SHA256";
+	var SHA384 = "SHA384";
+	var SHA512 = "SHA512";
+	var RIPEMD160 = "RIPEMD160";
+}
+
+@:coreApi
+class Digest {
+	
+	public static function make( data : haxe.io.Bytes, alg : DigestAlgorithm ) : haxe.io.Bytes {
+		return haxe.io.Bytes.ofData( dgst_make( data.getData(), untyped alg.__s ) );
+	}
+	
+	public static function sign( data : haxe.io.Bytes, privKey : Key, alg : DigestAlgorithm ) : haxe.io.Bytes {
+		return haxe.io.Bytes.ofData( dgst_sign( data.getData(), @:privateAccess privKey.__k, untyped alg.__s ) );
+	}
+	
+	public static function verify( data : haxe.io.Bytes, signature : haxe.io.Bytes, pubKey : Key, alg : DigestAlgorithm ) : Bool{
+		return dgst_verify( data.getData(), signature.getData(), @:privateAccess pubKey.__k, untyped alg.__s );
+	}
+
+	private static var dgst_make = neko.Lib.load("ssl","dgst_make",2);
+	private static var dgst_sign = neko.Lib.load("ssl","dgst_sign",3);
+	private static var dgst_verify = neko.Lib.load("ssl","dgst_verify",4);
+
+}

--- a/std/neko/_std/sys/ssl/Key.hx
+++ b/std/neko/_std/sys/ssl/Key.hx
@@ -1,0 +1,34 @@
+package sys.ssl;
+
+private typedef PKEY = Dynamic;
+
+@:coreApi
+class Key {
+	
+	private var __k : PKEY;
+
+	private function new( k : PKEY ){
+		__k = k;
+	}
+	
+	public static function loadFile( file : String, ?isPublic : Bool, ?pass : String ) : Key {
+		var data = sys.io.File.getBytes( file );
+		var str = neko.Lib.stringReference(data);
+		if( str.indexOf("-----BEGIN ") >= 0 )
+			return readPEM( str, isPublic==true, pass );
+		else
+			return readDER( data, isPublic==true );
+	}
+	
+	public static function readPEM( data : String, isPublic : Bool, ?pass : String ) : Key {
+		return new Key( key_from_pem( untyped data.__s, isPublic, pass == null ? null : untyped pass.__s ) );
+	}
+
+	public static function readDER( data : haxe.io.Bytes, isPublic : Bool ) : Key {
+		return new Key( key_from_der( data.getData(), isPublic ) );
+	}
+
+	private static var key_from_pem = neko.Lib.load("ssl","key_from_pem",3);
+	private static var key_from_der = neko.Lib.load("ssl","key_from_der",2);
+
+}

--- a/std/neko/_std/sys/ssl/Socket.hx
+++ b/std/neko/_std/sys/ssl/Socket.hx
@@ -1,0 +1,337 @@
+package sys.ssl;
+
+private typedef SocketHandle = Dynamic;
+private typedef CTX = Dynamic;
+private typedef SSL = Dynamic;
+
+private class SocketInput extends haxe.io.Input {
+	@:allow(sys.ssl.Socket) private var __s : SocketHandle;
+	@:allow(sys.ssl.Socket) private var ssl : SSL;
+
+	public function new( s : SocketHandle, ?ssl : SSL ) {
+		this.__s = s;
+		this.ssl = ssl;
+	}
+
+	public override function readByte() {
+		return try {
+			socket_recv_char( ssl );
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else if( __s == null )
+				throw haxe.io.Error.Custom(e);
+			else
+				throw new haxe.io.Eof();
+		}
+	}
+
+	public override function readBytes( buf : haxe.io.Bytes, pos : Int, len : Int ) : Int {
+		var r : Int;
+		if( ssl == null || __s == null )
+			throw "Invalid handle";
+		try {
+			r = socket_recv(  ssl, buf.getData(), pos, len );
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				throw haxe.io.Error.Custom(e);
+		}
+		if( r == 0 )
+			throw new haxe.io.Eof();
+		return r;
+	}
+
+	public override function close() {
+		super.close();
+		if( __s != null ) socket_close( __s );
+	}
+
+	private static var socket_recv = neko.Lib.load( "ssl", "ssl_recv", 4 );
+	private static var socket_recv_char = neko.Lib.load( "ssl", "ssl_recv_char", 1 );
+	private static var socket_close = neko.Lib.load( "std", "socket_close", 1 );
+
+}
+
+private class SocketOutput extends haxe.io.Output {
+	@:allow(sys.ssl.Socket) private var __s : SocketHandle;
+	@:allow(sys.ssl.Socket) private var ssl : SSL;
+
+	public function new( s : SocketHandle, ?ssl : SSL ) {
+		this.__s = s;
+		this.ssl = ssl;
+	}
+
+	public override function writeByte( c : Int ) {
+		if( __s == null )
+			throw "Invalid handle";
+		try {
+			socket_send_char( ssl, c);
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				throw haxe.io.Error.Custom(e);
+		}
+	}
+
+	public override function writeBytes( buf : haxe.io.Bytes, pos : Int, len : Int) : Int {
+		return try {
+			socket_send( ssl, buf.getData(), pos, len);
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				throw haxe.io.Error.Custom(e);
+		}
+	}
+
+	public override function close() {
+		super.close();
+		if( __s != null ) socket_close(__s);
+	}
+
+	private static var socket_close = neko.Lib.load( "std", "socket_close", 1 );
+	private static var socket_send_char = neko.Lib.load( "ssl", "ssl_send_char", 2 );
+	private static var socket_send = neko.Lib.load( "ssl", "ssl_send", 4 );
+}
+
+@:coreApi
+class Socket implements sys.net.ISocket {
+	
+	public static var DEFAULT_VERIFY_CERT : Null<Bool> = true;
+
+	public static var DEFAULT_CA : Null<Certificate>;
+	
+	public var input(default,null) : haxe.io.Input;
+	public var output(default,null) : haxe.io.Output;
+	public var custom : Dynamic;
+
+	private var __s : SocketHandle;
+	private var ctx : CTX;
+	private var ssl : SSL;
+	
+	public var verifyCert : Null<Bool>;
+	private var caCert : Null<Certificate>;
+	private var hostname : String;
+
+	private var ownCert : Null<Certificate>;
+	private var ownKey : Null<Key>;
+	private var altSNIContexts : Null<Array<{match: String->Bool, key: Key, cert: Certificate}>>;
+	private var sniCallback : Dynamic;
+
+	public function new() {
+		__s = socket_new( false );
+		input = new SocketInput( __s );
+		output = new SocketOutput( __s );
+		if( DEFAULT_VERIFY_CERT && DEFAULT_CA == null ){
+			try {
+				DEFAULT_CA = Certificate.loadDefaults();
+			}catch( e : Dynamic ){}
+		}
+		verifyCert = DEFAULT_VERIFY_CERT;
+		caCert = DEFAULT_CA;
+	}
+
+	public function connect(host : sys.net.Host, port : Int) : Void {
+		try {
+			ctx = buildSSLContext( false );
+			ssl = ssl_new( ctx );
+			ssl_set_socket( ssl, __s );
+			var input : SocketInput = cast input;
+			var output : SocketOutput = cast output;
+			input.ssl = ssl;
+			output.ssl = ssl;
+			if( hostname == null )
+				hostname = host.host;
+			if( hostname != null )
+				ssl_set_hostname( ssl, untyped hostname.__s );
+			socket_connect( __s, host.ip, port );
+			handshake();
+		} catch( s : String ) {
+			if( s == "std@socket_connect" )
+				throw "Failed to connect on "+host.host+":"+port;
+			else
+				neko.Lib.rethrow(s);
+		} catch( e : Dynamic ) {
+			neko.Lib.rethrow(e);
+		}
+	}
+
+	public function handshake() : Void {
+		try {
+			ssl_handshake( ssl );
+		} catch( e : Dynamic ) {
+			if( e == "Blocking" )
+				throw haxe.io.Error.Blocked;
+			else
+				neko.Lib.rethrow( e );
+		}
+	}
+
+	public function setCA( cert : Certificate ) : Void {
+		caCert = cert;
+	}
+
+	public function setHostname( name : String ) : Void {
+		hostname = name;
+	}
+
+	public function setCertificate( cert : Certificate, key : Key ) : Void {
+		ownCert = cert;
+		ownKey = key;
+	}
+
+	public function read() : String {
+		var b = ssl_read( ssl );
+		if( b == null )
+			return "";
+		return new String(cast b);
+	}
+
+	public function write( content : String ) : Void {
+		ssl_write( ssl, untyped content.__s );
+	}
+
+	public function close() : Void {
+		if( ssl != null ) ssl_close( ssl );
+		if( ctx != null ) conf_close( ctx );
+		if( altSNIContexts != null )
+			sniCallback = null;
+		socket_close( __s );
+		var input : SocketInput = cast input;
+		var output : SocketOutput = cast output;
+		@:privateAccess input.__s = output.__s = null;
+		@:privateAccess input.ssl = output.ssl = null;
+		input.close();
+		output.close();
+	}
+
+	public function addSNICertificate( cbServernameMatch : String->Bool, cert : Certificate, key : Key ) : Void {
+		if( altSNIContexts == null )
+			altSNIContexts = [];
+		altSNIContexts.push( {match: cbServernameMatch, cert: cert, key: key} );
+	}
+
+	public function bind( host : sys.net.Host, port : Int ) : Void {
+		ctx = buildSSLContext( true );
+
+		socket_bind( __s, host.ip, port );
+	}
+
+	public function listen( connections : Int ) : Void {
+		socket_listen( __s, connections );
+	}
+
+	public function accept() : Socket {
+		var c = socket_accept( __s );
+		var ssl = ssl_new( ctx );
+		ssl_set_socket( ssl, c );
+
+		var s = Type.createEmptyInstance( sys.ssl.Socket );
+		s.__s = c;
+		s.ssl = ssl;
+		s.input = new SocketInput(c, ssl);
+		s.output = new SocketOutput(c, ssl);
+
+		return s;
+	}
+
+	public function peer() : { host : sys.net.Host, port : Int } {
+		var a : Dynamic = socket_peer(__s);
+		var h = new sys.net.Host("127.0.0.1");
+		untyped h.ip = a[0];
+		return { host : h, port : a[1] };
+	}
+
+	public function peerCertificate() : sys.ssl.Certificate {
+		var x = ssl_get_peer_certificate( ssl );
+		return x==null ? null : new sys.ssl.Certificate( x );
+	}
+
+	public function shutdown( read : Bool, write : Bool ) : Void {
+		socket_shutdown( __s, read, write );
+	}
+
+	public function host() : { host : sys.net.Host, port : Int } {
+		var a : Dynamic = socket_host( __s );
+		var h = new sys.net.Host( "127.0.0.1" );
+		untyped h.ip = a[0];
+		return { host : h, port : a[1] };
+	}
+
+	public function setTimeout( timeout : Float ) : Void {
+		socket_set_timeout( __s, timeout );
+	}
+
+	public function waitForRead() : Void {
+		sys.net.Socket.select([__s],null,null,null);
+	}
+
+	public function setBlocking( b : Bool ) : Void {
+		socket_set_blocking(__s,b);
+	}
+
+	public function setFastSend( b : Bool ) : Void {
+		socket_set_fast_send(__s,b);
+	}
+
+	private function buildSSLContext( server : Bool ) : CTX {
+		var ctx : CTX = conf_new( server );
+
+		if( ownCert != null && ownKey != null )
+			conf_set_cert( ctx, @:privateAccess ownCert.__x, @:privateAccess ownKey.__k );
+
+		if ( altSNIContexts != null ) {
+			sniCallback = function(servername) {
+				var servername = new String(cast servername);
+				for( c in altSNIContexts ){
+					if( c.match(servername) )
+						return @:privateAccess {key: c.key.__k, cert: c.cert.__x};
+				}
+				if( ownKey != null && ownCert != null )
+					return @:privateAccess { key: ownKey.__k, cert: ownCert.__x };
+				return null;
+			}
+			conf_set_servername_callback( ctx, sniCallback );
+		}
+
+		if ( caCert != null ) 
+			conf_set_ca( ctx, caCert == null ? null : @:privateAccess caCert.__x  );
+		conf_set_verify( ctx, verifyCert );
+		
+		return ctx;
+	}
+	
+	private static var ssl_new = neko.Lib.load( "ssl", "ssl_new", 1 );
+	private static var ssl_close = neko.Lib.load( "ssl", "ssl_close", 1 );
+	private static var ssl_handshake = neko.Lib.load( "ssl", "ssl_handshake", 1 );
+	private static var ssl_set_socket = neko.Lib.load( "ssl", "ssl_set_socket", 2 );
+	private static var ssl_set_hostname = neko.Lib.load( "ssl", "ssl_set_hostname", 2 );
+	private static var ssl_get_peer_certificate = neko.Lib.load( "ssl", "ssl_get_peer_certificate", 1 );
+
+	private static var ssl_read = neko.Lib.load( "ssl", "ssl_read", 1 );
+	private static var ssl_write = neko.Lib.load( "ssl", "ssl_write", 2 );
+
+	private static var conf_new = neko.Lib.load( "ssl", "conf_new", 1 );
+	private static var conf_close = neko.Lib.load( "ssl", "conf_close", 1 );
+	private static var conf_set_ca = neko.Lib.load( "ssl", "conf_set_ca", 2 );
+	private static var conf_set_verify = neko.Lib.load( "ssl", "conf_set_verify", 2 );
+	private static var conf_set_cert = neko.Lib.load( "ssl", "conf_set_cert", 3 );
+	private static var conf_set_servername_callback = neko.Lib.load( "ssl", "conf_set_servername_callback", 2 );
+
+	private static var socket_new = neko.Lib.load("std","socket_new",1);
+	private static var socket_close = neko.Lib.load("std","socket_close",1);
+	private static var socket_connect = neko.Lib.load("std","socket_connect",3);
+	private static var socket_listen = neko.Lib.load("std","socket_listen",2);
+	private static var socket_bind = neko.Lib.load("std","socket_bind",3);
+	private static var socket_accept = neko.Lib.load("std","socket_accept",1);
+	private static var socket_peer = neko.Lib.load("std","socket_peer",1);
+	private static var socket_host = neko.Lib.load("std","socket_host",1);
+	private static var socket_set_timeout = neko.Lib.load("std","socket_set_timeout",2);
+	private static var socket_shutdown = neko.Lib.load("std","socket_shutdown",3);
+	private static var socket_set_blocking = neko.Lib.load("std","socket_set_blocking",2);
+	private static var socket_set_fast_send = neko.Lib.loadLazy("std","socket_set_fast_send",2);
+
+}

--- a/std/neko/net/ServerLoop.hx
+++ b/std/neko/net/ServerLoop.hx
@@ -64,7 +64,7 @@ class ServerLoop<ClientData> {
 	public var updateTime : Float;
 
 	var newData : Socket -> ClientData;
-	var socks : Array<Socket>;
+	var socks : Array<sys.net.ISocket>;
 	public var clients : List<ClientData>;
 
 	/**

--- a/std/php/_std/sys/net/Socket.hx
+++ b/std/php/_std/sys/net/Socket.hx
@@ -24,7 +24,7 @@ package sys.net;
 import sys.io.File;
 
 @:coreApi
-class Socket {
+class Socket implements sys.net.ISocket {
 
 	private var __s : FileHandle;
 	private var protocol : String;
@@ -163,7 +163,7 @@ class Socket {
 		return untyped __call__('getprotobyname', protocol);
  	}
 
-	public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> }
+	public static function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float) : { read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket> }
 	{
 		throw "Not implemented";
 		return null;

--- a/std/python/_std/sys/net/Socket.hx
+++ b/std/python/_std/sys/net/Socket.hx
@@ -110,7 +110,7 @@ private class SocketOutput extends haxe.io.Output {
 /**
     A TCP socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
 **/
-@:coreApi class Socket {
+@:coreApi class Socket implements sys.net.ISocket {
 
 
     var __s:PSocket;
@@ -258,7 +258,7 @@ private class SocketOutput extends haxe.io.Output {
         [select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
         In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
     **/
-    public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> } {
+    public static function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float) : { read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket> } {
         var t3 = Select.select(read,write,others,timeout);
         return {read:t3._1,write:t3._2,others:t3._3};
     }

--- a/std/sys/net/ISocket.hx
+++ b/std/sys/net/ISocket.hx
@@ -1,0 +1,39 @@
+package sys.net;
+
+interface ISocket {
+
+	var input(default,null) : haxe.io.Input;
+
+	var output(default, null) : haxe.io.Output;
+	
+	var custom : Dynamic;
+
+	function close() : Void;
+
+	function read() : String;
+
+	function write( content : String ) : Void;
+
+	function connect( host : Host, port : Int ) : Void;
+
+	function listen( connections : Int ) : Void;
+
+	function shutdown( read : Bool, write : Bool ) : Void;
+
+	function bind( host : Host, port : Int ) : Void;
+
+	function accept() : ISocket;
+
+	function peer() : { host : Host, port : Int };
+
+	function host() : { host : Host, port : Int };
+
+	function setTimeout( timeout : Float ) : Void;
+
+	function waitForRead() : Void;
+
+	public function setBlocking( b : Bool ) : Void;
+
+	public function setFastSend( b : Bool ) : Void;
+
+}

--- a/std/sys/net/Socket.hx
+++ b/std/sys/net/Socket.hx
@@ -24,7 +24,7 @@ package sys.net;
 /**
 	A TCP socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
 **/
-extern class Socket {
+extern class Socket implements ISocket {
 
 	/**
 		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
@@ -125,6 +125,6 @@ extern class Socket {
 		[select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
 		In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
 	**/
-	static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> };
+	static function select(read : Array<ISocket>, write : Array<ISocket>, others : Array<ISocket>, ?timeout : Float) : { read: Array<ISocket>,write: Array<ISocket>,others: Array<ISocket> };
 
 }

--- a/std/sys/ssl/Certificate.hx
+++ b/std/sys/ssl/Certificate.hx
@@ -1,0 +1,25 @@
+package sys.ssl;
+
+extern class Certificate {
+	
+	public static function loadFile( file : String ) : Certificate;
+	
+	public static function loadPath( path : String ) : Certificate;
+	
+	public static function loadDefaults() : Certificate;
+
+	public var commonName(get,null) : Null<String>;
+
+	public var altNames(get,null) : Array<String>;
+	
+	public var notBefore(get,null) : Date;
+	
+	public var notAfter(get,null) : Date;
+	
+	public function subject( field : String ) : Null<String>;
+	
+	public function issuer( field : String ) : Null<String>;
+	
+	public function next() : Null<Certificate>;
+
+}

--- a/std/sys/ssl/Digest.hx
+++ b/std/sys/ssl/Digest.hx
@@ -1,0 +1,22 @@
+package sys.ssl;
+
+@:enum
+abstract DigestAlgorithm(String) {
+	var MD5 = "MD5";
+	var SHA1 = "SHA1";
+	var SHA224 = "SHA224";
+	var SHA256 = "SHA256";
+	var SHA384 = "SHA384";
+	var SHA512 = "SHA512";
+	var RIPEMD160 = "RIPEMD160";
+}
+
+extern class Digest {
+	
+	static function make( data : haxe.io.Bytes, alg : DigestAlgorithm ) : haxe.io.Bytes;
+	
+	static function sign( data : haxe.io.Bytes, privKey : Key, alg : DigestAlgorithm ) : haxe.io.Bytes;
+	
+	static function verify( data : haxe.io.Bytes, signature : haxe.io.Bytes, pubKey : Key, alg : DigestAlgorithm ) : Bool;
+
+}

--- a/std/sys/ssl/Key.hx
+++ b/std/sys/ssl/Key.hx
@@ -1,0 +1,11 @@
+package sys.ssl;
+
+extern class Key {
+	
+	static function loadFile( file : String, ?isPublic : Bool, ?pass : String ) : Key;
+	
+	static function readPEM( data : String, isPublic : Bool, ?pass : String ) : Key;
+
+	static function readDER( data : haxe.io.Bytes, isPublic : Bool ) : Key;
+
+}

--- a/std/sys/ssl/Socket.hx
+++ b/std/sys/ssl/Socket.hx
@@ -1,0 +1,141 @@
+package sys.ssl;
+
+/**
+	A TLS socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
+**/
+extern class Socket implements sys.net.ISocket {
+
+	static var DEFAULT_VERIFY_CERT : Null<Bool>;
+
+	static var DEFAULT_CA : Null<sys.ssl.Certificate>;
+	
+	/**
+		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
+		use [setBlocking(false)] or [setTimeout] to prevent infinite waiting.
+	**/	
+	var input(default,null) : haxe.io.Input;
+
+	/**
+		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use [setBlocking(false)] or [setTimeout] to prevent that.
+	**/
+	var output(default, null) : haxe.io.Output;
+	
+	/**
+		A custom value that can be associated with the socket. Can be used to retreive your custom infos after a [select].
+	***/
+	var custom : Dynamic;
+	
+	/**
+		Define if peer certificate is verified during SSL handshake.
+	**/
+	var verifyCert : Null<Bool>;
+
+	/**
+		Creates a new unconnected socket.
+	**/
+	function new();
+
+	/**
+		Closes the socket : make sure to properly close all your sockets or you will crash when you run out of file descriptors.
+	**/
+	function close() : Void;
+	
+	/**
+		Connect to the given server host/port. Throw an exception in case we couldn't sucessfully connect.
+		In blocking mode the SSL handshake is done automatically.
+	**/
+	function connect(host : sys.net.Host, port : Int) : Void;
+
+	/**
+		Perform the SSL handshake.
+	**/
+	function handshake() : Void;
+	
+	/**
+		Configure the certificate chain for peer certificate verification.
+	**/	
+	function setCA( cert : sys.ssl.Certificate ) : Void;
+
+	/**
+		Configure the hostname for Server Name Indication TLS extension.
+	**/
+	function setHostname( name : String ) : Void;
+
+	/**
+		Configure own certificate and private key.
+	**/
+	function setCertificate( cert : Certificate, key : Key ) : Void;
+
+	/**
+		Read the whole data available on the socket.
+	**/
+	function read() : String;
+	
+	/**
+		Write the whole data to the socket output.
+	**/
+	function write( content : String ) : Void;
+	
+	/**
+		Configure additionals certificates and private keys for Server Name Indication extension.
+		The callback may be called during handshake to determine the certificate to use.
+	**/
+	function addSNICertificate( cbServernameMatch : String->Bool, cert : Certificate, key : Key ) : Void;
+	
+	/**
+		Bind the socket to the given host/port so it can afterwards listen for connections there.
+	**/
+	function bind( host : sys.net.Host, port : Int ) : Void;
+
+	/**
+		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use [accept()] to accept incoming connections.
+	**/
+	function listen( connections : Int ) : Void;
+	
+	/**
+		Accept a new connected client. This will return a connected socket on which you must call [handshake()] before read/write some data.
+	**/
+	function accept() : Socket;
+
+	/**
+		Return the informations about the other side of a connected socket.
+	**/
+	function peer() : { host : sys.net.Host, port : Int };
+
+	/**
+		Return the certificate received from the other side of a connection.
+	**/
+	function peerCertificate() : sys.ssl.Certificate;
+
+	/**
+		Shutdown the socket, either for reading or writing.
+	**/
+	function shutdown( read : Bool, write : Bool ) : Void;
+	
+	/**
+		Return the informations about our side of a connected socket.
+	**/
+	function host() : { host : sys.net.Host, port : Int };
+
+	/**
+		Gives a timeout after which blocking socket operations (such as reading and writing) will abort and throw an exception.
+	**/
+	function setTimeout( timeout : Float ) : Void;
+
+	/**
+		Block until some data is available for read on the socket.
+	**/
+	function waitForRead() : Void;
+	
+	/**
+		Change the blocking mode of the socket. A blocking socket is the default behavior. A non-blocking socket will abort blocking operations immediatly by throwing a haxe.io.Error.Blocking value.
+		If you call [setBlocking(false)] before [connect()], you need to call [handshake()] before read/write some data.
+	**/
+	function setBlocking( b : Bool ) : Void;
+	
+	/**
+		Allows the socket to immediatly send the data when written to its output : this will cause less ping but might increase the number of packets / data size, especially when doing a lot of small writes.
+	**/
+	function setFastSend( b : Bool ) : Void;
+	
+}

--- a/tests/unit/src/unitstd/Https.unit.hx
+++ b/tests/unit/src/unitstd/Https.unit.hx
@@ -1,0 +1,4 @@
+#if (cpp || (neko && !macro && !interp))
+var r = haxe.Http.requestUrl("https://raw.githubusercontent.com/HaxeFoundation/haxe/development/tests/unit/res1.txt");
+r == "Héllo World !";
+#end


### PR DESCRIPTION
Haxe wrapper for a new SSL lib for hxcpp and neko :

neko PR : https://github.com/HaxeFoundation/neko/pull/114
hxcpp PR : https://github.com/HaxeFoundation/hxcpp/pull/393

It's based on hxssl, but I switch from OpenSSL to mbedTLS to enable better compatibility on all hxcpp platforms.

Main features :
 - SSL sockets for client and server :
  - standard certificate and commonName verification
  - use certificate / key
  - Server Name Indication
 - Load Certificate from file or directory
 - Load Private / Public Key
 - Digest signature and verification using public / private key

