### PR TITLE
Omit internal defines from --help-defines

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -1335,7 +1335,7 @@ try
 			let rec loop i =
 				let d = Obj.magic i in
 				if d <> Define.Last then begin
-					let t, doc = Define.infos d in
+					let t, doc, params = Define.infos d in
 					if String.length t > !m then m := String.length t;
 					((String.concat "-" (ExtString.String.nsplit t "_")),doc) :: (loop (i + 1))
 				end else
@@ -1456,7 +1456,7 @@ try
 			add_std "neko";
 			"n"
 		| Js ->
-			if not (PMap.exists (fst (Define.infos Define.JqueryVer)) com.defines) then
+			if not (PMap.exists (Define.to_string Define.JqueryVer) com.defines) then
 				Common.define_value com Define.JqueryVer "11202";
 
 			let es_version =

--- a/src/main.ml
+++ b/src/main.ml
@@ -1337,7 +1337,10 @@ try
 				if d <> Define.Last then begin
 					let t, doc, params = Define.infos d in
 					if String.length t > !m then m := String.length t;
-					((String.concat "-" (ExtString.String.nsplit t "_")),doc) :: (loop (i + 1))
+					let next = (loop (i + 1)) in
+					if List.mem Define.Internal params == false then 
+						((String.concat "-" (ExtString.String.nsplit t "_")),doc) :: next
+					else next;
 				end else
 					[]
 			in

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -246,95 +246,102 @@ module Define = struct
 		| NoMacroCache
 		| Last (* must be last *)
 
+	type define_parameter =
+		| Internal
+
 	let infos = function
-		| AbsolutePath -> ("absolute_path","Print absolute file path in trace output")
-		| AdvancedTelemetry -> ("advanced-telemetry","Allow the SWF to be measured with Monocle tool")
-		| AnnotateSource -> ("annotate_source","Add additional comments to generated source code")
+		| AbsolutePath -> ("absolute_path","Print absolute file path in trace output",[])
+		| AdvancedTelemetry -> ("advanced-telemetry","Allow the SWF to be measured with Monocle tool",[])
+		| AnnotateSource -> ("annotate_source","Add additional comments to generated source code",[])
 		(* | Analyzer -> ("analyzer","Use static analyzer for optimization (experimental)") *)
