### PR TITLE
Small modifications to PHP exception/error handling

### DIFF
--- a/src/generators/genphp.ml
+++ b/src/generators/genphp.ml
@@ -1562,7 +1562,7 @@ and gen_expr ctx e =
 		let catchall = ref false in
 		let evar = define_local ctx "_ex_" in
 		newline ctx;
-		print ctx "$%s = ($%s instanceof HException) ? $%s->e : $%s" evar ex ex ex;
+		print ctx "$%s = ($%s instanceof HException) && $%s->getCode() == null ? $%s->e : $%s" evar ex ex ex ex;
 		old();
 		List.iter (fun (v,e) ->
 			let ev = define_local ctx v.v_name in

--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -318,8 +318,8 @@ function _hx_error_handler($errno, $errmsg, $filename, $linenum, $vars) {
 	if (!(error_reporting() & $errno)) {
 		return false;
 	}
-	$msg = $errmsg . ' (errno: ' . $errno . ') in ' . $filename . ' at line #' . $linenum;
-	$e = new HException($msg, $errmsg, $errno, _hx_anonymous(array('fileName' => 'Boot.hx', 'lineNumber' => __LINE__, 'className' => 'php.Boot', 'methodName' => '_hx_error_handler')));
+	$msg = $errmsg . ' (errno: ' . $errno . ')';
+	$e = new HException($msg, '', $errno, _hx_anonymous(array('fileName' => 'Boot.hx', 'lineNumber' => __LINE__, 'className' => 'php.Boot', 'methodName' => '_hx_error_handler')));
 	$e->setFile($filename);
 	$e->setLine($linenum);
 	throw $e;

--- a/tests/unit/src/unit/issues/Issue4973.hx
+++ b/tests/unit/src/unit/issues/Issue4973.hx
@@ -1,13 +1,11 @@
 package unit.issues;
 
-#if php
 class Issue4973 extends Test {
-
+	#if php
 	function test() {
 		try sys.io.File.getContent("not-existant")
 		catch(exc:php.Exception) t(untyped __php__("{0} instanceof Exception", exc))
 		catch(exc:Dynamic) t(untyped __php__("{0} instanceof Exception", exc));
 	}
-	
+	#end
 }
-#end

--- a/tests/unit/src/unit/issues/Issue4973.hx
+++ b/tests/unit/src/unit/issues/Issue4973.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+#if php
+class Issue4973 extends Test {
+
+	function test() {
+		try sys.io.File.getContent("not-existant")
+		catch(exc:php.Exception) t(untyped __php__("{0} instanceof Exception", exc))
+		catch(exc:Dynamic) t(untyped __php__("{0} instanceof Exception", exc));
+	}
+	
+}
+#end


### PR DESCRIPTION
make HExceptions with an error code != null catchable, i.e. HExceptions from _hx_error_handler
remove duplicated error message, filename and line in HException from  _hx_error_handler