### PR TITLE
add EReg.escape

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -20,6 +20,10 @@
 	php/php7: fixed accessing enum constructors on enum type stored to a variable (#6159)
 	php: fix invoking functions stored in dynamic static vars (#6158)
 
+	Standard Library:
+
+	all : added EReg.escape
+
 2017-03-20: 3.4.2
 
 	Bugfixes:

--- a/std/EReg.hx
+++ b/std/EReg.hx
@@ -192,4 +192,13 @@ class EReg {
 	public function map( s : String, f : EReg -> String ) : String {
 		return null;
 	}
+
+	/**
+		Escape the string `s` for use as a part of regular expression.
+
+		If `s` is null, the result is unspecified.
+	**/
+	public static function escape( s : String ) : String {
+		return null;
+	}
 }

--- a/std/cpp/_std/EReg.hx
+++ b/std/cpp/_std/EReg.hx
@@ -173,6 +173,10 @@
 		return buf.toString();
 	}
 
+	public static function escape( s : String ) : String {
+		return escapeRegExpRe.map(s, function(r) return "\\" + r.matched(0));
+	}
+	static var escapeRegExpRe = ~/[\[\]{}()*+?.\\\^$|]/g;
 
    @:extern @:native("_hx_regexp_new_options")
 	static function _hx_regexp_new_options(s:String, options:String) : Dynamic return null;

--- a/std/cs/_std/EReg.hx
+++ b/std/cs/_std/EReg.hx
@@ -130,4 +130,8 @@ import cs.system.text.regularexpressions.*;
 			buf.add(s.substr(offset));
 		return buf.toString();
 	}
+
+	public static inline function escape( s : String ) : String {
+		return Regex.Escape(s);
+	}
 }

--- a/std/flash/_std/EReg.hx
+++ b/std/flash/_std/EReg.hx
@@ -112,4 +112,9 @@
 			buf.add(s.substr(offset));
 		return buf.toString();
 	}
+
+	public static inline function escape( s : String ) : String {
+		return (cast s).replace(escapeRe, "\\$&");
+	}
+	static var escapeRe = new flash.utils.RegExp("[.*+?^${}()|[\\]\\\\]", "g");
 }

--- a/std/hl/_std/EReg.hx
+++ b/std/hl/_std/EReg.hx
@@ -183,6 +183,10 @@ private typedef ERegValue = hl.Abstract<"ereg">;
 		return buf.toString();
 	}
 
+	public static function escape( s : String ) : String {
+		return escapeRegExpRe.map(s, function(r) return "\\" + r.matched(0));
+	}
+	static var escapeRegExpRe = ~/[\[\]{}()*+?.\\\^$|]/g;
 
 	@:hlNative("std", "regexp_new_options") static function regexp_new_options( bytes : hl.Bytes, options : hl.Bytes ) : ERegValue {
 		return null;

--- a/std/java/_std/EReg.hx
+++ b/std/java/_std/EReg.hx
@@ -177,4 +177,8 @@ import java.util.regex.*;
 			buf.add(s.substr(offset));
 		return buf.toString();
 	}
+
+	public static inline function escape( s : String ) : String {
+		return Pattern.quote(s);
+	}
 }

--- a/std/js/_std/EReg.hx
+++ b/std/js/_std/EReg.hx
@@ -108,6 +108,11 @@
 			buf.add(s.substr(offset));
 		return buf.toString();
 	}
+
+	public static inline function escape( s : String ) : String {
+		return (cast s).replace(escapeRe, "\\$&");
+	}
+	static var escapeRe = new js.RegExp("[.*+?^${}()|[\\]\\\\]", "g");
 }
 
 @:native("RegExp")

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -154,6 +154,11 @@ class EReg {
 		return buf.toString();
 	}
 
