### PR TITLE
[lua] Add multireturn behavior handling for lua externs

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -229,7 +229,6 @@ let is_dynamic_iterator ctx e =
 	| _ ->
 		false
 
-(* from genphp *)
 let rec is_uncertain_type t =
 	match follow t with
 	| TInst (c, _) -> c.cl_interface
@@ -278,7 +277,56 @@ let rec is_string_type t =
 	| _ -> false
 
 let is_string_expr e = is_string_type e.etype
-(* /from genphp *)
+
+let is_multireturn ctx e =
+    match follow(e.etype) with
+	| TInst(cl,_) ->  Meta.has Meta.MultiReturn cl.cl_meta
+	| _ -> false
+
+let multi_value_meta ctx e =
+    match e.etype with
+	| TInst (tc, _) ->
+		let econst_of_field ctx cf =
+		    (cf.cf_name, (EConst(String((temp ctx) ^ "_" ^ cf.cf_name)), null_pos)) in
+		let econst_fields =
+		    List.map (econst_of_field ctx) tc.cl_ordered_fields in
+		[(EObjectDecl econst_fields, null_pos)]
+	|_ ->
+		[]
+
+let multi_value_tmp_names meta =
+    let (_,els,_) = Meta.get Meta.MultiReturn meta in
+    match els with
+	| [(EObjectDecl vals,_)] ->
+		List.map (fun (_, expr) ->
+		    match expr with
+		    | (EConst(String(name)),_)-> name
+		    | _-> raise (Failure "@:MultiReturn metadata must be EObjectDecl of String constants")
+		) vals
+	| _-> raise (Failure "@:MultiReturn metadata must be single EObjectDecl of String constants")
+
+let multi_value_tmp_lookup meta field_name =
+    let (_,els,_) = Meta.get Meta.MultiReturn meta in
+    match els with
+	| [(EObjectDecl vals,_)] ->
+		let (_, expr) = List.find (fun (name,_) ->  name = field_name ) vals in
+		( match expr with
+		    | (EConst(String(name)),_)-> name
+		    | _-> raise (Failure "@:MultiReturn metadata must be EObjectDecl of String constants")
+		)
+	| _-> raise (Failure "@:MultiReturn metadata must be single EObjectDecl of String constants")
+
+let rec multi_find_expr_idx lst field_name x = begin
+    match lst with
+	| [] ->raise (Failure "Not Found");
+	| cf::t  -> if cf.cf_name = field_name then x else 1 + (multi_find_expr_idx lst field_name x);
+end
+
+let multi_value_idx_lookup_expr ctx e field_name =
+    match e.etype with
+	| TInst (tc, _) ->
+	    multi_find_expr_idx tc.cl_ordered_fields field_name 1
+	| _-> raise (Failure "field name not found in multireturn idx")
 
 let rec is_int_type ctx t =
     match follow t with
@@ -477,6 +525,10 @@ and gen_expr ?(local=true) ctx e = begin
 		spr ctx "]";
 	| TBinop (op,e1,e2) ->
 		gen_tbinop ctx op e1 e2;
+	| TField ({eexpr = TCall _} as e, f) when is_multireturn ctx e ->
+		print ctx "_G.select(%i, " (multi_value_idx_lookup_expr ctx e (field_name f));
+		gen_value ctx e;
+		spr ctx ")";
 	| TField (x,f) when field_name f = "iterator" && is_dynamic_iterator ctx e ->
 		add_feature ctx "use._iterator";
 		print ctx "_iterator(";
@@ -512,8 +564,14 @@ and gen_expr ?(local=true) ctx e = begin
 		spr ctx " end )({";
 		concat ctx ", " (fun (f,e) -> print ctx "%s = " (anon_field f); gen_value ctx e) fields;
 		spr ctx "})";
-	| TField (x,f) ->
-		gen_value ctx x;
+	| TField ({eexpr = TLocal tv} as e, f) when is_multireturn ctx e ->
+		(match f with
+		| FInstance(_,_,cf)->
+			let tmpname = multi_value_tmp_lookup tv.v_meta cf.cf_name in
+			spr ctx tmpname;
+		| _-> ());
+	| TField (e,f) ->
+		gen_value ctx e;
 		let name = field_name f in
 		spr ctx (match f with FStatic _ | FEnum _ | FInstance _ | FAnon _ | FDynamic _ | FClosure _ -> field name)
 	| TTypeExpr t ->
@@ -578,6 +636,15 @@ and gen_expr ?(local=true) ctx e = begin
 				spr ctx (ident v.v_name);
 			| Some e ->
 				match e.eexpr with
