### PR TITLE
Allow multiple inheritance on externs

### DIFF
--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -1443,14 +1443,13 @@ module Inheritance = struct
 		(* Pass 1: Check and set relations *)
 		let check_herit t is_extends =
 			if is_extends then begin
-				let extern_multiple_extend = c.cl_super <> None && c.cl_extern in
-				if c.cl_super <> None && not c.cl_extern then error "Cannot extend several classes" p;
+				let extern_multiple_extends = match c.cl_super,c.cl_extern with None,_ -> false | Some _,true -> true | Some _,false -> error "Cannot extend several classes" p in
 				let csup,params = check_extends ctx c t p in
-				if c.cl_interface || extern_multiple_extend then begin
-					if not csup.cl_interface && not extern_multiple_extend then error "Cannot extend by using a class" p;
-					if csup.cl_interface && extern_multiple_extend then error "Cannot extend by using an interface" p;
+				if c.cl_interface || extern_multiple_extends then begin
+					if not csup.cl_interface && not extern_multiple_extends then error "Cannot extend by using a class" p;
+					if csup.cl_interface && extern_multiple_extends then error "Cannot extend by using an interface" p;
 					c.cl_implements <- (csup,params) :: c.cl_implements;
-					if extern_multiple_extend then begin
+					if extern_multiple_extends then begin
 						PMap.iter (fun id f ->
 							c.cl_fields <- PMap.add id f c.cl_fields;
 						) csup.cl_fields

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -1368,7 +1368,7 @@ module Inheritance = struct
 							display_error ctx (error_msg (Unify l)) p;
 						end
 			with
-				| Not_found when not c.cl_interface ->
+				| Not_found when not c.cl_interface && not c.cl_extern ->
 					let msg = if !is_overload then
 						let ctx = print_context() in
 						let args = match follow f.cf_type with | TFun(args,_) -> String.concat ", " (List.map (fun (n,o,t) -> (if o then "?" else "") ^ n ^ " : " ^ (s_type ctx t)) args) | _ -> assert false in
@@ -1449,11 +1449,6 @@ module Inheritance = struct
 					if not csup.cl_interface && not extern_multiple_extends then error "Cannot extend by using a class" p;
 					if csup.cl_interface && extern_multiple_extends then error "Cannot extend by using an interface" p;
 					c.cl_implements <- (csup,params) :: c.cl_implements;
-					if extern_multiple_extends then begin
-						PMap.iter (fun id f ->
-							c.cl_fields <- PMap.add id f c.cl_fields;
-						) csup.cl_fields
-					end;
 					if not !has_interf then begin
 						if not is_lib then delay ctx PForce (fun() -> check_interfaces ctx c);
 						has_interf := true;


### PR DESCRIPTION
See https://github.com/HaxeFoundation/haxe/issues/5297

Useful when making hxcpp extern since c++ has this and some libraries uses it.

More hacky than making cl_super a list but less invasive, considering only externs can do it.