### PR TITLE
[cs] support field name hash collisions in dynamic objects (closes #5572)

### DIFF
--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -2182,6 +2182,7 @@ let configure gen =
 				let t = gen.gclasses.nativearray_type hash_array.etype in
 				{ hash_array with eexpr = TCall(rcf_static_remove t, [hash_array; length; pos]); etype = gen.gcon.basic.tvoid }
 			)
+			None
 		in
 
 	ReflectionCFs.UniversalBaseClass.configure gen (get_cl (get_type gen (["haxe";"lang"],"HxObject")) ) object_iface dynamic_object;

--- a/tests/unit/src/unit/issues/Issue5572.hx
+++ b/tests/unit/src/unit/issues/Issue5572.hx
@@ -1,0 +1,28 @@
+package unit.issues;
+
+class Issue5572 extends unit.Test {
+	// these two fields have the same hash value
+	static var field1 = "baseReward";
+	static var field2 = "user_3235_65290";
+
+	function test() {
+		var o = {};
+		Reflect.setField(o, field1, 1); // first, goes into hashes array 
+		Reflect.setField(o, field2, 2); // second, added to object's "conflicts"
+		Reflect.setField(o, field2, 3); // should find one from "conflicts" and change the value
+		eq(Reflect.field(o, field1), 1); // retrieved from the hashes array
+		eq(Reflect.field(o, field2), 3); // retreived from "conflicts"
+		var expectedFields = [field1, field2];
+		for (field in Reflect.fields(o)) {
+			if (!expectedFields.remove(field))
+				t(false);
+		}
+		eq(expectedFields.length, 0);
+		Reflect.deleteField(o, field1); // removed from hashes array
+		Reflect.deleteField(o, field2); // removed from "conflicts"
+		eq(Reflect.field(o, field1), null);
+		eq(Reflect.field(o, field2), null);
+		eq(Reflect.fields(o).length, 0);
+
+	}
+}

