### PR TITLE
Make dump=pretty look more like Haxe code

### DIFF
--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -920,7 +920,7 @@ module Dump = struct
 				let rec print_field stat f =
 					print "\n\t%s%s%s%s%s %s%s"
 						(s_metas f.cf_meta "\t")
-						(if f.cf_public then "public " else "")
+						(if (f.cf_public && not (c.cl_extern || c.cl_interface)) then "public " else "")
 						(if stat then "static " else "")
 						(match f.cf_kind with
 							| Var v -> ""

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -935,7 +935,13 @@ module Dump = struct
 						(params f.cf_params);
 					match f.cf_kind with
 						| Var v -> print ":%s;\n" (s_type f.cf_type)
-						| Method m -> print "";
+						| Method m -> if (c.cl_extern || c.cl_interface) then (
+							match f.cf_type with
+							| TFun(al,t) -> print "(%s):%s;" (String.concat ", " (
+								List.map (fun (n,o,t) -> n ^ ":" ^ (s_type t)) al))
+								(s_type t); 
+							| _ -> ()
+						) else ();
 					(match f.cf_expr with
 					| None -> ()
 					| Some e -> match e.eexpr with

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -944,13 +944,7 @@ module Dump = struct
 						) else ();
 					(match f.cf_expr with
 					| None -> ()
-					| Some e -> match e.eexpr with
-						(* partially handle functions at field level ourselves *)
-						| TFunction f ->
-							let slist f l = String.concat ", " (List.map f l) in
-							let args = slist (fun (v,o) -> Printf.sprintf "%s:%s%s" v.v_name (s_type v.v_type) (match o with None -> "" | Some c -> " = " ^ s_const c)) f.tf_args in
-							print "(%s):%s %s" args (s_type f.tf_type) (s_expr_pretty false "\t" s_type f.tf_expr)
-						| _ -> print " %s" (s_expr s_type e));
+					| Some e -> print " %s" (s_expr s_type e));
 					print "\n";
 					List.iter (fun f -> print_field stat f) f.cf_overloads
 				in

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -976,7 +976,7 @@ module Dump = struct
 					print "\t%s%s;\n" f.ef_name (
 						match f.ef_type with
 						| TFun (al,t) -> Printf.sprintf "(%s)" (String.concat ", "
-							(List.map (fun (n,o,t) -> n ^ ":" ^ (if o then "?" else "") ^ (s_type t)) al))
+							(List.map (fun (n,o,t) -> (if o then "?" else "") ^ n ^ ":" ^ (s_type t)) al))
 						| _ -> "")
 				) e.e_names;
 				print "}"

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -970,7 +970,10 @@ module Dump = struct
 				print "%s%s%senum %s%s {\n" (s_metas e.e_meta "") (if e.e_private then "private " else "") (if e.e_extern then "extern " else "") (s_type_path path) (params e.e_params);
 				List.iter (fun n ->
 					let f = PMap.find n e.e_constrs in
-					print "\t%s : %s;\n" f.ef_name (s_type f.ef_type);
+					print "\t%s%s;\n" f.ef_name (
+						match f.ef_type with
+						| TEnum _ -> ""
+						| _ -> "(" ^ (s_type f.ef_type) ^ ")");
 				) e.e_names;
 				print "}"
 			| Type.TTypeDecl t ->

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -975,8 +975,9 @@ module Dump = struct
 					let f = PMap.find n e.e_constrs in
 					print "\t%s%s;\n" f.ef_name (
 						match f.ef_type with
-						| TEnum _ -> ""
-						| _ -> "(" ^ (s_type f.ef_type) ^ ")");
+						| TFun (al,t) -> Printf.sprintf "(%s)" (String.concat ", "
+							(List.map (fun (n,o,t) -> n ^ ":" ^ (if o then "?" else "") ^ (s_type t)) al))
+						| _ -> "")
 				) e.e_names;
 				print "}"
 			| Type.TTypeDecl t ->

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -965,9 +965,9 @@ module Dump = struct
 				(match c.cl_init with
 				| None -> ()
 				| Some e ->
-					print "\n\n\t__init__ = ";
+					print "\n\tstatic function __init__() ";
 					print "%s" (s_expr s_type e);
-					print "}\n");
+					print "\n");
 				print "}";
 			| Type.TEnumDecl e ->
 				print "%s%s%senum %s%s {\n" (s_metas e.e_meta "") (if e.e_private then "private " else "") (if e.e_extern then "extern " else "") (s_type_path path) (params e.e_params);

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -944,7 +944,7 @@ module Dump = struct
 						) else ();
 					(match f.cf_expr with
 					| None -> ()
-					| Some e -> print " %s" (s_expr s_type e));
+					| Some e -> print "%s" (s_expr s_type e));
 					print "\n";
 					List.iter (fun f -> print_field stat f) f.cf_overloads
 				in

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -910,7 +910,7 @@ module Dump = struct
 			(match mt with
 			| Type.TClassDecl c ->
 				let rec print_field stat f =
-					print "\t%s%s%s%s%s %s%s"
+					print "\n\t%s%s%s%s%s %s%s"
 						(s_metas f.cf_meta)
 						(if f.cf_public then "public " else "")
 						(if stat then "static " else "")
@@ -937,7 +937,7 @@ module Dump = struct
 							let args = slist (fun (v,o) -> Printf.sprintf "%s:%s%s" v.v_name (s_type v.v_type) (match o with None -> "" | Some c -> " = " ^ s_const c)) f.tf_args in
 							print "(%s):%s %s" args (s_type f.tf_type) (s_expr_pretty false "\t" s_type f.tf_expr)
 						| _ -> print " %s" (s_expr s_type e));
