### PR TITLE
Fix haxe.EntryPoint on Node.js

### DIFF
--- a/std/haxe/EntryPoint.hx
+++ b/std/haxe/EntryPoint.hx
@@ -115,7 +115,7 @@ class EntryPoint {
 		processEvents();
 
 		#if nodejs
-		(untyped process).nextTick(run);
+		(untyped setImmediate)(run);
 		#else
 		var window : Dynamic = js.Browser.window;
 		var rqf : Dynamic = window.requestAnimationFrame ||


### PR DESCRIPTION
The current implementation with `process.nextTick()` blocks all I/O events, as described in the Node.js documentation :
> Note: the next tick queue is completely drained on each pass of the event loop before additional I/O is processed. As a result, recursively setting nextTick callbacks will block any I/O from happening, just like a while(true); loop.

With `setImmediate(run)` the function is called after I/O events callbacks.