### PR TITLE
[php7] Remove null from getPostData

### DIFF
--- a/std/php7/Web.hx
+++ b/std/php7/Web.hx
@@ -269,13 +269,15 @@ class Web {
 		var h = fopen("php://input", "r");
 		var bsize = 8192;
 		var max = 32;
-		var data : String = null;
+		var data = '';
 		var counter = 0;
 		while (!feof(h) && counter < max) {
 			data = Syntax.binop(data, ' . ', fread(h, bsize));
 			counter++;
 		}
 		fclose(h);
+		if (counter == 0) 
+			return null;
 		return data;
 	}
 


### PR DESCRIPTION
The current behaviour causes post data to be prefixed with `null` (as string).  
For example if I expected a post body of `test`, I'd actually get `nulltest`. 