### PR TITLE
Positive / negative infinity are members of the Number class in AS3

### DIFF
--- a/src/generators/genas3.ml
+++ b/src/generators/genas3.ml
@@ -556,8 +556,8 @@ and gen_field_access ctx t s =
 	let field c =
 		match fst c.cl_path, snd c.cl_path, s with
 		| [], "Math", "NaN"
-		| [], "Math", "NEGATIVE_INFINITY"
-		| [], "Math", "POSITIVE_INFINITY"
+		| [], "Number", "NEGATIVE_INFINITY"
+		| [], "Number", "POSITIVE_INFINITY"
 		| [], "Math", "isFinite"
 		| [], "Math", "isNaN"
 		| [], "Date", "now"


### PR DESCRIPTION
See: http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/Number.html

Current output is: Math["POSITIVE_INFINITY"], which is undefined, and when assigned to a Number, results in NaN. Number["POSITIVE_INFINITY"] works.

Testcase:

```
class Test
{
  static function main() {
    var inf:Float = Math.POSITIVE_INFINITY;
    trace("inf is: "+inf);
  }
}
```

Compiles to:
```
package  {
	import haxe.Log;
	public class Test {
		static public function main() : void {
			var inf : Number = Math["POSITIVE_INFINITY"];
			(haxe.Log._trace)("inf is: " + inf,{ fileName : "Test.hx", lineNumber : 7, className : "Test", methodName : "main"});
		}
		
	}
}
```

And (slightly modified for textfield):
![selection_999 166](https://cloud.githubusercontent.com/assets/2192439/21164587/417b1064-c157-11e6-809e-0664af7b1691.png)

Fixed:
![selection_999 168](https://cloud.githubusercontent.com/assets/2192439/21164612/77e6f2bc-c157-11e6-9303-f608fbe871e2.png)
