### PR TITLE
add switch-break labeling and use it for generating better js

### DIFF
--- a/src/context/meta.ml
+++ b/src/context/meta.ml
@@ -85,6 +85,7 @@ type strict_meta =
 	| KeepInit
 	| KeepSub
 	| LibType
+	| LoopLabel
 	| LuaRequire
 	| Meta
 	| Macro
@@ -280,6 +281,7 @@ let get_info = function
 	| KeepInit -> ":keepInit",("Causes a class to be kept by DCE even if all its field are removed",[UsedOn TClass])
 	| KeepSub -> ":keepSub",("Extends @:keep metadata to all implementing and extending classes",[UsedOn TClass])
 	| LibType -> ":libType",("Used by -net-lib and -java-lib to mark a class that shouldn't be checked (overrides, interfaces, etc) by the type loader",[UsedInternally; UsedOn TClass; Platforms [Java;Cs]])
+	| LoopLabel -> ":loopLabel",("Mark loop and break expressions with a label to support breaking from within switch",[UsedInternally])
 	| Meta -> ":meta",("Internally used to mark a class field as being the metadata field",[])
 	| Macro -> ":macro",("(deprecated)",[])
 	| MaybeUsed -> ":maybeUsed",("Internally used by DCE to mark fields that might be kept",[UsedInternally])


### PR DESCRIPTION
I ported the `SwitchBreakSynf` from `gencommon.ml` to a simplier filter that detects loop `break`s inside `switch` and label them and their loops with a `TMeta` intended to be used in a target generator.

Then I added usage of these labels in `genjs.ml` to generate labeled loops and breaks instead of try-catches (see #3883).

I also tried to remove the `SwitchBreakSynf` from `gencommon.ml` and use the metadata directly in `gencs.ml` (to generate `goto`) and `genjava.ml` (to generate the same as js), but turns out it's not that easy since `gencommon.ml` filters out `TMeta`s and even if I whitelist the new one, it still doesn't work properly, so this requires more research.

Anyway, this PR is more a first try of extracting and simplifying bits of `gencommon.ml`. I don't really expect it to be merged as it is, instead I'd like to see some discussion about how to proprely factor this stuff out, where to place it and how to use it. cc @Simn @waneck 

Here's some beautiful code tho :)

Source:

``` haxe
class Main {
    static function main() {
        for (i in 0...10) {
            for (j in 0...10) {
                switch (j) {
                    case 0: continue;
                    case 1: break;
                }
            }
            switch (i) {
                case 0: continue;
                case 1: break;
            }
        }
    }
}
```

Before:

``` js
Main.main = function() {
    var _g = 0;
    try {
        while(_g < 10) {
            var i = _g++;
            var _g1 = 0;
            try {
                while(_g1 < 10) switch(_g1++) {
                case 0:
                    continue;
                    break;
                case 1:
                    throw "__break__";
                    break;
                }
            } catch( e ) { if( e != "__break__" ) throw e; }
            switch(i) {
            case 0:
                continue;
                break;
            case 1:
                throw "__break__";
                break;
            }
        }
    } catch( e ) { if( e != "__break__" ) throw e; }
};
```

After:

``` js
Main.main = function() {
    var _g = 0;
    _hx_loop1: while(_g < 10) {
        var i = _g++;
        var _g1 = 0;
        _hx_loop2: while(_g1 < 10) switch(_g1++) {
        case 0:
            continue;
        case 1:
            break _hx_loop2;
        }
        switch(i) {
        case 0:
            continue;
        case 1:
            break _hx_loop1;
        }
    }
};
```
