### PR TITLE
[php7] use strlen for strings in FileInput.readBytes

### DIFF
--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -2395,6 +2395,10 @@ class virtual type_builder ctx wrapper =
 					self#write "strlen(";
 					self#write_expr expr;
 					self#write ")"
+				| (_, FInstance ({ cl_path = [], "String"}, _, { cf_name = "length"; cf_kind = Var _ })) ->
+					self#write "strlen(";
+					self#write_expr expr;
+					self#write ")"
 				| (_, FInstance (_, _, field)) -> write_access "->" (field_name field)
 				| (_, FStatic (_, ({ cf_kind = Var _ } as field))) ->
 					(match (reveal_expr expr).eexpr with

--- a/tests/sys/src/io/TestFileInput.hx
+++ b/tests/sys/src/io/TestFileInput.hx
@@ -1,5 +1,6 @@
 package io;
 
+import haxe.io.Bytes;
 import sys.io.FileInput;
 import sys.FileSystem;
 import sys.io.File;
@@ -34,6 +35,14 @@ class TestFileInput extends haxe.unit.TestCase {
 		assertEquals(116, file.readByte());
 		assertEquals(4, file.tell());
 		file.close();
+	}
+
+	public function testReadBytes() {
+		var file : FileInput = File.read(path);
+		var bytes : Bytes = Bytes.alloc (9);
+		var count = file.readBytes(bytes, 0, 9);
+		assertEquals(9, count);
+		assertEquals(116, bytes.get(0));
 	}
 
 	public function testSeekBeginCur() {

--- a/tests/sys/src/io/TestFileInput.hx
+++ b/tests/sys/src/io/TestFileInput.hx
@@ -43,6 +43,7 @@ class TestFileInput extends haxe.unit.TestCase {
 		var count = file.readBytes(bytes, 0, 9);
 		assertEquals(9, count);
 		assertEquals(116, bytes.get(0));
+		file.close();
 	}
 
 	public function testSeekBeginCur() {


### PR DESCRIPTION
When trying to use FileInput.readBytes with php7, I get a PHP error: `Trying to get property of non-object in out/lib/sys/io/FileInput.php:xx`, pointing to the line containing `$r1 = $r->length;` which tries to access field `length` of a php string instance, instead of using `strlen`.

Initially I tried to fix it in `std`, but that didn't feel like it's the correct place. So I went and modified the generator code instead (with the hope and risk of affecting more than just that one usecase). 
I am not an ocaml expert and I am not sure, if my patch is corect or if it should completely replace the pattern prio to it, or if it needs additional treatment. So please let me know what corrections I should make.
