### PR TITLE
tests/README.md: run times -> compilation times

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,7 @@ Assuming all test dependencies has been installed, we compile and run the unit t
 
 ### Cpp unit tests
 
-Cpp unit tests are compiled with `-D HXCPP_NO_DEBUG_LINK` (removes debug symbols) to speed up run times. You can remove this from `compile-cpp.hxml` to be able to open the generated `Test-debug.exe` in Visual Studio and debug it. This is useful if it's difficult to figure out why a test is failing, or also _which_ test is failing (for instance with a segmentation fault).
+Cpp unit tests are compiled with `-D HXCPP_NO_DEBUG_LINK` (removes debug symbols) to speed up compilation times. You can remove this from `compile-cpp.hxml` to be able to open the generated `Test-debug.exe` in Visual Studio and debug it. This is useful if it's difficult to figure out why a test is failing, or also _which_ test is failing (for instance with a segmentation fault).
 
 ## Sys tests
 


### PR DESCRIPTION
HXCPP_NO_DEBUG_LINK does not speed up run times.