### PR TITLE
fix haxe.maco.Constant value documentation

### DIFF
--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -56,17 +56,17 @@ enum Constant {
 	**/
 	CInt( v : String );
 
-	/*
+	/**
 		Represents a float literal.
 	**/
 	CFloat( f : String );
 
-	/*
+	/**
 		Represents a string literal.
 	**/
 	CString( s : String );
 
-	/*
+	/**
 		Represents an indentifier.
 	**/
 	CIdent( s : String );


### PR DESCRIPTION
They need two asterisks  
http://api.haxe.org/haxe/macro/Constant.html