### PR TITLE
allow `TOptional(null)` and generate monomorphs from it

### DIFF
--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -420,7 +420,7 @@ and encode_ctype t =
 	| CTExtend (tl,fields) ->
 		4, [enc_array (List.map encode_path tl); enc_array (List.map encode_field fields)]
 	| CTOptional t ->
-		5, [encode_ctype t]
+		5, [null encode_ctype t]
 	in
 	encode_enum ~pos:(Some (pos t)) ICType tag pl
 
@@ -718,7 +718,7 @@ and decode_ctype t =
 	| 4, [tl;fl] ->
 		CTExtend (List.map decode_path (dec_array tl), List.map decode_field (dec_array fl))
 	| 5, [t] ->
-		CTOptional (decode_ctype t)
+		CTOptional (opt decode_ctype t)
 	| _ ->
 		raise Invalid_expr),p
 

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -154,7 +154,7 @@ and complex_type =
 	| CTAnonymous of class_field list
 	| CTParent of type_hint
 	| CTExtend of placed_type_path list * class_field list
-	| CTOptional of type_hint
+	| CTOptional of type_hint option
 
 and type_hint = complex_type * pos
 
@@ -550,7 +550,7 @@ let map_expr loop (e,p) =
 			let tl = List.map tpath tl in
 			let fl = List.map cfield fl in
 			CTExtend (tl,fl)
-		| CTOptional t -> CTOptional (type_hint t)),p
+		| CTOptional t -> CTOptional (Option.map type_hint t)),p
 	and tparamdecl t =
 		let constraints = List.map type_hint t.tp_constraints in
 		let params = List.map tparamdecl t.tp_params in
@@ -748,7 +748,7 @@ let s_expr e =
 		| CTFunction (cl,(c,_)) -> if List.length cl > 0 then String.concat " -> " (List.map (fun (t,_) -> s_complex_type tabs t) cl) else "Void" ^ " -> " ^ s_complex_type tabs c
 		| CTAnonymous fl -> "{ " ^ String.concat "; " (List.map (s_class_field tabs) fl) ^ "}";
 		| CTParent(t,_) -> "(" ^ s_complex_type tabs t ^ ")"
-		| CTOptional(t,_) -> "?" ^ s_complex_type tabs t
+		| CTOptional(t) -> "?" ^ (Option.map_default (fun (t,_) -> s_complex_type tabs t) "" t)
 		| CTExtend (tl, fl) -> "{> " ^ String.concat " >, " (List.map (s_complex_type_path tabs) tl) ^ ", " ^ String.concat ", " (List.map (s_class_field tabs) fl) ^ " }"
 	and s_class_field tabs f =
 		match f.cff_doc with

--- a/src/syntax/parser.mly
+++ b/src/syntax/parser.mly
@@ -278,7 +278,7 @@ let reify in_macro =
 		| CTAnonymous fields -> ct "TAnonymous" [to_array to_cfield fields p]
 		| CTParent t -> ct "TParent" [to_type_hint t p]
 		| CTExtend (tl,fields) -> ct "TExtend" [to_array to_tpath tl p; to_array to_cfield fields p]
-		| CTOptional t -> ct "TOptional" [to_type_hint t p]
+		| CTOptional t -> ct "TOptional" [to_opt to_type_hint t p]
 	and to_type_hint (t,p) _ =
 		(* to_obj ["type",to_ctype t p;"pos",to_pos p] p *)
 		to_ctype (t,p) p
@@ -929,7 +929,7 @@ and parse_complex_type_inner = parser
 		| [< l,p2 = parse_class_fields true p1 >] -> CTAnonymous l,punion p1 p2
 		| [< >] -> serror())
 	| [< '(Question,p1); t,p2 = parse_complex_type_inner >] ->
-		CTOptional (t,p2),punion p1 p2
+		CTOptional (Some (t,p2)),punion p1 p2
 	| [< t,p = parse_type_path >] ->
 		CTPath t,p
 

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -536,6 +536,7 @@ and load_complex_type ctx allow_display p (t,pn) =
 	match t with
 	| CTParent t -> load_complex_type ctx allow_display p t
 	| CTPath t -> load_instance ~allow_display ctx (t,pn) false p
+	| CTOptional None -> mk_mono()
 	| CTOptional _ -> error "Optional type not allowed here" p
 	| CTExtend (tl,l) ->
 		(match load_complex_type ctx allow_display p (CTAnonymous l,p) with
@@ -676,7 +677,7 @@ and load_complex_type ctx allow_display p (t,pn) =
 			TFun ([],load_complex_type ctx allow_display p r)
 		| _ ->
 			TFun (List.map (fun t ->
-				let t, opt = (match fst t with CTOptional t -> t, true | _ -> t,false) in
+				let t, opt = (match fst t with CTOptional (Some t) -> t, true | _ -> t,false) in
 				"",opt,load_complex_type ctx allow_display p t
 			) args,load_complex_type ctx allow_display p r)
 

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -534,7 +534,7 @@ enum ComplexType {
 	/**
 		Represents an optional type.
 	**/
-	TOptional( t : ComplexType );
+	TOptional( t : Null<ComplexType> );
 }
 
 /**


### PR DESCRIPTION
This PR reinterprets `TOptional(null)` to introduce monomorphs, which allows encoding unknown types explicitly in macro-generated type-hints. Since the construct currently has no meaning and just errors when decoded, this should be a safe change.

I'm not introducing a new ComplexType constructor because that would unnecessarily break some macros. We can change this later if we decide to add a new constructor for another reason, in which case it would make no difference.

There is no accompanying syntax for this at the moment, and I'm not sure introducing one would be worth it. 