### PR TITLE
[js] generate ternary operator with spaces

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -941,9 +941,9 @@ and gen_value ctx e =
 			| _ -> cond
 		) in
 		gen_value ctx cond;
-		spr ctx "?";
+		spr ctx " ? ";
 		gen_value ctx e;
-		spr ctx ":";
+		spr ctx " : ";
 		(match eo with
 		| None -> spr ctx "null"
 		| Some e -> gen_value ctx e);

--- a/tests/optimization/src/issues/Issue5477.hx
+++ b/tests/optimization/src/issues/Issue5477.hx
@@ -2,7 +2,7 @@ package issues;
 
 class Issue5477 {
 	@:js('
-		issues_Issue5477["use"](issues_Issue5477.pureUse(12) > 0.5?1:issues_Issue5477.pureUse(12));
+		issues_Issue5477["use"](issues_Issue5477.pureUse(12) > 0.5 ? 1 : issues_Issue5477.pureUse(12));
 	')
 	static function testIssue5477() {
 		var v = pureUse(12);


### PR DESCRIPTION
The ternary always seems to generate without spaces while the rest generates spaces around anything. This should add spaces around the `?` and `:`.