### PR TITLE
[php7] Actually withdraw fetched row

### DIFF
--- a/std/php7/_std/sys/db/Mysql.hx
+++ b/std/php7/_std/sys/db/Mysql.hx
@@ -180,7 +180,9 @@ private class MysqlResultSet implements ResultSet {
 
 	function withdrawFetched() : Dynamic {
 		if (fetchedRow == null) return null;
-		return Boot.createAnon(fetchedRow);
+		var row = fetchedRow;
+		fetchedRow = null;
+		return Boot.createAnon(row);
 	}
 
 	function correctArrayTypes(row:NativeAssocArray<String>):NativeAssocArray<Scalar> {

--- a/tests/unit/src/unit/MySpodClass.hx
+++ b/tests/unit/src/unit/MySpodClass.hx
@@ -104,3 +104,7 @@ abstract AbstractSpodTest<A>(A) from A
 
 @:keep class IssueC3828 extends BaseIssueC3828 {
 }
+
+@:keep class Issue6041Table extends Object {
+	public var id:SInt = 0;
+}

--- a/tests/unit/src/unit/TestSpod.hx
+++ b/tests/unit/src/unit/TestSpod.hx
@@ -27,12 +27,14 @@ class TestSpod extends Test
 		try cnx.request('DROP TABLE ClassWithStringId') catch(e:Dynamic) {}
 		try cnx.request('DROP TABLE ClassWithStringIdRef') catch(e:Dynamic) {}
 		try cnx.request('DROP TABLE IssueC3828') catch(e:Dynamic) {}
+		try cnx.request('DROP TABLE Issue6041Table') catch(e:Dynamic) {}
 		TableCreate.create(MySpodClass.manager);
 		TableCreate.create(OtherSpodClass.manager);
 		TableCreate.create(NullableSpodClass.manager);
 		TableCreate.create(ClassWithStringId.manager);
 		TableCreate.create(ClassWithStringIdRef.manager);
 		TableCreate.create(IssueC3828.manager);
+		TableCreate.create(Issue6041Table.manager);
 	}
 
 	private function setManager()
@@ -166,6 +168,19 @@ class TestSpod extends Test
 		var u2 = IssueC3828.manager.search($refUser == u1).first();
 		eq(u1.id, u1id);
 		eq(u2.id, u2id);
+	}
+
+	public function testIssue6041()
+	{
+		setManager();
+		var item = new Issue6041Table();
+		item.insert();
+		var result = cnx.request('SELECT * FROM Issue6041Table LIMIT 1');
+		var amount = 1;
+		for(row in result) {
+			if(--amount < 0) throw "Invalid amount of rows in result";
+		}
+		eq(amount, 0);
 	}
 
 	public function testStringIdRel()


### PR DESCRIPTION
Using the mysql resultset in a simple for loop caused everything to hang for me. The `hasNext` method checks if `fetchedRow` is not `null` but it seems `fetchedRow` is never cleared. I assume that's what the `withdrawFetched` method is for, but wasn't actually implemented.