### PR TITLE
[lua] dce adjustments for lua

### DIFF
--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -54,6 +54,7 @@ let keep_whole_class dce c =
 	|| super_forces_keep c
 	|| (match c with
 		| { cl_path = ([],("Math"|"Array"))} when dce.com.platform = Js -> false
+		| { cl_path = ([],("Math"|"Array"|"String"))} when dce.com.platform = Lua -> false
 		| { cl_extern = true }
 		| { cl_path = ["flash";"_Boot"],"RealBoot" } -> true
 		| { cl_path = [],"String" }


### PR DESCRIPTION
@nadako  here's the adjustments I could find for lua.  It looks like it's ok to drop the Array and String class definitions.  I can't think of a reason why they need to always be present unless they're used... unless we want to provide a lot of dynamic run time safety for methods.  Maybe this could be a compiler flag?

FWIW, this drops the minimal "hello world" generated output from ~2500 bytes to ~1100.