### PR TITLE
[php] Use `property_exists` instead of `isset` when checking function fields

### DIFF
--- a/src/generators/genphp.ml
+++ b/src/generators/genphp.ml
@@ -987,9 +987,9 @@ and gen_tfield ctx e e1 s =
 				| _ ->
 					gen_expr ctx e1) in
 
-			spr ctx "(isset(";
-			gen_field_access ctx true e1 s;
-			spr ctx ") ? ";
+			spr ctx "(property_exists(";
+			ob e1.eexpr;
+			print ctx ", \"%s\") ? " (s_ident s);
 			gen_field_access ctx true e1 s;
 			spr ctx ": array(";
 			ob e1.eexpr;

--- a/tests/unit/src/unit/issues/Issue5470.hx
+++ b/tests/unit/src/unit/issues/Issue5470.hx
@@ -1,0 +1,10 @@
+package unit.issues;
+
+class Issue5470 extends unit.Test {
+  var cb:Void->Void;
+  
+	function test() {
+		eq(new Issue5470().cb, null);
+	}
+
+}


### PR DESCRIPTION
Should close #3650 and #5427