### PR TITLE
[js] use ES5 by default, add -D js-es=<ver>

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -1458,6 +1458,22 @@ try
 		| Js ->
 			if not (PMap.exists (fst (Define.infos Define.JqueryVer)) com.defines) then
 				Common.define_value com Define.JqueryVer "11202";
+
+			let es_version =
+				try
+					int_of_string (Common.defined_value com Define.JsEs)
+				with
+				| Not_found ->
+					(Common.define_value com Define.JsEs "5"; 5)
+				| _ ->
+					0
+			in
+
+			if es_version < 3 || es_version = 4 then (* we don't support ancient and there's no 4th *)
+				failwith "Invalid -D js-es value";
+
+			if es_version >= 5 then Common.raw_define com "js-es5"; (* backward-compatibility *)
+
 			add_std "js";
 			"js"
 		| Php ->

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -196,7 +196,7 @@ module Define = struct
 		| JavaVer
 		| JqueryVer
 		| JsClassic
-		| JsEs5
+		| JsEs
 		| JsUnflatten
 		| KeepOldOutput
 		| LoopUnrollMaxCost
@@ -286,7 +286,7 @@ module Define = struct
 		| JavaVer -> ("java_ver", "<version:5-7> Sets the Java version to be targeted")
 		| JqueryVer -> ("jquery_ver", "The jQuery version supported by js.jquery.*. The version is encoded as an interger. e.g. 1.11.3 is encoded as 11103")
 		| JsClassic -> ("js_classic","Don't use a function wrapper and strict mode in JS output")
-		| JsEs5 -> ("js_es5","Generate JS for ES5-compliant runtimes")
+		| JsEs -> ("js_es","Generate JS compilant with given ES standard version (default 5)")
 		| JsUnflatten -> ("js_unflatten","Generate nested objects for packages and types")
 		| KeepOldOutput -> ("keep_old_output","Keep old source files in the output directory (for C#/Java)")
 		| LoopUnrollMaxCost -> ("loop_unroll_max_cost","Maximum cost (number of expressions * iterations) before loop unrolling is canceled (default 250)")

--- a/std/js/_std/Array.hx
+++ b/std/js/_std/Array.hx
@@ -45,7 +45,7 @@ extern class Array<T> {
 		return @:privateAccess HxOverrides.remove(this,x);
 	}
 
-#if js_es5
+#if (js_es >= 5)
 	function indexOf( x : T, ?fromIndex:Int ) : Int;
 	function lastIndexOf( x : T, ?fromIndex:Int ) : Int;
 

--- a/std/js/_std/HxOverrides.hx
+++ b/std/js/_std/HxOverrides.hx
@@ -76,7 +76,7 @@ class HxOverrides {
 				return "";
 		}
 
-		#if !js_es5
+		#if (js_es < 5)
 		if (pos < 0) {
 			pos = s.length + pos;
 			if (pos < 0)
@@ -138,7 +138,7 @@ class HxOverrides {
 	}
 
 	static function __init__() untyped {
-#if !js_es5
+#if (js_es < 5)
 		__feature__('HxOverrides.indexOf', if( Array.prototype.indexOf ) __js__("HxOverrides").indexOf = function(a,o,i) return Array.prototype.indexOf.call(a, o, i));
 		__feature__('HxOverrides.lastIndexOf', if( Array.prototype.lastIndexOf ) __js__("HxOverrides").lastIndexOf = function(a,o,i) return Array.prototype.lastIndexOf.call(a, o, i));
 #end

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -91,7 +91,7 @@ import js.Boot;
 			var Void = __feature__("Type.resolveEnum", $hxClasses["Void"] = { __ename__ : ["Void"] }, { __ename__ : ["Void"] });
 		});
 
-#if !js_es5
+#if (js_es < 5)
 		__feature__("Array.map",
 			if( Array.prototype.map == null )
 				Array.prototype.map = function(f) {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -171,7 +171,7 @@ class RunCi {
 				Sys.putEnv("AUDIODEV", "null");
 				requireAptPackages([
 					"libcurl3:i386", "libglib2.0-0:i386", "libx11-6:i386", "libxext6:i386",
-					"libxt6:i386", "libxcursor1:i386", "libnss3:i386", "libgtk2.0-0:i386"	
+					"libxt6:i386", "libxcursor1:i386", "libnss3:i386", "libgtk2.0-0:i386"
 				]);
 				runCommand("wget", ["-nv", "http://fpdownload.macromedia.com/pub/flashplayer/updaters/11/flashplayer_11_sa_debug.i386.tar.gz"], true);
 				runCommand("tar", ["-xf", "flashplayer_11_sa_debug.i386.tar.gz", "-C", Sys.getEnv("HOME")]);
@@ -675,8 +675,8 @@ class RunCi {
 	*/
 	static function deployPPA():Void {
 		if (
-			gitInfo.branch == "development" && 
-			Sys.getEnv("DEPLOY") != null && 
+			gitInfo.branch == "development" &&
+			Sys.getEnv("DEPLOY") != null &&
 			Sys.getEnv("haxeci_decrypt") != null
 		) {
 			// setup haxeci_ssh
@@ -959,11 +959,11 @@ class RunCi {
 					getJSDependencies();
 
 					var jsOutputs = [
-						for (es5 in       [[], ["-D", "js-es5"]])
+						for (es3 in       [[], ["-D", "js-es=3"]])
 						for (unflatten in [[], ["-D", "js-unflatten"]])
 						for (classic in   [[], ["-D", "js-classic"]])
 						{
-							var extras = args.concat(es5).concat(unflatten).concat(classic);
+							var extras = args.concat(es3).concat(unflatten).concat(classic);
 
 							runCommand("haxe", ["compile-js.hxml"].concat(extras));
 

--- a/tests/unit/src/RunSauceLabs.hx
+++ b/tests/unit/src/RunSauceLabs.hx
@@ -226,7 +226,7 @@ class RunSauceLabs {
 
 			var browserSuccess = true;
 			var urls = if (!isEs5(caps)) {
-				urls.filter(function(url:String) return url.indexOf("-es5") < 0);
+				urls.filter(function(url:String) return url.indexOf("js-es=3") != -1);
 			} else {
 				urls;
 			}


### PR DESCRIPTION
See #4961

This PR adds the new define `-D js-es=<version>` that allows setting the ECMAScript compilance version and deprecates `-D js-es5` which is now automatically set for all `js-es` values greater than or equal 5 for backward compatibility. It also sets default ES version to 5.

This should be safe for 3.3, I think.

I wonder if we could/should warn about usage of deprecated compiler defines, i.e. emit a deprecation message on `#if js_es5` and `-D js-es5`.