-		| As3 -> ("as3","Defined when outputing flash9 as3 source code")
-		| CheckXmlProxy -> ("check_xml_proxy","Check the used fields of the xml proxy")
-		| CoreApi -> ("core_api","Defined in the core api context")
-		| CoreApiSerialize -> ("core_api_serialize","Mark some generated core api classes with the Serializable attribute on C#")
-		| CppAst -> ("cppast", "Generate experimental cpp code")
-		| Cppia -> ("cppia", "Generate cpp instruction assembly")
-		| Dce -> ("dce","<mode:std|full||no> Set the dead code elimination mode (default std)")
-		| DceDebug -> ("dce_debug","Show DCE log")
-		| Debug -> ("debug","Activated when compiling with -debug")
-		| Display -> ("display","Activated during completion")
-		| DllExport -> ("dll_export", "GenCPP experimental linking")
-		| DllImport -> ("dll_import", "GenCPP experimental linking")
-		| DocGen -> ("doc_gen","Do not perform any removal/change in order to correctly generate documentation")
-		| Dump -> ("dump","Dump the complete typed AST for internal debugging in a dump subdirectory - use dump=pretty for Haxe-like formatting")
-		| DumpDependencies -> ("dump_dependencies","Dump the classes dependencies in a dump subdirectory")
-		| DumpIgnoreVarIds -> ("dump_ignore_var_ids","Remove variable IDs from non-pretty dumps (helps with diff)")
-		| DynamicInterfaceClosures -> ("dynamic_interface_closures","Use slow path for interface closures to save space")
-		| EraseGenerics -> ("erase_generics","Erase generic classes on C#")
-		| Fdb -> ("fdb","Enable full flash debug infos for FDB interactive debugging")
-		| FileExtension -> ("file_extension","Output filename extension for cpp source code")
-		| FlashStrict -> ("flash_strict","More strict typing for flash target")
-		| FlashUseStage -> ("flash_use_stage","Keep the SWF library initial stage")
+		| As3 -> ("as3","Defined when outputing flash9 AS3 source code",[])
+		| CheckXmlProxy -> ("check_xml_proxy","Check the used fields of the xml proxy",[])
+		| CoreApi -> ("core_api","Defined in the core api context",[])
+		| CoreApiSerialize -> ("core_api_serialize","Mark some generated core api classes with the Serializable attribute on C#",[])
+		| CppAst -> ("cppast", "Generate experimental cpp code",[])
+		| Cppia -> ("cppia", "Generate cpp instruction assembly",[])
+		| Dce -> ("dce","<mode:std|full||no> Set the dead code elimination mode (default std)",[])
+		| DceDebug -> ("dce_debug","Show DCE log",[])
+		| Debug -> ("debug","Activated when compiling with -debug",[])
+		| Display -> ("display","Activated during completion",[])
+		| DllExport -> ("dll_export", "GenCPP experimental linking",[])
+		| DllImport -> ("dll_import", "GenCPP experimental linking",[])
+		| DocGen -> ("doc_gen","Do not perform any removal/change in order to correctly generate documentation",[])
+		| Dump -> ("dump","Dump the complete typed AST for internal debugging in a dump subdirectory - use dump=pretty for Haxe-like formatting",[])
+		| DumpDependencies -> ("dump_dependencies","Dump the classes dependencies in a dump subdirectory",[])
+		| DumpIgnoreVarIds -> ("dump_ignore_var_ids","Remove variable IDs from non-pretty dumps (helps with diff)",[])
+		| DynamicInterfaceClosures -> ("dynamic_interface_closures","Use slow path for interface closures to save space",[])
+		| EraseGenerics -> ("erase_generics","Erase generic classes on C#",[])
+		| Fdb -> ("fdb","Enable full flash debug infos for FDB interactive debugging",[])
+		| FileExtension -> ("file_extension","Output filename extension for cpp source code",[])
+		| FlashStrict -> ("flash_strict","More strict typing for flash target",[])
+		| FlashUseStage -> ("flash_use_stage","Keep the SWF library initial stage",[])
 		(* force_lib_check is only here as a debug facility - compiler checking allows errors to be found more easily *)