+	public static function escape( s : String ) : String {
+		return escapeRegExpRe.map(s, function(r) return "\\" + r.matched(0));
+	}
+	static var escapeRegExpRe = ~/[\[\]{}()*+?.\\\^$|]/g;
+
 	static function __init__() : Void {
 		if (Rex == null){
 			throw "Rex is missing.  Please install lrexlib-pcre.";

--- a/std/neko/_std/EReg.hx
+++ b/std/neko/_std/EReg.hx
@@ -197,6 +197,11 @@
 		return buf.toString();
 	}
 
+	public static function escape( s : String ) : String {
+		return escapeRegExpRe.map(s, function(r) return "\\" + r.matched(0));
+	}
+	static var escapeRegExpRe = ~/[\[\]{}()*+?.\\\^$|]/g;
+
 	static var regexp_new_options = neko.Lib.load("regexp","regexp_new_options",2);
 	static var regexp_match = neko.Lib.load("regexp","regexp_match",4);
 	static var regexp_matched = neko.Lib.load("regexp","regexp_matched",2);

--- a/std/php/_std/EReg.hx
+++ b/std/php/_std/EReg.hx
@@ -118,4 +118,8 @@
 			buf.add(s.substr(offset));
 		return buf.toString();
 	}
+
+	public static function escape( s : String ) : String {
+		return untyped __call__("preg_quote", s);
+	}
 }

--- a/std/php7/Global.hx
+++ b/std/php7/Global.hx
@@ -758,6 +758,11 @@ extern class Global {
 	static function preg_match_all( pattern:String, subject:String, ?matches:NativeArray, ?flags:Int, ?offset:Int ) : EitherType<Bool,Int> ;
 
 	/**
+		@see http://php.net/manual/en/function.preg-quote.php
+	**/
+	static function preg_quote( str:String, ?delimiter:String ) : String;
+
+	/**
 		@see http://php.net/manual/en/function.preg-split.php
 	**/
 	static function preg_split( pattern:String, subject:String, limit:Int = -1, flags:Int = 0 ) : EitherType<Bool,NativeArray> ;

--- a/std/php7/_std/EReg.hx
+++ b/std/php7/_std/EReg.hx
@@ -134,4 +134,8 @@ import php.*;
 		}
 		return buf.toString();
 	}
+
+	public static inline function escape( s : String ) : String {
+		return Global.preg_quote(s);
+	}
 }

--- a/std/python/_std/EReg.hx
+++ b/std/python/_std/EReg.hx
@@ -168,4 +168,8 @@ class EReg {
 		return buf.toString();
 
 	}
+
+	public static inline function escape( s : String ) : String {
+		return Re.escape(s);
+	}
 }

--- a/std/python/lib/Re.hx
+++ b/std/python/lib/Re.hx
@@ -199,7 +199,7 @@ extern class Re
 
 	public static function subn(pattern:Pattern, repl:Repl, string:String, count:Int=0, flags:Int=0):String;
 
-	public static function escape(string:String):TODO;
+	public static function escape(string:String):String;
 
 	public static function purge():Void;
 }

--- a/tests/unit/src/unitstd/EReg.unit.hx
+++ b/tests/unit/src/unitstd/EReg.unit.hx
@@ -107,3 +107,6 @@ pos.len == 2;
 ~/(Hello)/.map("Hello", function(e) return "Hallo") == "Hallo";
 ~/(World)/.map("Hello World", function(e) return "Hallo") == "Hello Hallo";
 ~/(Hola)/.map("Hello World", function(e) return throw "not called") == "Hello World";
+
+// escape
+new EReg("^" + EReg.escape("\\ ^ $ * + ? . ( ) | { } [ ]") + "$", "").match("\\ ^ $ * + ? . ( ) | { } [ ]") == true;


### PR DESCRIPTION
I need this from time to time and I think it should be in the std lib. I tried to use platform-native (or recommended) regex escaping functions, but for others (cpp,neko,hl,lua) I used the implementation involving `map`. It works but it may not be the most efficient solution which can be improved in future.

I know we're in feature freeze, but this addition seems to be very minor and safe for 3.3.
