### PR TITLE
Update documentation 

### DIFF
--- a/std/Math.hx
+++ b/std/Math.hx
@@ -75,7 +75,7 @@ extern class Math
 
 		@php In PHP versions prior to 5.3.1 VC 9 there may be unexpected
 		results when performing arithmetic operations with `NaN` on Windows,
-		see [https://bugs.php.net/bug.php?id=42143]
+		see <https://bugs.php.net/bug.php?id=42143>
 	**/
 	static var NaN(default, null) : Float;
 

--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -20,7 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 /**
-	This class gives you access to many base functionalities of system platforms. Looks in [sys] sub packages for more system APIs.
+	This class gives you access to many base functionalities of system platforms. Looks in `sys` sub packages for more system APIs.
 **/
 @:require(sys)
 extern class Sys {
@@ -61,7 +61,7 @@ extern class Sys {
 	static function sleep( seconds : Float ) : Void;
 
 	/**
-		Change the current time locale, which will affect [DateTools.format] date formating.
+		Change the current time locale, which will affect `DateTools.format` date formating.
 		Returns true if the locale was successfully changed
 	**/
 	static function setTimeLocale( loc : String ) : Bool;
@@ -126,12 +126,12 @@ extern class Sys {
 	static function programPath() : String;
 
 	/**
-		Read a single input character from the standard input (without blocking) and returns it. Setting [echo] to true will also display it on the output.
+		Read a single input character from the standard input (without blocking) and returns it. Setting `echo` to true will also display it on the output.
 	**/
 	static function getChar( echo : Bool ) : Int;
 
 	/**
-		Returns the process standard input, from which you can read what user enters. Usually it will block until the user send a full input line. See [getChar] for an alternative.
+		Returns the process standard input, from which you can read what user enters. Usually it will block until the user send a full input line. See `getChar` for an alternative.
 	**/
 	static function stdin() : haxe.io.Input;
 

--- a/std/Type.hx
+++ b/std/Type.hx
@@ -21,7 +21,7 @@
  */
 
 /**
-	The haxe Reflection API allows retrieval of type information at runtime.
+	The Haxe Reflection API allows retrieval of type information at runtime.
 
 	This class complements the more lightweight Reflect class, with a focus on
 	class and enum instances.
@@ -71,7 +71,7 @@ extern class Type {
 		If `c` is inside a package, the package structure is returned dot-
 		separated, with another dot separating the class name:
 		`pack1.pack2.(...).packN.ClassName`
-		If `c` is a sub-type of a haxe module, that module is not part of the
+		If `c` is a sub-type of a Haxe module, that module is not part of the
 		package structure.
 
 		If `c` has no package, the class name is returned.
@@ -88,7 +88,7 @@ extern class Type {
 		If `e` is inside a package, the package structure is returned dot-
 		separated, with another dot separating the enum name:
 		`pack1.pack2.(...).packN.EnumName`
-		If `e` is a sub-type of a haxe module, that module is not part of the
+		If `e` is a sub-type of a Haxe module, that module is not part of the
 		package structure.
 
 		If `e` has no package, the enum name is returned.
@@ -171,7 +171,7 @@ extern class Type {
 		Creates an instance of enum `e` by calling its constructor number
 		`index` with arguments `params`.
 
-		The constructor indices are preserved from haxe syntax, so the first
+		The constructor indices are preserved from Haxe syntax, so the first
 		declared is index 0, the next index 1 etc.
 
 		If `e` or `constr` is null, or if enum `e` has no constructor named

--- a/std/Xml.hx
+++ b/std/Xml.hx
@@ -117,7 +117,7 @@ class Xml {
 
 	/**
 		Returns the parent object in the Xml hierarchy.
-		The parent can be [null], an Element or a Document.
+		The parent can be `null`, an Element or a Document.
 	**/
 	public var parent(default, null) : Xml;
 
@@ -214,7 +214,7 @@ class Xml {
 	}
 
 	/**
-		Get the given attribute of an Element node. Returns [null] if not found.
+		Get the given attribute of an Element node. Returns `null` if not found.
 		Attributes are case-sensitive.
 	**/
 	public function get( att : String ) : String {
@@ -258,7 +258,7 @@ class Xml {
 	}
 
 	/**
-		Returns an [Iterator] on all the attribute names.
+		Returns an `Iterator` on all the attribute names.
 	**/
 	public function attributes() : Iterator<String> {
 		if (nodeType != Element) {
@@ -319,7 +319,7 @@ class Xml {
 
 	/**
 		Adds a child node to the Document or Element.
-		A child node can only be inside one given parent node, which is indicated by the [parent] property.
+		A child node can only be inside one given parent node, which is indicated by the `parent` property.
 		If the child is already inside this Document or Element, it will be moved to the last position among the Document or Element's children.
 		If the child node was previously inside a different node, it will be moved to this Document or Element.
 	**/

--- a/std/cpp/vm/Debugger.hx
+++ b/std/cpp/vm/Debugger.hx
@@ -279,7 +279,7 @@ class Debugger
      * Breaks all threads except the debugger thread (which should be the same
      * as the calling thread!).
      *
-     * If [wait] is true, waits up to 2 seconds for all threads to be broken.
+     * If `wait` is true, waits up to 2 seconds for all threads to be broken.
      * Threads which are in blocking system calls and cannot break after 2
      * seconds remain running when this function returns.
      **/
@@ -291,7 +291,7 @@ class Debugger
     /**
      * Continue execution of all stopped threads.  If specialThreadNumber
      * is a valid thread number, then it will be continued past
-     * [continueCount] breakpoints instead of just 1 like all of the other
+     * `continueCount` breakpoints instead of just 1 like all of the other
      * threads.
      **/
     public static function continueThreads(specialThreadNumber : Int,

--- a/std/cpp/vm/Thread.hx
+++ b/std/cpp/vm/Thread.hx
@@ -54,9 +54,9 @@ class Thread {
 	}
 
 	/**
-		Reads a message from the thread queue. If [block] is true, the function
-		blocks until a message is available. If [block] is false, the function
-		returns [null] if no message is available.
+		Reads a message from the thread queue. If `block` is true, the function
+		blocks until a message is available. If `block` is false, the function
+		returns `null` if no message is available.
 	**/
 	public static function readMessage( block : Bool ) : Dynamic {
 		return untyped __global__.__hxcpp_thread_read_message(block);

--- a/std/cpp/vm/Thread.hx
+++ b/std/cpp/vm/Thread.hx
@@ -32,7 +32,7 @@ class Thread {
 	}
 
 	/**
-		Send a message to the thread queue. This message can be readed by using [readMessage].
+		Send a message to the thread queue. This message can be readed by using `readMessage`.
 	**/
 	public function sendMessage( msg : Dynamic ) {
 		untyped __global__.__hxcpp_thread_send(handle,msg);
@@ -47,7 +47,7 @@ class Thread {
 	}
 
 	/**
-		Creates a new thread that will execute the [callb] function, then exit.
+		Creates a new thread that will execute the `callb` function, then exit.
 	**/
 	public static function create( callb : Void -> Void ) {
 		return new Thread(untyped __global__.__hxcpp_thread_create(callb));

--- a/std/cs/Boot.hx
+++ b/std/cs/Boot.hx
@@ -37,6 +37,7 @@ import cs.StdTypes;
 import haxe.ds.StringMap;
 import Reflect;
 
+@:dox(hide)
 class Boot
 {
 

--- a/std/cs/Flags.hx
+++ b/std/cs/Flags.hx
@@ -25,9 +25,9 @@
 	Use this type to have access to the bitwise operators of C# enums that have a `cs.system.FlagsAttribute` attribute.
 
 	Usage example:
+
 	```haxe
 		import cs.system.reflection.BindingFlags;
-
 		var binding = new Flags(BindingFlags.Public) | BindingFlags.Static | BindingFlags.NonPublic;
 	```
  **/

--- a/std/cs/_std/sys/net/Socket.hx
+++ b/std/cs/_std/sys/net/Socket.hx
@@ -44,17 +44,17 @@ class Socket {
 
 	/**
 		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
-		use [setBlocking(false)] or [setTimeout] to prevent infinite waiting.
+		use `setBlocking(false)` or `setTimeout` to prevent infinite waiting.
 	**/
 	public var input(default,null) : haxe.io.Input;
 
 	/**
-		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use [setBlocking(false)] or [setTimeout] to prevent that.
+		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use `setBlocking(false)` or `setTimeout` to prevent that.
 	**/
 	public var output(default,null) : haxe.io.Output;
 
 	/**
-		A custom value that can be associated with the socket. Can be used to retreive your custom infos after a [select].
+		A custom value that can be associated with the socket. Can be used to retreive your custom infos after a `select`.
 	***/
 	public var custom : Dynamic;
 
@@ -103,7 +103,7 @@ class Socket {
 	}
 
 	/**
-		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use [accept()] to accept incoming connections.
+		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
 	**/
 	public function listen( connections : Int ) : Void {
 		sock.Listen( connections );
@@ -194,11 +194,11 @@ class Socket {
 
 	/**
 		Wait until one of the sockets groups is ready for the given operation :
-		[read] contains sockets on which we want to wait for available data to be read,
-		[write] contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-		[others] contains sockets on which we want to wait for exceptional conditions.
-		[select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-		In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
+		* `read` contains sockets on which we want to wait for available data to be read,
+		* `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
+		* `others` contains sockets on which we want to wait for exceptional conditions.
+		* `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
+		In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
 	**/
 	static public function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> } {
 		throw "Not implemented yet.";

--- a/std/cs/internal/Exceptions.hx
+++ b/std/cs/internal/Exceptions.hx
@@ -29,7 +29,7 @@ import cs.system.Exception;
 	static var exception:cs.system.Exception;
 }
 
-//should NOT be usable inside haxe code
+//should NOT be usable inside Haxe code
 @:classCode('override public string Message { get { return this.toString(); } }\n\n')
 @:nativeGen @:keep @:native("haxe.lang.HaxeException") private class HaxeException extends Exception
 {

--- a/std/flash/Boot.hx
+++ b/std/flash/Boot.hx
@@ -41,6 +41,7 @@ package flash;
 }
 #end
 
+@:dox(hide)
 @:keep
 class Boot extends flash.display.MovieClip {
 

--- a/std/haxe/EnumFlags.hx
+++ b/std/haxe/EnumFlags.hx
@@ -26,7 +26,7 @@ package haxe;
 	interface for an actual Int. Each flag can be tested/set with the
 	corresponding enum instance. Up to 32 flags can be stored that way.
 
-	Enum constructor indices are preserved from haxe syntax, so the first
+	Enum constructor indices are preserved from Haxe syntax, so the first
 	declared is index 0, the next index 1 etc. The methods are optimized if the
 	enum instance is passed directly, e.g. as has(EnumCtor). Otherwise
 	Type.enumIndex() reflection is used.

--- a/std/haxe/EnumTools.hx
+++ b/std/haxe/EnumTools.hx
@@ -38,7 +38,7 @@ extern class EnumTools {
 		If `e` is inside a package, the package structure is returned dot-
 		separated, with another dot separating the enum name:
 			pack1.pack2.(...).packN.EnumName
-		If `e` is a sub-type of a haxe module, that module is not part of the
+		If `e` is a sub-type of a Haxe module, that module is not part of the
 		package structure.
 
 		If `e` has no package, the enum name is returned.
@@ -68,7 +68,7 @@ extern class EnumTools {
 		Creates an instance of enum `e` by calling its constructor number
 		`index` with arguments `params`.
 
-		The constructor indices are preserved from haxe syntax, so the first
+		The constructor indices are preserved from Haxe syntax, so the first
 		declared is index 0, the next index 1 etc.
 
 		If `e` or `index` is `null`, or if enum `e` has no constructor

--- a/std/haxe/EnumTools.hx
+++ b/std/haxe/EnumTools.hx
@@ -22,6 +22,15 @@
 
 package haxe;
 
+/**
+	This class provides advanced methods on enums. It is ideally used with
+	`using EnumTools` and then acts as an 
+  [extension](http://haxe.org/manual/lf-static-extension.html) to the 
+  `enum` types.
+
+	If the first argument to any of the methods is null, the result is
+	unspecified.
+**/
 extern class EnumTools {
 	/**
 		Returns the name of enum `e`, including its path.
@@ -101,6 +110,15 @@ extern class EnumTools {
 	}
 }
 
+/**
+	This class provides advanced methods on enum values. It is ideally used with
+	`using EnumValueTools` and then acts as an 
+  [extension](http://haxe.org/manual/lf-static-extension.html) to the 
+  `EnumValue` types.
+
+	If the first argument to any of the methods is null, the result is
+	unspecified.
+**/
 extern class EnumValueTools {
 
 	/**

--- a/std/haxe/Http.hx
+++ b/std/haxe/Http.hx
@@ -42,15 +42,15 @@ private typedef AbstractSocket = {
 	This class can be used to handle Http requests consistently across
 	platforms. There are two intended usages:
 
-	- call haxe.Http.requestUrl(url) and receive the result as a String (not
-	available on flash)
-	- create a new haxe.Http(url), register your callbacks for onData, onError
-	and onStatus, then call request().
+	- call `haxe.Http.requestUrl(url)` and receive the result as a `String`
+	(not available on flash)
+	- create a `new haxe.Http(url)`, register your callbacks for `onData`, 
+	`onError` and `onStatus`, then call `request()`.
 **/
 class Http {
 
 	/**
-		The url of `this` request. It is used only by the request() method and
+		The url of `this` request. It is used only by the `request()` method and
 		can be changed in order to send the same request to different target
 		Urls.
 	**/
@@ -78,10 +78,10 @@ class Http {
 	/**
 		Creates a new Http instance with `url` as parameter.
 
-		This does not do a request until request() is called.
+		This does not do a request until `request()` is called.
 
 		If `url` is null, the field url must be set to a value before making the
-		call to request(), or the result is unspecified.
+		call to `request()`, or the result is unspecified.
 
 		(Php) Https (SSL) connections are allowed only if the OpenSSL extension
 		is enabled.
@@ -184,14 +184,14 @@ class Http {
 		sent as GET request.
 
 		Depending on the outcome of the request, this method calls the
-		onStatus(), onError() or onData() callback functions.
+		`onStatus()`, `onError()` or `onData()` callback functions.
 
 		If `this.url` is null, the result is unspecified.
 
-		If `this.url` is an invalid or inaccessible Url, the onError() callback
+		If `this.url` is an invalid or inaccessible Url, the `onError()` callback
 		function is called.
 
-		(Js) If `this.async` is false, the callback functions are called before
+		[js] If `this.async` is false, the callback functions are called before
 		this method returns.
 	**/
 	public function request( ?post : Bool ) : Void {
@@ -740,7 +740,7 @@ class Http {
 		This method is called upon a successful request, with `data` containing
 		the result String.
 
-		The intended usage is to bind it to a custom function:
+		The intended usage is to bind it to a custom function:  
 		`httpInstance.onData = function(data) { // handle result }`
 	**/
 	public dynamic function onData( data : String ) {
@@ -750,7 +750,7 @@ class Http {
 		This method is called upon a request error, with `msg` containing the
 		error description.
 
-		The intended usage is to bind it to a custom function:
+		The intended usage is to bind it to a custom function:  
 		`httpInstance.onError = function(msg) { // handle error }`
 	**/
 	public dynamic function onError( msg : String ) {
@@ -760,7 +760,7 @@ class Http {
 		This method is called upon a Http status change, with `status` being the
 		new status.
 
-		The intended usage is to bind it to a custom function:
+		The intended usage is to bind it to a custom function:  
 		`httpInstance.onStatus = function(status) { // handle status }`
 	**/
 	public dynamic function onStatus( status : Int ) {
@@ -771,7 +771,7 @@ class Http {
 		Makes a synchronous request to `url`.
 
 		This creates a new Http instance and makes a GET request by calling its
-		request(false) method.
+		`request(false)` method.
 
 		If `url` is null, the result is unspecified.
 	**/

--- a/std/haxe/Int64Helper.hx
+++ b/std/haxe/Int64Helper.hx
@@ -25,8 +25,13 @@ using haxe.Int64;
 
 import StringTools;
 
+/**
+	Helper for parsing to `Int64` instances.
+**/
 class Int64Helper {
-
+	/**
+		Create `Int64` from given string.
+	**/
 	public static function parseString( sParam : String ) : Int64 {
 		var base = Int64.ofInt(10);
 		var current = Int64.ofInt(0);
@@ -64,6 +69,9 @@ class Int64Helper {
 		return current;
 	}
 
+	/**
+		Create `Int64` from given float.
+	**/
 	public static function fromFloat( f : Float ) : Int64 {
 		if (Math.isNaN(f) || !Math.isFinite(f)) {
 			throw "Number is NaN or Infinite";

--- a/std/haxe/Log.hx
+++ b/std/haxe/Log.hx
@@ -22,8 +22,8 @@
 package haxe;
 
 /**
-	Log primarily provides the trace() method, which is invoked upon a call to
-	trace() in haxe code.
+	Log primarily provides the `trace()` method, which is invoked upon a call to
+	`trace()` in Haxe code.
 **/
 class Log {
 
@@ -31,7 +31,7 @@ class Log {
 		Outputs `v` in a platform-dependent way.
 
 		The second parameter `infos` is injected by the compiler and contains
-		information about the position where the trace() call was made.
+		information about the position where the `trace()` call was made.
 
 		This method can be rebound to a custom function:
 			var oldTrace = haxe.Log.trace; // store old function
@@ -39,7 +39,7 @@ class Log {
 			...
 			haxe.Log.trace = oldTrace;
 
-		If it is bound to null, subsequent calls to trace() will cause an
+		If it is bound to null, subsequent calls to `trace()` will cause an
 		exception.
 	**/
 	public static dynamic function trace( v : Dynamic, ?infos : PosInfos ) : Void {

--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -27,7 +27,7 @@ package haxe;
 
 	This class can be used in two ways:
 
-	- create a `new Serializer()` instance, call its serialize() method with
+	- create a `new Serializer()` instance, call its `serialize()` method with
 		any argument and finally retrieve the String representation from
 		`toString()`
 	- call `Serializer.run()` to obtain the serialized representation of a

--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -43,7 +43,7 @@ class Serializer {
 
 	/**
 		If the values you are serializing can contain circular references or
-		objects repetitions, you should set USE_CACHE to true to prevent
+		objects repetitions, you should set `USE_CACHE` to true to prevent
 		infinite loops.
 
 		This may also reduce the size of serialization Strings at the expense of

--- a/std/haxe/Ucs2.hx
+++ b/std/haxe/Ucs2.hx
@@ -128,7 +128,7 @@ abstract Ucs2(String) {
 		If `delimiter` is null, the result is unspecified.
 
 		Otherwise, `this` Ucs2 is split into parts at each occurence of
-		`delimiter`. If `this` Ucs2 starts (or ends) with [delimiter}, the
+		`delimiter`. If `this` Ucs2 starts (or ends) with `delimiter`, the
 		result Array contains a leading (or trailing) empty Ucs2 "" element.
 		Two subsequent delimiters also result in an empty Ucs2 "" element.
 	**/

--- a/std/haxe/Unserializer.hx
+++ b/std/haxe/Unserializer.hx
@@ -47,17 +47,17 @@ class Unserializer {
 	/**
 		This value can be set to use custom type resolvers.
 
-		A type resolver finds a Class or Enum instance from a given String. By
-		default, the haxe Type Api is used.
+		A type resolver finds a `Class` or `Enum` instance from a given `String`. 
+		By default, the Haxe `Type` Api is used.
 
 		A type resolver must provide two methods:
 
-		1. resolveClass(name:String):Class<Dynamic> is called to determine a
-				Class from a class name
-		2. resolveEnum(name:String):Enum<Dynamic> is called to determine an
-				Enum from an enum name
+		1. `resolveClass(name:String):Class<Dynamic>` is called to determine a
+				`Class` from a class name
+		2. `resolveEnum(name:String):Enum<Dynamic>` is called to determine an
+				`Enum` from an enum name
 
-		This value is applied when a new Unserializer instance is created.
+		This value is applied when a new `Unserializer` instance is created.
 		Changing it afterwards has no effect on previously created instances.
 	**/
 	public static var DEFAULT_RESOLVER : TypeResolver = new DefaultResolver();
@@ -223,11 +223,11 @@ class Unserializer {
 
 		This operation may fail on structurally valid data if a type cannot be
 		resolved or if a field cannot be set. This can happen when unserializing
-		Strings that were serialized on a different haxe target, in which the
+		Strings that were serialized on a different Haxe target, in which the
 		serialization side has to make sure not to include platform-specific
 		data.
 
-		Classes are created from Type.createEmptyInstance, which means their
+		Classes are created from `Type.createEmptyInstance`, which means their
 		constructors are not called.
 	**/
  	public function unserialize() : Dynamic {

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -207,6 +207,9 @@ class BalancedTree<K,V> {
 	}
 }
 
+/**
+	A tree node of `haxe.ds.BalancedTree`.
+**/
 class TreeNode<K,V> {
 	public var left : TreeNode<K,V>;
 	public var right : TreeNode<K,V>;

--- a/std/haxe/ds/GenericStack.hx
+++ b/std/haxe/ds/GenericStack.hx
@@ -21,6 +21,11 @@
  */
 package haxe.ds;
 
+/**
+	A cell of `haxe.ds.GenericStack`.
+  
+	@see http://haxe.org/manual/std-GenericStack.html
+**/
 #if (flash || cpp)
 @:generic
 #end

--- a/std/haxe/ds/ListSort.hx
+++ b/std/haxe/ds/ListSort.hx
@@ -95,7 +95,7 @@ class ListSort {
 
 
 	/**
-		Same as [sort] but on single linked list.
+		Same as `sort` but on single linked list.
 	**/
 	public static inline function sortSingleLinked<T:{next:T}>(list:T, cmp : T -> T -> Int) : T {
 		if( list == null )

--- a/std/haxe/io/Eof.hx
+++ b/std/haxe/io/Eof.hx
@@ -22,7 +22,7 @@
 package haxe.io;
 
 /**
-	This exception is raised when reading while data is no longer available in the [Input].
+	This exception is raised when reading while data is no longer available in the `haxe.io.Input`.
 **/
 class Eof {
 	public function new() {

--- a/std/haxe/io/Output.hx
+++ b/std/haxe/io/Output.hx
@@ -23,8 +23,8 @@ package haxe.io;
 
 /**
 	An Output is an abstract write. A specific output implementation will only
-	have to override the [writeByte] and maybe the [write], [flush] and [close]
-	methods. See [File.write] and [String.write] for two ways of creating an
+	have to override the `writeByte` and maybe the `write`, `flush` and `close`
+	methods. See `File.write` and `String.write` for two ways of creating an
 	Output.
 **/
 class Output {

--- a/std/haxe/macro/ComplexTypeTools.hx
+++ b/std/haxe/macro/ComplexTypeTools.hx
@@ -27,12 +27,12 @@ import haxe.macro.Expr;
 /**
 	This class provides some utility methods to work with AST-level types. It is
 	best used through 'using haxe.macro.ComplexTypeTools' syntax and then provides
-	additional methods on haxe.macro.Expr.ComplexType instances.
+	additional methods on `haxe.macro.Expr.ComplexType` instances.
 **/
 class ComplexTypeTools {
 
 	/**
-		Converts type [c] to a human-readable String representation.
+		Converts type `c` to a human-readable `String` representation.
 
 		The result is guaranteed to be valid haxe code, but there may be
 		differences from the original lexical syntax.
@@ -43,9 +43,9 @@ class ComplexTypeTools {
 	#if macro
 
 	/**
-		Returns a type corresponding to [c].
+		Returns a type corresponding to `c`.
 
-		If [c] is null, the result is null.
+		If `c` is null, the result is null.
 	**/
 	static public function toType( c : ComplexType ) : Null<Type>
 		return c == null ? null : Context.resolveType(c,Context.currentPos());

--- a/std/haxe/macro/ComplexTypeTools.hx
+++ b/std/haxe/macro/ComplexTypeTools.hx
@@ -34,7 +34,7 @@ class ComplexTypeTools {
 	/**
 		Converts type `c` to a human-readable `String` representation.
 
-		The result is guaranteed to be valid haxe code, but there may be
+		The result is guaranteed to be valid Haxe code, but there may be
 		differences from the original lexical syntax.
 	**/
 	static public function toString( c : ComplexType ) : String

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -272,7 +272,7 @@ class Context {
 	}
 
 	/**
-		Parses `expr` as haxe code, returning the corresponding AST.
+		Parses `expr` as Haxe code, returning the corresponding AST.
 
 		String interpolation of single quote strings within `expr` is not
 		supported.

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -36,7 +36,7 @@ using Lambda;
 class ExprTools {
 
 	/**
-		Converts expression [e] to a human-readable String representation.
+		Converts expression `e` to a human-readable String representation.
 
 		The result is guaranteed to be valid haxe code, but there may be
 		differences from the original lexical syntax.
@@ -45,11 +45,11 @@ class ExprTools {
 		return new Printer().printExpr(e);
 
 	/**
-		Calls function [f] on each sub-expression of [e].
+		Calls function `f` on each sub-expression of `e`.
 
-		If [e] has no sub-expressions, this operation has no effect.
+		If `e` has no sub-expressions, this operation has no effect.
 
-		Otherwise [f] is called once per sub-expression of [e], with the
+		Otherwise `f` is called once per sub-expression of `e`, with the
 		sub-expression as argument. These calls are done in order of the
 		sub-expression declarations.
 
@@ -57,7 +57,7 @@ class ExprTools {
 		in a recursive function which handles the expression nodes of interest.
 
 		Usage example:
-
+		```haxe
 		function findStrings(e:Expr) {
 			switch(e.expr) {
 				case EConst(CString(s)):
@@ -66,6 +66,7 @@ class ExprTools {
 					ExprTools.iter(e, findStrings);
 			}
 		}
+		  ```
 	**/
 	static public function iter( e : Expr, f : Expr -> Void ) : Void {
 		switch(e.expr) {
@@ -131,11 +132,11 @@ class ExprTools {
 	}
 
 	/**
-		Transforms the sub-expressions of [e] by calling [f] on each of them.
+		Transforms the sub-expressions of `e` by calling `f` on each of them.
 
-		If [e] has no sub-expressions, this operation returns [e] unchanged.
+		If `e` has no sub-expressions, this operation returns `e` unchanged.
 
-		Otherwise [f] is called once per sub-expression of [e], with the
+		Otherwise `f` is called once per sub-expression of `e`, with the
 		sub-expression as argument. These calls are done in order of the
 		sub-expression declarations.
 
@@ -143,7 +144,7 @@ class ExprTools {
 		in a recursive function which handles the expression nodes of interest.
 
 		Usage example:
-
+		```haxe
 		function capitalizeStrings(e:Expr) {
 			return switch(e.expr) {
 				case EConst(CString(s)):
@@ -152,6 +153,7 @@ class ExprTools {
 					ExprTools.map(e, capitalizeStrings);
 			}
 		}
+		```haxe
 	**/
 	static public function map( e : Expr, f : Expr -> Expr ) : Expr {
 		return {pos: e.pos, expr: switch(e.expr) {

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -66,7 +66,7 @@ class ExprTools {
 					ExprTools.iter(e, findStrings);
 			}
 		}
-		  ```
+		```
 	**/
 	static public function iter( e : Expr, f : Expr -> Void ) : Void {
 		switch(e.expr) {

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -38,7 +38,7 @@ class ExprTools {
 	/**
 		Converts expression `e` to a human-readable String representation.
 
-		The result is guaranteed to be valid haxe code, but there may be
+		The result is guaranteed to be valid Haxe code, but there may be
 		differences from the original lexical syntax.
 	**/
 	static public function toString( e : Expr ) : String

--- a/std/haxe/macro/Tools.hx
+++ b/std/haxe/macro/Tools.hx
@@ -22,12 +22,32 @@
 package haxe.macro;
 
 /**
-	This class can be added via 'using haxe.macro.Tools' in order to enable
-	'using' functionality on all macro tool classes listed below.
+	This class can be added via `using haxe.macro.Tools` in order to enable
+	`using` functionality on these macro tool classes:
+
+	- `haxe.macro.ExprTools`
+	- `haxe.macro.ComplexTypeTools`
+	- `haxe.macro.TypeTools`
+	- `haxe.macro.MacroStringTools`
+	- `haxe.macro.TypedExprTools`
+	- `haxe.macro.PositionTools`
+  
+  @see <http://haxe.org/manual/lf-static-extension.html>
 **/
+@:dox(hide)
 typedef TExprTools = ExprTools;
+
+@:dox(hide)
 typedef TComplexTypeTools = ComplexTypeTools;
+
+@:dox(hide)
 typedef TTypeTools = TypeTools;
+
+@:dox(hide)
 typedef TMacroStringTools = MacroStringTools;
+
+@:dox(hide)
 typedef TTypedExprTools = TypedExprTools;
+
+@:dox(hide)
 typedef TPositionTools = PositionTools;

--- a/std/haxe/macro/TypedExprTools.hx
+++ b/std/haxe/macro/TypedExprTools.hx
@@ -24,6 +24,11 @@ package haxe.macro;
 
 import haxe.macro.Type;
 
+/**
+	This class provides some utility methods to work with typed expressions.
+	It is best used through 'using haxe.macro.TypedExprTools' syntax and then 
+	provides additional methods on `haxe.macro.TypedExpr` instances.
+**/
 class TypedExprTools {
 	static function with(e:TypedExpr, ?edef:TypedExprDef, ?t:Type) {
 		return {
@@ -34,7 +39,7 @@ class TypedExprTools {
 	}
 
 	/**
-		Transforms the sub-expressions of [e] by calling [f] on each of them.
+		Transforms the sub-expressions of `e` by calling `f` on each of them.
 
 		See `haxe.macro.ExprTools.map` for details on expression mapping in
 		general. This function works the same way, but with a different data
@@ -69,7 +74,7 @@ class TypedExprTools {
 	}
 
 	/**
-		Calls function [f] on each sub-expression of [e].
+		Calls function `f` on each sub-expression of `e`.
 
 		See `haxe.macro.ExprTools.iter` for details on iterating expressions in
 		general. This function works the same way, but with a different data
@@ -112,7 +117,7 @@ class TypedExprTools {
 	}
 
 	/**
-		Transforms the sub-expressions of [e] by calling [f] on each of them.
+		Transforms the sub-expressions of `e` by calling `f` on each of them.
 		Additionally, types are mapped using `ft` and variables are mapped using
 		`fv`.
 

--- a/std/haxe/remoting/SocketProtocol.hx
+++ b/std/haxe/remoting/SocketProtocol.hx
@@ -35,15 +35,20 @@ typedef Socket =
 /**
 	The Haxe Remoting Socket Protocol is composed of serialized string exchanges.
 	Each string is prefixed with a 2-chars header encoding the string size (up to 4KB)
-	and postfixed with the \0 message delimiting char.
+	and postfixed with the `\0` message delimiting char.
+
 	A request string is composed of the following serialized values :
-		- the boolean true for a request
-		- an array of strings representing the object+method path
-		- an array of parameters
+
+	 - the boolean true for a request
+	 - an array of strings representing the object+method path
+	 - an array of parameters
+
 	A response string is composed of the following serialized values :
-		- the boolean false for a response
-		- a serialized value representing the result
-	Exceptions are serialized with [serializeException] so they will be thrown immediatly
+
+	 - the boolean false for a response
+	 - a serialized value representing the result
+
+	Exceptions are serialized with `serializeException` so they will be thrown immediatly
 	when they are unserialized.
 **/
 class SocketProtocol {

--- a/std/haxe/remoting/SocketWrapper.hx
+++ b/std/haxe/remoting/SocketWrapper.hx
@@ -23,7 +23,7 @@ package haxe.remoting;
 import haxe.remoting.SocketProtocol.Socket;
 
 /**
-	See [js.XMLSocket]
+	@see `js.XMLSocket`
 **/
 class SocketWrapper {
 

--- a/std/hl/Boot.hx
+++ b/std/hl/Boot.hx
@@ -3,6 +3,7 @@ package hl;
 import hl.types.ArrayDyn;
 import hl.types.BaseType;
 
+@:dox(hide)
 extern class Boot {
 	@:extern public inline static function dump( v : Dynamic ) : Void {
 		untyped $dump(v);

--- a/std/java/Boot.hx
+++ b/std/java/Boot.hx
@@ -45,6 +45,7 @@ import java.lang.Throwable;
 import java.internal.StringExt;
 import java.internal.FieldLookup;
 
+@:dox(hide)
 extern class Boot
 {
 

--- a/std/java/Lib.hx
+++ b/std/java/Lib.hx
@@ -23,7 +23,7 @@ package java;
 
 /**
 	Platform-specific Java Library. Provides some platform-specific functions for the Java target,
-	such as conversion from haxe types to native types and vice-versa.
+	such as conversion from Haxe types to native types and vice-versa.
 **/
 //we cannot use the java package for custom classes, so we're redefining it as "haxe.java.Lib"
 @:native('haxe.java.Lib') class Lib

--- a/std/java/Lib.hx
+++ b/std/java/Lib.hx
@@ -33,7 +33,7 @@ package java;
 		Returns a native array from the supplied Array. This native array is unsafe to be written on,
 		as it may or may not be linked to the actual Array implementation.
 
-		If equalLengthRequired is true, the result might be a copy of an array with the correct size.
+		If `equalLengthRequired` is true, the result might be a copy of an array with the correct size.
 	**/
 	inline public static function nativeArray<T>(arr:Array<T>, equalLengthRequired:Bool):NativeArray<T>
 	{

--- a/std/js/Cookie.hx
+++ b/std/js/Cookie.hx
@@ -24,7 +24,7 @@ package js;
 class Cookie {
 	/**
 		Create or update a cookie.
-		expireDelay (seconds), if null, the cookie expires at end of session
+		@param  expireDelay  In seconds. If null, the cookie expires at end of session.
 	**/
 	public static function set( name : String, value : String, ?expireDelay : Int, ?path : String, ?domain : String ){
 		var s = name+"="+StringTools.urlEncode(value);
@@ -42,7 +42,7 @@ class Cookie {
 	}
 
 	/**
-		Returns all cookies
+		Returns all cookies.
 	**/
 	public static function all(){
 		var h = new haxe.ds.StringMap();
@@ -65,14 +65,14 @@ class Cookie {
 	}
 
 	/**
-		Returns true if a cookie [name] exists
+		Returns true if a cookie `name` exists.
 	**/
 	public static function exists( name : String ){
 		return all().exists(name);
 	}
 
 	/**
-		Remove a cookie
+		Remove a cookie.
 	**/
 	public static function remove( name : String, ?path : String, ?domain : String ){
 		set(name,"",-10,path,domain);

--- a/std/js/RegExp.hx
+++ b/std/js/RegExp.hx
@@ -24,7 +24,8 @@
 /**
     Native JavaScript regular expressions.
 
-    For cross-platform regular expressions, use Haxe `EReg` class or [regexp literals](http://haxe.org/manual/std-regex.html).
+    For cross-platform regular expressions, use Haxe `EReg` class or 
+    [regexp literals](http://haxe.org/manual/std-regex.html).
 **/
 @:native("RegExp")
 extern class RegExp {

--- a/std/js/RegExp.hx
+++ b/std/js/RegExp.hx
@@ -24,7 +24,7 @@
 /**
     Native JavaScript regular expressions.
 
-    For cross-platform regular expressions, use haxe `EReg` class or regexp literals.
+    For cross-platform regular expressions, use Haxe `EReg` class or [regexp literals](http://haxe.org/manual/std-regex.html).
 **/
 @:native("RegExp")
 extern class RegExp {

--- a/std/js/XMLSocket.hx
+++ b/std/js/XMLSocket.hx
@@ -22,7 +22,8 @@
 package js;
 
 /**
-	By compiling the [haxe.remoting.SocketWrapper] into a SWF, you can create and use XMLSockets directly from Javascript.
+	By compiling the `haxe.remoting.SocketWrapper` into a SWF, you can create 
+	and use XMLSockets directly from Javascript.
 **/
 class XMLSocket {
 

--- a/std/lua/Bit.hx
+++ b/std/lua/Bit.hx
@@ -21,10 +21,10 @@
  */
 
 package lua;
-/**
-  Externs for the "bit" class that is required for haxe lua
-**/
 
+/**
+  Externs for the "bit" class that is required for Haxe lua
+**/
 @:native("_hx_bit")
 extern class Bit {
 	public static function bnot(x:Float) : Int;

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -31,6 +31,7 @@ import haxe.io.Path;
 import haxe.Constraints.Function;
 using lua.PairTools;
 
+@:dox(hide)
 class Boot {
 
 	// Used temporarily for bind()
@@ -64,11 +65,17 @@ class Boot {
 		return f;
 	}
 
+	/*
+	   Indicates if the given object is a class.
+	*/
 	static inline public function isClass(o:Dynamic) : Bool {
 		if (Lua.type(o) != "table") return false;
 		else return untyped __define_feature__("lua.Boot.isClass", o.__name__);
 	}
 
+	/*
+	   Indicates if the given object is a enum.
+	*/
 	static inline public function isEnum(e:Dynamic) : Bool {
 		if (Lua.type(e) != "table") return false;
 		else return untyped __define_feature__("lua.Boot.isEnum", e.__ename__);
@@ -176,7 +183,6 @@ class Boot {
 	*/
 	static inline function printClass(c:Table<String,Dynamic>, s : String) : String {
 		return '{${printClassRec(c,'',s)}}';
-
 	}
 
 	/*
@@ -258,6 +264,9 @@ class Boot {
 		return untyped _hx_o(t);
 	}
 
+	/*
+	   Get Date object as string representation
+	*/
 	public static function dateStr( date : std.Date ) : String {
 		var m = date.getMonth() + 1;
 		var d = date.getDate();
@@ -309,7 +318,7 @@ class Boot {
 	}
 
 	/*
-	   create an empty table.
+	   Create an empty table.
 	*/
 	public inline static function createTable<K,V>() : Table<K,V> {
 		return untyped __lua__("{}");

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -22,7 +22,7 @@
 
 package lua;
 
-// Bit and Table must be imported for basic haxe datatypes to work.
+// Bit and Table must be imported for basic Haxe datatypes to work.
 import lua.Bit;
 import lua.Table;
 import lua.Thread;

--- a/std/lua/Debug.hx
+++ b/std/lua/Debug.hx
@@ -22,7 +22,7 @@
 
 package lua;
 /**
-  Externs for the "debug" class for haxe lua  
+  Externs for the "debug" class for Haxe lua  
 **/
 import haxe.Constraints.Function;
 

--- a/std/lua/HaxeIterator.hx
+++ b/std/lua/HaxeIterator.hx
@@ -23,7 +23,7 @@
 package lua;
 
 /**
-  An implementation of the haxe iterator datastructure needed for identical 
+  An implementation of the Haxe iterator datastructure needed for identical 
   lua iterator behavior. 
  **/
 class HaxeIterator<T> {

--- a/std/lua/lib/lfs/LfsFileStat.hx
+++ b/std/lua/lib/lfs/LfsFileStat.hx
@@ -22,25 +22,62 @@
 package lua.lib.lfs;
 
 /**
-	File informations, as given by [sys.FileSystem.stat]
+	File informations, as given by `sys.FileSystem.stat`.
 **/
 typedef LfsFileStat = {
-	/** the user group id for the file **/
-	var gid : Int;
-	/** the user id for the file **/
-	var uid : Int;
-	/** the last access time for the file (when enabled by the file system) **/
-	var atime : Date;
-	/** the last modification time for the file **/
-	var mtime : Date;
-	/** the creation time for the file (not all filesystems support this) **/
-	var ctime : Date;
-	/** the size of the file **/
-	var size : Int;
-	var dev : Int;
-	var ino : Int;
-	var nlink : Int;
-	var rdev : Int;
-	var mode : String;
-}
 
+	/**
+		The user group id for the file's owner.
+	**/
+	var gid : Int;
+
+	/** 
+		The user id for the file's owner.
+	**/
+	var uid : Int;
+
+	/** 
+		The last access time for the file (when enabled by the file system).
+	**/
+	var atime : Date;
+
+	/** 
+		The last modification time for the file.
+	**/
+	var mtime : Date;
+
+	/**
+		The creation time for the file (not all filesystems support this).
+	**/
+	var ctime : Date;
+
+	/** 
+		The size of the file, in bytes. 
+	**/
+	var size : Int;
+
+	/** 
+		The device on which stat resides.
+	**/
+	var dev : Int;
+
+	/** 
+		The inode number for stat.
+	**/
+	var ino : Int;
+
+	/** 
+		The number of hard links to stat.
+	**/
+	var nlink : Int;
+
+	/** 
+		The device type on which stat resides (special files only).
+	**/
+	var rdev : Int;
+
+	/** 
+		The permission bits of stat. The meaning of the bits is platform dependent.
+	**/
+	var mode : Int;
+}

--- a/std/lua/lib/lrexlib/Rex.hx
+++ b/std/lua/lib/lrexlib/Rex.hx
@@ -7,23 +7,23 @@ extern class Rex {
 	}
 
 	/**
-	  The function searches for the first match of the regexp patt in the
-	  string subj, starting from offset init, subject to flags cf and ef.
-	  Returns matched string, or array of strings.
+	  The function searches for the first match of the regexp `patt` in the
+	  string `subj`, starting from offset `init`, subject to flags `cf` and `ef`.
+    
+	  @return matched string, or array of strings.
 	 **/
 	public static function match(patt : String, ?init : Int, ?ef : Int) : Dynamic;
 
 	/**
 	 The function searches for the first match of the regexp patt in the string
-	 subj, starting from offset init, subject to flags cf and ef. 
-	 Returns 
+	 `subj`, starting from offset `init`, subject to flags `cf` and `ef`. 
 	 **/
 	public static function find(subj : String, ?init : Int, ?ef : Int) : Dynamic;
 
 
 	/**
 	 The function is intended for use in the generic for Lua construct. It is
-	 used for splitting a subject string subj into parts (sections). The sep
+	 used for splitting a subject string `subj` into parts (sections). The `sep`
 	 parameter is a regular expression pattern representing separators between
 	 the sections. 
 	 **/
@@ -32,24 +32,33 @@ extern class Rex {
 
 
 	/**
-	  This function counts matches of the pattern patt in the string subj.
+	  This function counts matches of the pattern `patt` in the string `subj`.
 	**/	
 	public static function count(subj : String, patt : String, cf : Int, ef : Int) : Dynamic;
 	public static function flags(tb:Dynamic) : Dynamic;
 
+  /**
+    The function searches for the first match of the regexp in the string 
+    `subj`, starting from offset `init`, subject to execution flags `ef`.
+  **/
 	public function tfind(subj : String, ?init : Int, ?ef : Int) : Dynamic;
+	
+	/**
+	  This function searches for the first match of the regexp in the string 
+	  `subj`, starting from offset `init`, subject to execution flags `ef`.
+	**/
 	public function exec(subj : String, ?init : Int, ?ef : Int) : Dynamic;
 
 	/**
 	 The function is intended for use in the generic for Lua construct. It
 	 returns an iterator for repeated matching of the pattern patt in the
-	 string subj, subject to flags cf and ef.
+	 string `subj`, subject to flags `cf` and `ef`.
 	 **/
 	public static function gmatch(subj : String, ?cf : Int, ?ef : Int) : Dynamic; // TODO: Extern a lua iterator
 
 	/**
-	  This function searches for all matches of the pattern patt in the string subj
-	  and replaces them according to the parameters repl and n.
+	  This function searches for all matches of the pattern `patt` in the string 
+    `subj` and replaces them according to the parameters `repl` and `n`.
 	 **/
 	@:overload(	  function     (subj : String, patt : Rex,    repl: Dynamic, ?n: Int, ?cf : Int, ?ef : Int) : String {})
 	public static function gsub(subj : String, patt : String, repl: Dynamic, ?n: Int, ?cf : Int, ?ef : Int) : String;

--- a/std/neko/Boot.hx
+++ b/std/neko/Boot.hx
@@ -21,6 +21,7 @@
  */
 package neko;
 
+@:dox(hide)
 @:keep
 class Boot {
 

--- a/std/neko/Lib.hx
+++ b/std/neko/Lib.hx
@@ -69,14 +69,14 @@ class Lib {
 	}
 
 	/**
-		Unserialize a string using native Neko serialization. See [serialize].
+		Unserialize a string using native Neko serialization. See `serialize`.
 	**/
 	public static function unserialize( s : haxe.io.Bytes ) : Dynamic {
 		return untyped __unserialize(s.getData(),__dollar__loader);
 	}
 
 	/**
-		Unserialize a string using native Neko serialization. See [serialize].
+		Unserialize a string using native Neko serialization. See `serialize`.
 		This function assume that all the serialized data was serialized with current
 		module, even if the module name was different. This can happen if you are unserializing
 		some data into mod_neko that was serialized on a different server using a different

--- a/std/neko/Web.hx
+++ b/std/neko/Web.hx
@@ -44,8 +44,8 @@ class Web {
 
 	/**
 		Returns an Array of Strings built using GET / POST values.
-		If you have in your URL the parameters [a[]=foo;a[]=hello;a[5]=bar;a[3]=baz] then
-		[neko.Web.getParamValues("a")] will return [["foo","hello",null,"baz",null,"bar"]]
+		If the URL contains the parameters `[a[]=foo;a[]=hello;a[5]=bar;a[3]=baz]` then
+		`neko.Web.getParamValues("a")` will return `["foo","hello",null,"baz",null,"bar"]`
 	**/
 	public static function getParamValues( param : String ) : Array<String> {
 		var reg = new EReg("^"+param+"(\\[|%5B)([0-9]*?)(\\]|%5D)=(.*?)$", "");
@@ -72,7 +72,7 @@ class Web {
 	}
 
 	/**
-		Returns the local server host name
+		Returns the local server host name.
 	**/
 	public static function getHostName() {
 		return new String(_get_host_name());
@@ -138,7 +138,7 @@ class Web {
 	}
 
 	/**
-		Returns all the GET parameters String
+		Returns all the GET parameters String.
 	**/
 	public static function getParamsString() {
 		var p = _get_params_string();
@@ -147,10 +147,10 @@ class Web {
 
 	/**
 		Returns all the POST data. POST Data is always parsed as
-		being application/x-www-form-urlencoded and is stored into
+		being `application/x-www-form-urlencoded` and is stored into
 		the getParams hashtable. POST Data is maximimized to 256K
-		unless the content type is multipart/form-data. In that
-		case, you will have to use [getMultipart] or [parseMultipart]
+		unless the content type is `multipart/form-data`. In that
+		case, you will have to use `getMultipart` or `parseMultipart`
 		methods.
 	**/
 	public static function getPostData() {
@@ -162,7 +162,7 @@ class Web {
 
 	/**
 		Returns an hashtable of all Cookies sent by the client.
-		Modifying the hashtable will not modify the cookie, use setCookie instead.
+		Modifying the hashtable will not modify the cookie, use `setCookie` instead.
 	**/
 	public static function getCookies():Map<String,String> {
 		var p = _get_cookies();
@@ -178,7 +178,7 @@ class Web {
 
 
 	/**
-		Set a Cookie value in the HTTP headers. Same remark as setHeader.
+		Set a Cookie value in the HTTP headers. Same remark as `setHeader`.
 	**/
 	public static function setCookie( key : String, value : String, ?expire: Date, ?domain: String, ?path: String, ?secure: Bool, ?httpOnly: Bool ) {
 		var buf = new StringBuf();
@@ -260,9 +260,9 @@ class Web {
 	}
 
 	/**
-		Parse the multipart data. Call [onPart] when a new part is found
+		Parse the multipart data. Call `onPart` when a new part is found
 		with the part name and the filename if present
-		and [onData] when some part data is readed. You can this way
+		and `onData` when some part data is readed. You can this way
 		directly save the data on hard drive in the case of a file upload.
 	**/
 	public static function parseMultipart( onPart : String -> String -> Void, onData : haxe.io.Bytes -> Int -> Int -> Void ) : Void {
@@ -281,14 +281,14 @@ class Web {
 	}
 
 	/**
-		Get the HTTP method used by the client. This api requires Neko 1.7.1+
+		Get the HTTP method used by the client. This API requires Neko 1.7.1+.
 	**/
 	public static function getMethod() : String {
 		return new String(_get_http_method());
 	}
 
 	/**
-		Write a message into the web server log file. This api requires Neko 1.7.1+
+		Write a message into the web server log file. This API requires Neko 1.7.1+.
 	**/
 	public static function logMessage( msg : String ) {
 		_log_message(untyped msg.__s);

--- a/std/neko/net/ServerLoop.hx
+++ b/std/neko/net/ServerLoop.hx
@@ -59,7 +59,7 @@ class ServerLoop<ClientData> {
 	public var listenCount : Int;
 
 	/**
-		See [update].
+		See `update`.
 	**/
 	public var updateTime : Float;
 
@@ -68,7 +68,7 @@ class ServerLoop<ClientData> {
 	public var clients : List<ClientData>;
 
 	/**
-		Creates a server instance. The [newData] methods must return
+		Creates a server instance. The `newData` methods must return
 		the data associated with the Client.
 	**/
 	public function new( ?newData ) {
@@ -93,9 +93,9 @@ class ServerLoop<ClientData> {
 	}
 
 	/**
-		The [update] method is called after each socket event has been
-		processed or when [updateTime] has been reached. It can be used
-		to perform time-regular tasks such as pings. By default [updateTime]
+		The `update` method is called after each socket event has been
+		processed or when `updateTime` has been reached. It can be used
+		to perform time-regular tasks such as pings. By default `updateTime`
 		is set to one second.
 	**/
 	public function update() {
@@ -138,7 +138,7 @@ class ServerLoop<ClientData> {
 
 	/**
 		Called when an error occured. This enable you to log the error somewhere.
-		By default the error is displayed using [trace].
+		By default the error is displayed using `trace`.
 	**/
 	public function onError( e : Dynamic ) {
 		trace(Std.string(e)+"\n"+haxe.CallStack.toString(haxe.CallStack.exceptionStack()));

--- a/std/neko/vm/Loader.hx
+++ b/std/neko/vm/Loader.hx
@@ -54,8 +54,8 @@ class Loader {
 	}
 
 	/**
-		The default loader contains a search path in its [path] field. It's a
-		linked list of Neko strings that is a parsed version of the [NEKOPATH].
+		The default loader contains a search path in its `path` field. It's a
+		linked list of Neko strings that is a parsed version of the `NEKOPATH`.
 		This path is used to lookup for modules and libraries.
 	**/
 	public function getPath() {
@@ -69,7 +69,7 @@ class Loader {
 	}
 
 	/**
-		Adds a directory to the search path. See [getPath]
+		Adds a directory to the search path. See `getPath`.
 	**/
 	public function addPath( s : String ) {
 		untyped l.path = __dollar__array(s.__s,l.path);
@@ -115,7 +115,7 @@ class Loader {
 	}
 
 	/**
-		Loads a neko primitive. By default, the name is of the form [library@method].
+		Loads a neko primitive. By default, the name is of the form `[library@method]`.
 		The primitive might not be used directly in Haxe since some of the Neko values
 		needs an object wrapper in Haxe.
 	**/
@@ -124,7 +124,7 @@ class Loader {
 	}
 
 	/**
-		Loads a Module with the given name. If [loader] is defined, this will be
+		Loads a Module with the given name. If `loader` is defined, this will be
 		this Module loader, else this loader will be inherited. When loaded this
 		way, the module is directly executed.
 	**/
@@ -143,7 +143,7 @@ class Loader {
 
 	/**
 		Creates a loader using two methods. This loader will not have an accessible cache or path,
-		although you can implement such mecanism in the methods body.
+		although you can implement such mechanism in the methods body.
 	**/
 	public static function make( loadPrim : String -> Int -> Dynamic, loadModule : String -> Loader -> Module ) {
 		var l = {

--- a/std/neko/vm/Module.hx
+++ b/std/neko/vm/Module.hx
@@ -28,8 +28,8 @@ enum ModuleHandle {
 }
 
 /**
-	A Neko Module represent a execution unit for the Neko Virtual Machine. Each compiled [.n] bytecode
-	file is a module once loaded by the NekoVM.
+	A Neko Module represent a execution unit for the Neko Virtual Machine. 
+	Each compiled `.n` bytecode file is a module once loaded by the NekoVM.
 **/
 class Module {
 
@@ -63,7 +63,7 @@ class Module {
 
 
 	/**
-		Returns the Loader that this Module was loaded with.s
+		Returns the Loader that this Module was loaded with.
 	**/
 	public function loader() {
 		return new Loader(_module_loader(m));

--- a/std/neko/vm/Thread.hx
+++ b/std/neko/vm/Thread.hx
@@ -33,7 +33,7 @@ class Thread {
 	}
 
 	/**
-		Send a message to the thread queue. This message can be readed by using [readMessage].
+		Send a message to the thread queue. This message can be readed by using `readMessage`.
 	**/
 	public function sendMessage( msg : Dynamic ) {
 		thread_send(handle,msg);
@@ -48,16 +48,16 @@ class Thread {
 	}
 
 	/**
-		Creates a new thread that will execute the [callb] function, then exit.
+		Creates a new thread that will execute the `callb` function, then exit.
 	**/
 	public static function create( callb : Void -> Void ) {
 		return new Thread(thread_create(function(_) { return callb(); },null));
 	}
 
 	/**
-		Reads a message from the thread queue. If [block] is true, the function
-		blocks until a message is available. If [block] is false, the function
-		returns [null] if no message is available.
+		Reads a message from the thread queue. If `block` is true, the function
+		blocks until a message is available. If `block` is false, the function
+		returns `null` if no message is available.
 	**/
 	public static function readMessage( block : Bool ) : Dynamic {
 		return thread_read_message(block);

--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -21,6 +21,7 @@
  */
 package php;
 
+@:dox(hide)
 @:keep
 class Boot {
 	static var qtypes;

--- a/std/python/Boot.hx
+++ b/std/python/Boot.hx
@@ -33,6 +33,7 @@ import python.lib.Inspect;
 
 import python.Syntax;
 
+@:dox(hide)
 class Boot {
 
 	static var keywords:Set<String> = new Set(

--- a/std/python/KwArgs.hx
+++ b/std/python/KwArgs.hx
@@ -29,8 +29,10 @@ import python.Dict;
 
 	Example:
 
-        function f(kwargs:KwArgs<{a:Int}>) {}
-        f({a: 10});
+	```haxe
+	function f(kwargs:KwArgs<{a:Int}>) {}
+	f({a: 10});
+	```
 **/
 abstract KwArgs<T:{}>(Dict<String,Dynamic>) {
 	inline function new (d:Dict<String,Dynamic>) {

--- a/std/python/NativeIterable.hx
+++ b/std/python/NativeIterable.hx
@@ -25,24 +25,24 @@ import python.HaxeIterable;
 import python.NativeIterator;
 
 /**
-    This type represents native python iterables (objects that implement __iter__() method).
-    It supports haxe iteration and conversion to `Iterable` by creating wrapper objects.
+    This type represents native Python iterables (objects that implement `__iter__()` method).
+    It supports Haxe iteration and conversion to `Iterable` by creating wrapper objects.
 **/
 abstract NativeIterable<T>(NativeIterableRaw<T>) to NativeIterableRaw<T> from NativeIterableRaw<T> {
 
     /**
-        Return haxe `Iterable` object wrapping `this` native iterable.
+        Return Haxe `Iterable` object wrapping `this` native iterable.
     **/
 	@:to public inline function toHaxeIterable():HaxeIterable<T> return new HaxeIterable(this);
 
     /**
-        Return haxe `Iterator` object by wrapping `this.__iter__()` native iterator.
+        Return Haxe `Iterator` object by wrapping `this.__iter__()` native iterator.
     **/
 	public inline function iterator():HaxeIterator<T> return new HaxeIterator(this.__iter__());
 }
 
 /**
-    Native python iterable protocol.
+    Native Python iterable protocol.
 **/
 typedef NativeIterableRaw<T> = {
 	private function __iter__():NativeIterator<T>;

--- a/std/python/NativeIterator.hx
+++ b/std/python/NativeIterator.hx
@@ -24,20 +24,20 @@ package python;
 import python.NativeIterable.NativeIterableRaw;
 
 /**
-    This type represents native python iterators.
-    It supports automatic conversion to haxe `Iterator` by creating wrapper object.
+    This type represents native Python iterators.
+    It supports automatic conversion to Haxe `Iterator` by creating wrapper object.
 **/
 abstract NativeIterator<T>(NativeIteratorRaw<T>) to NativeIteratorRaw<T> to NativeIterable<T> {
 	public inline function new(p:NativeIteratorRaw<T>) this = p;
 
     /**
-        Return haxe `Iterator` object by wrapping `this` native iterator.
+        Return Haxe `Iterator` object by wrapping `this` native iterator.
     **/
 	@:to public inline function toHaxeIterator():HaxeIterator<T> return new HaxeIterator(this);
 }
 
 /**
-    Native python iterator protocol.
+    Native Python iterator protocol.
 **/
 typedef NativeIteratorRaw<T> = {
 	>NativeIterableRaw<T>,

--- a/std/python/VarArgs.hx
+++ b/std/python/VarArgs.hx
@@ -29,8 +29,10 @@ import python.internal.UBuiltins.list;
 
 	Example:
 
-		function f(args:VarArgs<Int>) {}
-		f([1, 2, 3]);
+	```haxe
+	function f(args:VarArgs<Int>) {}
+	f([1, 2, 3]);
+	```
 **/
 @:analyzer(no_simplification)
 abstract VarArgs<T>(Dynamic) {

--- a/std/python/_std/Type.hx
+++ b/std/python/_std/Type.hx
@@ -75,7 +75,7 @@ enum ValueType {
 		if (Internal.hasClassName(c)) {
 			return Internal.fieldClassName(c);
 		} else {
-			// it's not a haxe class
+			// it's not a Haxe class
 			if (c == Array) return "Array";
 			if (c == Math) return "Math";
 			if (c == String) return "String";

--- a/std/python/_std/sys/net/Socket.hx
+++ b/std/python/_std/sys/net/Socket.hx
@@ -116,7 +116,7 @@ private class SocketOutput extends haxe.io.Output {
     var __s:PSocket;
     /**
         The stream on which you can read available data. By default the stream is blocking until the requested data is available,
-        use [setBlocking(false)] or [setTimeout] to prevent infinite waiting.
+        use `setBlocking(false)` or `setTimeout` to prevent infinite waiting.
     **/
     public var input(default,null) : haxe.io.Input;
 
@@ -126,7 +126,7 @@ private class SocketOutput extends haxe.io.Output {
     public var output(default,null) : haxe.io.Output;
 
     /**
-        A custom value that can be associated with the socket. Can be used to retreive your custom infos after a [select].
+        A custom value that can be associated with the socket. Can be used to retreive your custom infos after a `select`.
     ***/
     public var custom : Dynamic;
 
@@ -173,7 +173,7 @@ private class SocketOutput extends haxe.io.Output {
     }
 
     /**
-        Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use [accept()] to accept incoming connections.
+        Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
     **/
     public function listen( connections : Int ) : Void {
         __s.listen(connections);
@@ -252,11 +252,11 @@ private class SocketOutput extends haxe.io.Output {
 
     /**
         Wait until one of the sockets groups is ready for the given operation :
-        [read] contains sockets on which we want to wait for available data to be read,
-        [write] contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-        [others] contains sockets on which we want to wait for exceptional conditions.
-        [select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-        In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
+        - `read` contains sockets on which we want to wait for available data to be read,
+        - `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
+        - `others` contains sockets on which we want to wait for exceptional conditions.
+        - `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
+        In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
     **/
     public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> } {
         var t3 = Select.select(read,write,others,timeout);

--- a/std/python/lib/net/Socket.hx
+++ b/std/python/lib/net/Socket.hx
@@ -51,7 +51,7 @@ extern class Socket {
     //function create_connection() :
 
     /**
-        Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use [accept()] to accept incoming connections.
+        Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
     **/
     function listen( connections : Int ) : Void;
 
@@ -105,11 +105,11 @@ extern class Socket {
 
     /**
         Wait until one of the sockets groups is ready for the given operation :
-        [read] contains sockets on which we want to wait for available data to be read,
-        [write] contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-        [others] contains sockets on which we want to wait for exceptional conditions.
-        [select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-        In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
+        - `read` contains sockets on which we want to wait for available data to be read,
+        - `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
+        - `others` contains sockets on which we want to wait for exceptional conditions.
+        - `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
+        In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
     **/
     //static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> };
 

--- a/std/sys/FileStat.hx
+++ b/std/sys/FileStat.hx
@@ -22,24 +22,62 @@
 package sys;
 
 /**
-	File informations, as given by [sys.FileSystem.stat]
+	File informations, as given by `sys.FileSystem.stat`.
 **/
 typedef FileStat = {
-	/** the user group id for the file **/
+
+	/**
+		The user group id for the file's owner.
+	**/
 	var gid : Int;
-	/** the user id for the file **/
+
+	/** 
+		The user id for the file's owner.
+	**/
 	var uid : Int;
-	/** the last access time for the file (when enabled by the file system) **/
+
+	/** 
+		The last access time for the file (when enabled by the file system).
+	**/
 	var atime : Date;
-	/** the last modification time for the file **/
+
+	/** 
+		The last modification time for the file.
+	**/
 	var mtime : Date;
-	/** the creation time for the file (not all filesystems support this) **/
+
+	/**
+		The creation time for the file (not all filesystems support this).
+	**/
 	var ctime : Date;
-	/** the size of the file **/
+
+	/** 
+		The size of the file, in bytes. 
+	**/
 	var size : Int;
+
+	/** 
+		The device on which stat resides.
+	**/
 	var dev : Int;
+
+	/** 
+		The inode number for stat.
+	**/
 	var ino : Int;
+
+	/** 
+		The number of hard links to stat.
+	**/
 	var nlink : Int;
+
+	/** 
+		The device type on which stat resides (special files only).
+	**/
 	var rdev : Int;
+
+	/** 
+		The permission bits of stat. The meaning of the bits is platform dependent.
+	**/
 	var mode : Int;
 }

--- a/std/sys/db/Types.hx
+++ b/std/sys/db/Types.hx
@@ -107,7 +107,7 @@ typedef SNull<T> = Null<T>
 /** specify that the integer use custom encoding **/
 typedef SEncoded = Null<Int>
 
-/** haxe Serialized string **/
+/** Haxe Serialized string **/
 typedef SSerialized = String
 
 /** native neko serialized bytes **/

--- a/std/sys/db/Types.hx
+++ b/std/sys/db/Types.hx
@@ -45,13 +45,13 @@ typedef SSingle = Null<Float>
 /** double precision float **/
 typedef SFloat = Null<Float>
 
-/** use tinyint(1) to distinguish with int **/
+/** use `tinyint(1)` to distinguish with int **/
 typedef SBool = Null<Bool>
 
-/** same as varchar(n) **/
+/** same as `varchar(n)` **/
 typedef SString<Const> = String
 
-/** date only, use SDateTime for date+time **/
+/** date only, use `SDateTime` for date+time **/
 typedef SDate = Date
 
 /** mysql DateTime **/
@@ -81,22 +81,22 @@ typedef SBinary = haxe.io.Bytes
 /** same as binary(n) **/
 typedef SBytes<Const> = haxe.io.Bytes
 
-/** one byte signed [-128...127] **/
+/** one byte signed `-128...127` **/
 typedef STinyInt = Null<Int>
 
-/** two bytes signed [-32768...32767] **/
+/** two bytes signed `-32768...32767` **/
 typedef SSmallInt = Null<Int>
 
-/** three bytes signed [-8388608...8388607] **/
+/** three bytes signed `-8388608...8388607` **/
 typedef SMediumInt = Null<Int>
 
-/** one byte [0...255] **/
+/** one byte `0...255` **/
 typedef STinyUInt = Null<Int>
 
-/** two bytes [0...65535] **/
+/** two bytes `0...65535` **/
 typedef SSmallUInt = Null<Int>
 
-/** three bytes [0...16777215] **/
+/** three bytes `0...16777215` **/
 typedef SMediumUInt = Null<Int>
 
 // extra
@@ -116,7 +116,7 @@ typedef SNekoSerialized = haxe.io.Bytes
 /** a set of bitflags of different enum values **/
 typedef SFlags<T:EnumValue> = Null<haxe.EnumFlags<T>>
 
-/** same as [SFlags] but will adapt the storage size to the number of flags **/
+/** same as `SFlags` but will adapt the storage size to the number of flags **/
 typedef SSmallFlags<T:EnumValue> = SFlags<T>;
 
 /** allow to store any value in serialized form **/

--- a/std/sys/io/FileInput.hx
+++ b/std/sys/io/FileInput.hx
@@ -22,7 +22,7 @@
 package sys.io;
 
 /**
-	Use [sys.io.File.read] to create a [FileInput]
+	Use `sys.io.File.read` to create a `FileInput`.
 **/
 extern class FileInput extends haxe.io.Input {
 

--- a/std/sys/io/FileOutput.hx
+++ b/std/sys/io/FileOutput.hx
@@ -22,7 +22,7 @@
 package sys.io;
 
 /**
-	Use [sys.io.File.write] to create a [FileOutput]
+	Use `sys.io.File.write` to create a `FileOutput`.
 **/
 extern class FileOutput extends haxe.io.Output {
 

--- a/std/sys/net/Address.hx
+++ b/std/sys/net/Address.hx
@@ -22,7 +22,8 @@
 package sys.net;
 
 /**
-	An address is used to represent a port on a given host ip. It is used by UdpSocket.
+	An address is used to represent a port on a given host ip. 
+	It is used by `sys.net.UdpSocket`.
 **/
 class Address {
 	public var host : Int;

--- a/std/sys/net/Socket.hx
+++ b/std/sys/net/Socket.hx
@@ -28,17 +28,17 @@ extern class Socket {
 
 	/**
 		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
-		use [setBlocking(false)] or [setTimeout] to prevent infinite waiting.
+		use `setBlocking(false)` or `setTimeout` to prevent infinite waiting.
 	**/
 	var input(default,null) : haxe.io.Input;
 
 	/**
-		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use [setBlocking(false)] or [setTimeout] to prevent that.
+		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use `setBlocking(false)` or `setTimeout` to prevent that.
 	**/
 	var output(default,null) : haxe.io.Output;
 
 	/**
-		A custom value that can be associated with the socket. Can be used to retreive your custom infos after a [select].
+		A custom value that can be associated with the socket. Can be used to retreive your custom infos after a `select`.
 	***/
 	var custom : Dynamic;
 
@@ -68,7 +68,7 @@ extern class Socket {
 	function connect( host : Host, port : Int ) : Void;
 
 	/**
-		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use [accept()] to accept incoming connections.
+		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
 	**/
 	function listen( connections : Int ) : Void;
 
@@ -119,11 +119,11 @@ extern class Socket {
 
 	/**
 		Wait until one of the sockets groups is ready for the given operation :
-		[read] contains sockets on which we want to wait for available data to be read,
-		[write] contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-		[others] contains sockets on which we want to wait for exceptional conditions.
-		[select] will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-		In case a [timeout] (in seconds) is specified, select might wait at worse until the timeout expires.
+		 - `read`contains sockets on which we want to wait for available data to be read,
+		 - `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
+		 - `others` contains sockets on which we want to wait for exceptional conditions.
+		 - `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
+		In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
 	**/
 	static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> };
 


### PR DESCRIPTION
This looks like a big commit, but it's basically just a few things.
* I replaced [thing] with `thing` to make things link.
* haxe > Haxe
* fixed some links
* added some class descriptions, mostly for tools that can be used with `using`
* hide some classes from dox (like Boot, Tools typedefs)
* filestat documentation
* some typos / improved formatting