### PR TITLE
[js] also check typeof(o) == "number" for Std.is(o, Int)

### DIFF
--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -179,10 +179,11 @@ let api_inline ctx c field params p = match c.cl_path, field, params with
 		| TTypeExpr (TAbstractDecl ({ a_path = [],"Bool" })) -> Some (typeof "boolean")
 		| TTypeExpr (TAbstractDecl ({ a_path = [],"Float" })) -> Some (typeof "number")
 		| TTypeExpr (TAbstractDecl ({ a_path = [],"Int" })) when is_trivial o ->
-			(* generate (o|0) === o check *)
+			(* generate typeof(o) == "number" && (o|0) === o check *)
 			let teq = mk_local ctx "__strict_eq__" (tfun [tint; tint] tbool) p in
 			let lhs = mk (TBinop (Ast.OpOr, o, mk (TConst (TInt Int32.zero)) tint p)) tint p in
-			Some (mk (TCall (teq, [lhs; o])) tbool p)
+			let jscheck = mk (TCall (teq, [lhs; o])) tbool p in
+			Some(mk (TBinop (Ast.OpBoolAnd, typeof "number", jscheck)) tbool p)
 		| TTypeExpr (TClassDecl ({ cl_path = [],"Array" })) ->
 			(* generate (o instanceof Array) && o.__enum__ == null check *)
 			let iof = mk_local ctx "__instanceof__" (tfun [o.etype;t.etype] tbool) p in

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -191,7 +191,7 @@ class Boot {
 			return false;
 		switch( cl ) {
 		case Int:
-			return (untyped __js__("(o|0) === o"));
+			return (untyped __js__("typeof"))(o) == "number" && untyped __js__("(o|0) === o");
 		case Float:
 			return (untyped __js__("typeof"))(o) == "number";
 		case Bool:

--- a/tests/unit/src/unit/issues/Issue4962.hx
+++ b/tests/unit/src/unit/issues/Issue4962.hx
@@ -1,0 +1,15 @@
+package unit.issues;
+
+private class C {
+	public function new() { }
+	@:keep function toString() return toString();
+}
+
+class Issue4962 extends Test {
+	function test() {
+		var int:Dynamic = Int;
+		f(Std.is(new C(), int));
+
+		f(Std.is(new C(), Int));
+	}
+}

--- a/tests/unit/src/unit/issues/Issue4962.hx
+++ b/tests/unit/src/unit/issues/Issue4962.hx
@@ -2,7 +2,7 @@ package unit.issues;
 
 private class C {
 	public function new() { }
-	@:keep function toString() return toString();
+	@:keep function toString():String return toString();
 }
 
 class Issue4962 extends Test {


### PR DESCRIPTION
closes #4962 by adding a `typeof(o) == "number"` check.

"You should call toString() or Std.string() only on sane objects" seems to be reasonable limitation therefore I think we should follow, but "Std.is()" not working leads to too much surprising behaviors.

Note: although this kind of type checking is used for typed catch in JS, this commit does not fix HaxeError and will not allow throwing objects with broken toString(), e.g.

```
try {
    throw new C();
} catch (c:Int) {
    //
}
```

I wondered if real world source codes actually throw some garbage and catch Int, so didn't add to the test case.