-		| ForceLibCheck -> ("force_lib_check","Force the compiler to check -net-lib and -java-lib added classes (internal)")
-		| ForceNativeProperty -> ("force_native_property","Tag all properties with :nativeProperty metadata for 3.1 compatibility")
-		| FormatWarning -> ("format_warning","Print a warning for each formated string, for 2.x compatibility")
-		| GencommonDebug -> ("gencommon_debug","GenCommon internal")
-		| HaxeBoot -> ("haxe_boot","Given the name 'haxe' to the flash boot class instead of a generated name")
-		| HaxeVer -> ("haxe_ver","The current Haxe version value")
-		| HxcppApiLevel -> ("hxcpp_api_level","Provided to allow compatibility between hxcpp versions")
-		| IncludePrefix -> ("include_prefix","prepend path to generated include files")
-		| Interp -> ("interp","The code is compiled to be run with --interp")
-		| JavaVer -> ("java_ver", "<version:5-7> Sets the Java version to be targeted")
-		| JqueryVer -> ("jquery_ver", "The jQuery version supported by js.jquery.*. The version is encoded as an interger. e.g. 1.11.3 is encoded as 11103")
-		| JsClassic -> ("js_classic","Don't use a function wrapper and strict mode in JS output")
-		| JsEs -> ("js_es","Generate JS compilant with given ES standard version (default 5)")
-		| JsUnflatten -> ("js_unflatten","Generate nested objects for packages and types")
-		| KeepOldOutput -> ("keep_old_output","Keep old source files in the output directory (for C#/Java)")
-		| LoopUnrollMaxCost -> ("loop_unroll_max_cost","Maximum cost (number of expressions * iterations) before loop unrolling is canceled (default 250)")
-		| Macro -> ("macro","Defined when code is compiled in the macro context")
-		| MacroTimes -> ("macro_times","Display per-macro timing when used with --times")
-		| NetVer -> ("net_ver", "<version:20-45> Sets the .NET version to be targeted")
-		| NetTarget -> ("net_target", "<name> Sets the .NET target. Defaults to \"net\". xbox, micro (Micro Framework), compact (Compact Framework) are some valid values")
-		| NekoSource -> ("neko_source","Output neko source instead of bytecode")
-		| NekoV1 -> ("neko_v1","Keep Neko 1.x compatibility")
-		| NetworkSandbox -> ("network-sandbox","Use local network sandbox instead of local file access one")
-		| NoAnalyzer -> ("no-analyzer","Disable the static analyzer")
-		| NoCompilation -> ("no-compilation","Disable final compilation for Cs, Cpp and Java")
-		| NoCOpt -> ("no_copt","Disable completion optimization (for debug purposes)")
-		| NoCppAst -> ("no_cppast", "Do not generate experimental cpp code")
-		| NoDebug -> ("no_debug","Remove all debug macros from cpp output")
-		| NoDeprecationWarnings -> ("no-deprecation-warnings","Do not warn if fields annotated with @:deprecated are used")
-		| NoFlashOverride -> ("no-flash-override", "Change overrides on some basic classes into HX suffixed methods, flash only")
-		| NoOpt -> ("no_opt","Disable optimizations")
-		| NoPatternMatching -> ("no_pattern_matching","Disable pattern matching")
-		| NoInline -> ("no_inline","Disable inlining")
-		| NoRoot -> ("no_root","Generate top-level types into haxe.root namespace")
-		| NoMacroCache -> ("no_macro_cache","Disable macro context caching")
-		| NoSwfCompress -> ("no_swf_compress","Disable SWF output compression")
-		| NoTraces -> ("no_traces","Disable all trace calls")
-		| Objc -> ("objc","Sets the hxcpp output to objective-c++ classes. Must be defined for interop")
-		| PhpPrefix -> ("php_prefix","Compiled with --php-prefix")
-		| RealPosition -> ("real_position","Disables Haxe source mapping when targetting C#, removes position comments in Java output")
-		| ReplaceFiles -> ("replace_files","GenCommon internal")
-		| Scriptable -> ("scriptable","GenCPP internal")
-		| ShallowExpose -> ("shallow-expose","Expose types to surrounding scope of Haxe generated closure without writing to window object")
-		| SourceHeader -> ("source-header","Print value as comment on top of generated files, use '' value to disable")
-		| SourceMapContent -> ("source-map-content","Include the hx sources as part of the JS source map")
-		| Swc -> ("swc","Output a SWC instead of a SWF")
-		| SwfCompressLevel -> ("swf_compress_level","<level:1-9> Set the amount of compression for the SWF output")
-		| SwfDebugPassword -> ("swf_debug_password", "Set a password for debugging")
-		| SwfDirectBlit -> ("swf_direct_blit", "Use hardware acceleration to blit graphics")
-		| SwfGpu -> ("swf_gpu", "Use GPU compositing features when drawing graphics")
-		| SwfMetadata -> ("swf_metadata", "<file> Include contents of <file> as metadata in the swf")
-		| SwfPreloaderFrame -> ("swf_preloader_frame", "Insert empty first frame in swf")
-		| SwfProtected -> ("swf_protected","Compile Haxe private as protected in the SWF instead of public")
-		| SwfScriptTimeout -> ("swf_script_timeout", "Maximum ActionScript processing time before script stuck dialog box displays (in seconds)")
-		| SwfUseDoAbc -> ("swf_use_doabc", "Use DoAbc swf-tag instead of DoAbcDefine")
-		| Sys -> ("sys","Defined for all system platforms")
-		| Unsafe -> ("unsafe","Allow unsafe code when targeting C#")
-		| UseNekoc -> ("use_nekoc","Use nekoc compiler instead of internal one")
-		| UseRttiDoc -> ("use_rtti_doc","Allows access to documentation during compilation")
-		| Vcproj -> ("vcproj","GenCPP internal")
+		| ForceLibCheck -> ("force_lib_check","Force the compiler to check -net-lib and -java-lib added classes (internal)",[Internal])
+		| ForceNativeProperty -> ("force_native_property","Tag all properties with :nativeProperty metadata for 3.1 compatibility",[])
+		| FormatWarning -> ("format_warning","Print a warning for each formated string, for 2.x compatibility",[])
+		| GencommonDebug -> ("gencommon_debug","GenCommon internal",[Internal])
+		| HaxeBoot -> ("haxe_boot","Given the name 'haxe' to the flash boot class instead of a generated name",[])
+		| HaxeVer -> ("haxe_ver","The current Haxe version value",[])
+		| HxcppApiLevel -> ("hxcpp_api_level","Provided to allow compatibility between hxcpp versions",[])
+		| IncludePrefix -> ("include_prefix","prepend path to generated include files",[])
+		| Interp -> ("interp","The code is compiled to be run with --interp",[])
+		| JavaVer -> ("java_ver", "<version:5-7> Sets the Java version to be targeted",[])
+		| JqueryVer -> ("jquery_ver", "The jQuery version supported by js.jquery.*. The version is encoded as an interger. e.g. 1.11.3 is encoded as 11103",[])
+		| JsClassic -> ("js_classic","Don't use a function wrapper and strict mode in JS output",[])
+		| JsEs -> ("js_es","Generate JS compilant with given ES standard version (default 5)",[])
+		| JsUnflatten -> ("js_unflatten","Generate nested objects for packages and types",[])
+		| KeepOldOutput -> ("keep_old_output","Keep old source files in the output directory (for C#/Java)",[])
+		| LoopUnrollMaxCost -> ("loop_unroll_max_cost","Maximum cost (number of expressions * iterations) before loop unrolling is canceled (default 250)",[])
+		| Macro -> ("macro","Defined when code is compiled in the macro context",[])
+		| MacroTimes -> ("macro_times","Display per-macro timing when used with --times",[])
+		| NetVer -> ("net_ver", "<version:20-45> Sets the .NET version to be targeted",[])
+		| NetTarget -> ("net_target", "<name> Sets the .NET target. Defaults to \"net\". xbox, micro (Micro Framework), compact (Compact Framework) are some valid values",[])
+		| NekoSource -> ("neko_source","Output neko source instead of bytecode",[])
+		| NekoV1 -> ("neko_v1","Keep Neko 1.x compatibility",[])
+		| NetworkSandbox -> ("network-sandbox","Use local network sandbox instead of local file access one",[])
+		| NoAnalyzer -> ("no-analyzer","Disable the static analyzer",[])
+		| NoCompilation -> ("no-compilation","Disable final compilation for Cs, Cpp and Java",[])
+		| NoCOpt -> ("no_copt","Disable completion optimization (for debug purposes)",[])
+		| NoCppAst -> ("no_cppast", "Do not generate experimental cpp code",[])
+		| NoDebug -> ("no_debug","Remove all debug macros from cpp output",[])
+		| NoDeprecationWarnings -> ("no-deprecation-warnings","Do not warn if fields annotated with @:deprecated are used",[])
+		| NoFlashOverride -> ("no-flash-override", "Change overrides on some basic classes into HX suffixed methods, flash only",[])
+		| NoOpt -> ("no_opt","Disable optimizations",[])
+		| NoPatternMatching -> ("no_pattern_matching","Disable pattern matching",[])
+		| NoInline -> ("no_inline","Disable inlining",[])
+		| NoRoot -> ("no_root","Generate top-level types into haxe.root namespace",[])
+		| NoMacroCache -> ("no_macro_cache","Disable macro context caching",[])
+		| NoSwfCompress -> ("no_swf_compress","Disable SWF output compression",[])
+		| NoTraces -> ("no_traces","Disable all trace calls",[])
+		| Objc -> ("objc","Sets the hxcpp output to objective-c++ classes. Must be defined for interop",[])
+		| PhpPrefix -> ("php_prefix","Compiled with --php-prefix",[])
+		| RealPosition -> ("real_position","Disables Haxe source mapping when targetting C#, removes position comments in Java output",[])
+		| ReplaceFiles -> ("replace_files","GenCommon internal",[Internal])
+		| Scriptable -> ("scriptable","GenCPP internal",[Internal])
+		| ShallowExpose -> ("shallow-expose","Expose types to surrounding scope of Haxe generated closure without writing to window object",[])
+		| SourceHeader -> ("source-header","Print value as comment on top of generated files, use '' value to disable",[])
+		| SourceMapContent -> ("source-map-content","Include the hx sources as part of the JS source map",[])
+		| Swc -> ("swc","Output a SWC instead of a SWF",[])
+		| SwfCompressLevel -> ("swf_compress_level","<level:1-9> Set the amount of compression for the SWF output",[])
+		| SwfDebugPassword -> ("swf_debug_password", "Set a password for debugging",[])
+		| SwfDirectBlit -> ("swf_direct_blit", "Use hardware acceleration to blit graphics",[])
+		| SwfGpu -> ("swf_gpu", "Use GPU compositing features when drawing graphics",[])
+		| SwfMetadata -> ("swf_metadata", "<file> Include contents of <file> as metadata in the swf",[])
+		| SwfPreloaderFrame -> ("swf_preloader_frame", "Insert empty first frame in swf",[])
+		| SwfProtected -> ("swf_protected","Compile Haxe private as protected in the SWF instead of public",[])
+		| SwfScriptTimeout -> ("swf_script_timeout", "Maximum ActionScript processing time before script stuck dialog box displays (in seconds)",[])
+		| SwfUseDoAbc -> ("swf_use_doabc", "Use DoAbc swf-tag instead of DoAbcDefine",[])
+		| Sys -> ("sys","Defined for all system platforms",[])
+		| Unsafe -> ("unsafe","Allow unsafe code when targeting C#",[])
+		| UseNekoc -> ("use_nekoc","Use nekoc compiler instead of internal one",[])
+		| UseRttiDoc -> ("use_rtti_doc","Allows access to documentation during compilation",[])
+		| Vcproj -> ("vcproj","GenCPP internal",[Internal])
 		| Last -> assert false
