### PR TITLE
[cpp] Fix @:coreType abstracts handling, and add @:scalar

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -646,7 +646,7 @@ let is_native_gen_module = function
    | TClassDecl class_def -> is_native_gen_class class_def
    | _ -> false
 ;;
-  
+
 
 
 (*  Get a string to represent a type.
@@ -1658,12 +1658,13 @@ let rec cpp_type_of ctx haxe_type =
    | TInst (klass,params) ->
       cpp_instance_type ctx klass params
 
-   | TAbstract (abs,pl) when abs.a_impl <> None ->
-       cpp_type_from_path ctx abs.a_path pl (fun () -> 
+   | TAbstract (abs,pl) when not (Meta.has Meta.CoreType abs.a_meta) ->
+       cpp_type_from_path ctx abs.a_path pl (fun () ->
             cpp_type_of ctx (Abstract.get_underlying_type abs pl) )
 
    | TAbstract (a,params) ->
-       cpp_type_from_path ctx a.a_path params (fun () -> cpp_type_of ctx (follow haxe_type) )
+       cpp_type_from_path ctx a.a_path params (fun () ->
+            TCppScalar(join_class_path a.a_path "::") )
 
    | TType (type_def,params) ->
        cpp_type_from_path ctx type_def.t_path params (fun () ->

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -156,6 +156,7 @@ module Meta = struct
 		| Rtti
 		| Runtime
 		| RuntimeValue
+		| Scalar
 		| SelfCall
 		| Setter
 		| SkipCtor

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -498,6 +498,7 @@ module MetaInfo = struct
 		| Rtti -> ":rtti",("Adds runtime type informations",[UsedOn TClass])
 		| Runtime -> ":runtime",("?",[])
 		| RuntimeValue -> ":runtimeValue",("Marks an abstract as being a runtime value",[UsedOn TAbstract])
+		| Scalar -> ":scalar",("Used by hxcpp to mark a custom coreType abstract",[UsedOn TAbstract; Platform Cpp])
 		| SelfCall -> ":selfCall",("Translates method calls into calling object directly",[UsedOn TClassField; Platform Js])
 		| Setter -> ":setter",("Generates a native setter function on the given field",[HasParam "Class field name";UsedOn TClassField;Platform Flash])
 		| StackOnly -> ":stackOnly",("Instances of this type can only appear on the stack",[Platform Cpp])


### PR DESCRIPTION
Right now, the following code will generate an endless loop in hxcpp:

```haxe
class Main {

  static function main() {
    var t:Test = 1;
    t++;
    trace(t);
  }

}

@:coreType abstract Test from Int to Int {}
```

Adding new `@:coreType` abstracts is useful so libraries can add their own types that aren't officially supported by hxcpp, like `IntPtr`. After some discussion with Hugh, it was settled that a new metadata, `@:scalar` would be used to denote these types. So with this patch, the following program will compile and work correctly:

```haxe
class Main {

  static function main() {
    var t:Test = 1;
    t++;
    trace(t);
  }

}

@:include("../../test.h")
@:scalar
@:coreType extern abstract Test from Int to Int {}
```

`test.h`:
```c++
typedef int Test;
```