### PR TITLE
use the path given in --display instead of Common.find_file result

### DIFF
--- a/typeload.ml
+++ b/typeload.ml
@@ -3399,7 +3399,15 @@ let resolve_module_file com m remap p =
 			) in
 			String.concat "/" (x :: l) ^ "/" ^ name
 	) ^ ".hx" in
-	let file = if ExtString.String.ends_with (!Parser.resume_display).pfile file then (!Parser.resume_display).pfile else Common.find_file com file in
+	let file = (match com.display with
+		| DMNone -> Common.find_file com file
+		| _ ->  let revm   = (snd m ^ ".hx") :: List.rev (fst m) in
+				let pflist = List.rev (ExtString.String.nsplit (!Parser.resume_display).pfile "/") in
+				if fst (List.fold_left ( fun (a, p) m -> match (a,p) with
+					| false, _       -> false, p  (* once wrong, always wrong *)
+					| true,  []      -> false, p  (* module longer than pfile, so not what we're looking for *)
+					| true,  p :: pt -> m = p, pt (* actual test *)
+				) (true,pflist) revm) then (!Parser.resume_display).pfile else Common.find_file com file) in
 	let file = (match String.lowercase (snd m) with
 	| "con" | "aux" | "prn" | "nul" | "com1" | "com2" | "com3" | "lpt1" | "lpt2" | "lpt3" when Sys.os_type = "Win32" ->
 		(* these names are reserved by the OS - old DOS legacy, such files cannot be easily created but are reported as visible *)

--- a/typeload.ml
+++ b/typeload.ml
@@ -3399,7 +3399,7 @@ let resolve_module_file com m remap p =
 			) in
 			String.concat "/" (x :: l) ^ "/" ^ name
 	) ^ ".hx" in
-	let file = Common.find_file com file in
+	let file = if ExtString.String.ends_with (!Parser.resume_display).pfile file then (!Parser.resume_display).pfile else Common.find_file com file in
 	let file = (match String.lowercase (snd m) with
 	| "con" | "aux" | "prn" | "nul" | "com1" | "com2" | "com3" | "lpt1" | "lpt2" | "lpt3" when Sys.os_type = "Win32" ->
 		(* these names are reserved by the OS - old DOS legacy, such files cannot be easily created but are reported as visible *)


### PR DESCRIPTION
This change makes sure completion uses the file given in --display instead of the Common.find_file result, which might return a different path from Common.file_lookup_cache instead.

It allows authors of haxe plugins for editors/IDEs to use a temporary directory and file for the intermediate changes to a file during typing. Please see https://github.com/HaxeFoundation/haxe/issues/4651 for a number of plugin authors who weighed in and called for a solution for the general problem of having to save the original file on almost every keystroke, and this comment https://github.com/HaxeFoundation/haxe/issues/4651#issuecomment-159606171 describing the exact problem this simple and unintrusive change solves.

An example for the use of a temporary directory can be found in the vscode-haxe plugin when using the  "haxe.haxeTmpDirectory": "" setting. This way, changes to the original project file are only made when explicitly saving it, which arguably also is the expected behavior for most editors and IDEs, and hence consistent with the principle of least surprise. 

Other advantages include: 
- reduced disk io in the compiler (as opposed to checking the classpaths)
- reduced disk io for plugins when using a temporary file that is stored in memory, like under /dev/shm on Linux or files created with FILE_ATTRIBUTE_TEMPORARY on windows 
- third party tools that react to file changes aren't triggered on every keystroke (which is what originally brought me here)