+
+	let to_string d =
+		match infos d with
+			| (t,_,_) -> t
 end
 
 module MetaInfo = struct
@@ -558,7 +565,7 @@ let default_config =
 	}
 
 let get_config com =
-	let defined f = PMap.mem (fst (Define.infos f)) com.defines in
+	let defined f = PMap.mem (Define.to_string f) com.defines in
 	match com.platform with
 	| Cross ->
 		default_config
@@ -795,13 +802,13 @@ let raw_defined ctx v =
 	PMap.mem v ctx.defines
 
 let defined ctx v =
-	raw_defined ctx (fst (Define.infos v))
+	raw_defined ctx (Define.to_string v)
 
 let raw_defined_value ctx k =
 	PMap.find k ctx.defines
 
 let defined_value ctx v =
-	raw_defined_value ctx (fst (Define.infos v))
+	raw_defined_value ctx (Define.to_string v)
 
 let defined_value_safe ctx v =
 	try defined_value ctx v
@@ -815,10 +822,10 @@ let raw_define ctx v =
 	ctx.defines_signature <- None
 
 let define_value ctx k v =
-	raw_define ctx (fst (Define.infos k) ^ "=" ^ v)
+	raw_define ctx (Define.to_string k ^ "=" ^ v)
 
 let define ctx v =
