### PR TITLE
Update Type.hx

### DIFF
--- a/std/Type.hx
+++ b/std/Type.hx
@@ -19,6 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
+
 /**
 	The diffent possible runtime types of a value.
 **/


### PR DESCRIPTION
Add return for ValueType documentation, it seems docs are not used without http://api.haxe.org/v/dev/ValueType.html