### PR TITLE
Require Pointer.addressOf to take a variable as argument

### DIFF
--- a/std/cpp/Pointer.hx
+++ b/std/cpp/Pointer.hx
@@ -21,6 +21,8 @@
  */
  package cpp;
 
+import haxe.extern.AsVar;
+
 @:coreType
 extern class Pointer<T> extends ConstPointer<T> implements ArrayAccess<T>
 {
@@ -42,7 +44,7 @@ extern class Pointer<T> extends ConstPointer<T> implements ArrayAccess<T>
 
    public static function fromPointer<T>(inNativePointer:Dynamic) : Pointer<T>;
 
-   public static function addressOf<T>(inVariable:T) : Pointer<T>;
+   public static function addressOf<T>(inVariable:AsVar<T>) : Pointer<T>;
 
    public static function endOf<T:{}>(inVariable:T) : Pointer<cpp.Void>;
 


### PR DESCRIPTION
Fixes an issue where the variable used in Pointer.addressOf gets value-inlined in the call.

```haxe
class Test {
    public static function main () {
        var i = 0;
        trace(cpp.Pointer.addressOf(i).get_raw());
    }
}
```
```
./src/Test.cpp: In static member function ‘static void Test_obj::main()’:
./src/Test.cpp:29:67: error: no matching function for call to ‘cpp::Pointer_obj::addressOf(int)’
 HXDLIN(   4)  int* _hx_tmp1 = ::cpp::Pointer_obj::addressOf((int)0)->get_raw();
                                                                   ^
./src/Test.cpp:29:67: note: candidate is:
In file included from /home/ibilon/Code/Haxe/libs/hxcpp/include/hxcpp.h:336:0:
/home/ibilon/Code/Haxe/libs/hxcpp/include/cpp/Pointer.h:514:27: note: static cpp::Pointer<T> cpp::Pointer_obj::addressOf(T&) [with T = int]
  inline static Pointer<T> addressOf(T &value)  { return Pointer<T>(&value); }
                           ^
/home/ibilon/Code/Haxe/libs/hxcpp/include/cpp/Pointer.h:514:27: note:   no known conversion for argument 1 from ‘int’ to ‘int&’
Error: Build failed
```