### PR TITLE
Fix haxe.Template resolve method (resolves #5287)

### DIFF
--- a/std/haxe/Template.hx
+++ b/std/haxe/Template.hx
@@ -116,9 +116,9 @@ class Template {
 		if( value != null || Reflect.hasField(context,v) )
 			return value;
 		for( ctx in stack ) {
-			var v = Reflect.getProperty(ctx,v);
-			if( v != null || Reflect.hasField(ctx,v) )
-				return v;
+			value = Reflect.getProperty(ctx,v);
+			if( value != null || Reflect.hasField(ctx,v) )
+				return value;
 		}
 		if( v == "__current__" )
 			return context;


### PR DESCRIPTION
The `resolve` method looks for matches in the template context, and a context stack before finally checking globals.

If a match did not resolve on `template.context`, the code wrongfully overwrote the name of the string key you were looking for. This would eventually lead to a wrongful `Reflect.hasField(ctx,null)` call that crashes Neko. You cannot pass a null string value to `Reflect.hasField` on Neko

This fix looks like the correct behavior