### PR TITLE
Fixed missing separator after __properties__

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1104,6 +1104,7 @@ let generate_class ctx c =
 		| [] -> ()
 		| props ->
 			print ctx "%s.__properties__ = {%s}" p (gen_props props);
+			ctx.separator <- true;
 			newline ctx);
 	end;
 


### PR DESCRIPTION
This fixes a missing separator in the .__properties__ attribute.
Generated code used to be like this:
```
format_swf__$SWFData_SWFData_$Impl_$.__name__ = ["format","swf","_SWFData","SWFData_Impl_"];
format_swf__$SWFData_SWFData_$Impl_$.__properties__ = {set_length:"set_length",get_length:"get_length"}
format_swf__$SWFData_SWFData_$Impl_$._new = function() {
```

Now is like this:
```
format_swf__$SWFData_SWFData_$Impl_$.__name__ = ["format","swf","_SWFData","SWFData_Impl_"];
format_swf__$SWFData_SWFData_$Impl_$.__properties__ = {set_length:"set_length",get_length:"get_length"};
format_swf__$SWFData_SWFData_$Impl_$._new = function() {
```

Notice the ; after the } of properties.