### PR TITLE
[display] some refactorings + get_real_path changes

### DIFF
--- a/src/display/display.ml
+++ b/src/display/display.ml
@@ -166,6 +166,70 @@ let print_fields fields details =
 	Buffer.add_string b "</list>\n";
 	Buffer.contents b
 
+let print_toplevel il =
+	let b = Buffer.create 0 in
+	Buffer.add_string b "<il>\n";
+	let s_type t = htmlescape (s_type (print_context()) t) in
+	let s_doc d = Option.map_default (fun s -> Printf.sprintf " d=\"%s\"" (htmlescape s)) "" d in
+	List.iter (fun id -> match id with
+		| IdentifierType.ITLocal v ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"local\" t=\"%s\">%s</i>\n" (s_type v.v_type) v.v_name);
+		| IdentifierType.ITMember(c,cf) ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"member\" t=\"%s\"%s>%s</i>\n" (s_type cf.cf_type) (s_doc cf.cf_doc) cf.cf_name);
+		| IdentifierType.ITStatic(c,cf) ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"static\" t=\"%s\"%s>%s</i>\n" (s_type cf.cf_type) (s_doc cf.cf_doc) cf.cf_name);
+		| IdentifierType.ITEnum(en,ef) ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"enum\" t=\"%s\"%s>%s</i>\n" (s_type ef.ef_type) (s_doc ef.ef_doc) ef.ef_name);
+		| IdentifierType.ITEnumAbstract(a,cf) ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"enumabstract\" t=\"%s\"%s>%s</i>\n" (s_type cf.cf_type) (s_doc cf.cf_doc) cf.cf_name);
+		| IdentifierType.ITGlobal(mt,s,t) ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"global\" p=\"%s\" t=\"%s\">%s</i>\n" (s_type_path (t_infos mt).mt_path) (s_type t) s);
+		| IdentifierType.ITType(mt) ->
+			let infos = t_infos mt in
+			Buffer.add_string b (Printf.sprintf "<i k=\"type\" p=\"%s\"%s>%s</i>\n" (s_type_path infos.mt_path) (s_doc infos.mt_doc) (snd infos.mt_path));
+		| IdentifierType.ITPackage s ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"package\">%s</i>\n" s)
+	) il;
+	Buffer.add_string b "</il>";
+	Buffer.contents b
+
+let print_type t p =
+	let b = Buffer.create 0 in
+	if p = null_pos then
+		Buffer.add_string b "<type>\n"
+	else begin
+		let error_printer file line = Printf.sprintf "%s:%d:" (Common.unique_full_path file) line in
+		let epos = Lexer.get_error_pos error_printer p in
+		Buffer.add_string b ("<type p=\"" ^ (htmlescape epos) ^ "\">\n")
+	end;
+	Buffer.add_string b (htmlescape (s_type (print_context()) t));
+	Buffer.add_string b "\n</type>\n";
+	Buffer.contents b
+
+let print_signatures tl =
+	let b = Buffer.create 0 in
+	List.iter (fun (t,doc) ->
+		Buffer.add_string b "<type";
+		Option.may (fun s -> Buffer.add_string b (Printf.sprintf " d=\"%s\"" (htmlescape s))) doc;
+		Buffer.add_string b ">\n";
+		Buffer.add_string b (htmlescape (s_type (print_context()) (follow t)));
+		Buffer.add_string b "\n</type>\n";
+	) tl;
+	Buffer.contents b
+
+let print_positions pl =
+	let b = Buffer.create 0 in
+	let error_printer file line = Printf.sprintf "%s:%d:" (Common.unique_full_path file) line in
+	Buffer.add_string b "<list>\n";
+	List.iter (fun p ->
+		let epos = Lexer.get_error_pos error_printer p in
+		Buffer.add_string b "<pos>";
+		Buffer.add_string b epos;
+		Buffer.add_string b "</pos>\n";
+	) pl;
+	Buffer.add_string b "</list>";
+	Buffer.contents b
+
 let pos_to_json_range p =
 	if p.pmin = -1 then
 		JNull

