### PR TITLE
Wrap function args of type function in parenthesis

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -110,7 +110,13 @@ class Printer {
 	// TODO: check if this can cause loops
 	public function printComplexType(ct:ComplexType) return switch(ct) {
 		case TPath(tp): printTypePath(tp);
-		case TFunction(args, ret): (args.length>0 ? args.map(printComplexType).join(" -> ") : "Void") + " -> " + printComplexType(ret);
+		case TFunction(args, ret): 
+				function printArg(ct) return switch ct {
+					case TFunction(_): "(" + printComplexType(ct) + ")";
+					default: printComplexType(ct);
+				}
+				$type(args); // this line is a hack for the compiler to type things correctly?!
+				(args.length>0 ? args.map(printArg).join(" -> ") :"Void") + " -> " + printComplexType(ret);
 		case TAnonymous(fields): "{ " + [for (f in fields) printField(f) + "; "].join("") + "}";
 		case TParent(ct): "(" + printComplexType(ct) + ")";
 		case TOptional(ct): "?" + printComplexType(ct);


### PR DESCRIPTION
```haxe
var fn = macro:Dynamic->Dynamic;
var cb = macro:$fn->Dynamic;
trace(haxe.macro.ComplexTypeTools.toString(cb));
```
The above codes prints `Dynamic->Dynamic->Dynamic`.
It however should be `(Dynamic->Dynamic)->Dynamic`

This PR fixes it but somehow the compiler doesn't type it correctly...
I am just lucky enough to find a trick (`$type(args)`) to work around it....

