### PR TITLE
[cs/java] extract DefaultArguments from gencommon into PASS 1.5 filters

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -38,6 +38,14 @@ type basic_types = {
 	mutable tarray : t -> t;
 }
 
+let const_type basic const default =
+	match const with
+	| TString _ -> basic.tstring
+	| TInt _ -> basic.tint
+	| TFloat _ -> basic.tfloat
+	| TBool _ -> basic.tbool
+	| _ -> default
+
 type stats = {
 	s_files_parsed : int ref;
 	s_classes_built : int ref;

--- a/src/generators/gencommon.ml
+++ b/src/generators/gencommon.ml
@@ -168,14 +168,6 @@ let anon_class t =
 	| _ -> assert false
 
 
-let const_type basic const default =
-	match const with
-	| TString _ -> basic.tstring
-	| TInt _ -> basic.tint
-	| TFloat _ -> basic.tfloat
-	| TBool _ -> basic.tbool
-	| _ -> default
-
 let get_cl mt = match mt with TClassDecl cl -> cl | _ -> failwith (Printf.sprintf "Unexpected module type (class expected) for %s: %s" (s_type_path (t_path mt)) (s_module_type_kind mt))
 let get_abstract mt = match mt with TAbstractDecl a -> a | _ -> failwith (Printf.sprintf "Unexpected module type (abstract expected) for %s: %s" (s_type_path (t_path mt)) (s_module_type_kind mt))
 

--- a/src/generators/gencommon/fixOverrides.ml
+++ b/src/generators/gencommon/fixOverrides.ml
@@ -37,7 +37,7 @@ open Gencommon
 
 *)
 let name = "fix_overrides"
-let priority = solve_deps name [DAfter DefaultArguments.priority]
+let priority = solve_deps name []
 
 (*
 	if the platform allows explicit interface implementation (C#),

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -3071,7 +3071,6 @@ let generate con =
 
 		ArrayDeclSynf.configure gen native_arr_cl change_param_type;
 
-		DefaultArguments.configure gen;
 		InterfaceMetas.configure gen;
 
 		CSharpSpecificSynf.configure gen runtime_cl;

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -2631,8 +2631,6 @@ let generate con =
 		gen.greal_type <- real_type;
 		gen.greal_type_param <- change_param_type;
 
-		SetHXGen.run_filter gen.gcon gen.gtypes_list;
-
 		(* before running the filters, follow all possible types *)
 		(* this is needed so our module transformations don't break some core features *)
 		(* like multitype selection *)

--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -2377,7 +2377,6 @@ let generate con =
 
 	ArrayDeclSynf.configure gen native_arr_cl change_param_type;
 
-	DefaultArguments.configure gen;
 	InterfaceMetas.configure gen;
 
 	JavaSpecificSynf.configure gen runtime_cl;

--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -2059,8 +2059,6 @@ let generate con =
 	gen.greal_type <- real_type;
 	gen.greal_type_param <- change_param_type;
 
-	SetHXGen.run_filter gen.gcon gen.gtypes_list;
-
 	(* before running the filters, follow all possible types *)
 	(* this is needed so our module transformations don't break some core features *)
 	(* like multitype selection *)

--- a/src/optimization/filters.ml
+++ b/src/optimization/filters.ml
@@ -1132,10 +1132,12 @@ let run com tctx main =
 	] in
 	let filters = match com.platform with
 	| Cs ->
+		SetHXGen.run_filter com new_types;
 		filters @ [
 			TryCatchWrapper.configure_cs com
 		]
 	| Java ->
+		SetHXGen.run_filter com new_types;
 		filters @ [
 			TryCatchWrapper.configure_java com
 		]


### PR DESCRIPTION
Run the gencommon's `DefaultArguments` filter by filters.ml in the pre-analyzer pass, which makes output nicer in some cases (thanks to local DCE and expression fusion).

As a side-effect it's now also run before `rename_local_vars`, meaning that it can reuse the argument name for the var without worrying about name clases, so it doesn't have to generate those ugly `__temp_arg1` names.

The `SetHXGen` is also run by filters.ml now, since `DefaultArguments` checks for meta added by that filter.

Will merge on Travis greenlight.

> PS The `DefaultArguments` is actually a normal expression filter, but it needs some refactoring to be used as one, so I'm running it in PASS 1.5 right now.