### PR TITLE
[cs/java] run TryCatchWrapper as a normal filter before analyzer/dce

### DIFF
--- a/src/generators/codegen.ml
+++ b/src/generators/codegen.ml
@@ -32,6 +32,16 @@ module ExprBuilder = struct
 		let ta = TAnon { a_fields = c.cl_statics; a_status = ref (Statics c) } in
 		mk (TTypeExpr (TClassDecl c)) ta p
 
+	let make_typeexpr mt pos =
+		let t =
+			match mt with
+			| TClassDecl c -> TAnon { a_fields = c.cl_statics; a_status = ref (Statics c) }
+			| TEnumDecl e -> TAnon { a_fields = PMap.empty; a_status = ref (EnumStatics e) }
+			| TAbstractDecl a -> TAnon { a_fields = PMap.empty; a_status = ref (AbstractStatics a) }
+			| _ -> assert false
+		in
+		mk (TTypeExpr mt) t pos
+
 	let make_static_field c cf p =
 		let e_this = make_static_this c p in
 		mk (TField(e_this,FStatic(c,cf))) cf.cf_type p

--- a/src/generators/gencommon.ml
+++ b/src/generators/gencommon.ml
@@ -142,15 +142,6 @@ let is_string t =
 	| TInst({ cl_path = ([], "String") }, []) -> true
 	| _ -> false
 
-let mk_mt_access mt pos =
-	let t = match mt with
-		| TClassDecl cl -> TAnon { a_fields = cl.cl_statics; a_status = ref (Statics cl) }
-		| TEnumDecl e -> TAnon { a_fields = PMap.empty; a_status = ref (EnumStatics e) }
-		| TAbstractDecl a -> TAnon { a_fields = PMap.empty; a_status = ref (AbstractStatics a) }
-		| _ -> assert false
-	in
-	mk (TTypeExpr mt) t pos
-
 let anon_class t =
 	match follow t with
 	| TAnon anon ->

--- a/src/generators/gencommon/switchToIf.ml
+++ b/src/generators/gencommon/switchToIf.ml
@@ -18,6 +18,7 @@
 *)
 open Common
 open Type
+open Codegen
 open Gencommon
 
 (* ******************************************* *)
@@ -110,7 +111,7 @@ let configure gen (should_convert:texpr->bool) =
 							| _ -> raise Not_found
 						in
 						if Meta.has Meta.Class real_enum.e_meta then raise Not_found;
-						let enum_expr = mk_mt_access (TEnumDecl(real_enum)) e.epos in
+						let enum_expr = ExprBuilder.make_typeexpr (TEnumDecl(real_enum)) e.epos in
 						let fields = Hashtbl.create (List.length real_enum.e_names) in
 						PMap.iter (fun _ ef -> Hashtbl.add fields ef.ef_index ef) real_enum.e_constrs;
 						let cases = List.map (fun (el,e) ->

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -152,7 +152,7 @@ let in_runtime_class gen =
 module CSharpSpecificESynf =
 struct
 	let name = "csharp_specific_e"
-	let priority = solve_deps name [DBefore ExpressionUnwrap.priority; DBefore ClassInstance.priority; DAfter TryCatchWrapper.priority]
+	let priority = solve_deps name [DBefore ExpressionUnwrap.priority; DBefore ClassInstance.priority]
 
 	let get_cl_from_t t =
 		match follow t with
@@ -1449,8 +1449,6 @@ let generate con =
 						write w "*(";
 						expr_s w e;
 						write w ")"
-					| TCall ({ eexpr = TLocal( { v_name = "__rethrow__" } ) }, _) ->
-						write w "throw"
 					(* operator overloading handling *)
 					| TCall({ eexpr = TField(ef, FInstance(cl,_,{ cf_name = "__get" })) }, [idx]) when not (is_hxgen (TClassDecl cl)) ->
 						expr_s w { e with eexpr = TArray(ef, idx) }
@@ -1631,6 +1629,8 @@ let generate con =
 						if is_some eopt then (write w " "; expr_s w (get eopt))
 					| TBreak -> write w "break"
 					| TContinue -> write w "continue"
+					| TThrow { eexpr = TLocal { v_name = "__rethrow__" } } ->
+						write w "throw"
 					| TThrow e ->
 						write w "throw ";
 						expr_s w e
@@ -3044,45 +3044,6 @@ let generate con =
 				end);
 
 		FilterClosures.configure gen (fun e1 s -> true) (ReflectionCFs.get_closure_func rcf_ctx closure_cl);
