### PR TITLE
[lua] table pairs iterator

### DIFF
--- a/std/lua/Lua.hx
+++ b/std/lua/Lua.hx
@@ -53,7 +53,7 @@ extern class Lua {
 		to a non-existent field in the table is assigned. Existing fields may
 		however be modified. In particular, existing fields may be cleared.
 	**/
-	public static function next<K,V>(k:Table<K, V>, ?i : V): NextResult<K,V>;
+	public static function next<K,V>(k:Table<K, V>, ?i : K): NextResult<K,V>;
 
 	/**
 		Receives an argument of any type and converts it to a string in a reasonable

--- a/std/lua/PairsIterator.hx
+++ b/std/lua/PairsIterator.hx
@@ -1,0 +1,36 @@
+package lua;
+
+import lua.Lua;
+
+class PairsIterator<K,V>
+{
+	private var table : Table<K,V>;
+	private var result : NextResult<K,V>;
+	
+	public function new( table : Table<K,V> )
+	{
+		this.table = table;
+	}
+	
+	public function hasNext() : Bool
+	{
+		this.result = Lua.next(table, null == result ? null : result.index);
+		return null != result.index;
+	}
+	
+	public function next() : PairsNextResult<K,V>
+	{
+		return new PairsNextResult(result.index, result.value);
+	}
+}
+
+class PairsNextResult<K,V> 
+{
+	public var index : K;
+	public var value : V;
+	public function new ( index : K, value : V)
+	{
+		this.index = index;
+		this.value = value;
+	}
+}


### PR DESCRIPTION
**NOTICE**: the 2nd commit patches a probable typo/bug in an interface type 

not seeing any great way to do the equivalent of the following Lua code, but in Haxe:

```lua
for target,_nil in pairs(CONES) do
	for _nil, item in pairs(items) do
		if item.prefab == target then
			log(string.format("%s {%2.2f, %2.2f, %2.2f}", tostring(item), item.Transform:GetWorldPosition()));
			return true;
		end
	end
end
```

the closest existing approximation seems like `lua.PairTools.pairsEach()`, however because it calls a function, the usual flow control keywords like `return` and `break` are not usable within.

```haxe
PairTools.pairsEach(CONES, function(target : String, ignored : Void) : Void {
	PairTools.pairsEach(items, function(ignored : Void, item : Entity) : Void {
		if (target == item.prefab) {
			log(MyStringTools.format("%s {%2.2f, %2.2f, %2.2f}", Lua.tostring(item), item.Transform.GetWorldPosition()));
			return true; // meant to exit the two for loops and the enclosing function above, but cannot in this context
		}
	});
});
```

Therefore, I propose some variation of the following Haxe iterator implementation for distribution within the core Haxe `lua.*` package:

(see `std/lua/PairsIterator.hx`)

used like so:

```haxe
for (p1 in new PairsIterator(CONES))
{
	var target = p1.index;
	for (p2 in new PairsIterator(items))
	{
		var item = p2.value;
		var itemWorldPos = item.Transform.GetWorldPosition();
		if (target == item.prefab)
		{
			log(MyStringTools.format("%s {%2.2f, %2.2f, %2.2f}", Lua.tostring(item), itemWorldPos.x, itemWorldPos.y, itemWorldPos.z));
			return true;
		}
	}
}
```

unless perhaps this already exists and i missed it...

if any interest in the project, its here
https://github.com/mikesmullin/dst-pickup-meat-first