### PR TITLE
Fix EnumFlags.unset

### DIFF
--- a/std/haxe/EnumFlags.hx
+++ b/std/haxe/EnumFlags.hx
@@ -73,7 +73,7 @@ abstract EnumFlags<T:EnumValue>(Int) {
 		If `v` is null, the result is unspecified.
 	**/
 	public inline function unset( v : T ) : Void {
-		this &= 0xFFFFFFF - (1 << Type.enumIndex(v));
+		this &= 0xFFFFFFFF - (1 << Type.enumIndex(v));
 	}
 
 	/**

--- a/tests/unit/src/unit/TestSpecification.hx
+++ b/tests/unit/src/unit/TestSpecification.hx
@@ -113,6 +113,13 @@ enum EnumFlagTest {
 	EC;
 }
 
+enum EnumFlagTest2 {
+	EF_00; EF_01; EF_02; EF_03; EF_04; EF_05; EF_06; EF_07;
+	EF_08; EF_09; EF_10; EF_11; EF_12; EF_13; EF_14; EF_15;
+	EF_16; EF_17; EF_18; EF_19; EF_20; EF_21; EF_22; EF_23;
+	EF_24; EF_25; EF_26; EF_27; EF_28; EF_29; EF_30; EF_31;
+}
+
 enum EVMTest {
 	EVMA;
 	EVMB(?s:String);

--- a/tests/unit/src/unitstd/haxe/EnumFlags.unit.hx
+++ b/tests/unit/src/unitstd/haxe/EnumFlags.unit.hx
@@ -41,3 +41,11 @@ flags.unset(EA);
 flags.has(EA) == false;
 flags.has(EB) == true;
 flags.has(EC) == false;
+
+// Big Enum (32)
+var bigFlags = new haxe.EnumFlags(1<<31);
+bigFlags.has( EF_31 ) == true;
+bigFlags.unset( EF_31 );
+bigFlags.has( EF_31 ) == false;
+bigFlags.set( EF_31 );
+bigFlags.has( EF_31 ) == true;


### PR DESCRIPTION
Fixes haxe.EnumFlags.unset() for enum indexes 28 to 31.