### PR TITLE
POC Int64 hexadecimal literal support ( don't merge :) )

### DIFF
--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -55,7 +55,15 @@ let type_constant com c p =
 	let t = com.basic in
 	match c with
 	| Int s ->
-		if String.length s > 10 && String.sub s 0 2 = "0x" then error "Invalid hexadecimal integer" p;
+		if String.length s > 10 && String.sub s 0 2 = "0x" then
+			(try
+				let v = Int64.of_string s in
+				let idx = DynArray.length com.int64_storage in
+				DynArray.add com.int64_storage v;
+				mk (TConst (TInt (Int32.of_int idx))) t.tint64 p
+			with _ ->
+				assert false (*error "Invalid hexadecimal integer" p*))
+		else
 		(try mk (TConst (TInt (Int32.of_string s))) t.tint p
 		with _ -> mk (TConst (TFloat s)) t.tfloat p)
 	| Float f -> mk (TConst (TFloat f)) t.tfloat p

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -30,6 +30,7 @@ type pos = Ast.pos
 type basic_types = {
 	mutable tvoid : t;
 	mutable tint : t;
+	mutable tint64 : t;
 	mutable tfloat : t;
 	mutable tbool : t;
 	mutable tnull : t -> t;
@@ -207,6 +208,7 @@ type context = {
 	(* typing *)
 	mutable basic : basic_types;
 	memory_marker : float array;
+	int64_storage : Int64.t DynArray.t;
 }
 
 exception Abort of string * Ast.pos
@@ -782,6 +784,7 @@ let create version s_version args =
 		basic = {
 			tvoid = m;
 			tint = m;
+			tint64 = m;
 			tfloat = m;
 			tbool = m;
 			tnull = (fun _ -> assert false);
@@ -793,6 +796,7 @@ let create version s_version args =
 		cached_macros = Hashtbl.create 0;
 		memory_marker = memory_marker;
 		parser_cache = Hashtbl.create 0;
+		int64_storage = DynArray.create ();
 	}
 
 let log com str =

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -279,6 +279,7 @@ let type_var_field ctx t e stat do_display p =
 	let e = type_expr ctx e (WithType t) in
 	let e = (!cast_or_unify_ref) ctx t e p in
 	match t with
+	| TAbstract ({ a_path = (["haxe"],"Int64") },[]) when stat -> { e with etype = t }
 	| TType ({ t_path = ([],"UInt") },[]) | TAbstract ({ a_path = ([],"UInt") },[]) when stat -> { e with etype = t }
 	| _ -> e
 

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -5286,6 +5286,11 @@ let rec create com =
 	with
 		Error (Module_not_found ([],"StdTypes"),_) -> error "Standard library not found" null_pos
 	);
+	let m_64 = (try
+		Typeload.load_module ctx (["haxe"],"Int64") null_pos
+	with
+		Error (Module_not_found (["haxe"],"Int64"),_) -> error "haxe.Int64 not found" null_pos
+	) in
 	(* We always want core types to be available so we add them as default imports (issue #1904 and #3131). *)
 	ctx.m.module_types <- List.map (fun t -> t,null_pos) ctx.g.std.m_types;
 	List.iter (fun t ->
@@ -5320,6 +5325,12 @@ let rec create com =
 				ctx.t.tnull <- mk_null;
 			| _ -> ());
 	) ctx.g.std.m_types;
+	List.iter ( fun t -> match t with
+		| TAbstractDecl a -> (match snd a.a_path with
+			| "Int64" -> ctx.t.tint64 <- TAbstract (a,[])
+			| _ -> ())
+		| _ -> ()
+	) m_64.m_types;
 	let m = Typeload.load_module ctx ([],"String") null_pos in
 	(match m.m_types with
 	| [TClassDecl c] -> ctx.t.tstring <- TInst (c,[])


### PR DESCRIPTION
Proof of concept int64 literals - adopted hxcpp implementation to use the temporary int64 storage. 
Don't merge this pull request, it's just intended to allow for an easy overview of the changes.

The below program produces the following output:
```
Test64.hx:14: 281474976710655
Test64.hx:15: 281474976710640
Test64.hx:16: 281474976710641
Test64.hx:17: 281474976710655
Test64.hx:18: 281474976710640
Test64.hx:19: 281474976710641
```

```
import haxe.Int64;

class Test64 {

    static inline var X:Int64 = 0xFFFFFFFFFFFF;
    static inline var Y:Int64 = 0xFFFFFFFFFFF0;
    static inline var Z:Int64 = 0xFFFFFFFFFFF1;

    static var x:Int64 = 0xFFFFFFFFFFFF;
    static var y:Int64 = 0xFFFFFFFFFFF0;
    static var z:Int64 = 0xFFFFFFFFFFF1;

    static function main(){
        trace(X);
        trace(Y);
        trace(Z);
        trace(x);
        trace(y);
        trace(z);
    }

}
```

