### PR TITLE
More fixes on Node.js EntryPoint

### DIFF
--- a/std/haxe/EntryPoint.hx
+++ b/std/haxe/EntryPoint.hx
@@ -112,10 +112,12 @@ class EntryPoint {
 	@:keep public static function run() @:privateAccess {
 		#if js
 
-		processEvents();
+		var nextTick = processEvents();
 
 		#if nodejs
-		(untyped setImmediate)(run);
+		if( nextTick < 0 )
+			return;
+		(untyped setTimeout)(run,nextTick);
 		#else
 		var window : Dynamic = js.Browser.window;
 		var rqf : Dynamic = window.requestAnimationFrame ||


### PR DESCRIPTION
I made my previous pull request (https://github.com/HaxeFoundation/haxe/pull/5413) too quickly.

After watching the sys implementation I did some additional corrections:
- The run loop must stop if the nextTick returned by processEvents is less than zero.
- We can use this nextTick with setTimeout and avoid useless calls of run()