### PR TITLE
Properly escape php get/set fields

### DIFF
--- a/src/generators/genphp.ml
+++ b/src/generators/genphp.ml
@@ -1896,13 +1896,13 @@ let generate_field ctx static f =
 				| AccCall, _ ->
 					let m = "get_" ^ f.cf_name in
 					if not (is_method_defined ctx m static) then generate_self_method ctx rights m static false;
-					print ctx "%s $%s" rights (s_ident_field f.cf_name);
+					print ctx "%s $%s" rights (s_ident f.cf_name);
 					gen_assigned_value ctx f.cf_expr;
 					true
 				| _, AccCall ->
 					let m = "set_" ^ f.cf_name in
 					if not (is_method_defined ctx m static) then generate_self_method ctx rights m static true;
-					print ctx "%s $%s" rights (s_ident_field f.cf_name);
+					print ctx "%s $%s" rights (s_ident f.cf_name);
 					gen_assigned_value ctx f.cf_expr;
 					true
 				| _ ->

--- a/tests/unit/src/unit/issues/Issue4810.hx
+++ b/tests/unit/src/unit/issues/Issue4810.hx
@@ -1,0 +1,10 @@
+package unit.issues;
+
+class Issue4810 extends Test {
+	static public var DEFAULT(get, null): Bool;
+    static function get_DEFAULT()
+        return true;
+	function test() {
+		eq(true, DEFAULT);
+	}
+}

--- a/tests/unit/src/unit/issues/Issue4810.hx
+++ b/tests/unit/src/unit/issues/Issue4810.hx
@@ -2,8 +2,8 @@ package unit.issues;
 
 class Issue4810 extends Test {
 	static public var DEFAULT(get, null): Bool;
-    static function get_DEFAULT()
-        return true;
+	static function get_DEFAULT()
+		return true;
 	function test() {
 		eq(true, DEFAULT);
 	}


### PR DESCRIPTION
This fixes #4810 
Seems like the behaviour was [already correct](https://github.com/benmerckx/haxe/blob/86ebc5d176f1392936f0b31395a6eecb0942bb8a/src/generators/genphp.ml#L1888) for variables created with (get, set). Only (get, ..) and (.., set) were not handled correctly.