-					print "\n\n"; (* TODO: only one newline if last list entry *)
+					print "\n";
 					List.iter (fun f -> print_field stat f) f.cf_overloads
 				and s_metas ml =
 					match ml with
@@ -949,7 +949,7 @@ module Dump = struct
 				List.iter (fun (c,pl) -> print " implements %s" (s_type (TInst (c,pl)))) c.cl_implements;
 				(match c.cl_dynamic with None -> () | Some t -> print " implements Dynamic<%s>" (s_type t));
 				(match c.cl_array_access with None -> () | Some t -> print " implements ArrayAccess<%s>" (s_type t));
-				print "{\n";
+				print " {\n";
 				(match c.cl_constructor with
 				| None -> ()
 				| Some f -> print_field false f);

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -931,7 +931,10 @@ module Dump = struct
 								| MethInline -> "inline "
 								| MethMacro -> "macro ")
 						(match f.cf_kind with Var v -> "var" | Method m -> "function")
-						(f.cf_name ^ match f.cf_kind with Var v -> s_kind f.cf_kind | _ -> "")
+						(f.cf_name ^ match f.cf_kind with 
+							| Var { v_read = AccNormal; v_write = AccNormal } -> ""
+							| Var v -> "(" ^ s_access true v.v_read ^ "," ^ s_access false v.v_write ^ ")"
+							| _ -> "")
 						(params f.cf_params);
 					match f.cf_kind with
 						| Var v -> print ":%s;\n" (s_type f.cf_type)

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -1001,7 +1001,7 @@ module Dump = struct
 
 	let dump_types com =
 		match Common.defined_value_safe com Define.Dump with
-			| "pretty" -> dump_types com (Type.s_expr_pretty false "\t")
+			| "pretty" -> dump_types com (Type.s_expr_pretty false "\t" true)
 			| "legacy" -> dump_types com Type.s_expr
 			| "record" -> dump_record com
 			| _ -> dump_types com (Type.s_expr_ast (not (Common.defined com Define.DumpIgnoreVarIds)) "\t")

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -976,8 +976,9 @@ module Dump = struct
 			| Type.TTypeDecl t ->
 				print "%s%stypedef %s%s = %s" (s_metas t.t_meta "") (if t.t_private then "private " else "") (s_type_path path) (params t.t_params) (s_type t.t_type);
 			| Type.TAbstractDecl a ->
