### PR TITLE
[lua] Support UTF-8 mode in EReg

### DIFF
--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -32,17 +32,21 @@ class EReg {
 	var s : String; // the last matched string
 	var m : Table<Int,Int>; // the [start:Int, end:Int, and submatches:String (matched groups)] as a single table.
 
+	static var FLAGS: Table<String, Int>; // Available PCRE flags
+
 	public function new( r : String, opt : String ) : Void {
-		var ropt = new StringBuf();
+		var ropt = 0;
 		for (i in 0...opt.length){
 			switch(opt.charAt(i)){
-				case "i", "m", "s" : ropt.add(opt.charAt(i));
+				case "i" : ropt |= FLAGS.CASELESS;
+				case "m" : ropt |= FLAGS.MULTILINE;
+				case "s" : ropt |= FLAGS.DOTALL;
 				case "g" : global = true;
 				default : null;
 			}
 		}
 		if (global == null) global = false;
-		this.r = Rex.create(r, ropt.toString());
+		this.r = Rex.create(r, ropt);
 	}
 
 	public function match( s : String ) : Bool {
@@ -152,6 +156,7 @@ class EReg {
 		if (Rex == null){
 			throw "Rex is missing.  Please install lrexlib-pcre.";
 		}
+		FLAGS = Rex.flags();
 	}
 
 }

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -41,6 +41,7 @@ class EReg {
 				case "i" : ropt |= FLAGS.CASELESS;
 				case "m" : ropt |= FLAGS.MULTILINE;
 				case "s" : ropt |= FLAGS.DOTALL;
+				case "u" : ropt |= FLAGS.UTF8;
 				case "g" : global = true;
 				default : null;
 			}

--- a/std/lua/lib/lrexlib/Rex.hx
+++ b/std/lua/lib/lrexlib/Rex.hx
@@ -2,6 +2,7 @@ package lua.lib.lrexlib;
 @:luaRequire("rex_pcre")
 extern class Rex {
 
+	@:overload(          function       (expr : String, flag : Int) : Rex{})
 	inline public static function create(expr : String, flag : String) : Rex{
 		return untyped Rex['new'](expr, flag);
 	}
@@ -35,7 +36,7 @@ extern class Rex {
 	  This function counts matches of the pattern `patt` in the string `subj`.
 	**/	
 	public static function count(subj : String, patt : String, cf : Int, ef : Int) : Dynamic;
-	public static function flags(tb:Dynamic) : Dynamic;
+	public static function flags(?tb:Dynamic) : Dynamic;
 
   /**
     The function searches for the first match of the regexp in the string 


### PR DESCRIPTION
This PR adds support for UTF-8 mode (`u` flag) to EReg on Lua, as in Neko, C++ and PHP.
