### PR TITLE
This is a work in progress change that enables multiple returns in Lua

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1680,7 +1680,7 @@ let check_multireturn ctx c =
 	    else if (match c.cl_kind with KExtension _ -> true | _ -> false) then
 		error "MultiReturns must not extend another class" c.cl_pos
 	    else if List.length c.cl_ordered_statics > 0 then
-		error "MultiReturns must not contain static fields c.cl_pos
+		error "MultiReturns must not contain static fields" c.cl_pos
 	    else if (List.exists (fun cf -> match cf.cf_kind with Method _ -> true | _-> false) c.cl_ordered_fields) then
 		error "MultiReturns must not contain methods" c.cl_pos;
     | {cl_super = Some(csup,_)} when Meta.has Meta.MultiReturn csup.cl_meta ->

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -117,6 +117,7 @@ module Meta = struct
 		| Macro
 		| MaybeUsed
 		| MergeBlock
+		| MultiReturn
 		| MultiType
 		| Native
 		| NativeChildren

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -518,6 +518,7 @@ module MetaInfo = struct
 		| Macro -> ":macro",("(deprecated)",[])
 		| MaybeUsed -> ":maybeUsed",("Internally used by DCE to mark fields that might be kept",[Internal])
 		| MergeBlock -> ":mergeBlock",("Merge the annotated block into the current scope",[UsedOn TExpr])
+		| MultiReturn -> ":multiReturn",("Specifies that a given extern method returns multiple return values",[Platform Lua; UsedOn TClass])
 		| MultiType -> ":multiType",("Specifies that an abstract chooses its this-type from its @:to functions",[UsedOn TAbstract; HasParam "Relevant type parameters"])
 		| Native -> ":native",("Rewrites the path of a class or enum during generation",[HasParam "Output type path";UsedOnEither [TClass;TEnum]])
 		| NativeChildren -> ":nativeChildren",("Annotates that all children from a type should be treated as if it were an extern definition - platform native",[Platforms [Java;Cs]; UsedOn TClass])


### PR DESCRIPTION
# DO NOT COMMIT YET, THIS IS CURRENTLY FOR DISCUSSION

Lua supports [multiple returns](https://www.lua.org/pil/5.1.html) and uses them heavily in its standard
library. Currently, Haxe does not support multiple returns, so
accessing the return values from these methods is problematic, and
describing the full result of these methods in the haxe type system is
impossible.

```lua
local begin,end = string.find("foo bar", "foo")
```

```haxe
var begin = lua.NativeStringTools("foo bar", "foo");
$type(begin); // String
```

Currently, the multi-return methods are treated as only returning one
result, and typing is provided for that return only.

I've tried different approaches at remedying the situation.  The first
attempt simply wraps the results of multiple return methods in a table,
enabling the values to be passed as a single variable reference.
This makes it easier to access arbitrary return values, but it carries
significant overhead since it needs to allocate a table to wrap the values.

The second approach was to create a special abstract typedef metadata,
that would  mark the type as containing a multiple return value:

```haxe
@:multiReturn typedef StringFind = {
    begin : Int,
    end : Int
}
```

This enabled the type to be "unpacked" into a sequence of variable
declarations.  Haxe code:
```haxe
var strfind = lua.NativeStringTools.find("foo bar", "foo");
trace(strfind.begin);
```

Turns into this lua code:
```lua
local _hx_1, _hx_2 = string.find("foo bar", "foo");
haxe.Log.trace(_hx_1);
```

When a variable is declared to accept the result of a multireturn
method, it will populate a new "v_multi" field with a list of temporary
variable names corresponding to each of its fields.  Each time those fields
are requested, they are resolved against the v_multi index, and that
temporary variable name is used instead of the field expression.

While the technique worked in principle, a problem happened with the
structural typedefs unifying too readily with other typedefs.  This
will likely cause a lot of confusion when working with multi return
typedefs in conjunction with other normal typedefs.

This next approach attaches the @:multiReturn metadata to a special
class instance instead, but it works more or less the same, and does not
have nearly the same problems with unification since it uses the more
structured inheritance semantics.

The end result is the ability to provide quite robust multi return
semantics without having to wrap the values.

```haxe

class Main {
    static function test(){
        trace(find("foo bar", "foo").begin + " is the value for k"); // we can access the fields of the return immediately
        var k = find("foo bar", "foo"); // we can assign to a new variable, which has special semantics.
        var l = k.begin; // we can assign out of the multireturn type to a new variable
        trace(l + " is the value for l");
        trace(k.end + " is the value for k.end");

        // the multireturn reference is just a list of variables,
        // so it doesn't print correctly... yet.
        trace(k + " is the value for k");

        return k; // but, we can return multireturn types
    }
    static function main() {
        var f = test();
        // get the multi return value from test, the semantics are preserved.
        trace(f.end + " is the value for f.end");
    }
    static function find(str1:String, str2:String) : StringFind {
        return untyped lua.NativeStringTools.find(str1, str2);
    }

}

// This is our special multireturn wrapper type.
// The order of the declared instance variables is the order
// of the multiple returns from the corresponding method.
@:multiReturn extern class StringFind {
    var begin : Int;
    var end : Int;
}

```

```lua
Main.new = {}
Main.__name__ = true
Main.test = function() 
  haxe.Log.trace(_G.select(1, Main.find("foo bar","foo")) .. " is the value for k",_hx_o({__fields__={fileName=true,lineNumber=true,className=true,methodName=true},fileName="Main.hx",lineNumber=3,className="Main",methodName="test"}));
  local _hx_1, _hx_2 = Main.find("foo bar","foo");
  local l = _hx_1;
  haxe.Log.trace(Std.string(l) .. " is the value for l",_hx_o({__fields__={fileName=true,lineNumber=true,className=true,methodName=true},fileName="Main.hx",lineNumber=6,className="Main",methodName="test"}));
  haxe.Log.trace(_hx_2 .. " is the value for k.end",_hx_o({__fields__={fileName=true,lineNumber=true,className=true,methodName=true},fileName="Main.hx",lineNumber=7,className="Main",methodName="test"}));
  haxe.Log.trace(Std.string(_hx_1, _hx_2) .. " is the value for k",_hx_o({__fields__={fileName=true,lineNumber=true,className=true,methodName=true},fileName="Main.hx",lineNumber=11,className="Main",methodName="test"}));
  do return _hx_1, _hx_2 end;
end
Main.main = function() 
  haxe.Log.trace(_G.select(2, Main.test()) .. " is the value for f.end",_hx_o({__fields__={fileName=true,lineNumber=true,className=true,methodName=true},fileName="Main.hx",lineNumber=18,className="Main",methodName="main"}));
end
Main.find = function(str1,str2) 
  do return _G.string.find(str1,str2) end;
end


```