### PR TITLE
fix vector blit

### DIFF
--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -146,9 +146,32 @@ abstract Vector<T>(VectorData<T>) {
 		#elseif cpp
 			dest.toData().blit(destPos,src.toData(), srcPos,len);
 		#else
-			for (i in 0...len)
-			{
-				dest[destPos + i] = src[srcPos + i];
+			if (src == dest) {
+				if (srcPos < destPos)
+				{
+					var i = srcPos + len;
+					var j = destPos + len;
+					for (k in 0...len) {
+						i--;
+						j--;
+						src[j] = src[i];
+					}
+				}
+				else
+				if (srcPos > destPos) {
+					var i = srcPos;
+					var j = destPos;
+					for (k in 0...len) {
+						src[j] = src[i];
+						i++;
+						j++;
+					}
+				}
+			}
+			else {
+				for (i in 0...len) {
+					dest[destPos + i] = src[srcPos + i];
+				}
 			}
 		#end
 	}

--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -157,8 +157,7 @@ abstract Vector<T>(VectorData<T>) {
 						src[j] = src[i];
 					}
 				}
-				else
-				if (srcPos > destPos) {
+				else if (srcPos > destPos) {
 					var i = srcPos;
 					var j = destPos;
 					for (k in 0...len) {

--- a/tests/unit/src/unitstd/haxe/ds/Vector.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/Vector.unit.hx
@@ -89,6 +89,30 @@ vec3[4] == 4;
 vec3[5] == 5;
 vec3[6] == 6;
 
+var vec5 = haxe.ds.Vector.fromArrayCopy([0,1,2,3,4]);
+haxe.ds.Vector.blit(vec5, 0, vec5, 1, 4);
+vec5[0] == 0;
+vec5[1] == 0;
+vec5[2] == 1;
+vec5[3] == 2;
+vec5[4] == 3;
+
+var vec5 = haxe.ds.Vector.fromArrayCopy([0,1,2,3,4]);
+haxe.ds.Vector.blit(vec5, 1, vec5, 0, 4);
+vec5[0] == 1;
+vec5[1] == 2;
+vec5[2] == 3;
+vec5[3] == 4;
+vec5[4] == 4;
+
+var vec5 = haxe.ds.Vector.fromArrayCopy([0,1,2,3,4]);
+haxe.ds.Vector.blit(vec5, 0, vec5, 0, 5);
+vec5[0] == 0;
+vec5[1] == 1;
+vec5[2] == 2;
+vec5[3] == 3;
+vec5[4] == 4;
+
 // test iteration
 
 var vec1 = new haxe.ds.Vector(2);


### PR DESCRIPTION
In neko, cpp, cs and java copying takes place as if an intermediate buffer is used, allowing the destination and source to overlap if src and dest point to the same vector. So for all remaining targets the blit code should be adjusted.

Example:
var v = new haxe.ds.Vector<Int>(10);
for (i in 0...10) v.set(i, i); //[0,1,2,3,4,5,6,7,8,9]
haxe.ds.Vector.blit(v, 0, v, 1, 9);
trace(v); //outputs [0,0,0,0,0,0,0,0,0,0] but should be [0,0,1,2,3,4,5,6,7,8]