### PR TITLE
add haxe.macro.CompilationServer

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -313,9 +313,10 @@ let get_signature com =
 
 module CompilationServer = struct
 	type cache = {
-		mutable c_haxelib : (string list, string list) Hashtbl.t;
-		mutable c_files : ((string * string), float * Ast.package) Hashtbl.t;
-		mutable c_modules : (path * string, module_def) Hashtbl.t;
+		c_haxelib : (string list, string list) Hashtbl.t;
+		c_files : ((string * string), float * Ast.package) Hashtbl.t;
+		c_modules : (path * string, module_def) Hashtbl.t;
+		c_directories : (string, (string * float ref) list) Hashtbl.t;
 	}
 
 	type t = {
@@ -329,6 +330,7 @@ module CompilationServer = struct
 		c_haxelib = Hashtbl.create 0;
 		c_files = Hashtbl.create 0;
 		c_modules = Hashtbl.create 0;
+		c_directories = Hashtbl.create 0;
 	}
 
 	let create () =
@@ -393,6 +395,14 @@ module CompilationServer = struct
 
 	let cache_haxelib cs key value =
 		Hashtbl.replace cs.cache.c_haxelib key value
+
+	(* directories *)
+
+	let find_directories cs key =
+		Hashtbl.find cs.cache.c_directories key
+
+	let add_directories cs key value =
+		Hashtbl.replace cs.cache.c_directories key value
 end
 
 module Define = struct

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -324,6 +324,11 @@ module CompilationServer = struct
 		mutable signs : (string * string) list;
 	}
 