--- a/src/display/display.ml
+++ b/src/display/display.ml
@@ -145,6 +145,13 @@ let display_enum_field dm ef p = match dm.dms_kind with
 
 open Json
 
+let htmlescape s =
+	let s = String.concat "&amp;" (ExtString.String.nsplit s "&") in
+	let s = String.concat "&lt;" (ExtString.String.nsplit s "<") in
+	let s = String.concat "&gt;" (ExtString.String.nsplit s ">") in
+	let s = String.concat "&quot;" (ExtString.String.nsplit s "\"") in
+	s
+
 let print_fields fields details =
 	let b = Buffer.create 0 in
 	Buffer.add_string b "<list>\n";

--- a/src/display/display.ml
+++ b/src/display/display.ml
@@ -219,7 +219,7 @@ let print_signatures tl =
 
 let print_positions pl =
 	let b = Buffer.create 0 in
-	let error_printer file line = Printf.sprintf "%s:%d:" (Common.unique_full_path file) line in
+	let error_printer file line = Printf.sprintf "%s:%d:" (get_real_path file) line in
 	Buffer.add_string b "<list>\n";
 	List.iter (fun p ->
 		let epos = Lexer.get_error_pos error_printer p in

--- a/src/display/display.ml
+++ b/src/display/display.ml
@@ -145,6 +145,27 @@ let display_enum_field dm ef p = match dm.dms_kind with
 
 open Json
 
+let print_fields fields details =
+	let b = Buffer.create 0 in
+	Buffer.add_string b "<list>\n";
+	List.iter (fun (n,t,k,d) ->
+		let s_kind = match k with
+			| Some k -> (match k with
+				| FKVar -> "var"
+				| FKMethod -> "method"
+				| FKType -> "type"
+				| FKPackage -> "package"
+				| FKMetadata -> "metadata")
+			| None -> ""
+		in
+		if details then
+			Buffer.add_string b (Printf.sprintf "<i n=\"%s\" k=\"%s\"><t>%s</t><d>%s</d></i>\n" n s_kind (htmlescape t) (htmlescape d))
+		else
+			Buffer.add_string b (Printf.sprintf "<i n=\"%s\"><t>%s</t><d>%s</d></i>\n" n (htmlescape t) (htmlescape d))
+	) (List.sort (fun (a,_,ak,_) (b,_,bk,_) -> compare (ak,a) (bk,b)) fields);
+	Buffer.add_string b "</list>\n";
+	Buffer.contents b
+
 let pos_to_json_range p =
 	if p.pmin = -1 then
 		JNull

--- a/src/main.ml
+++ b/src/main.ml
@@ -1741,68 +1741,13 @@ with
 		in
 		complete_fields com fields
 	| Display.DisplayType (t,p) ->
-		let ctx = print_context() in
-		let b = Buffer.create 0 in
-		if p = null_pos then
-			Buffer.add_string b "<type>\n"
-		else begin
-			let error_printer file line = sprintf "%s:%d:" (Common.unique_full_path file) line in
-			let epos = Lexer.get_error_pos error_printer p in
-			Buffer.add_string b ("<type p=\"" ^ (htmlescape epos) ^ "\">\n")
-		end;
-		Buffer.add_string b (htmlescape (s_type ctx t));
-		Buffer.add_string b "\n</type>\n";
-		raise (Completion (Buffer.contents b))
+		raise (Completion (Display.print_type t p))
 	| Display.DisplaySignatures tl ->
-		let ctx = print_context() in
-		let b = Buffer.create 0 in
-		List.iter (fun (t,doc) ->
-			Buffer.add_string b "<type";
-			Option.may (fun s -> Buffer.add_string b (Printf.sprintf " d=\"%s\"" (htmlescape s))) doc;
-			Buffer.add_string b ">\n";
-			Buffer.add_string b (htmlescape (s_type ctx (follow t)));
-			Buffer.add_string b "\n</type>\n";
-		) tl;
-		raise (Completion (Buffer.contents b))
+		raise (Completion (Display.print_signatures tl))
 	| Display.DisplayPosition pl ->
-		let b = Buffer.create 0 in
-		let error_printer file line = sprintf "%s:%d:" (Common.unique_full_path file) line in
-		Buffer.add_string b "<list>\n";
-		List.iter (fun p ->
-			let epos = Lexer.get_error_pos error_printer p in
-			Buffer.add_string b "<pos>";
-			Buffer.add_string b epos;
-			Buffer.add_string b "</pos>\n";
-		) pl;
-		Buffer.add_string b "</list>";
-		raise (Completion (Buffer.contents b))
+		raise (Completion (Display.print_positions pl))
 	| Display.DisplayToplevel il ->
-		let b = Buffer.create 0 in
-		Buffer.add_string b "<il>\n";
-		let ctx = print_context() in
-		let s_type t = htmlescape (s_type ctx t) in
-		let s_doc d = Option.map_default (fun s -> Printf.sprintf " d=\"%s\"" (htmlescape s)) "" d in
-		List.iter (fun id -> match id with
-			| IdentifierType.ITLocal v ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"local\" t=\"%s\">%s</i>\n" (s_type v.v_type) v.v_name);
-			| IdentifierType.ITMember(c,cf) ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"member\" t=\"%s\"%s>%s</i>\n" (s_type cf.cf_type) (s_doc cf.cf_doc) cf.cf_name);
-			| IdentifierType.ITStatic(c,cf) ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"static\" t=\"%s\"%s>%s</i>\n" (s_type cf.cf_type) (s_doc cf.cf_doc) cf.cf_name);
-			| IdentifierType.ITEnum(en,ef) ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"enum\" t=\"%s\"%s>%s</i>\n" (s_type ef.ef_type) (s_doc ef.ef_doc) ef.ef_name);
-			| IdentifierType.ITEnumAbstract(a,cf) ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"enumabstract\" t=\"%s\"%s>%s</i>\n" (s_type cf.cf_type) (s_doc cf.cf_doc) cf.cf_name);
-			| IdentifierType.ITGlobal(mt,s,t) ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"global\" p=\"%s\" t=\"%s\">%s</i>\n" (s_type_path (t_infos mt).mt_path) (s_type t) s);
-			| IdentifierType.ITType(mt) ->
-				let infos = t_infos mt in
-				Buffer.add_string b (Printf.sprintf "<i k=\"type\" p=\"%s\"%s>%s</i>\n" (s_type_path infos.mt_path) (s_doc infos.mt_doc) (snd infos.mt_path));
-			| IdentifierType.ITPackage s ->
-				Buffer.add_string b (Printf.sprintf "<i k=\"package\">%s</i>\n" s)
-		) il;
-		Buffer.add_string b "</il>";
-		raise (Completion (Buffer.contents b))
+		raise (Completion (Display.print_toplevel il))
 	| Parser.TypePath (p,c,is_import) ->
 		(match c with
 		| None ->

--- a/src/main.ml
+++ b/src/main.ml
@@ -405,7 +405,7 @@ let get_module_path_from_file_path com spath =
 		| [] -> None
 		| cp :: l ->
 			let cp = (if cp = "" then "./" else cp) in
-			let c = add_trailing_slash (get_real_path (Common.get_full_path cp)) in
+			let c = add_trailing_slash (get_real_path cp) in
 			let clen = String.length c in
 			if clen < String.length spath && String.sub spath 0 clen = c then begin
 				let path = String.sub spath clen (String.length spath - clen) in

--- a/src/main.ml
+++ b/src/main.ml
@@ -145,39 +145,14 @@ let error ctx msg p =
 	message ctx msg p;
 	ctx.has_error <- true
 
-let htmlescape s =
-	let s = String.concat "&amp;" (ExtString.String.nsplit s "&") in
-	let s = String.concat "&lt;" (ExtString.String.nsplit s "<") in
-	let s = String.concat "&gt;" (ExtString.String.nsplit s ">") in
-	let s = String.concat "&quot;" (ExtString.String.nsplit s "\"") in
-	s
-
 let reserved_flags = [
 	"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
 	"as3";"swc";"macro";"sys"
 	]
 
 let complete_fields com fields =
-	let b = Buffer.create 0 in
 	let details = Common.raw_defined com "display-details" in
-	Buffer.add_string b "<list>\n";
-	List.iter (fun (n,t,k,d) ->
-		let s_kind = match k with
-			| Some k -> (match k with
-				| Display.FKVar -> "var"
-				| Display.FKMethod -> "method"
-				| Display.FKType -> "type"
-				| Display.FKPackage -> "package"
-				| Display.FKMetadata -> "metadata")
-			| None -> ""
-		in
-		if details then
-			Buffer.add_string b (Printf.sprintf "<i n=\"%s\" k=\"%s\"><t>%s</t><d>%s</d></i>\n" n s_kind (htmlescape t) (htmlescape d))
-		else
-			Buffer.add_string b (Printf.sprintf "<i n=\"%s\"><t>%s</t><d>%s</d></i>\n" n (htmlescape t) (htmlescape d))
-	) (List.sort (fun (a,_,ak,_) (b,_,bk,_) -> compare (ak,a) (bk,b)) fields);
-	Buffer.add_string b "</list>\n";
-	raise (Completion (Buffer.contents b))
+	raise (Completion (Display.print_fields fields details))
 
 let report_times print =
 	let tot = ref 0. in

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -1138,6 +1138,13 @@ let add_filter ctx f =
 let add_final_filter ctx f =
 	ctx.callbacks.after_generation <- f :: ctx.callbacks.after_generation
 
+let htmlescape s =
+	let s = String.concat "&amp;" (ExtString.String.nsplit s "&") in
+	let s = String.concat "&lt;" (ExtString.String.nsplit s "<") in
+	let s = String.concat "&gt;" (ExtString.String.nsplit s ">") in
+	let s = String.concat "&quot;" (ExtString.String.nsplit s "\"") in
+	s
+
 let find_file ctx f =
 	try
 		(match Hashtbl.find ctx.file_lookup_cache f with

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -1177,26 +1177,24 @@ let find_file ctx f =
 let is_windows = Sys.os_type = "Win32" || Sys.os_type = "Cygwin"
 let path_sep = if is_windows then "\\" else "/"
 
-(** Returns absolute path for given path `f`.
-    Doesn't fix path case on Windows. *)
+(** Returns absolute path. Doesn't fix path case on Windows. *)
 let get_full_path f = try Extc.get_full_path f with _ -> f
 
+(** Returns absolute path (on Windows ensures proper case with drive letter upper-cased)
+    Use for returning positions from IDE support functions *)
+let get_real_path =
+	if is_windows then
+		(fun p -> try Extc.get_real_path p with _ -> p)
+	else
+		get_full_path
+
 (** Returns absolute path guaranteed to be the same for different letter case.
-    For use where equality comparison is required, lowercases the path on Windows *)
+    Use where equality comparison is required, lowercases the path on Windows *)
 let unique_full_path =
 	if is_windows then
 		(fun f -> String.lowercase (get_full_path f))
 	else
 		get_full_path
-
-(** On Windows: returns absolute path with proper case (drive letter upper-cased),
-    unless there's an error, then is a no-op. On non-Windows is a no-op.
-    ¯\_(ツ)_/¯ *)
-let get_real_path p =
-	try
-		Extc.get_real_path p
-	with _ ->
-		p
 
 let get_path_parts f =
 	(*

--- a/src/typing/common.ml
+++ b/src/typing/common.ml
@@ -1138,13 +1138,6 @@ let add_filter ctx f =
 let add_final_filter ctx f =
 	ctx.callbacks.after_generation <- f :: ctx.callbacks.after_generation
 
-let htmlescape s =
-	let s = String.concat "&amp;" (ExtString.String.nsplit s "&") in
-	let s = String.concat "&lt;" (ExtString.String.nsplit s "<") in
-	let s = String.concat "&gt;" (ExtString.String.nsplit s ">") in
-	let s = String.concat "&quot;" (ExtString.String.nsplit s "\"") in
-	s
-
 let find_file ctx f =
 	try
 		(match Hashtbl.find ctx.file_lookup_cache f with

--- a/tests/display/src/DisplayTestContext.hx
+++ b/tests/display/src/DisplayTestContext.hx
@@ -154,9 +154,8 @@ class DisplayTestContext {
 			p = Sys.getCwd() + p;
 		}
 		if (Sys.systemName() == "Windows") {
-			// on windows, haxe returns lowercase paths with backslashes
+			// on windows, haxe returns paths with backslashes
 			p = p.replace("/", "\\");
-			p = p.toLowerCase();
 		}
 		return p;
 	}

--- a/tests/misc/projects/Issue1968/compile.hxml.stderr
+++ b/tests/misc/projects/Issue1968/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):4: characters 18-61</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):4: characters 18-61</pos>
 </list>

--- a/tests/misc/projects/Issue2991/compile.hxml.stderr
+++ b/tests/misc/projects/Issue2991/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):6: characters 12-13</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):6: characters 12-13</pos>
 </list>

