### PR TITLE
Detect rethrows

### DIFF
--- a/src/optimization/analyzerTexprTransformer.ml
+++ b/src/optimization/analyzerTexprTransformer.ml
@@ -26,6 +26,12 @@ open AnalyzerTypes.BasicBlock
 open AnalyzerTypes.Graph
 open AnalyzerTexpr
 
+let is_catch_variable v =
+	Meta.has Meta.CatchVariable v.v_meta
+
+let make_catch_variable v p =
+	v.v_meta <- (Meta.CatchVariable,[],p) :: v.v_meta
+
 (*
 	Transforms an expression to a graph, and a graph back to an expression. This module relies on TexprFilter being
 	run first.
@@ -431,6 +437,8 @@ let rec func ctx bb tf t p =
 			else begin
 				let is_reachable = ref (not (bb_try_next == g.g_unreachable)) in
 				let catches = List.map (fun (v,e) ->
+					if not (is_catch_variable v) then
+						make_catch_variable v e.epos;
 					let bb_catch = create_node (BKCatch v) e.etype e.epos in
 					add_cfg_edge bb_exc bb_catch CFGGoto;
 					let bb_catch_next = block bb_catch e in
@@ -607,6 +615,21 @@ let from_texpr com config e =
 	set_syntax_edge bb_exit SEEnd;
 	ctx
 
+let rethrow com e =
+	try
+		(* It would be nice if these guys could agree on something... *)
+		let s = match com.platform with
+			| Neko -> "__dollar__rethrow"
+			| Hl -> "$rethrow"
+			| Cs -> "__rethrow__"
+			| _ -> raise Exit
+		in
+		let v = alloc_unbound_var s t_dynamic in
+		let ev = Codegen.ExprBuilder.make_local v e.epos in
+		mk (TCall(ev,[e])) com.basic.tvoid e.epos
+	with Exit ->
+		mk (TThrow e) com.basic.tvoid e.epos
+
 let rec block_to_texpr_el ctx bb =
 	if bb.bb_dominator == ctx.graph.g_unreachable then
 		[]
@@ -619,6 +642,15 @@ let rec block_to_texpr_el ctx bb =
 				Some bb_next,(block bb_sub) :: el
 			| el,SEMerge bb_next ->
 				Some bb_next,el
+			| {eexpr = TThrow ({eexpr = TLocal v} as e1)} as e :: el,SENone when is_catch_variable v ->
+				let v' = get_var_origin ctx.graph v in
+				let rec find_catch_var bb = match bb.bb_kind with
+					| BKCatch v -> v
+					| _ -> find_catch_var bb.bb_dominator
+				in
+				let v'' = find_catch_var bb in
+				let e = if v == v' && v == v'' then rethrow ctx.com e1 else e in
+				None,e :: el
 			| el,(SEEnd | SENone) ->
 				None,el
 			| {eexpr = TWhile(e1,_,flag)} as e :: el,(SEWhile(_,bb_body,bb_next)) ->

--- a/src/optimization/analyzerTexprTransformer.ml
+++ b/src/optimization/analyzerTexprTransformer.ml
@@ -618,15 +618,16 @@ let from_texpr com config e =
 let rethrow com e =
 	try
 		(* It would be nice if these guys could agree on something... *)
-		let s = match com.platform with
-			| Neko -> "__dollar__rethrow"
-			| Hl -> "$rethrow"
-			| Cs -> "__rethrow__"
+		let s,el = match com.platform with
+			| Neko -> "__dollar__rethrow",[e]
+			| Hl -> "$rethrow",[e]
+			| Cs -> "__rethrow__",[e]
+			| Js -> add_feature com "js.Lib.rethrow"; "__rethrow__",[]
 			| _ -> raise Exit
 		in
 		let v = alloc_unbound_var s t_dynamic in
 		let ev = Codegen.ExprBuilder.make_local v e.epos in
-		mk (TCall(ev,[e])) com.basic.tvoid e.epos
+		mk (TCall(ev,el)) com.basic.tvoid e.epos
 	with Exit ->
 		mk (TThrow e) com.basic.tvoid e.epos
 

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -45,6 +45,7 @@ module Meta = struct
 		| Build
 		| BuildXml
 		| Callable
+		| CatchVariable
 		| Class
 		| ClassCode
 		| Commutative

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -376,6 +376,7 @@ module MetaInfo = struct
 		| Build -> ":build",("Builds a class or enum from a macro",[HasParam "Build macro call";UsedOnEither [TClass;TEnum]])
 		| BuildXml -> ":buildXml",("Specify xml data to be injected into Build.xml",[Platform Cpp])
 		| Callable -> ":callable",("Abstract forwards call to its underlying type",[UsedOn TAbstract])
+		| CatchVariable -> ":catchVariable",("Internally used to mark catch variables",[Internal])
 		| Class -> ":class",("Used internally to annotate an enum that will be generated as a class",[Platforms [Java;Cs]; UsedOn TEnum; Internal])
 		| ClassCode -> ":classCode",("Used to inject platform-native code into a class",[Platforms [Java;Cs]; UsedOn TClass])
 		| Commutative -> ":commutative",("Declares an abstract operator as commutative",[UsedOn TAbstractField])

--- a/std/cs/Lib.hx
+++ b/std/cs/Lib.hx
@@ -175,6 +175,7 @@ class Lib
 		Rethrow an exception. This is useful when manually filtering an exception in order
 		to keep the previous exception stack.
 	**/
+	@:deprecated("Use throw instead, the compiler detects rethrows")
 	@:extern inline public static function rethrow(e:Dynamic):Void
 	{
 		untyped __rethrow__();

--- a/std/haxe/Template.hx
+++ b/std/haxe/Template.hx
@@ -403,11 +403,7 @@ class Template {
 			} catch( e : Dynamic ) {
 				var plstr = try pl.join(",") catch( e : Dynamic ) "???";
 				var msg = "Macro call "+m+"("+plstr+") failed ("+Std.string(e)+")";
-				#if neko
-				neko.Lib.rethrow(msg);
-				#else
 				throw msg;
-				#end
 			}
 		}
 	}

--- a/std/haxe/io/Input.hx
+++ b/std/haxe/io/Input.hx
@@ -180,7 +180,7 @@ class Input {
 		} catch( e : Eof ) {
 			s = buf.toString();
 			if( s.length == 0 )
-				#if neko neko.Lib.rethrow #else throw #end (e);
+				throw e;
 		}
 		return s;
 	}