-				print "%s%sabstract %s%s {}" (s_metas a.a_meta "") (if a.a_private then "private " else "") (s_type_path path) (params a.a_params)
-				(*(String.concat " from " (List.map (fun (t,cf) -> s_type t) a.a_from_field));*)
+				print "%s%sabstract %s%s%s%s {}" (s_metas a.a_meta "") (if a.a_private then "private " else "") (s_type_path path) (params a.a_params)
+				(String.concat " " (List.map (fun t -> " from " ^ s_type t) a.a_from))
+				(String.concat " " (List.map (fun t -> " to " ^ s_type t) a.a_to));
 			);
 			close();
 		) com.types

--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -908,9 +908,13 @@ module Dump = struct
 			let buf,close = create_dumpfile_from_path com path in
 			let print fmt = Printf.kprintf (fun s -> Buffer.add_string buf s) fmt in
 			let s_metas ml tabs =
-					match ml with
+				let args el =
+					match el with
 					| [] -> ""
-					| ml -> String.concat " " (List.map (fun me -> match me with (m,_,_) -> "@" ^ Meta.to_string m) ml) ^ "\n" ^ tabs in
+					| el -> Printf.sprintf "(%s)" (String.concat ", " (List.map (fun e -> Ast.s_expr e) el)) in
+				match ml with
+				| [] -> ""
+				| ml -> String.concat " " (List.map (fun me -> match me with (m,el,_) -> "@" ^ Meta.to_string m ^ args el) ml) ^ "\n" ^ tabs in
 			(match mt with
 			| Type.TClassDecl c ->
 				let rec print_field stat f =

--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -124,12 +124,12 @@ module Transformer = struct
 
 	and debug_expr e =
 		let s_type = Type.s_type (print_context()) in
-		let s = Type.s_expr_pretty false "    " s_type e in
+		let s = Type.s_expr_pretty false "    " false s_type e in
 		Printf.printf "%s\n" s
 
 	and debug_expr_with_type e =
 		let s_type = Type.s_type (print_context()) in
-		let es = Type.s_expr_pretty false "    " s_type e in
+		let es = Type.s_expr_pretty false "    " false s_type e in
 		let t = s_type e.etype in
 		Printf.printf "%s : %s\n" es t
 

--- a/src/macro/interp.ml
+++ b/src/macro/interp.ml
@@ -2467,7 +2467,7 @@ let macro_lib =
 			VString (Type.s_type (print_context()) (decode_type v))
 		);
 		"s_expr", Fun2 (fun v b ->
-			let f = match b with VBool true -> Type.s_expr_pretty false "" | _ -> Type.s_expr_ast true "" in
+			let f = match b with VBool true -> Type.s_expr_pretty false "" false | _ -> Type.s_expr_ast true "" in
 			VString (f (Type.s_type (print_context())) (decode_texpr v))
 		);
 		"is_fmt_string", Fun1 (fun v ->

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -1198,7 +1198,7 @@ module Run = struct
 				prerr_endline (Printf.sprintf "While analyzing %s.%s" (s_type_path c.cl_path) cf.cf_name);
 				List.iter (fun (s,e) ->
 					prerr_endline (Printf.sprintf "<%s>" s);
-					prerr_endline (Type.s_expr_pretty true "" (s_type (print_context())) e);
+					prerr_endline (Type.s_expr_pretty true "" false (s_type (print_context())) e);
 					prerr_endline (Printf.sprintf "</%s>" s);
 				) (List.rev actx.debug_exprs);
 				Debug.dot_debug actx c cf;

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -21,7 +21,7 @@ open Ast
 open Type
 open Common
 
-let s_expr_pretty e = s_expr_pretty false "" (s_type (print_context())) e
+let s_expr_pretty e = s_expr_pretty false "" false (s_type (print_context())) e
 
 let rec is_true_expr e1 = match e1.eexpr with
 	| TConst(TBool true) -> true

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -624,7 +624,7 @@ module Fusion = struct
 				let blocked = ref false in
 				let ir = InterferenceReport.from_texpr e1 in
 				if config.fusion_debug then print_endline (Printf.sprintf "\tInterferenceReport: %s\n\t%s"
-					 (InterferenceReport.to_string ir) (Type.s_expr_pretty true "\t" (s_type (print_context())) (mk (TBlock el) t_dynamic null_pos)));
+					 (InterferenceReport.to_string ir) (Type.s_expr_pretty true "\t" false (s_type (print_context())) (mk (TBlock el) t_dynamic null_pos)));
 				(* This function walks the AST in order of evaluation and tries to find an occurrence of v1. If successful, that occurrence is
 				   replaced with e1. If there's an interference "on the way" the replacement is canceled. *)
 				let rec replace e =

--- a/src/optimization/analyzerTypes.ml
+++ b/src/optimization/analyzerTypes.ml
@@ -111,7 +111,7 @@ module BasicBlock = struct
 		| CFGGoto -> "CFGGoto"
 		| CFGFunction -> "CFGFunction"
 		| CFGMaybeThrow -> "CFGMaybeThrow"
-		| CFGCondBranch e -> "CFGCondBranch " ^ (s_expr_pretty false "" (s_type (print_context())) e)
+		| CFGCondBranch e -> "CFGCondBranch " ^ (s_expr_pretty false "" false (s_type (print_context())) e)
 		| CFGCondElse -> "CFGCondElse"
 
 	let has_flag edge flag =

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -24,7 +24,7 @@ open Common
 exception Internal_match_failure
 
 let s_type = s_type (print_context())
-let s_expr_pretty = s_expr_pretty false "" s_type
+let s_expr_pretty = s_expr_pretty false "" false s_type
 
 let fake_tuple_type = TInst(mk_class null_module ([],"-Tuple") null_pos, [])
 
@@ -518,7 +518,7 @@ module Decision_tree = struct
 
 	let s_case_expr tabs case = match case.case_expr with
 		| None -> ""
-		| Some e -> Type.s_expr_pretty false tabs s_type e
+		| Some e -> Type.s_expr_pretty false tabs false s_type e
 
 	let rec to_string tabs dt = match dt.dt_t with
 		| Leaf case ->
@@ -529,7 +529,7 @@ module Decision_tree = struct
 			in
 			let s_cases = String.concat "" (List.map s_case cases) in
 			let s_default = to_string (tabs ^ "\t") dt in
-			Printf.sprintf "switch (%s) {%s\n%s\tdefault: %s\n%s}" (Type.s_expr_pretty false tabs s_type e) s_cases tabs s_default tabs
+			Printf.sprintf "switch (%s) {%s\n%s\tdefault: %s\n%s}" (Type.s_expr_pretty false tabs false s_type e) s_cases tabs s_default tabs
 		| Bind(bl,dt) ->
 			(String.concat "" (List.map (fun (v,_,e) -> if v.v_name = "_" then "" else Printf.sprintf "%s<%i> = %s; " v.v_name v.v_id (s_expr_pretty e)) bl)) ^
 			to_string tabs dt
@@ -888,8 +888,8 @@ module Compile = struct
 	let s_case (case,bindings,patterns) =
 		let s_bindings = String.concat ", " (List.map (fun (v,_,e) -> Printf.sprintf "%s<%i> = %s" v.v_name v.v_id (s_expr_pretty e)) bindings) in
 		let s_patterns = String.concat " " (List.map Pattern.to_string patterns) in
-		let s_expr = match case.case_expr with None -> "" | Some e -> Type.s_expr_pretty false "\t\t" s_type e in
-		let s_guard = match case.case_guard with None -> "" | Some e -> Type.s_expr_pretty false "\t\t" s_type e in
+		let s_expr = match case.case_expr with None -> "" | Some e -> Type.s_expr_pretty false "\t\t" false s_type e in
+		let s_guard = match case.case_guard with None -> "" | Some e -> Type.s_expr_pretty false "\t\t" false s_type e in
 		Printf.sprintf "\n\t\tbindings: %s\n\t\tpatterns: %s\n\t\tguard: %s\n\t\texpr: %s" s_bindings s_patterns s_guard s_expr
 
 	let s_cases cases =

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1085,7 +1085,9 @@ let rec s_expr_pretty print_var_ids tabs top_level s_type e =
 	| TBlock el ->
 		let ntabs = tabs ^ "\t" in
 		let s = sprintf "{\n%s" (String.concat "" (List.map (fun e -> sprintf "%s%s;\n" ntabs (s_expr_pretty print_var_ids ntabs top_level s_type e)) el)) in
-		s ^ tabs ^ "}"
+		(match el with
+			| [] -> "{}"
+			| _ ->  s ^ tabs ^ "}")
 	| TFor (v,econd,e) ->
 		sprintf "for (%s in %s) %s" (local v) (loop econd) (loop e)
 	| TIf (e,e1,e2) ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1056,7 +1056,8 @@ let rec s_expr s_type e =
 let rec s_expr_pretty print_var_ids tabs top_level s_type e =
 	let sprintf = Printf.sprintf in
 	let loop = s_expr_pretty print_var_ids tabs false s_type in
-	let slist f l = String.concat "," (List.map f l) in
+	let slist c f l = String.concat c (List.map f l) in
+	let clist f l = slist ", " f l in
 	let local v = if print_var_ids then sprintf "%s<%i>" v.v_name v.v_id else v.v_name in
 	match e.eexpr with
 	| TConst c -> s_const c
@@ -1067,17 +1068,17 @@ let rec s_expr_pretty print_var_ids tabs top_level s_type e =
 	| TField (e1,s) -> sprintf "%s.%s" (loop e1) (field_name s)
 	| TTypeExpr mt -> (s_type_path (t_path mt))
 	| TParenthesis e1 -> sprintf "(%s)" (loop e1)
-	| TObjectDecl fl -> sprintf "{%s}" (slist (fun (f,e) -> sprintf "%s : %s" f (loop e)) fl)
-	| TArrayDecl el -> sprintf "[%s]" (slist loop el)
-	| TCall (e1,el) -> sprintf "%s(%s)" (loop e1) (slist loop el)
+	| TObjectDecl fl -> sprintf "{%s}" (clist (fun (f,e) -> sprintf "%s : %s" f (loop e)) fl)
+	| TArrayDecl el -> sprintf "[%s]" (clist loop el)
+	| TCall (e1,el) -> sprintf "%s(%s)" (loop e1) (clist loop el)
 	| TNew (c,pl,el) ->
-		sprintf "new %s(%s)" (s_type_path c.cl_path) (slist loop el)
+		sprintf "new %s(%s)" (s_type_path c.cl_path) (clist loop el)
 	| TUnop (op,f,e) ->
 		(match f with
 		| Prefix -> sprintf "%s %s" (s_unop op) (loop e)
 		| Postfix -> sprintf "%s %s" (loop e) (s_unop op))
 	| TFunction f ->
-		let args = slist (fun (v,o) -> sprintf "%s:%s%s" (local v) (s_type v.v_type) (match o with None -> "" | Some c -> " = " ^ s_const c)) f.tf_args in
+		let args = clist (fun (v,o) -> sprintf "%s:%s%s" (local v) (s_type v.v_type) (match o with None -> "" | Some c -> " = " ^ s_const c)) f.tf_args in
 		sprintf "%s(%s) %s" (if top_level then "" else "function") args (loop f.tf_expr)
 	| TVar (v,eo) ->
 		sprintf "var %s" (sprintf "%s%s" (local v) (match eo with None -> "" | Some e -> " = " ^ loop e))
@@ -1095,10 +1096,10 @@ let rec s_expr_pretty print_var_ids tabs top_level s_type e =
 		| DoWhile -> sprintf "do (%s) while(%s)" (loop e) (loop econd))
 	| TSwitch (e,cases,def) ->
 		let ntabs = tabs ^ "\t" in