+				| TCall _ when is_multireturn ctx e ->
+				    if Meta.has Meta.MultiReturn v.v_meta then
+					raise (Failure "@:MultiReturn metadata must not be set on variables receiving multiple returns");
+				    v.v_meta <- [(Meta.MultiReturn, multi_value_meta ctx e, null_pos)];
+				    let local_tmp_names = multi_value_tmp_names v.v_meta in
+				    v.v_name <- String.concat ", " local_tmp_names;
+				    print ctx "local %s =" v.v_name;
+				    gen_value ctx e;
+				    semicolon ctx;
 				| TBinop(OpAssign, e1, e2) ->
 				    gen_tbinop ctx OpAssign e1 e2;
 				    if local then
@@ -1425,6 +1492,7 @@ let generate_class ctx c =
 	let p = s_path ctx c.cl_path in
 	let hxClasses = has_feature ctx "Type.resolveClass" in
 	newline ctx;
+
 	print ctx "%s.new = " p;
 	(match c.cl_kind with
 		| KAbstractImpl _ ->
@@ -1630,6 +1698,22 @@ let generate_require ctx path meta =
 
 	newline ctx
 
+
+let check_multireturn ctx c =
+    match c with
+    | _ when Meta.has Meta.MultiReturn c.cl_meta ->
+	    if not c.cl_extern then
+		error "MultiReturns must be externs" c.cl_pos
+	    else if (match c.cl_kind with KExtension _ -> true | _ -> false) then
+		error "MultiReturns must not extend another class" c.cl_pos
+	    else if List.length c.cl_ordered_statics > 0 then
+		error "MultiReturns must not contain static fields" c.cl_pos
+	    else if (List.exists (fun cf -> match cf.cf_kind with Method _ -> true | _-> false) c.cl_ordered_fields) then
+		error "MultiReturns must not contain methods" c.cl_pos;
+    | {cl_super = Some(csup,_)} when Meta.has Meta.MultiReturn csup.cl_meta ->
+		error "Cannot extend a MultiReturn" c.cl_pos
+    | _ -> ()
+
 let generate_type ctx = function
 	| TClassDecl c ->
 		(match c.cl_init with
@@ -1649,7 +1733,9 @@ let generate_type ctx = function
 		else if Meta.has Meta.InitPackage c.cl_meta then
 			(match c.cl_path with
 			| ([],_) -> ()
-			| _ -> generate_package_create ctx c.cl_path)
+			| _ -> generate_package_create ctx c.cl_path);
+
+		check_multireturn ctx c;
 	| TEnumDecl e when e.e_extern ->
 		if Meta.has Meta.LuaRequire e.e_meta && is_directly_used ctx.com e.e_meta then
 		    generate_require ctx e.e_path e.e_meta;

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -118,6 +118,7 @@ module Meta = struct
 		| MaybeUsed
 		| MergeBlock
 		| MultiType
+		| MultiReturn
 		| Native
 		| NativeChildren
 		| NativeGen

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -519,6 +519,7 @@ module MetaInfo = struct
 		| MaybeUsed -> ":maybeUsed",("Internally used by DCE to mark fields that might be kept",[Internal])
 		| MergeBlock -> ":mergeBlock",("Merge the annotated block into the current scope",[UsedOn TExpr])
 		| MultiType -> ":multiType",("Specifies that an abstract chooses its this-type from its @:to functions",[UsedOn TAbstract; HasParam "Relevant type parameters"])
+		| MultiReturn -> ":multiReturn",("Specifies that a given extern method returns multiple return values",[Platform Lua; UsedOn TClass])
 		| Native -> ":native",("Rewrites the path of a class or enum during generation",[HasParam "Output type path";UsedOnEither [TClass;TEnum]])
 		| NativeChildren -> ":nativeChildren",("Annotates that all children from a type should be treated as if it were an extern definition - platform native",[Platforms [Java;Cs]; UsedOn TClass])
 		| NativeGen -> ":nativeGen",("Annotates that a type should be treated as if it were an extern definition - platform native",[Platforms [Java;Cs;Python]; UsedOnEither[TClass;TEnum]])

--- a/std/lua/Lua.hx
+++ b/std/lua/Lua.hx
@@ -10,7 +10,7 @@ import haxe.extern.Rest;
 @:native("_G")
 extern class Lua {
 	/**
-		A global variable that holds a string containing the current interpreter 
+		A global variable that holds a string containing the current interpreter
 		version.
 	**/
 	public static var _VERSION : String;
@@ -23,103 +23,103 @@ extern class Lua {
 	public static function getmetatable(tbl:Table<Dynamic,Dynamic>): Table<Dynamic,Dynamic>;
 
 	/**
-		Pops a table from the stack and sets it as the new metatable for the value 
+		Pops a table from the stack and sets it as the new metatable for the value
 		at the given acceptable index.
 	**/
 	public static function setmetatable(tbl:Table<Dynamic,Dynamic>, mtbl: Table<Dynamic, Dynamic>): Void;
 
 	/**
-		Pops a table from the stack and sets it as the new environment for the value 
-		at the given index. If the value at the given index is neither a function nor 
-		a thread nor a userdata, lua_setfenv returns `0`. 
+		Pops a table from the stack and sets it as the new environment for the value
+		at the given index. If the value at the given index is neither a function nor
+		a thread nor a userdata, lua_setfenv returns `0`.
 		Otherwise it returns `1`.
 	**/
 	public static function setfenv(i:Int , tbl:Table<Dynamic, Dynamic>): Void;
 
 	/**
-		Allows a program to traverse all fields of a table. 
-		Its first argument is a table and its second argument is an index in this 
-		table. `next` returns the next index of the table and its associated value. 
+		Allows a program to traverse all fields of a table.
+		Its first argument is a table and its second argument is an index in this
+		table. `next` returns the next index of the table and its associated value.
 		When `i` is `null`, `next` returns an initial index and its associated value.
 		When called with the last index, or with `null` in an empty table, `next`
-		returns `null`.  In particular, you can use `next(t)` to check whether a 
+		returns `null`.  In particular, you can use `next(t)` to check whether a
 		table is empty.
 
-		The order in which the indices are enumerated is not specified, even for 
-		numeric indices. (To traverse a table in numeric order, use a numerical for 
+		The order in which the indices are enumerated is not specified, even for
+		numeric indices. (To traverse a table in numeric order, use a numerical for
 		or the `ipairs` function).
 
-		The behavior of next is undefined if, during the traversal, any value 
-		to a non-existent field in the table is assigned. Existing fields may 
+		The behavior of next is undefined if, during the traversal, any value
+		to a non-existent field in the table is assigned. Existing fields may
 		however be modified. In particular, existing fields may be cleared.
 	**/
 	public static function next<T>(k:Table<Dynamic, T>, ?i : Null<Int>): T;
 
 	/**
-		Receives an argument of any type and converts it to a string in a reasonable 
-		format. 
-		
+		Receives an argument of any type and converts it to a string in a reasonable
+		format.
+
 		For complete control of how numbers are converted, use`NativeStringTools.format`.
 	**/
 	public static function tostring(v:Dynamic): String;
 
-	public static function ipairs<T>(t:Table<Int,T>): Void->T;
+	public static function ipairs<T>(t:Table<Int,T>): Void->IPairTuple<T>;
 
-	public static function pairs<A,B>(t:Table<A,B>): Void->A;
+	public static function pairs<A,B>(t:Table<A,B>): Void->PairTuple<A,B>;
 
 	public static function require(module:String) : Dynamic;
 
 	/**
-		Converts the Lua value at the given acceptable base to `Int`. 
-		The Lua value must be a number or a string convertible to a number, 
+		Converts the Lua value at the given acceptable base to `Int`.
+		The Lua value must be a number or a string convertible to a number,
 		otherwise `tonumber` returns `0`.
 	**/
 	public static function tonumber(str:String, ?base:Int): Int;
 
 	/**
-		Returns the Lua type of its only argument as a string. 
+		Returns the Lua type of its only argument as a string.
 		The possible results of this function are:
-		
+
 		 * `"nil"` (a string, not the Lua value nil),
 		 * `"number"`
 		 * `"string"`
 		 * `"boolean"`
-		 * `"table"` 
-		 * `"function"` 
+		 * `"table"`
+		 * `"function"`
 		 * `"thread"`
 		 * `"userdata"`
 	**/
 	public static function type(v:Dynamic) : String;
 
 	/**
-		Receives any number of arguments, and prints their values to stdout, 
-		using the tostring function to convert them to strings. 
-		`print` is not intended for formatted output, but only as a quick way to show 
-		a value, typically for debugging. 
-		
+		Receives any number of arguments, and prints their values to stdout,
+		using the tostring function to convert them to strings.
+		`print` is not intended for formatted output, but only as a quick way to show
+		a value, typically for debugging.
+
 		For complete control of how numbers are converted, use `NativeStringTools.format`.
 	**/
 	public static function print(v:Dynamic) : Void;
 
 	/**
 		If `n` is a number, returns all arguments after argument number `n`.
-		Otherwise, `n` must be the string `"#"`, and select returns the total 
+		Otherwise, `n` must be the string `"#"`, and select returns the total
 		number of extra arguments it received.
 	**/
 	public static function select(n:Dynamic, rest:Rest<Dynamic>) : Dynamic;
 
 	/**
-		Gets the real value of `table[index]`, without invoking any metamethod. 
+		Gets the real value of `table[index]`, without invoking any metamethod.
 	**/
 	public static function rawget<K,V>(t:Table<K,V>, k:K) : V;
 
 	/**
-		Sets the real value of `table[index]` to value, without invoking any metamethod. 
+		Sets the real value of `table[index]` to value, without invoking any metamethod.
 	**/
 	public static function rawset<K,V>(t:Table<K,V>, k:K, v:V) : Void;
 
 	/**
-		This function is a generic interface to the garbage collector. 
+		This function is a generic interface to the garbage collector.
 		It performs different functions according to its first argument.
 	**/
 	public static function collectgarbage(opt:CollectGarbageOption, ?arg:Int) : Int;
@@ -130,15 +130,15 @@ extern class Lua {
 		when absent, it defaults to "assertion failed!"
 	**/
 	public static function assert<T>(v:T, ?message:String) : T;
-	
+
 	/**
-		Loads and runs the given file. 
+		Loads and runs the given file.
 	**/
 	public static function dofile(filename:String) : Void;
 
 	/**
-		Generates a Lua error. The error message (which can actually be a Lua value 
-		of any type) must be on the stack top. This function does a long jump, 
+		Generates a Lua error. The error message (which can actually be a Lua value
+		of any type) must be on the stack top. This function does a long jump,
 		and therefore never returns.
 	**/
 	public static function error(message:String, ?level:Int) : Void;
@@ -149,21 +149,21 @@ extern class Lua {
 	public static function pcall(f:Function, rest:Rest<Dynamic>) : Bool;
 
 	/**
-		Returns `true` if the two values in acceptable indices `v1` and `v2` are 
-		primitively equal (that is, without calling metamethods). 
-		Otherwise returns `false`. 
+		Returns `true` if the two values in acceptable indices `v1` and `v2` are
+		primitively equal (that is, without calling metamethods).
+		Otherwise returns `false`.
 		Also returns `false` if any of the indices are non valid.
 	**/
 	public static function rawequal(v1:Dynamic, v2:Dynamic) : Bool;
 
 	/**
-		This function is similar to pcall, except that you can set a new error 
+		This function is similar to pcall, except that you can set a new error
 		handler.
 	**/
 	public static function xpcall(f:Function, msgh:Function, rest:Rest<Dynamic> ) : Bool;
 
 	/**
-		Loads the chunk from file filename or from the standard input if no filename 
+		Loads the chunk from file filename or from the standard input if no filename
 		is given.
 	**/
 	public static function loadfile(filename:String) : Void;
@@ -191,4 +191,14 @@ abstract CollectGarbageOption(String) {
 	var Step = "step";
 	var SetPause = "setpause";
 	var SetStepMul = "setstepmul";
+}
+
+@:multiReturn extern class IPairTuple<T>  {
+	var index : Int;
+	var value : T;
+}
+
+@:multiReturn extern class PairTuple<A,B>  {
+	var key : A;
+	var value : B;
 }

--- a/std/lua/NativeStringTools.hx
+++ b/std/lua/NativeStringTools.hx
@@ -49,7 +49,7 @@ extern class NativeStringTools {
 		       a plain "find substring" operation, with no characters in pattern 
 		       being considered "magic". Note that if plain is given, then `start` must be given as well.
 	**/
-	public static function find(str : String, target : String, ?start : Int, ?plain : Bool): Int;
+	public static function find(str : String, target : String, ?start : Int, ?plain : Bool): StringFind;
 
 	/**
 		Returns the internal numerical codes of the characters `str[index]`.
@@ -127,3 +127,7 @@ extern class NativeStringTools {
 	public static function dump(d:Dynamic) : Dynamic;
 }
 
+@:multiReturn extern class StringFind {
+	var begin : Int;
+	var end   : Int;
+}

--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -47,7 +47,7 @@ class String {
 	public function indexOf( str : String, ?startIndex : Int ) : Int {
 		if (startIndex == null) startIndex = 1;
 		else startIndex += 1;
-		var r = NativeStringTools.find(this, str, startIndex, true);
+		var r = NativeStringTools.find(this, str, startIndex, true).begin;
 		if (r != null && r > 0) return r-1;
 		else return -1;
 	}
@@ -70,7 +70,7 @@ class String {
 		while (idx != null){
 			var newidx = 0;
 			if (delimiter.length > 0){
-				newidx = NativeStringTools.find(this, delimiter, idx, true);
+				newidx = NativeStringTools.find(this, delimiter, idx, true).begin;
 			} else if (idx >= this.length){
 				newidx = null;
 			} else {


### PR DESCRIPTION
# DON'T MERGE THIS YET, STILL UNDER DISCUSSION

This is the third version of multireturn behavior.  This version detects
when a variable is assigned from the result of a Meta.Multireturn method
call.  In this case, the Meta.MultiReturn meta is added to the v_meta
field of the local variable, along with a local mapping of the field
names to the temp name aliases.

This method is in contrast to the previous attempt, which used a special
v_multi field on the variable itself.
