### PR TITLE
fix the base haxe.io.Input class for reading bytes

### DIFF
--- a/std/haxe/io/Input.hx
+++ b/std/haxe/io/Input.hx
@@ -63,20 +63,22 @@ class Input {
 		var b = #if (js || hl) @:privateAccess s.b #else s.getData() #end;
 		if( pos < 0 || len < 0 || pos + len > s.length )
 			throw Error.OutsideBounds;
-		while( k > 0 ) {
-			#if neko
-				untyped __dollar__sset(b,pos,readByte());
-			#elseif php
-				b.set(pos, readByte());
-			#elseif cpp
-				b[pos] = untyped readByte();
-			#else
-				b[pos] = cast readByte();
-			#end
-			pos++;
-			k--;
-		}
-		return len;
+		try {
+			while( k > 0 ) {
+			    #if neko
+				    untyped __dollar__sset(b,pos,readByte());
+			    #elseif php
+				    b.set(pos, readByte());
+			    #elseif cpp
+				    b[pos] = untyped readByte();
+			    #else
+				    b[pos] = cast readByte();
+			    #end
+			    pos++;
+			    k--;
+			}
+		} catch (eof: haxe.io.Eof){}
+		return len-k;
 	}
 
 	/**
@@ -117,8 +119,7 @@ class Input {
 					throw Error.Blocked;
 				total.addBytes(buf,0,len);
 			}
-		} catch( e : Eof ) {
-		}
+		} catch( e : Eof ) { }
 		return total.getBytes();
 	}
 
@@ -130,6 +131,8 @@ class Input {
 	public function readFullBytes( s : Bytes, pos : Int, len : Int ) : Void {
 		while( len > 0 ) {
 			var k = readBytes(s,pos,len);
+			if (k == 0)
+				throw Error.Blocked;
 			pos += k;
 			len -= k;
 		}


### PR DESCRIPTION
Here's the fix for haxe.io.Input I talked about earlier.  I'm opening as a pull request since it involves some of the core types that are extended by most of the targets.  I wanted to have a few more eyes on it before I pulled the trigger.

The travis CI build for this branch is clean:
https://travis-ci.org/HaxeFoundation/haxe/builds/131537312