-		let s = sprintf "switch (%s) {\n%s%s" (loop e) (slist (fun (cl,e) -> sprintf "%scase %s: %s\n" ntabs (slist loop cl) (s_expr_pretty print_var_ids ntabs top_level s_type e)) cases) (match def with None -> "" | Some e -> ntabs ^ "default: " ^ (s_expr_pretty print_var_ids ntabs top_level s_type e) ^ "\n") in
+		let s = sprintf "switch (%s) {\n%s%s" (loop e) (slist "" (fun (cl,e) -> sprintf "%scase %s: %s;\n" ntabs (clist loop cl) (s_expr_pretty print_var_ids ntabs top_level s_type e)) cases) (match def with None -> "" | Some e -> ntabs ^ "default: " ^ (s_expr_pretty print_var_ids ntabs top_level s_type e) ^ "\n") in
 		s ^ tabs ^ "}"
 	| TTry (e,cl) ->
-		sprintf "try %s%s" (loop e) (slist (fun (v,e) -> sprintf "catch( %s : %s ) %s" (local v) (s_type v.v_type) (loop e)) cl)
+		sprintf "try %s%s" (loop e) (clist (fun (v,e) -> sprintf "catch( %s : %s ) %s" (local v) (s_type v.v_type) (loop e)) cl)
 	| TReturn None ->
 		"return"
 	| TReturn (Some e) ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1089,7 +1089,7 @@ let rec s_expr_pretty print_var_ids tabs top_level s_type e =
 	| TFor (v,econd,e) ->
 		sprintf "for (%s in %s) %s" (local v) (loop econd) (loop e)
 	| TIf (e,e1,e2) ->
