### PR TITLE
UNC paths are absolute paths as well

### DIFF
--- a/std/haxe/io/Path.hx
+++ b/std/haxe/io/Path.hx
@@ -301,6 +301,7 @@ class Path {
 	public static function isAbsolute ( path : String ) : Bool {
 		if (StringTools.startsWith(path, '/')) return true;
 		if (path.charAt(1) == ':') return true;
+		if (StringTools.startsWith(path, '\\\\')) return true;
 		return false;
 	}
 


### PR DESCRIPTION
While working with the file system @back2dos was right to suggest this change. More infos here: https://groups.google.com/forum/#!topic/haxelang/aP4fQWiEmD4