-
-		begin
-			let base_exception = get_cl (get_type gen (["System"], "Exception")) in
-			let base_exception_t = TInst(base_exception, []) in
-
-			let hx_exception = get_cl (get_type gen (["haxe";"lang"], "HaxeException")) in
-			let hx_exception_t = TInst(hx_exception, []) in
-
-			let exc_cl = get_cl (get_type gen (["haxe";"lang"],"Exceptions")) in
-
-			let rec is_exception t =
-				match follow t with
-					| TInst(cl,_) ->
-						if cl == base_exception then
-							true
-						else
-							(match cl.cl_super with | None -> false | Some (cl,arg) -> is_exception (TInst(cl,arg)))
-					| _ -> false
-			in
-
-			let v_rethrow = alloc_var "__rethrow__" t_dynamic in
-			TryCatchWrapper.configure gen
-				(fun t -> not (is_exception (real_type t)))
-				(fun throwexpr expr ->
-					let e_hxexception = ExprBuilder.make_static_this hx_exception expr.epos in
-					let e_wrap = fcall e_hxexception "wrap" [expr] hx_exception_t expr.epos in
-					mk (TThrow e_wrap) basic.tvoid expr.epos
-				)
-				(fun local_to_unwrap -> Codegen.field (mk_cast hx_exception_t local_to_unwrap) "obj" t_dynamic local_to_unwrap.epos)
-				(fun rethrow -> mk (TCall ((mk_local v_rethrow rethrow.epos),[rethrow])) basic.tvoid rethrow.epos)
-				base_exception_t
-				hx_exception_t
-				(fun v e ->
-					let e_exc = ExprBuilder.make_static_this exc_cl e.epos in
-					let e_field = Codegen.field e_exc "exception" base_exception_t e.epos in
-					let e_setstack = binop OpAssign e_field (mk_local v e.epos) v.v_type e.epos in
-					Type.concat e_setstack e;
-				)
-		end;
 
 		ClassInstance.configure gen;
 

--- a/src/optimization/filters.ml
+++ b/src/optimization/filters.ml
@@ -1130,6 +1130,17 @@ let run com tctx main =
 		Optimizer.reduce_expression tctx;
 		captured_vars com;
 	] in
+	let filters = match com.platform with
+	| Cs ->
+		filters @ [
+			TryCatchWrapper.configure_cs com
+		]
+	| Java ->
+		filters @ [
+			TryCatchWrapper.configure_java com
+		]
+	| _ -> filters
+	in
 	List.iter (run_expression_filters tctx filters) new_types;
 	(* PASS 1.5: pre-analyzer type filters *)
 	List.iter (fun t ->

--- a/std/cs/Lib.hx
+++ b/std/cs/Lib.hx
@@ -178,7 +178,7 @@ class Lib
 	**/
 	@:extern inline public static function rethrow(e:Dynamic):Void
 	{
-		untyped __rethrow__();
+		throw untyped __rethrow__;
 	}
 
 	/**


### PR DESCRIPTION
This moves the `TryCatchWrapper` transform used in C#/Java targets into first-pass filters, so it's run before analyzer and DCE, resulting in much cleaner output. Obviously the filter now also doesn't depend on anything from gencommon and potentially can be easily re-used for other targets (I'm thinking about reworking the current JS hackery to it). This also means that c#/java/gencommon filters shouldn't add `TThrow`s of types that are not target-specific exception subclass, but there are only a couple places that I already changed it in `development`.

It needs some cleanup, but it passes all the tests for me, so I'm gonna merge it when Travis is green.