### PR TITLE
Use __hxcpp_println

### DIFF
--- a/std/cpp/_std/Sys.hx
+++ b/std/cpp/_std/Sys.hx
@@ -28,8 +28,7 @@ import cpp.NativeSys;
 	}
 
 	public static function println( v : Dynamic ) : Void {
-		print(v);
-		print("\n");
+		untyped __global__.__hxcpp_println(v);
 	}
 
    @:access(sys.io.FileInput)


### PR DESCRIPTION
hxcpp has a println function, so there is no need to double call "print"