### PR TITLE
update getLocalStorage/getSessionStorage check

### DIFF
--- a/std/js/Browser.hx
+++ b/std/js/Browser.hx
@@ -63,6 +63,11 @@ class Browser {
 		try {
 			var s = window.localStorage;
 			s.getItem("");
+			if (s.length == 0) {
+				var key = "_hx_" + Math.random();
+				s.setItem(key,key);
+				s.removeItem(key);
+			}
 			return s;
 		} catch( e : Dynamic ) {
 			return null;
@@ -78,6 +83,11 @@ class Browser {
 		try {
 			var s = window.sessionStorage;
 			s.getItem("");
+			if (s.length == 0) {
+				var key = "_hx_" + Math.random();
+				s.setItem(key,key);
+				s.removeItem(key);
+			}
 			return s;
 		} catch( e : Dynamic ) {
 			return null;


### PR DESCRIPTION
Closes #6050

If you are browsing private on iOS, localstorage is available but you cannot write in it. It'll throw "QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota."

This can be solved in the detection of localstorage by trying to write something in storage.