### PR TITLE
Multiple table id declaration

### DIFF
--- a/std/sys/db/RecordMacros.hx
+++ b/std/sys/db/RecordMacros.hx
@@ -363,7 +363,7 @@ class RecordMacros {
 			};
 			var isId = switch( fi.t ) {
 			case DId, DUId, DBigId: true;
-			default: fi.name == "id";
+			default: i.key == null && fi.name == "id";
 			}
 			if( isId ) {
 				switch(fi.t)


### PR DESCRIPTION
Take id field by name 'id' in case we don't have meta or type based field.

Example:
```haxe
@:table("handle")
@:id(ROWID)
class SomeHandle extends sys.db.Object
{
	public var ROWID : SUId;
	
	public var id : SText;
	public var country : SNull<SText>;
	public var service : SText;
	public var uncanonicalized_id : SNull<SText>;

	public static var manager = new sys.db.Manager<SomeHandle>(SomeHandle);
}
```