### PR TITLE
Improve handling of Transfer-encoding: chunked (closes #4950)

### DIFF
--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -492,6 +492,7 @@ class Http {
 			else
 				b.add("Content-Length: "+uri.length+"\r\n");
 		}
+		b.add("Connection: close\r\n");
 		for( h in headers ) {
 			b.add(h.header);
 			b.add(": ");
@@ -637,17 +638,23 @@ class Http {
 
 		var bufsize = 1024;
 		var buf = haxe.io.Bytes.alloc(bufsize);
-		if( size == null ) {
+		if( chunked ) {
+			try {
+				while( true ) {
+					var len = sock.input.readBytes(buf,0,bufsize);
+					if( !readChunk(chunk_re,api,buf,len) )
+						break;
+				}
+			} catch ( e : haxe.io.Eof ) {
+				throw "Transfer aborted";
+			}
+		} else if( size == null ) {
 			if( !noShutdown )
 				sock.shutdown(false,true);
 			try {
 				while( true ) {
 					var len = sock.input.readBytes(buf,0,bufsize);
-					if( chunked ) {
-						if( !readChunk(chunk_re,api,buf,len) )
-							break;
-					} else
-						api.writeBytes(buf,0,len);
+					api.writeBytes(buf,0,len);
 				}
 			} catch( e : haxe.io.Eof ) {
 			}
@@ -656,11 +663,7 @@ class Http {
 			try {
 				while( size > 0 ) {
 					var len = sock.input.readBytes(buf,0,if( size > bufsize ) bufsize else size);
-					if( chunked ) {
-						if( !readChunk(chunk_re,api,buf,len) )
-							break;
-					} else
-						api.writeBytes(buf,0,len);
+					api.writeBytes(buf,0,len);
 					size -= len;
 				}
 			} catch( e : haxe.io.Eof ) {


### PR DESCRIPTION
I add `Connection: close` in request headers, as defined in RFC :
> HTTP/1.1 applications that do not support persistent connections MUST include the "close" connection option in every message.

For body reading, I first check if the message is chunked, as we should ignore Content-Length in this case. RFC says :
> If a message is received with both a Transfer-Encoding header field and a Content-Length header field, the latter MUST be ignored.

I don't use `shutdown()` where transfer is chunked : we don't need an `Eof` in this case, a chunked message is ended by a 0-length chunk. In fact I think an Eof must be seen as an error here.

I left the `shutdown()` when we need an `Eof`. That should only concern HTTP 1.0 servers, as HTTP 1.1 requires Content-Length or chunked transfer :
> In order to remain persistent, all messages on the connection MUST have a self-defined message length (i.e., one not defined by closure of the connection)