### PR TITLE
Don't require Bool to be an enum (closes #5804, closes #4120)

### DIFF
--- a/std/cs/_std/Type.hx
+++ b/std/cs/_std/Type.hx
@@ -93,8 +93,6 @@ enum ValueType {
 		if (ret.length > 10 && StringTools.startsWith(ret, "haxe.root."))
 			ret = ret.substr(10);
 #end
-		if (ret.length == 14 && ret == "System.Boolean")
-			return "Bool";
 		return ret;
 	}
 

--- a/std/java/_std/Type.hx
+++ b/std/java/_std/Type.hx
@@ -86,8 +86,6 @@ enum ValueType {
 		var ret:String = c.getName();
 		if (ret.startsWith("haxe.root."))
 			return ret.substr(10);
-		else if (ret == "boolean" || ret == "java.lang.Boolean")
-			return "Bool";
 
 		return ret;
 	}

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -80,8 +80,7 @@ import js.Boot;
 			Float.__name__ = ["Float"];
 		});
 		__feature__("Bool.*",{
-			var Bool = __feature__("Type.resolveEnum",$hxClasses["Bool"] = __js__("Boolean"), __js__("Boolean"));
-			Bool.__ename__ = ["Bool"];
+			var Bool = __js__("Boolean");
 		});
 		__feature__("Class.*",{
 			var Class = __feature__("Type.resolveClass", $hxClasses["Class"] = { __name__ : ["Class"] }, { __name__ : ["Class"] });

--- a/std/lua/_lua/_hx_classes.lua
+++ b/std/lua/_lua/_hx_classes.lua
@@ -3,7 +3,6 @@ Int = (function() _hxClasses.Int = _hx_o({__fields__={__name__=true},__name__={"
 Dynamic = (function() _hxClasses.Dynamic = _hx_o({__fields__={__name__=true},__name__={"Dynamic"}}); return _hxClasses.Dynamic end)();
 Float = (function() _hxClasses.Float = _hx_e(); return _hxClasses.Float end)();
 Float.__name__ = {"Float"}
-Bool = (function() _hxClasses.Bool = _hx_e(); return _hxClasses.Bool end)();
-Bool.__ename__ = {"Bool"}
+Bool = _hx_e();
 Class = (function() _hxClasses.Class = _hx_o({__fields__={__name__=true},__name__={"Class"}}); return _hxClasses.Class end)();
 Enum = _hx_e();

--- a/tests/unit/src/unit/TestReflect.hx
+++ b/tests/unit/src/unit/TestReflect.hx
@@ -97,9 +97,9 @@ class TestReflect extends Test {
 			var name = TNAMES[i];
 			infos("type "+name);
 			f( t == null );
-			if( name == u("Enum") ) {
+			if( name == u("Enum") || name == u("Bool") ) {
 				// neither an enum or a class
-			} else if( t == MyEnum || t == Bool ) {
+			} else if( t == MyEnum ) {
 				eq( Type.getEnumName(t), name );
 				eq( Type.resolveEnum(name), t );
 			} else {


### PR DESCRIPTION
This removes a specification for `Type.getEnumName(Bool)` and `Type.resolveEnum("Bool")` and some of related implementations (see linked issues).

We should review and most probably remove other weird specifications such as `getClassName`/`resolveClass` for `Class`, `Enum`, `Float`, `Int`, `Dynamic` and other standard abstracts.