### PR TITLE
[cppia] Do not generate __scriptableFunctions from parent classes

### DIFF
--- a/tests/unit/src/scripthost/Issue5351.hx
+++ b/tests/unit/src/scripthost/Issue5351.hx
@@ -12,10 +12,30 @@ package scripthost;
 	public function doTest2() {
 		return 'doTest2';
 	}
+
+	public static function callDoTest1(i:Issue5351) {
+		return i.doTest1();
+	}
+
+	public static function callDoTest2(i:Issue5351) {
+		return i.doTest2();
+	}
 }
 
 @:keep class Issue5351_2 extends Issue5351 {
 	public function doTest3() {
 		return 'doTest3';
+	}
+
+	public static function callDoTest1(i:Issue5351_2) {
+		return i.doTest1();
+	}
+
+	public static function callDoTest2(i:Issue5351_2) {
+		return i.doTest2();
+	}
+
+	public static function callDoTest3(i:Issue5351_2) {
+		return i.doTest3();
 	}
 }

--- a/tests/unit/src/unit/issues/Issue5351.hx
+++ b/tests/unit/src/unit/issues/Issue5351.hx
@@ -6,8 +6,27 @@ class Issue5351 extends Test {
 	public function test() {
 		var t3:Issue5351_2 = Type.createInstance(Type.resolveClass('unit.issues.Issue5351_3'), []);
 		eq(t3.doTest1(), 'doTest1 override');
-		eq(t3.doTest2(), 'doTest2');
-		eq(t3.doTest3(), 'doTest3');
+		eq(t3.doTest2(), 'doTest2 override');
+		eq(t3.doTest3(), 'doTest3 override');
+
+		eq(scripthost.Issue5351.callDoTest1(t3), 'doTest1 override');
+		eq(scripthost.Issue5351.callDoTest2(t3), 'doTest2 override');
+		eq(scripthost.Issue5351_2.callDoTest1(t3), 'doTest1 override');
+		eq(scripthost.Issue5351_2.callDoTest2(t3), 'doTest2 override');
+		eq(scripthost.Issue5351_2.callDoTest3(t3), 'doTest3 override');
+
+    var t3 = new Issue5351_3();
+		eq(t3.doTest1(), 'doTest1 override');
+		eq(t3.doTest2(), 'doTest2 override');
+		eq(t3.doTest3(), 'doTest3 override');
+
+		eq(scripthost.Issue5351.callDoTest1(t3), 'doTest1 override');
+		eq(scripthost.Issue5351.callDoTest2(t3), 'doTest2 override');
+		eq(scripthost.Issue5351_2.callDoTest1(t3), 'doTest1 override');
+		eq(scripthost.Issue5351_2.callDoTest2(t3), 'doTest2 override');
+		eq(scripthost.Issue5351_2.callDoTest3(t3), 'doTest3 override');
+
+		eq(t3.doTest4(), 'doTest4');
 	}
 #end
 }
@@ -16,4 +35,16 @@ class Issue5351 extends Test {
 	override public function doTest1() {
 		return 'doTest1 override';
 	}
+
+	override public function doTest2() {
+		return 'doTest2 override';
+	}
+
+	override public function doTest3() {
+		return 'doTest3 override';
+	}
+
+  public function doTest4() {
+		return 'doTest4';
+  }
 }


### PR DESCRIPTION
Currently, the __scriptableFunctions array is being filled with functions
from all base classes. This not only makes the vtable grow very big,
but also confuses the vtable numbering in such a way that it is possible
to override a wrong function.

The changed test failed in multiple different ways because of that.