--- a/tests/misc/projects/Issue2993/compile.hxml.stderr
+++ b/tests/misc/projects/Issue2993/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):2: characters 15-18</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):2: characters 15-18</pos>
 </list>

--- a/tests/misc/projects/Issue2995/position.hxml.stderr
+++ b/tests/misc/projects/Issue2995/position.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):2: characters 4-21</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):2: characters 4-21</pos>
 </list>

--- a/tests/misc/projects/Issue2995/usage.hxml.stderr
+++ b/tests/misc/projects/Issue2995/usage.hxml.stderr
@@ -1,4 +1,4 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):5: characters 16-26</pos>
-<pos>$$normPath(::cwd::/Main.hx):9: characters 8-18</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):5: characters 16-26</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):9: characters 8-18</pos>
 </list>

--- a/tests/misc/projects/Issue2996/compile1.hxml.stderr
+++ b/tests/misc/projects/Issue2996/compile1.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/A.hx):1: characters 0-21</pos>
+<pos>$$normPath(::cwd::/A.hx, true):1: characters 0-21</pos>
 </list>

--- a/tests/misc/projects/Issue2996/compile2.hxml.stderr
+++ b/tests/misc/projects/Issue2996/compile2.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/pack/B.hx):3: characters 0-10</pos>
+<pos>$$normPath(::cwd::/pack/B.hx, true):3: characters 0-10</pos>
 </list>

