### PR TITLE
add Any type (closes #5322)

### DIFF
--- a/std/Any.hx
+++ b/std/Any.hx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C)2005-2016 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+	`Any` is a type that is compatible with any other in both ways.
+
+	This means that a value of any type can be assigned to `Any`, and
+	vice-versa, a value of `Any` type can be assigned to any other type.
+
+	It's a more type-safe alternative to `Dynamic`, because it doesn't
+	provide field access or array access and it doesn't become monomorph
+	when returned from a function, so to access its fields it needs to be
+	explicitly promoted to another type.
+**/
+abstract Any(Dynamic) from Dynamic {
+	@:noCompletion @:to inline function __promote<A>():A return this;
+}

--- a/std/StdTypes.hx
+++ b/std/StdTypes.hx
@@ -34,7 +34,7 @@
 	On static targets, `null` cannot be assigned to Float. If this is necessary,
 	`Null<Float>` can be used instead.
 
-	`Std.int` converts a `Float` to an `Int`, rounded towards 0.  
+	`Std.int` converts a `Float` to an `Int`, rounded towards 0.
 	`Std.parseFloat` converts a `String` to a `Float`.
 
 	@see http://haxe.org/manual/types-basic-types.html
@@ -48,7 +48,7 @@
 	On static targets, `null` cannot be assigned to `Int`. If this is necessary,
 	`Null<Int>` can be used instead.
 
-	`Std.int` converts a `Float` to an `Int`, rounded towards 0.  
+	`Std.int` converts a `Float` to an `Int`, rounded towards 0.
 	`Std.parseInt` converts a `String` to an `Int`.
 
 	@see http://haxe.org/manual/types-basic-types.html
@@ -90,7 +90,8 @@ typedef Null<T> = T
 	`Dynamic` is a special type which is compatible with all other types.
 
 	Use of `Dynamic` should be minimized as it prevents several compiler
-	checks and optimizations.
+	checks and optimizations. See `Any` type for a safer alternative for
+	representing values of any type.
 
 	@see http://haxe.org/manual/types-dynamic.html
 **/

--- a/tests/unit/src/unit/issues/Issue5322.hx
+++ b/tests/unit/src/unit/issues/Issue5322.hx
@@ -1,0 +1,31 @@
+package unit.issues;
+
+import unit.TestType.typeErrorText;
+import unit.TestType.typedAs;
+
+class Issue5322 extends unit.Test {
+	function test() {
+		// unifies!
+		var a:Any = 1;
+
+		// no fields!
+		eq("Any has no field f", typeErrorText(a.f));
+
+		// no array access!
+		eq("Array access is not allowed on Any", typeErrorText(a[0]));
+
+		// no comparison!
+		eq("Cannot compare Any and Int", typeErrorText(a > 1));
+
+		// kept as the return type!
+		typedAs(something(), (1:Any));
+
+		// promotes to another type successfully!
+		eq("HELLO", (something() : String).toUpperCase());
+
+		// can be used for array of mixed types!
+		var a:Array<Any> = [1,false,"hey",{}];
+	}
+
+	function something():Any return "hello";
+}


### PR DESCRIPTION
This PR adds a new toplevel `Any` type as an alternative to `Dynamic`. See the documentation and the test file for the reasoning, also [tink's documentation](https://github.com/haxetink/tink_core#any) has a great explanation.

The implementation is stolen from @back2dos's tink library, however I'm not sure if it's any better to use that `promote<A>():A` function instead of simple `to Dynamic`.

I propose merging this and promoting usage of `Any` as a go-to solution for storing "values of any type", while leaving `Dynamic` for the low-level platform-specific behaviour.

cc @Simn @ncannasse 