### PR TITLE
[lua] Fix String.substring

### DIFF
--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -99,7 +99,7 @@ class String {
 		if (endIndex == null) endIndex = this.length;
 		if (endIndex < 0) endIndex = 0;
 		if (startIndex < 0) startIndex = 0;
-		if (endIndex == 0) {
+		if (endIndex < startIndex) {
 			// swap the index positions
 			return NativeStringTools.sub(this, endIndex+1, startIndex);
 		} else {

--- a/tests/unit/src/unitstd/String.unit.hx
+++ b/tests/unit/src/unitstd/String.unit.hx
@@ -151,6 +151,8 @@ s.substring(0, 100) == "xfooxfooxxbarxbarxx";
 s.substring(100, 120) == "";
 s.substring(100, 0) == "xfooxfooxxbarxbarxx";
 s.substring(120, 100) == "";
+s.substring(5, 8) == "foo";
+s.substring(8, 5) == "foo";
 
 // fromCharCode
 String.fromCharCode(65) == "A";


### PR DESCRIPTION
Now the following test passes:
```haxe
"xfooxfooxxbarxbarxx".substring(8, 5) == "foo"
```