--- a/tests/misc/projects/Issue2997/compile1.hxml.stderr
+++ b/tests/misc/projects/Issue2997/compile1.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):2: characters 4-14</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):2: characters 4-14</pos>
 </list>

--- a/tests/misc/projects/Issue5123/compile.hxml.stderr
+++ b/tests/misc/projects/Issue5123/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<pos>$$normPath(::cwd::/Main.hx):5: lines 5-7</pos>
+<pos>$$normPath(::cwd::/Main.hx, true):5: lines 5-7</pos>
 </list>

--- a/tests/misc/src/Main.hx
+++ b/tests/misc/src/Main.hx
@@ -63,12 +63,13 @@ class Main {
 		return new haxe.Template(s).execute(context, macros);
 	}
 
-	static function normPath(resolve, p:String):String {
+	static function normPath(resolve, p:String, properCase = false):String {
 		if (Sys.systemName() == "Windows")
 		{
 			// on windows, haxe returns lowercase paths with backslashes
 			p = p.replace("/", "\\");
-			p = p.toLowerCase();
+			if (!properCase)
+				p = p.toLowerCase();
 		}
 		return p;
 	}


### PR DESCRIPTION
this moves (almost all) display printing functions from `main.ml` into `display.ml`
also it factors out `Parser.TypePath` handling into functions for better maintainability
and finally it makes `Common.get_real_path` consistently return absolute path with proper name case
oh, and it makes `@position` completion use `get_real_path` so IDEs on windows won't try to open a lowercased file

just making a PR for easy squash+merge and additional Travis testing.