--- a/std/hl/types/Api.hx
+++ b/std/hl/types/Api.hx
@@ -1,8 +1,6 @@
 package hl.types;
 
 extern class Api {
-
-	static inline function rethrow( v : Dynamic ) : Void { untyped $rethrow(v); }
 	@:hlNative("std","obj_get_field") static function getField( obj : Dynamic, hash : Int ) : Dynamic;
 	@:hlNative("std","obj_set_field") static function setField( obj : Dynamic, hash : Int, value : Dynamic ) : Void;
 	@:hlNative("std","obj_has_field") static function hasField( obj : Dynamic, hash : Int ) : Bool;

--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -106,6 +106,7 @@ class Lib {
 
 		Calling this only makes sense inside a catch statement.
 	**/
+	@:deprecated("Use throw instead, the compiler detects rethrows")
 	@:extern public static inline function rethrow() {
 		untyped __define_feature__("js.Lib.rethrow", __rethrow__());
 	}

--- a/std/neko/Lib.hx
+++ b/std/neko/Lib.hx
@@ -56,6 +56,7 @@ class Lib {
 		Rethrow an exception. This is useful when manually filtering an exception in order
 		to keep the previous exception stack.
 	**/
+	@:deprecated("Use throw instead, the compiler detects rethrows")
 	public static function rethrow( e : Dynamic ) : Dynamic {
 		return untyped __dollar__rethrow(e);
 	}

--- a/std/neko/_std/sys/net/Socket.hx
+++ b/std/neko/_std/sys/net/Socket.hx
@@ -158,7 +158,7 @@ class Socket {
 				// that a non-blocking connect is in progress
 			}
 			else
-				neko.Lib.rethrow(s);
+				throw s;
 		}
 	}
 

--- a/std/sys/db/Transaction.hx
+++ b/std/sys/db/Transaction.hx
@@ -40,11 +40,7 @@ class Transaction {
 			}
 			if( logError == null ) {
 				Manager.cnx.rollback();
-				#if neko
-				neko.Lib.rethrow(e);
-				#else
 				throw e;
-				#end
 			}
 			logError(e); // should ROLLBACK if needed
 		}


### PR DESCRIPTION
- auto-detects rethrows
- deprecated neko.Lib.rethrow and cs.Lib.rethrow
- removes hl.types.Api.rethrow

A rethrow occurs if the innermost catch-variable is `throw`n without being assigned to:

``` haxe
class Main {
    static function main() {
        try {
            call();
        } catch (v:String) {
            try {
                call();
            } catch(v2:String) {
                throw v; // no rethrow (not innermost catch-variable)
            } catch (v2:Dynamic) {
                throw v2; // rethrow
            }
            throw v; // rethrow
        } catch (v:Dynamic) {
            v = "bar";
            throw v; // no rethrow (catch variable is assigned to)
        }
    }

    static function call() { throw "foo"; return 1; }
}
```

Neko dump:

```
try {
    Main.call();
}catch( v : String ) {
    try {
        Main.call();
    }catch( v2 : String ) {
        throw v;
    },catch( v21 : Dynamic ) {
        __dollar__rethrow(v21);
    };
    __dollar__rethrow(v);
},catch( v1 : Dynamic ) {
    v1 = "bar";
    throw v1;
};
```
