### PR TITLE
Fix cpp sys.net.Socket

### DIFF
--- a/std/cpp/_std/sys/net/Socket.hx
+++ b/std/cpp/_std/sys/net/Socket.hx
@@ -124,7 +124,7 @@ class Socket {
 	}
 
 	private function init() : Void {
-		if( __s != null )__s = NativeSocket.socket_new(false);
+		if( __s == null )__s = NativeSocket.socket_new(false);
 		input = new SocketInput(__s);
 		output = new SocketOutput(__s);
 	}

--- a/std/cpp/_std/sys/ssl/Socket.hx
+++ b/std/cpp/_std/sys/ssl/Socket.hx
@@ -240,7 +240,6 @@ class Socket extends sys.net.Socket {
 
 		if ( altSNIContexts != null ) {
 			sniCallback = function(servername) {
-				trace("SNI haxe function called with name="+servername);
 				var servername = new String(cast servername);
 				for( c in altSNIContexts ){
 					if( c.match(servername) )


### PR DESCRIPTION
I left a typo in my last minute changes of yesterday. 
This should fix hxcpp CI tests.

The error on haxe CI cpp tests will be fixed by a PR on hxcpp.