-		sprintf "if (%s)%s%s" (loop e) (loop e1) (match e2 with None -> "" | Some e -> " else " ^ loop e)
+		sprintf "if (%s) %s%s" (loop e) (loop e1) (match e2 with None -> "" | Some e -> " else " ^ loop e)
 	| TWhile (econd,e,flag) ->
 		(match flag with
 		| NormalWhile -> sprintf "while (%s) %s" (loop econd) (loop e)
@@ -1099,7 +1099,7 @@ let rec s_expr_pretty print_var_ids tabs top_level s_type e =
 		let s = sprintf "switch (%s) {\n%s%s" (loop e) (slist "" (fun (cl,e) -> sprintf "%scase %s: %s;\n" ntabs (clist loop cl) (s_expr_pretty print_var_ids ntabs top_level s_type e)) cases) (match def with None -> "" | Some e -> ntabs ^ "default: " ^ (s_expr_pretty print_var_ids ntabs top_level s_type e) ^ "\n") in
 		s ^ tabs ^ "}"
 	| TTry (e,cl) ->
-		sprintf "try %s%s" (loop e) (clist (fun (v,e) -> sprintf "catch( %s : %s ) %s" (local v) (s_type v.v_type) (loop e)) cl)
+		sprintf "try %s%s" (loop e) (clist (fun (v,e) -> sprintf " catch (%s:%s) %s" (local v) (s_type v.v_type) (loop e)) cl)
 	| TReturn None ->
 		"return"
 	| TReturn (Some e) ->

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -1078,7 +1078,8 @@ let rec s_expr_pretty print_var_ids tabs s_type e =
 		| Postfix -> sprintf "%s %s" (loop e) (s_unop op))
 	| TFunction f ->
 		let args = slist (fun (v,o) -> sprintf "%s:%s%s" (local v) (s_type v.v_type) (match o with None -> "" | Some c -> " = " ^ s_const c)) f.tf_args in
-		sprintf "function(%s) = %s" args (loop f.tf_expr)
+		(* need to omit "function" if top-level - this is pretty hacky... *)
+		sprintf "%s(%s) %s" (if (String.length tabs == 1) then "" else "function") args (loop f.tf_expr)
 	| TVar (v,eo) ->
 		sprintf "var %s" (sprintf "%s%s" (local v) (match eo with None -> "" | Some e -> " = " ^ loop e))
 	| TBlock el ->


### PR DESCRIPTION
This makes the output from `dump=pretty` almost indistuingishable from regular Haxe code. While of course being a lot more readable, this also has the nice side effect of working nicely with Haxe syntax highlighting.

Some things that were not printed previously are now printed, like metas on type declarations and fields, or from and tos of abstracts.

Some comparisons:

[FlxSprite.dump **now**](https://gist.github.com/Gama11/628253dc8d21f643554186c2051f37f8)
[FlxSprite.dump before](https://gist.github.com/Gama11/cdec54857a6eca9254a8b82b9f319012)

[hscript.Expr.dump **now**](https://gist.github.com/Gama11/6139ff28577f5a76961a133675155480)
[hscript.Expr.dump before](https://gist.github.com/Gama11/07f705b0c561c75bc52e21a280a32558)