-	raw_define ctx (fst (Define.infos v))
+	raw_define ctx (Define.to_string v)
 
 let init_platform com pf =
 	com.platform <- pf;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -4525,7 +4525,7 @@ let make_macro_api ctx p =
 			let old_error = ctx.on_error in
 			let restore () =
 				if not is_displaying then begin
-					ctx.com.defines <- PMap.remove (fst (Define.infos Define.Display)) ctx.com.defines;
+					ctx.com.defines <- PMap.remove (Define.to_string Define.Display) ctx.com.defines;
 					ctx.com.display <- DMNone
 				end;
 				Parser.resume_display := old_resume;
@@ -4848,7 +4848,7 @@ let get_macro_context ctx p =
 		com2.defines_signature <- None;
 		com2.class_path <- List.filter (fun s -> not (ExtString.String.exists s "/_std/")) com2.class_path;
 		com2.class_path <- List.map (fun p -> p ^ "neko" ^ "/_std/") com2.std_path @ com2.class_path;
-		let to_remove = List.map (fun d -> fst (Define.infos d)) [Define.NoTraces] in
+		let to_remove = List.map (fun d -> Define.to_string d) [Define.NoTraces] in
 		let to_remove = to_remove @ List.map (fun (_,d) -> "flash" ^ d) Common.flash_versions in
 		com2.defines <- PMap.foldi (fun k v acc -> if List.mem k to_remove then acc else PMap.add k v acc) com2.defines PMap.empty;
 		Common.define com2 Define.Macro;


### PR DESCRIPTION
`define_parameter ` can eventually also be used for platforms etc similar to `meta_para
`.