### PR TITLE
[php7] fix recursive call in MysqlConnection.close

### DIFF
--- a/std/php7/_std/sys/db/Mysql.hx
+++ b/std/php7/_std/sys/db/Mysql.hx
@@ -69,7 +69,7 @@ private class MysqlConnection implements Connection {
 	}
 
 	public function close() : Void {
-		close();
+		db.close();
 	}
 
 	public function escape( s : String ) : String {


### PR DESCRIPTION
PHP ends up in a recursive loop when trying to close a Mysql connection.