### PR TITLE
Use Ocamlfind

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 env:
   global:
     # make variables
-    - OCAMLC=ocamlc.opt
-    - OCAMLOPT=ocamlopt.opt
     - ADD_REVISION=1
     # SauceLabs
     # - secure: SjyKefmjUEXi0IKHGGpcbLAajU0mLHONg8aA8LoY7Q9nAkSN6Aql+fzS38Boq7w1jWn+2FOpr+4jy0l6wVd/bftsF+huFfYpFJmdh8BlKmE0K71zZAral0H1c7YxkuQpPiJCIFGXqtkvev7SWTy0z31u7kuuQeEyW27boXe5cDA=
@@ -28,7 +26,7 @@ install_linux: &install_linux
   # Install opam + ocaml
   - sudo wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sh -s /usr/local/bin 4.02.3
   - export OPAMYES=1
-  - opam install camlp4
+  - opam install camlp4 ocamlfind
   - eval `opam config env`
   # Install neko and haxe dependencies
   - sudo add-apt-repository ppa:haxe/snapshots -y
@@ -61,7 +59,11 @@ install_osx: &install_osx
   # Install haxe dependencies
   - brew uninstall --force brew-cask # https://github.com/caskroom/homebrew-cask/pull/15381
   - travis_retry brew update
-  - travis_retry brew install ocaml camlp4;
+  - travis_retry brew install opam;
+  - export OPAMYES=1
+  - opam init
+  - opam install camlp4 ocamlfind
+  - eval `opam config env`
   # Install neko
   - travis_retry brew install neko --HEAD;
   # Setup database

--- a/Makefile.win
+++ b/Makefile.win
@@ -5,8 +5,6 @@ OUTPUT=haxe.exe
 EXTENSION=.exe
 PACKAGE_SRC_EXTENSION=.zip
 
-OCAMLOPT=ocamlopt.opt
-
 kill:
 	-@taskkill /F /IM haxe.exe
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
         HAXELIB_ROOT: C:/projects/haxelib
         CYG_ROOT: C:/cygwin
         ADD_REVISION: 1
-        OCAMLOPT: ocamlopt.opt
         MYSQL_PATH: C:\Program Files\MySQL\MySQL Server 5.7
         MYSQL_USER: root
         MYSQL_PASSWORD: Password12!
@@ -35,7 +34,7 @@ install:
     - 7z x "opam32.tar.xz" -so | 7z x -aoa -si -ttar
     - '%CYG_ROOT%/bin/bash -lc "cd \"$OLDPWD\" && bash opam32/install.sh"'
     - '%CYG_ROOT%/bin/bash -lc "opam init mingw \"https://github.com/fdopen/opam-repository-mingw.git\" --comp 4.02.3+mingw32c --switch 4.02.3+mingw32c --auto-setup --yes"'
-    - '%CYG_ROOT%/bin/bash -lc "opam install camlp4 --yes"'
+    - '%CYG_ROOT%/bin/bash -lc "opam install camlp4 ocamlfind --yes"'
     # Install neko
     - choco install neko --prerelease --ignore-dependencies -s 'https://ci.appveyor.com/nuget/neko' -y
     - choco install chocolatey-core.extension php --ignore-dependencies -y


### PR DESCRIPTION
This PR changes the build process to use ocamlfind and cleans up the Makefile some more. Currently, the only libraries we use are str and unix from the OCaml distribution, but there may be more in the future. We can also look into replacing some of the extlib libraries (objsize, pcre, xml-light, ziplib... maybe even extlib if someone is brave enough to look into that) at some point.

Obviously, this makes ocamlfind a build dependency.

CI is failing because lua.org is down.