### PR TITLE
User-defined modules in renamed packages (fixes #5921)

### DIFF
--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -3511,19 +3511,25 @@ let type_module ctx mpath file ?(is_extern=false) tdecls p =
 
 let resolve_module_file com m remap p =
 	let forbid = ref false in
-	let file = (match m with
+	let compose_path no_rename =
+		(match m with
 		| [] , name -> name
 		| x :: l , name ->
 			let x = (try
 				match PMap.find x com.package_rules with
 				| Forbidden -> forbid := true; x
-				| Directory d -> d
+				| Directory d -> if no_rename then x else d
 				| Remap d -> remap := d :: l; d
 				with Not_found -> x
 			) in
 			String.concat "/" (x :: l) ^ "/" ^ name
-	) ^ ".hx" in
-	let file = Common.find_file com file in
+		) ^ ".hx"
+	in
+	let file = try
+			Common.find_file com (compose_path false)
+		with Not_found ->
+			Common.find_file com (compose_path true)
+	in
 	let file = (match String.lowercase (snd m) with
 	| "con" | "aux" | "prn" | "nul" | "com1" | "com2" | "com3" | "lpt1" | "lpt2" | "lpt3" when Sys.os_type = "Win32" ->
 		(* these names are reserved by the OS - old DOS legacy, such files cannot be easily created but are reported as visible *)


### PR DESCRIPTION
If user defines any modules in `php` package then compiler cannot find them, because we expect all such modules to be located in `php7` directory.
This PR makes compiler to look into `php` directory if module is not found in `php7`.