### PR TITLE
Report skipped macro conditions in display mode

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -1246,6 +1246,8 @@ with
 			complete_type_path ctx p
 		| Some (c,cur_package) ->
 			complete_type_path_inner ctx p c cur_package is_import)
+	| Parser.SkippedPastDisplayPos el ->
+		print_endline ("The following must hold to reach this position: " ^ (String.concat " && " (List.map Ast.s_expr el)));
 	| Display.ModuleSymbols s | Display.Diagnostics s | Display.Statistics s | Display.Metadata s ->
 		raise (Completion s)
 	| Interp.Sys_exit i ->


### PR DESCRIPTION
I realized that we currently treat `#if macro` special by defaulting it to `true` in the display file. This is nice to get some completion while writing macros but very awkward in all other situations. Simply removing it would cause some completion regressions, so I looked into making the parser a bit smarter with regards to conditional compilation.

It now keeps track of skipped sections and, if it realizes it went past the display position in one of these sections, reports the conditionals that would have to hold in order to reach that position. Here's my crazy demo file for this annotated with what the compiler outputs:

```haxe
class Main {
	static public function main() {
		null; // works
		#if macro
			null; // macro
		#elseif really_not_macro
			null; // !macro && really_not_macro
			#if (x > 20)
				null; // !macro && really_not_macro && (x > 20)
			#else
				null; // !macro && really_not_macro && !(x > 20)
			#end
		#else
			#if (x > 20)
				null; // !macro && !really_not_macro && (x > 20)
			#elseif true
				null; // works
			#else
				null; // !macro && !really_not_macro && !(x > 20) && !true
			#end
		#end
		null; // works
		#if (macro || neko)
			null; // (macro || neko)
		#elseif (js && php)
			null; // !(macro || neko) && (js && php)
		#end
		null; // works
	}
}
```

My overall plan is the following:

1. Within the compiler we try if the condition would hold if we defined `macro`. If that's the case, we somehow re-enter compilation in macro mode for the file in question. The "somehow" part has yet to be figured out.
2. If we can't saturate the condition within the compiler, we report it back to the IDE. It can then try to do the saturation itself. This is going to work in many simple cases like an `#if js` block if there's an alternative JS configuration that can be used instead of whatever the original configuration was.

I acknowledge that this is still not trivial to handle, but I would like to make display modes more robust when conditional compilation is involved and this should be a first step. Currently entire code sections are basically invisible to the compiler and this usually requires a manual switch to another build/display configuration.

The impact on general parsing is minimal as it only affects the `#if`, `#elseif`, `#else` and `#end` tokens. The algorithm is as follows:

1. For any `#if` we push a "frame" onto a stack. For any `#end` we pop the topmost frame.
2. For any condition after `#if` or `#elseif` we push that condition onto a list in the topmost frame.
3. For any `#elseif` or `#else` we flip the topmost condition of the current frame by negating it (`macro` becomes `!macro`).
4. For any terminator after a skipped section (`#elseif`, `#else`, `#end`) we check if the display position is between the topmost frame condition and the terminator. If so, we report all conditions across all open frames.