### PR TITLE
Add CppGoto, use it for break-in-switch-in-loop

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -1101,19 +1101,6 @@ let array_arg_list inList =
 (* See if there is a haxe break statement that will be swollowed by c++ break *)
 exception BreakFound;;
 
-let contains_break expression =
-   try (
-   let rec check_all expression = match expression.eexpr with
-         | TBreak -> raise BreakFound
-         | TFor _
-         | TFunction _
-         | TWhile (_,_,_) -> ()
-         | _ -> Type.iter check_all expression;
-   in
-   check_all expression;
-   false;
-   ) with BreakFound -> true;;
-
 
 (* Decide is we should look the field up by name *)
 let dynamic_internal = function | "__Is" -> true | _ -> false
@@ -1297,6 +1284,8 @@ let hx_stack_push ctx output clazz func_name pos =
 
 (* { *)
 
+type label = int
+
 type tcpp =
    | TCppDynamic
    | TCppObject
@@ -1433,12 +1422,13 @@ and tcpp_expr_expr =
    | CppBlock of tcppexpr list * tcpp_closure list
    | CppFor of tvar * tcppexpr * tcppexpr
    | CppIf of tcppexpr * tcppexpr * tcppexpr option
-   | CppWhile of tcppexpr * tcppexpr * Ast.while_flag
+   | CppWhile of tcppexpr * tcppexpr * Ast.while_flag * label
    | CppIntSwitch of tcppexpr * (Int32.t list * tcppexpr) list * tcppexpr option
    | CppSwitch of tcppexpr * tcpp * (tcppexpr list * tcppexpr) list * tcppexpr option
    | CppTry of tcppexpr * (tvar * tcppexpr) list
    | CppBreak
    | CppContinue
+   | CppGoto of label
    | CppClassOf of path
    | CppReturn of tcppexpr option
    | CppThrow of tcppexpr
@@ -1510,6 +1500,7 @@ let rec s_tcpp = function
    | CppSwitch  _ -> "CppSwitch"
    | CppTry _ -> "CppTry"
    | CppBreak -> "CppBreak"
+   | CppGoto _ -> "CppGoto"
    | CppContinue -> "CppContinue"
    | CppClassOf _ -> "CppClassOf"
    | CppReturn _ -> "CppReturn"
@@ -1998,6 +1989,19 @@ let retype_expression ctx request_type function_args expression_tree =
    let undeclared = ref (Hashtbl.create 0) in
    let uses_this = ref None in
    let this_real = ref (if ctx.ctx_real_this_ptr then ThisReal else ThisDyanmic) in
+   let label_counter = ref (-1) in
+   let loop_stack = ref [] in
+   let begin_loop () =
+      incr label_counter;
+      loop_stack := (!label_counter,ref false) :: !loop_stack;
+      (fun () -> match !loop_stack with
+         | (label_id,used) :: tl ->
+            loop_stack := tl;
+            if !used then label_id else -1
+         | [] ->
+            error "Invalid inernal loop handling" expression_tree.epos
+      )
+   in
    (* '__trace' is at the top-level *)
    Hashtbl.add !declarations "__trace" ();
    List.iter (fun arg -> Hashtbl.add !declarations arg.v_name () ) function_args;
@@ -2054,7 +2058,13 @@ let retype_expression ctx request_type function_args expression_tree =
             end
 
          | TBreak ->
-            CppBreak, TCppVoid
+            begin match !loop_stack with
+               | [] ->
+                  CppBreak, TCppVoid
+               | (label_id,used) :: _ ->
+                  used := true;
+                  (CppGoto label_id),TCppVoid
+            end
 
          | TContinue ->
             CppContinue, TCppVoid
@@ -2417,8 +2427,9 @@ let retype_expression ctx request_type function_args expression_tree =
 
          | TWhile (e1,e2,flag) ->
             let condition = retype (TCppScalar("Bool")) e1 in
+            let close = begin_loop() in
             let block = retype TCppVoid (mk_block e2) in
-            CppWhile(condition, block, flag), TCppVoid
+            CppWhile(condition, block, flag, close()), TCppVoid
 
          | TArrayDecl el ->
             let retypedEls = List.map (retype TCppDynamic) el in
@@ -2482,9 +2493,7 @@ let retype_expression ctx request_type function_args expression_tree =
             let cppDef = match def with None -> None | Some e -> Some (retype TCppVoid (mk_block e)) in
             (try
                (match conditionType with TCppScalar("Int") | TCppScalar("Bool") -> () | _ -> raise Not_found );
-               (match def with None -> () | Some e -> if (contains_break e) then raise Not_found);
                let cases = List.map (fun (el,e2) ->
-                  if (contains_break e2) then raise Not_found;
                   (List.map const_int_of el), (retype TCppVoid (mk_block e2)) ) cases in
                CppIntSwitch(condition, cases, cppDef), TCppVoid
             with Not_found ->
@@ -2649,7 +2658,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args injection
    in
 
    let cppTree =  retype_expression ctx TCppVoid function_args tree in
-
+   let label_name i = Printf.sprintf "%s_%s_%i" (String.concat "_" (ExtString.String.nsplit class_name ".")) func_name i in
    let rec gen_with_injection injection expr =
       (match expr.cppexpr with
       | CppBlock(exprs,closures) ->
@@ -2685,6 +2694,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args injection
 
       | CppBreak -> out "break"
       | CppContinue -> out "continue"
+      | CppGoto label -> out (Printf.sprintf "goto %s" (label_name label))
 
       | CppVarDecl(var,init) ->
          out ( (cpp_var_type_of ctx var) ^ " " ^ (cpp_var_name_of var) );
@@ -3050,7 +3060,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args injection
            );
            out "(";  gen value; out ")"
 
-      | CppWhile(condition, block, while_flag) ->
+      | CppWhile(condition, block, while_flag, loop_id) ->
           (match while_flag with
           | NormalWhile ->
               out "while("; gen condition; out (")");
@@ -3060,6 +3070,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args injection
               gen block;
               out "while("; gen condition; out ")"
           );
+          if loop_id > -1 then output_i (Printf.sprintf "%s:" (label_name loop_id));
 
       | CppIf (condition,block,None) ->
           out "if ("; gen condition; out (") ");


### PR DESCRIPTION
Testing the waters here. I didn't add CppLabel or anything yet, instead labels are handled as part of CppWhile for now because that's the only place where we actually use it.

Output before:

```c++
void Main_obj::main(){
            	HX_STACK_FRAME("Main","main",0xed0e206e,"Main.main","Main.hx",7,0x087e5c05)
HXLINE(   8)		while(true){
HXLINE(   9)			Int _hx_tmp = ::Main_obj::getE()->getIndex();
HXDLIN(   9)			Int _hx_switch_0 = _hx_tmp;
            			if (  (_hx_switch_0==(int)0) ){
HXLINE(  11)				break;
            			}
            			else if (  (_hx_switch_0==(int)1) ){
            			}
            		}
HXLINE(  16)		::haxe::Log_obj::trace(HX_("Hello world",a4,86,ae,dc),hx::SourceInfo(HX_("Main.hx",05,5c,7e,08),16,HX_("Main",59,64,2f,33),HX_("main",39,38,56,48)));
            	}
```

Output now:

```c++
void Main_obj::main(){
            	HX_STACK_FRAME("Main","main",0xed0e206e,"Main.main","Main.hx",7,0x087e5c05)
HXLINE(   8)		while(true){
HXLINE(   9)			Int _hx_tmp = ::Main_obj::getE()->getIndex();
HXDLIN(   9)			switch((int)(_hx_tmp)){
            				case (int)0: {
HXLINE(  11)					goto Main_main_0;
            				}
            				break;
            				case (int)1: {
            				}
            				break;
            			}
            		}
            		Main_main_0:;
HXLINE(  16)		::haxe::Log_obj::trace(HX_("Hello world",a4,86,ae,dc),hx::SourceInfo(HX_("Main.hx",05,5c,7e,08),16,HX_("Main",59,64,2f,33),HX_("main",39,38,56,48)));
            	}
```