### PR TITLE
fix haxe.maco.Constant value documentation

### DIFF
--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -71,7 +71,7 @@ enum Constant {
 	**/
 	CIdent( s : String );
 
-	/*
+	/**
 		Represents a regular expression literal.
 
 		Example: `~/haxe/i`


### PR DESCRIPTION
Missed CRegexp! Sorry!