### PR TITLE
fix extending haxe.remoting.(Async)Proxy (closes #4937)

### DIFF
--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -3697,20 +3697,29 @@ let extend_remoting ctx c t p async prot =
 			{ cff_name = f.cff_name; cff_pos = f.cff_pos; cff_doc = None; cff_meta = []; cff_access = [APublic]; cff_kind = FFun fd } :: acc
 		| _ -> acc
 	in
-	let decls = List.map (fun d ->
-		match d with
-		| EClass c, p when fst c.d_name = t.tname ->
-			let is_public = List.mem HExtern c.d_flags || List.mem HInterface c.d_flags in
-			let fields = List.rev (List.fold_left (build_field is_public) base_fields c.d_data) in
-			(EClass { c with d_flags = []; d_name = new_name,pos c.d_name; d_data = fields },p)
-		| _ -> d
-	) decls in
+	let imports = ref [] in
+	let rec loop = function
+		| [] ->
+			error ("Module " ^ s_type_path path ^ " does not define type " ^ t.tname) p
+		| d :: rest ->
+			(match d with
+			| EClass c, p when fst c.d_name = t.tname ->
+				let is_public = List.mem HExtern c.d_flags || List.mem HInterface c.d_flags in
+				let fields = List.rev (List.fold_left (build_field is_public) base_fields c.d_data) in
+				(EClass { c with d_flags = []; d_name = new_name,pos c.d_name; d_data = fields },p)
+			| EImport _,_ | EUsing _,_ ->
+				imports := d :: !imports; (* use same imports *)
+				loop rest
+			| _ ->
+				loop rest)
+	in
+	let proxy_decl = loop decls in
+	let import_path = (List.map (fun s -> s,p) t.tpackage) @ [(t.tname, p)] in
+	let import_decl = (EImport (import_path,INormal)), p in (* import original module *)
+	let decls = List.rev (proxy_decl :: import_decl :: !imports) in
 	let m = type_module ctx (t.tpackage,new_name) file decls p in
 	add_dependency ctx.m.curmod m;
-	try
-		List.find (fun tdecl -> snd (t_path tdecl) = new_name) m.m_types
-	with Not_found ->
-		error ("Module " ^ s_type_path path ^ " does not define type " ^ t.tname) p
+	List.find (fun tdecl -> snd (t_path tdecl) = new_name) m.m_types
 	) in
 	match t with
 	| TClassDecl c2 when c2.cl_params = [] -> ignore(c2.cl_build()); c.cl_super <- Some (c2,[]);

--- a/tests/misc/projects/Issue4937/Api.hx
+++ b/tests/misc/projects/Issue4937/Api.hx
@@ -1,0 +1,11 @@
+import Some;
+
+interface Api {
+    function getResult():Result;
+    function test():Other;
+}
+
+typedef Result = {
+    var id:Int;
+    var name:String;
+}

--- a/tests/misc/projects/Issue4937/Main.hx
+++ b/tests/misc/projects/Issue4937/Main.hx
@@ -1,0 +1,18 @@
+import Api;
+
+class ApiProxy extends haxe.remoting.Proxy<Api> {}
+
+class Main {
+	static function main() {
+		var proxy = new ApiProxy(new ConnectionStub());
+		var result = proxy.getResult();
+		if (result.id != 1 || result.name != "test")
+			throw "assert";
+	}
+}
+
+class ConnectionStub implements haxe.remoting.Connection  {
+	public function new() {}
+	public function resolve( name : String ) : haxe.remoting.Connection return this;
+	public function call( params : Array<Dynamic> ) : Dynamic return {id: 1, name: "test"}
+}

--- a/tests/misc/projects/Issue4937/Some.hx
+++ b/tests/misc/projects/Issue4937/Some.hx
@@ -1,0 +1,1 @@
+typedef Other = {a:Int} // this module is here to tests that imports are preserved

--- a/tests/misc/projects/Issue4937/compile.hxml
+++ b/tests/misc/projects/Issue4937/compile.hxml
@@ -1,0 +1,1 @@
+--run Main


### PR DESCRIPTION
This PR changes the way `extend_remoting` works to remove duplication of types and thus fix #4937.

**BEFORE**: it copied every declaration into a new module, changing the main type to a generated `_Proxy` class.
**NOW**: it copies only import/using statements, adds import of the original module and adds a `_Proxy` type declaration.

I added a test for that and also tested haxelib client which compiles and works, but I can't test more since I don't have any code that uses haxe.remoting.

PS I want this to work so I can refactor haxelib modules.