### PR TITLE
Using target specific method separator

### DIFF
--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -242,7 +242,11 @@ class CallStack {
 			if( s != null ) b.add(")");
 		case Method(cname,meth):
 			b.add(cname);
-			b.add(".");
+			#if (cpp || php)
+				b.add("::");
+			#else
+				b.add(".");
+			#end
 			b.add(meth);
 		case LocalFunction(n):
 			b.add("local function #");


### PR DESCRIPTION
Stacktrace items in C++ and PHP use two colons instead of a dot to separate the method name from the fully qualified class name in their string representation:
  Called from test.TestRunner::main test.TestRunner.hx line 40