### PR TITLE
fixed: Int64Helper.parseString error'd on negative numbers ending in a zero

### DIFF
--- a/std/haxe/Int64Helper.hx
+++ b/std/haxe/Int64Helper.hx
@@ -51,19 +51,22 @@ class Int64Helper {
 			if (digitInt < 0 || digitInt > 9) {
 				throw "NumberFormatError";
 			}
-
-			var digit:Int64 = Int64.ofInt(digitInt);
-			if (sIsNegative) {
-				current = Int64.sub(current, Int64.mul(multiplier, digit));
-				if (!Int64.isNeg(current)) {
-					throw "NumberFormatError: Underflow";
-				}
-			} else {
-				current = Int64.add(current, Int64.mul(multiplier, digit));
-				if (Int64.isNeg(current)) {
-					throw "NumberFormatError: Overflow";
+			
+			if (digitInt != 0 ) {
+				var digit:Int64 = Int64.ofInt(digitInt);
+				if (sIsNegative) {
+					current = Int64.sub(current, Int64.mul(multiplier, digit));
+					if (!Int64.isNeg(current)) {
+						throw "NumberFormatError: Underflow";
+					}
+				} else {
+					current = Int64.add(current, Int64.mul(multiplier, digit));
+					if (Int64.isNeg(current)) {
+						throw "NumberFormatError: Overflow";
+					}
 				}
 			}
+			
 			multiplier = Int64.mul(multiplier, base);
 		}
 		return current;


### PR DESCRIPTION
Parsing a negative number ending in a zero (ie `"-20"`) would result in a "Conversion underflow" error (as 0 fails the `Int64.isNeg()` check)