+	type context_options =
+		| NormalContext
+		| MacroContext
+		| NormalAndMacroContext
+
 	let instance : t option ref = ref None
 
 	let create_cache () = {

--- a/src/generators/gencommon.ml
+++ b/src/generators/gencommon.ml
@@ -662,11 +662,11 @@ let new_ctx con =
 		gadd_type = (fun md should_filter ->
 			if should_filter then begin
 				gen.gtypes_list <- md :: gen.gtypes_list;
-				gen.gmodules <- { m_id = alloc_mid(); m_path = (t_path md); m_types = [md]; m_extra = module_extra "" "" 0. MFake } :: gen.gmodules;
+				gen.gmodules <- { m_id = alloc_mid(); m_path = (t_path md); m_types = [md]; m_extra = module_extra "" "" 0. MFake [] } :: gen.gmodules;
 				Hashtbl.add gen.gtypes (t_path md) md;
 			end else gen.gafter_filters_ended <- (fun () ->
 				gen.gtypes_list <- md :: gen.gtypes_list;
-				gen.gmodules <- { m_id = alloc_mid(); m_path = (t_path md); m_types = [md]; m_extra = module_extra "" "" 0. MFake } :: gen.gmodules;
+				gen.gmodules <- { m_id = alloc_mid(); m_path = (t_path md); m_types = [md]; m_extra = module_extra "" "" 0. MFake [] } :: gen.gmodules;
 				Hashtbl.add gen.gtypes (t_path md) md;
 			) :: gen.gafter_filters_ended;
 		);

--- a/src/macro/interp.ml
+++ b/src/macro/interp.ml
@@ -131,7 +131,7 @@ type extern_api = {
 	format_string : string -> Globals.pos -> Ast.expr;
 	cast_or_unify : Type.t -> texpr -> Globals.pos -> Type.texpr;
 	add_global_metadata : string -> string -> (bool * bool * bool) -> unit;
-	add_module_check_policy : string list -> int list -> bool -> unit;
+	add_module_check_policy : string list -> int list -> bool -> int -> unit;
 }
 
 type callstack = {
@@ -2797,12 +2797,12 @@ let macro_lib =
 				error()
 		);
 		(* Compilation server *)
-		"server_add_module_check_policy", Fun3 (fun filter policy recursive ->
-			match filter,policy,recursive with
-			| VArray vl1, VArray vl2, VBool b ->
+		"server_add_module_check_policy", Fun4 (fun filter policy recursive context_options ->
+			match filter,policy,recursive,context_options with
+			| VArray vl1, VArray vl2, VBool b, VInt i ->
 				let sl = Array.fold_left (fun acc v -> match v with VString s -> (s :: acc) | _ -> error()) [] vl1 in
 				let il = Array.fold_left (fun acc v -> match v with VInt i -> (i :: acc) | _ -> error()) [] vl2 in
-				(get_ctx()).curapi.add_module_check_policy sl il b;
+				(get_ctx()).curapi.add_module_check_policy sl il b i;
 				VNull
 			| _ ->
 				error()

--- a/src/path.ml
+++ b/src/path.ml
@@ -111,3 +111,37 @@ let add_trailing_slash p =
 	else match p.[l-1] with
 		| '\\' | '/' -> p
 		| _ -> p ^ "/"
+
+let rec remove_trailing_slash p =
+	let l = String.length p in
+	if l = 0 then
+		"./"
+	else match p.[l-1] with
+		| '\\' | '/' -> remove_trailing_slash (String.sub p 0 (l - 1))
+		| _ -> p
+
+open Globals
+
+let find_directories target paths =
+	let target_dirs = List.map platform_name platforms in
+	let rec loop acc dir =
+		try
+			let entries = Sys.readdir dir in
+			Array.fold_left (fun acc file ->
+				match file with
+					| "." | ".." ->
+						acc
+					| _ when Sys.is_directory (dir ^ file) && file.[0] >= 'a' && file.[0] <= 'z' ->
+						if List.mem file target_dirs && file <> target then
+							acc
+						else begin
+							let full = (dir ^ file) in
+							loop (full :: acc) (full ^ "/")
+						end
+					| _ ->
+						acc
+			) acc entries;
+		with Sys_error _ ->
+			acc
+	in
+	List.fold_left (fun acc dir -> loop acc dir) [] paths

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -296,7 +296,7 @@ and module_def = {
 and module_def_extra = {
 	m_file : string;
 	m_sign : string;
-	m_check_policy : module_check_policy list;
+	mutable m_check_policy : module_check_policy list;
 	mutable m_time : float;
 	mutable m_dirty : bool;
 	mutable m_added : int;

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -46,6 +46,12 @@ and method_kind =
 	| MethDynamic
 	| MethMacro
 
+type module_check_policy =
+	| NoCheckFileTimeModification
+	| CheckFileContentModification
+	| NoCheckDependencies
+	| NoCheckShadowing
+
 type t =
 	| TMono of t option ref
 	| TEnum of tenum * tparams
@@ -290,6 +296,7 @@ and module_def = {
 and module_def_extra = {
 	m_file : string;
 	m_sign : string;
+	m_check_policy : module_check_policy list;
 	mutable m_time : float;
 	mutable m_dirty : bool;
 	mutable m_added : int;
@@ -390,7 +397,7 @@ let mk_class m path pos name_pos =
 		cl_restore = (fun() -> ());
 	}
 
-let module_extra file sign time kind =
+let module_extra file sign time kind policy =
 	{
 		m_file = file;
 		m_sign = sign;
@@ -405,6 +412,7 @@ let module_extra file sign time kind =
 		m_macro_calls = [];
 		m_if_feature = [];
 		m_features = Hashtbl.create 0;
+		m_check_policy = policy;
 	}
 
 
@@ -427,7 +435,7 @@ let null_module = {
 		m_id = alloc_mid();
 		m_path = [] , "";
 		m_types = [];
-		m_extra = module_extra "" "" 0. MFake;
+		m_extra = module_extra "" "" 0. MFake [];
 	}
 
 let null_class =

--- a/src/typing/typecore.ml
+++ b/src/typing/typecore.ml
@@ -77,6 +77,7 @@ type typer_globals = {
 	mutable hook_generate : (unit -> unit) list;
 	type_patches : (path, (string * bool, type_patch) Hashtbl.t * type_patch) Hashtbl.t;
 	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
+	mutable module_check_policies : (string list * module_check_policy list * bool) list;
 	mutable get_build_infos : unit -> (module_type * t list * class_field list) option;
 	delayed_macros : (unit -> unit) DynArray.t;
 	mutable global_using : (tclass * pos) list;
@@ -287,7 +288,7 @@ let create_fake_module ctx file =
 			m_id = alloc_mid();
 			m_path = (["$DEP"],file);
 			m_types = [];
-			m_extra = module_extra file (Common.get_signature ctx.com) (file_time file) MFake;
+			m_extra = module_extra file (Common.get_signature ctx.com) (file_time file) MFake [];
 		} in
 		Hashtbl.add fake_modules file mdep;
 		mdep

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -70,12 +70,16 @@ let transform_abstract_field com this_t a_t a f =
 	| _ ->
 		f
 
+let get_policy ctx mpath =
+	let sl1 = full_dot_path mpath mpath in
+	List.fold_left (fun acc (sl2,policy,recursive) -> if match_path recursive sl1 sl2 then policy @ acc else acc) [] ctx.g.module_check_policies
+
 let make_module ctx mpath file loadp =
 	let m = {
 		m_id = alloc_mid();
 		m_path = mpath;
 		m_types = [];
-		m_extra = module_extra (Path.unique_full_path file) (Common.get_signature ctx.com) (file_time file) (if ctx.in_macro then MMacro else MCode);
+		m_extra = module_extra (Path.unique_full_path file) (Common.get_signature ctx.com) (file_time file) (if ctx.in_macro then MMacro else MCode) (get_policy ctx mpath);
 	} in
 	m
 
@@ -3865,7 +3869,7 @@ let rec build_generic ctx c p tl =
 			m_id = alloc_mid();
 			m_path = (pack,name);
 			m_types = [];
-			m_extra = module_extra (s_type_path (pack,name)) m.m_extra.m_sign 0. MFake;
+			m_extra = module_extra (s_type_path (pack,name)) m.m_extra.m_sign 0. MFake m.m_extra.m_check_policy;
 		} in
 		gctx.mg <- Some mg;
 		let cg = mk_class mg (pack,name) c.cl_pos null_pos in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -4814,6 +4814,9 @@ let make_macro_api ctx p =
 				ctx.g.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: ctx.g.global_metadata;
 			) meta;
 		);
+		Interp.add_module_check_policy = (fun sl il b ->
+			ctx.g.module_check_policies <- (List.fold_left (fun acc s -> (ExtString.String.nsplit s ".",List.map Obj.magic il,b) :: acc) ctx.g.module_check_policies sl)
+		);
 	}
 
 let rec init_macro_interp ctx mctx mint =
@@ -5184,6 +5187,7 @@ let call_init_macro ctx e =
 		in
 		let path, meth = (match loop e with
 		| [meth] -> (["haxe";"macro"],"Compiler"), meth
+		| [meth;"server"] -> (["haxe";"macro"],"CompilationServer"), meth
 		| meth :: cl :: path -> (List.rev path,cl), meth
 		| _ -> error "Invalid macro call" p) in
 		ignore(call_macro ctx path meth args p);
@@ -5204,6 +5208,7 @@ let rec create com =
 			types_module = Hashtbl.create 0;
 			type_patches = Hashtbl.create 0;
 			global_metadata = [];
+			module_check_policies = [];
 			delayed = [];
 			debug_delayed = [];
 			delayed_macros = DynArray.create();

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -4817,6 +4817,7 @@ let make_macro_api ctx p =
 		Interp.add_module_check_policy = (fun sl il b i ->
 			let add ctx =
 				ctx.g.module_check_policies <- (List.fold_left (fun acc s -> (ExtString.String.nsplit s ".",List.map Obj.magic il,b) :: acc) ctx.g.module_check_policies sl);
+				Hashtbl.iter (fun _ m -> m.m_extra.m_check_policy <- Typeload.get_policy ctx m.m_path) ctx.g.modules;
 			in
 			let add_macro ctx = match ctx.g.macros with
 				| None -> ()

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -4814,8 +4814,18 @@ let make_macro_api ctx p =
 				ctx.g.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: ctx.g.global_metadata;
 			) meta;
 		);
-		Interp.add_module_check_policy = (fun sl il b ->
-			ctx.g.module_check_policies <- (List.fold_left (fun acc s -> (ExtString.String.nsplit s ".",List.map Obj.magic il,b) :: acc) ctx.g.module_check_policies sl)
+		Interp.add_module_check_policy = (fun sl il b i ->
+			let add ctx =
+				ctx.g.module_check_policies <- (List.fold_left (fun acc s -> (ExtString.String.nsplit s ".",List.map Obj.magic il,b) :: acc) ctx.g.module_check_policies sl);
+			in
+			let add_macro ctx = match ctx.g.macros with
+				| None -> ()
+				| Some(_,mctx) -> add mctx;
+			in
+			match Obj.magic i with
+			| CompilationServer.NormalContext -> add ctx
+			| CompilationServer.MacroContext -> add_macro ctx
+			| CompilationServer.NormalAndMacroContext -> add ctx; add_macro ctx;
 		);
 	}
 

--- a/std/haxe/macro/CompilationServer.hx
+++ b/std/haxe/macro/CompilationServer.hx
@@ -5,7 +5,7 @@ import haxe.macro.Compiler;
 @:enum
 abstract ModuleCheckPolicy(Int) {
 	/**
-		Disables file modification checks, avoiding some filsystem operations.
+		Disables file modification checks, avoiding some filesystem operations.
 	**/
 	var NoCheckFileTimeModification = 0;
 

--- a/std/haxe/macro/CompilationServer.hx
+++ b/std/haxe/macro/CompilationServer.hx
@@ -1,0 +1,66 @@
+package haxe.macro;
+
+import haxe.macro.Compiler;
+
+@:enum
+abstract ModuleCheckPolicy(Int) {
+	/**
+		Disables file modification checks, avoiding some filsystem operations.
+	**/
+	var NoCheckFileTimeModification = 0;
+
+	/**
+		If a file is modified, also checks if its content changed. This check
+		is not free, but useful when .hx files are auto-generated.
+	**/
+	var CheckFileContentModification = 1;
+
+	/**
+		Disables dependency checks of the module.
+	**/
+	var NoCheckDependencies = 2;
+
+	/**
+		Disables file shadowing checks. Shadowing can occur when a new file
+		is added to a class-path that has higher priority than the class-path
+		of the current module file.
+	**/
+	var NoCheckShadowing = 3;
+}
+
+/**
+	This class provides some methods which can be invoked from command line using
+	`--macro server.field(args)`.
+**/
+class CompilationServer {
+	#if neko
+
+	/**
+		Sets the `ModuleCheckPolicy` of all files whose dot-path matches an
+		element of `pathFilters`.
+
+		If `recursive` is true, a dot-path is considered matched if it starts
+		with the path filter. This automatically applies to path filters of
+		packages. Otherwise an exact match is required.
+
+		If an element in `pathFilters` is the empty String `""` it matches
+		everything (if `recursive = true`) or only top-level types (if
+		`recursive = false`).
+
+		If a call to this function is added to the compilation parameters, the
+		compilation server should be restarted to ensure it takes effect.
+	**/
+	static public function setModuleCheckPolicy(pathFilters:Array<String>, policy:Array<ModuleCheckPolicy>, ?recursive = true) {
+		pathFilters = [for (pathFilter in pathFilters) untyped pathFilter.__s];
+		@:privateAccess Compiler.load("server_add_module_check_policy", 3)(untyped pathFilters.__neko(), policy.__neko(), recursive);
+	}
+
+	/**
+		Invalidates all files given in `filePaths`, removing them from the cache.
+	**/
+	static public function invalidateFiles(filePaths:Array<String>) {
+		filePaths = [for (filePath in filePaths) untyped filePath.__s];
+		@:privateAccess Compiler.load("server_invalidate_files", 1)(untyped filePaths.__neko());
+	}
+	#end
+}

--- a/std/haxe/macro/CompilationServer.hx
+++ b/std/haxe/macro/CompilationServer.hx
@@ -28,6 +28,23 @@ abstract ModuleCheckPolicy(Int) {
 	var NoCheckShadowing = 3;
 }
 
+@:enum abstract ContextOptions(Int) {
+	/**
+		Affects only the normal context.
+	**/
+	var NormalContext = 0;
+
+	/**
+		Affects only the macro context.
+	**/
+	var MacroContext = 1;
+
+	/**
+		Affects the normal and macro contexts.
+	**/
+	var NormalAndMacroContext = 2;
+}
+
 /**
 	This class provides some methods which can be invoked from command line using
 	`--macro server.field(args)`.
@@ -47,12 +64,15 @@ class CompilationServer {
 		everything (if `recursive = true`) or only top-level types (if
 		`recursive = false`).
 
+		The argument `contextOptions` determines which context (normal, macro
+		or both) this affects.
+
 		If a call to this function is added to the compilation parameters, the
 		compilation server should be restarted to ensure it takes effect.
 	**/
-	static public function setModuleCheckPolicy(pathFilters:Array<String>, policy:Array<ModuleCheckPolicy>, ?recursive = true) {
+	static public function setModuleCheckPolicy(pathFilters:Array<String>, policy:Array<ModuleCheckPolicy>, ?recursive = true, ?contextOptions:ContextOptions = NormalContext) {
 		pathFilters = [for (pathFilter in pathFilters) untyped pathFilter.__s];
-		@:privateAccess Compiler.load("server_add_module_check_policy", 3)(untyped pathFilters.__neko(), policy.__neko(), recursive);
+		@:privateAccess Compiler.load("server_add_module_check_policy", 4)(untyped pathFilters.__neko(), policy.__neko(), recursive, contextOptions);
 	}
 
 	/**


### PR DESCRIPTION
This adds a (currently small) API to interact with the compilation server. Right now we only support setting module caching policies and clearing files.

I acknowledge that it's possible to shoot yourself in the foot with this, but it's not really intended for the typical Haxe end-user anyway. The main focus here is IDEs and haxelib.

I'm testing this in an empty HaxeFlixel project. This is the compilation --times output without any flags:

```
name            | time(s) |   % |     # | info
-----------------------------------------
analyzer        |   0.479 |  23 | 49230 | 
filters         |   0.414 |  20 |     1 | 
generate        |   0.207 |  10 |     1 | 
  swf           |   0.207 |  10 |     1 | 
macro           |   0.125 |   6 |   183 | 
other           |   0.163 |   8 |     1 | 
parsing         |   0.001 |   0 |     4 | 
read            |   0.001 |   0 |     2 | 
  swf           |   0.001 |   0 |     2 | 
server          |   0.266 |  13 |  7223 | 
  module cache  |   0.266 |  13 |  7223 | 
    add modules |   0.052 |   3 |   185 | 
    check       |   0.209 |  10 |   513 | 
typing          |   0.344 |  17 |   151 | 
write           |   0.077 |   4 |     1 | 
  swf           |   0.077 |   4 |     1 | 
-----------------------------------------
total           |   2.078 | 100 |     0 | 
```

Next up is using `<haxeflag name="--macro server.setModuleCheckPolicy(['DefaultAssetLibrary'], [CheckFileContentModification])"/>`, which deals with an auto-generated OpenFL file that is a dependency of a lot of modules:

```
name            | time(s) |   % |    # | info
----------------------------------------
analyzer        |   0.007 |   1 | 1226 | 
filters         |   0.213 |  24 |    1 | 
generate        |   0.163 |  18 |    1 | 
  swf           |   0.163 |  18 |    1 | 
macro           |   0.038 |   4 |   13 | 
other           |   0.084 |  10 |    1 | 
parsing         |   0.002 |   0 |    4 | 
read            |   0.001 |   0 |    2 | 
  swf           |   0.001 |   0 |    2 | 
server          |   0.285 |  32 |   92 | 
  module cache  |   0.285 |  32 |   92 | 
    add modules |   0.144 |  16 |   11 | 
    check       |   0.141 |  16 |   17 | 
typing          |   0.010 |   1 |    1 | 
write           |   0.080 |   9 |    1 | 
  swf           |   0.080 |   9 |    1 | 
----------------------------------------
total           |   0.882 | 100 |    0 | 
```

And finally with `<haxeflag name="--macro server.setModuleCheckPolicy(['flash', 'openfl', 'flixel', 'lime', 'haxe'], [NoCheckShadowing], true)"/>` to tell the compiler that we aren't gonna shadow any of the files in the listed packages:

```
name            | time(s) |   % |    # | info
----------------------------------------
analyzer        |   0.006 |   1 | 1226 | 
filters         |   0.205 |  36 |    1 | 
generate        |   0.180 |  31 |    1 | 
  swf           |   0.180 |  31 |    1 | 
macro           |   0.018 |   3 |   15 | 
other           |   0.007 |   1 |    1 | 
parsing         |   0.001 |   0 |    4 | 
read            |   0.001 |   0 |    2 | 
  swf           |   0.001 |   0 |    2 | 
server          |   0.062 |  11 |   92 | 
  module cache  |   0.062 |  11 |   92 | 
    add modules |   0.009 |   2 |   11 | 
    check       |   0.052 |   9 |   17 | 
typing          |   0.008 |   1 |    1 | 
write           |   0.085 |  15 |    1 | 
  swf           |   0.085 |  15 |    1 | 
----------------------------------------
total           |   0.573 | 100 |    0 |
```

Field completion times are roughly as follows:

1. uncached: 500ms
2. cached: 130ms
3. with DefaultAssetLibrary fix: 130ms (no difference because it's not re-generated on compilation)
4. also with shadowing ignore: 55ms
5. also with dependency ignore: 25ms (this is probably not safe though)
