### PR TITLE
[cppia] Do not exclude IntIterator

### DIFF
--- a/std/cpp/cppia/HostClasses.hx
+++ b/std/cpp/cppia/HostClasses.hx
@@ -108,7 +108,7 @@ class HostClasses
    "haxe.crypto.Adler32",
    "haxe.crypto.Md5",
    "haxe.crypto.Sha1",
- 
+
    "haxe.io.BufferInput",
    "haxe.io.Bytes",
    "haxe.io.BytesBuffer",
@@ -153,7 +153,7 @@ class HostClasses
    "EReg",
    "Enum",
    "EnumValue",
-   "IntIterator",
+   // "IntIterator",
    "List",
    "Map",
    "String",


### PR DESCRIPTION
`IntIterator` doesn't contain any code that would not allow it to be compiled in cppia. And if it is excluded, Haxe compilation may fail on subsequent times if the compilation server is on, due to the fact that `IntIterator` has an inline constructor.