### PR TITLE
Rework assign-op/unop handling

### DIFF
--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -1241,9 +1241,7 @@ module Run = struct
 			| Some f -> process_field false f;
 		end;
 		begin match c.cl_init with
-			| None ->
-				()
-			| Some e ->
+			| Some e when not (Common.defined ctx.Typecore.com Define.As3) ->
 				let tf = { tf_args = []; tf_type = e.etype; tf_expr = e; } in
 				let e = mk (TFunction tf) (tfun [] e.etype) e.epos in
 				let actx = create_analyzer_context ctx.Typecore.com {config with optimize = false} e in
@@ -1253,6 +1251,8 @@ module Run = struct
 					| _ -> assert false
 				in
 				c.cl_init <- Some e
+			| _ ->
+				()
 		end
 
 	let run_on_type ctx config t =

--- a/src/optimization/filters.ml
+++ b/src/optimization/filters.ml
@@ -807,6 +807,7 @@ let add_field_inits ctx t =
 		let ethis = mk (TConst TThis) (TInst (c,List.map snd c.cl_params)) c.cl_pos in
 		(* TODO: we have to find a variable name which is not used in any of the functions *)
 		let v = alloc_var "_g" ethis.etype ethis.epos in
+		v.v_capture <- true; (* IF we use it it's gonna be a captured var *)
 		let need_this = ref false in
 		let inits,fields = List.fold_left (fun (inits,fields) cf ->
 			match cf.cf_kind,cf.cf_expr with

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -42,7 +42,8 @@ class ObjectMap<K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 	}
 
 	public function set(key:K, value:V):Void untyped {
-		var id : Int = getId(key) || assignId(key);
+		var id : Int = getId(key);
+		if (id == null) id = assignId(key);
 		h[id] = value;
 		h.__keys__[id] = key;
 	}

--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -798,7 +798,8 @@ class _hx_type {
 
 	public function __set($n, $v) {
 		if(($r = $this->__rfl__())==null) return null;
-		return $r->setStaticPropertyValue($n, $v);
+		$cls = $this->__tname__;
+		$cls::${$n} = $v;
 	}
 
 	public function __isset($n) {

--- a/tests/optimization/run.hxml
+++ b/tests/optimization/run.hxml
@@ -1,5 +1,6 @@
 -cp src
 -D analyzer-user-var-fusion
+-D analyzer-no-op-reconstruction
 --each
 
 -main TestAnalyzer

--- a/tests/optimization/src/issues/Issue2236.hx
+++ b/tests/optimization/src/issues/Issue2236.hx
@@ -1,42 +1,50 @@
 package issues;
 
 private class ArrayIterator<T> {
-    var a : Array<T>;
-    var pos : Int;
-    public inline function new(a) {
-        this.a = a;
-        this.pos = 0;
-    }
-    public inline function hasNext() {
-        return pos < a.length;
-    }
-    public inline function next() {
-        return a[pos++];
-    }
+	var a : Array<T>;
+	var pos : Int;
+	public inline function new(a) {
+		this.a = a;
+		this.pos = 0;
+	}
+	public inline function hasNext() {
+		return pos < a.length;
+	}
+	public inline function next() {
+		return a[pos++];
+	}
 }
 
 private abstract ArrayRead<T>(Array<T>) {
 
-    public inline function new(a) {
-        this = a;
-    }
+	public inline function new(a) {
+		this = a;
+	}
 
-    function toArray() : Array<T> {
-        return this;
-    }
+	function toArray() : Array<T> {
+		return this;
+	}
 
-    public inline function iterator() : ArrayIterator<T> {
-        return new ArrayIterator(this);
-    }
+	public inline function iterator() : ArrayIterator<T> {
+		return new ArrayIterator(this);
+	}
 
 }
 
 class Issue2236 {
+	#if analyzer_no_op_reconstruction
+	@:js('
+		var _g_a = [0];
+		var _g_pos = 0;
+		while(_g_pos < _g_a.length) _g_pos = _g_pos + 1;
+	')
+	#else
 	@:js('
 		var _g_a = [0];
 		var _g_pos = 0;
 		while(_g_pos < _g_a.length) ++_g_pos;
 	')
+	#end
 	static function test() {
 		var a = new ArrayRead([0]);
 		for( x in a ) {


### PR DESCRIPTION
This is part 1 of a 2-step plan:

1. Get rid of all increment/decrement unops and OpAssignOps.
2. Reconstruct them on targets that know how to deal with them.

The idea is to stabilize this first because it _should_ be a safe transformation to make. Afterwards we can do the reconstruction, which requires figuring out which targets require special attention here. This is what I know about:

* Lua and Python don't like unops and assign ops.
* Php is supposed to handle assign ops but has some problems with evaluation order, so we should simply not reconstruct them.
* C# has some issues with assign ops that involve `Null<T>` (not sure about unops).
* C++ is currently set to not reconstruct assign ops, but I'm not sure why.

Anything else?