--- a/tests/unit/src/unit/issues/Issue5572.hx
+++ b/tests/unit/src/unit/issues/Issue5572.hx
@@ -6,6 +6,7 @@ class Issue5572 extends unit.Test {
 	static var field2 = "user_3235_65290";
 
 	function test() {
+		#if !neko
 		var o = {};
 		Reflect.setField(o, field1, 1); // first, goes into hashes array 
 		Reflect.setField(o, field2, 2); // second, added to object's "conflicts"
@@ -23,6 +24,6 @@ class Issue5572 extends unit.Test {
 		eq(Reflect.field(o, field1), null);
 		eq(Reflect.field(o, field2), null);
 		eq(Reflect.fields(o).length, 0);
-
+		#end
 	}
 }


### PR DESCRIPTION
this makes DynamicObject implementation class look like this (reduced for readability):
```cs
public class DynamicObject : global::haxe.lang.HxObject {
    
    public global::haxe.lang.FieldHashConflict __hx_conflicts;
    public int[] __hx_hashes;
    public object[] __hx_dynamics;
    public int[] __hx_hashes_f;
    public double[] __hx_dynamics_f;
    public int __hx_length;
    public int __hx_length_f;
    
    public override bool __hx_deleteField(string field, int hash) {
        if (( hash < 0 )) {
            return global::haxe.lang.FieldLookup.deleteHashConflict(ref this.__hx_conflicts, hash, field);
        }
        
        // [ snip previous implementation ]
        
        return false;
    }
    
    
    public override object __hx_lookupField(string field, int hash, bool throwErrors, bool isCheck) {
        if (( hash < 0 )) {
            global::haxe.lang.FieldHashConflict conflict = global::haxe.lang.FieldLookup.getHashConflict(this.__hx_conflicts, hash, field);
            if (( conflict != null )) {
                return conflict.@value;
            }
            
        }
        else {
            // [ snip previous implementation ]
        }
        
        if (isCheck) {
            return global::haxe.lang.Runtime.undefined;
        }
        else {
            return null;
        }
        
    }
    
    
    public override double __hx_lookupField_f(string field, int hash, bool throwErrors) {
        if (( hash < 0 )) {
            global::haxe.lang.FieldHashConflict conflict = global::haxe.lang.FieldLookup.getHashConflict(this.__hx_conflicts, hash, field);
            if (( conflict != null )) {
                return ((double) (global::haxe.lang.Runtime.toDouble(conflict.@value)) );
            }
            
        }
        else {
            // [ snip previous implementation ]
        }
        
        return default(double);
    }
    
    
    public override object __hx_lookupSetField(string field, int hash, object @value) {
        if (( hash < 0 )) {
            global::haxe.lang.FieldLookup.setHashConflict(ref this.__hx_conflicts, hash, field, @value);
        }
        else {
            // [ snip previous implementation ]
        }
        
        return @value;
    }
    
    
    public override double __hx_lookupSetField_f(string field, int hash, double @value) {
        if (( hash < 0 )) {
            global::haxe.lang.FieldLookup.setHashConflict(ref this.__hx_conflicts, hash, field, @value);
        }
        else {
            // [ snip previous implementation ]
        }
        
        return @value;
    }
    
    
    public override void __hx_getFields(global::Array<object> baseArr) {

        // [ snip previous implementation ]

        global::haxe.lang.FieldLookup.addHashConflictNames(this.__hx_conflicts, baseArr);
        base.__hx_getFields(baseArr);
    }
}
```

and then in FieldLookup:
```cs
public sealed class FieldHashConflict {
	public FieldHashConflict(int hash, string name, object @value, global::haxe.lang.FieldHashConflict next) {
		this.hash = hash;
		this.name = name;
		this.@value = @value;
		this.next = next;
	}
	
	public readonly int hash;
	public readonly string name;
	public object @value;
	public global::haxe.lang.FieldHashConflict next;
}


public sealed class FieldLookup {

	// [ snip previous implementation ]

	
	public static global::haxe.lang.FieldHashConflict getHashConflict(global::haxe.lang.FieldHashConflict head, int hash, string name) {
		while (( head != null )) {
			if (( ( head.hash == hash ) && string.Equals(head.name, name) )) {
				return head;
			}
			
			head = head.next;
		}
		
		return null;
	}
	
	
	public static void setHashConflict(ref global::haxe.lang.FieldHashConflict head, int hash, string name, object @value) {
		global::haxe.lang.FieldHashConflict node = head;
		while (( node != null )) {
			if (( ( node.hash == hash ) && string.Equals(node.name, name) )) {
				node.@value = @value;
				return;
			}
			
			node = ((global::haxe.lang.FieldHashConflict) (node.next) );
		}
		
		head = ((global::haxe.lang.FieldHashConflict) (new global::haxe.lang.FieldHashConflict(hash, name, @value, ((global::haxe.lang.FieldHashConflict) (head) ))) );
	}
	
	
	public static bool deleteHashConflict(ref global::haxe.lang.FieldHashConflict head, int hash, string name) {
		if (( head == null )) {
			return false;
		}
		
		if (( ( head.hash == hash ) && string.Equals(head.name, name) )) {
			head = ((global::haxe.lang.FieldHashConflict) (head.next) );
			return true;
		}
		
		global::haxe.lang.FieldHashConflict prev = head;
		global::haxe.lang.FieldHashConflict node = head.next;
		while (( node != null )) {
			if (( ( node.hash == hash ) && string.Equals(node.name, name) )) {
				prev.next = node.next;
				return true;
			}
			
			node = node.next;
		}
		
		return false;
	}
	
	
	public static void addHashConflictNames(global::haxe.lang.FieldHashConflict head, global::Array<object> arr) {
		while (( head != null )) {
			arr.push(head.name);
			head = head.next;
		}
		
	}
}
```