### PR TITLE
Convert underscores to hyphens in php client headers

### DIFF
--- a/std/php/Web.hx
+++ b/std/php/Web.hx
@@ -189,8 +189,7 @@ class Web {
 		Retrieve a client header value sent with the request.
 	**/
 	public static function getClientHeader( k : String ) : String {
-		//Remark : PHP puts all headers in uppercase and replaces - with _, we deal with that here
-		var k = StringTools.replace(k.toUpperCase(),"-","_");
+		var k = k.toUpperCase();
 		for(i in getClientHeaders()) {
 			if(i.header == k)
 				return i.value;
@@ -209,10 +208,10 @@ class Web {
 			var h = Lib.hashOfAssociativeArray(untyped __php__("$_SERVER"));
 			for(k in h.keys()) {
 				if(k.substr(0,5) == "HTTP_") {
-					_client_headers.add({ header : k.substr(5).split('_').join('-'), value : h.get(k)});
+					_client_headers.add({ header : StringTools.replace(k.substr(5), '_', '-'), value : h.get(k)});
 				// this is also a valid prefix (issue #1883)
 				} else if(k.substr(0,8) == "CONTENT_") {
-					_client_headers.add({ header : k.split('_').join('-'), value : h.get(k)});
+					_client_headers.add({ header : StringTools.replace(k, '_', '-'), value : h.get(k)});
 				}
 			}
 		}

--- a/std/php/Web.hx
+++ b/std/php/Web.hx
@@ -209,10 +209,10 @@ class Web {
 			var h = Lib.hashOfAssociativeArray(untyped __php__("$_SERVER"));
 			for(k in h.keys()) {
 				if(k.substr(0,5) == "HTTP_") {
-					_client_headers.add({ header : k.substr(5), value : h.get(k)});
+					_client_headers.add({ header : k.substr(5).split('_').join('-'), value : h.get(k)});
 				// this is also a valid prefix (issue #1883)
 				} else if(k.substr(0,8) == "CONTENT_") {
-					_client_headers.add({ header : k, value : h.get(k)});
+					_client_headers.add({ header : k.split('_').join('-'), value : h.get(k)});
 				}
 			}
 		}


### PR DESCRIPTION
All incoming headers are transformed by php to an underscore format in $_SERVER. For example `Content-type` is found in `$_SERVER['CONTENT_TYPE']`. To correctly get the header keys, the underscores need to be converted to hyphens again. Headers containing underscores are very rare and ignored in most webservers (apache, nginx).
