### PR TITLE
haxe.macro.Printer misses a semicolon at the method of abstract types.

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -276,14 +276,7 @@ class Printer {
 					+ (interfaces != null ? (isInterface ? [for (tp in interfaces) " extends " + printTypePath(tp)] : [for (tp in interfaces) " implements " + printTypePath(tp)]).join("") : "")
 					+ " {\n"
 					+ [for (f in t.fields) {
-						var fstr = printField(f);
-						tabs + fstr + switch(f.kind) {
-							case FVar(_, _), FProp(_, _, _, _): ";";
-							case FFun({expr:null}): ";";
-							case FFun({expr:{expr:EBlock(_)}}): "";
-							case FFun(_): ";";
-							case _: "";
-						};
+						tabs + printFieldWithDelimiter(f);
 					}].join("\n")
 					+ "\n}";
 				case TDAlias(ct):
@@ -302,18 +295,24 @@ class Printer {
 					+ (to == null ? "" : [for (t in to) " to " + printComplexType(t)].join(""))
 					+ " {\n"
 					+ [for (f in t.fields) {
-						var fstr = printField(f);
-						tabs + fstr + switch(f.kind) {
-							case FVar(_, _), FProp(_, _, _, _): ";";
-							case FFun(func) if (func.expr == null): ";";
-							case _: "";
-						};
+						tabs + printFieldWithDelimiter(f);
 					}].join("\n")
 					+ "\n}";
 			}
 
 		tabs = old;
 		return str;
+	}
+
+	function printFieldWithDelimiter(f:Field):String
+	{
+		return printField(f) + switch(f.kind) {
+			case FVar(_, _), FProp(_, _, _, _): ";";
+			case FFun({expr:null}): ";";
+			case FFun({expr:{expr:EBlock(_)}}): "";
+			case FFun(_): ";";
+			case _: "";
+		};
 	}
 
 	function opt<T>(v:T, f:T->String, prefix = "") return v == null ? "" : (prefix + f(v));


### PR DESCRIPTION
```hx
import haxe.macro.Expr.FieldType;
import haxe.macro.Expr.TypeDefKind;
import haxe.macro.Printer;

class Main 
{
	static function main() {
		var result = new Printer().printTypeDefinition(
			{
				pack : [],
				name : "Sample",
				params: [],
				pos : null,
				kind : TypeDefKind.TDAbstract(macro:String),
				fields : [
					{
						name: "new",
						kind: FieldType.FFun(
							{
								args: [],
								ret: null,
								expr: (macro this = ""),
							}
						),
						pos : null,
					}
				],
			}
		);
		trace(result);
	}
}
```

I expected: 
```hx
abstract Sample(String) {
	function new() this = "";
}
```

but acutal:
```hx
abstract Sample(String) {
	function new() this = ""
}
```

This abstract causes "Missing ;" compile error.
