### PR TITLE
[display] add null, false and true to toplevel completion

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -207,6 +207,7 @@ module IdentifierType = struct
 		| ITGlobal of module_type * string * Type.t
 		| ITType of module_type
 		| ITPackage of string
+		| ITLiteral of string
 		| ITTimer of string
 
 	let get_name = function
@@ -216,6 +217,7 @@ module IdentifierType = struct
 		| ITGlobal(_,s,_) -> s
 		| ITType mt -> snd (t_infos mt).mt_path
 		| ITPackage s -> s
+		| ITLiteral s -> s
 		| ITTimer s -> s
 end
 

--- a/src/display/display.ml
+++ b/src/display/display.ml
@@ -847,6 +847,11 @@ module ToplevelCollector = struct
 				with Not_found ->
 					()
 			) ctx.m.module_globals;
+
+			(* literals *)
+			DynArray.add acc (ITLiteral "null");
+			DynArray.add acc (ITLiteral "true");
+			DynArray.add acc (ITLiteral "false");
 		end;
 
 		let module_types = ref [] in

--- a/src/display/displayOutput.ml
+++ b/src/display/displayOutput.ml
@@ -78,6 +78,8 @@ let print_toplevel il =
 			Buffer.add_string b (Printf.sprintf "<i k=\"type\" p=\"%s\"%s>%s</i>\n" (s_type_path infos.mt_path) (s_doc infos.mt_doc) (snd infos.mt_path));
 		| IdentifierType.ITPackage s ->
 			Buffer.add_string b (Printf.sprintf "<i k=\"package\">%s</i>\n" s)
+		| IdentifierType.ITLiteral s ->
+			Buffer.add_string b (Printf.sprintf "<i k=\"literal\">%s</i>\n" s)
 		| IdentifierType.ITTimer s ->
 			Buffer.add_string b (Printf.sprintf "<i k=\"timer\">%s</i>\n" s)
 	) il;


### PR DESCRIPTION
Right now, when typing something with `null`, vshaxe will suggest `Null` instead:

![](http://i.imgur.com/YvXfbvG.gif)

This is mildly annoying - if you press enter, you end up with incorrect code. The simple fix is to provide `null` in toplevel completion as well, providing an exact match.

![](http://i.imgur.com/PScBq8m.gif)

The same is true for `true` and `false`.

This is a pretty common approach, `null`, `false` and `true` are all suggested by FD's auto-comletion for instance.