### PR TITLE
Escape \r as well

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -76,7 +76,7 @@ class Printer {
 	}
 
 	function escapeString(s:String,delim:String) {
-		return delim + s.replace("\n","\\n").replace("\t","\\t").replace("'","\\'").replace('"',"\\\"") #if sys .replace("\x00","\\x00") #end + delim;
+		return delim + s.replace("\n","\\n").replace("\t","\\t").replace("\r","\\r").replace("'","\\'").replace('"',"\\\"") #if sys .replace("\x00","\\x00") #end + delim;
 	}
 
 	public function printFormatString(s:String) {


### PR DESCRIPTION
Currently:

```haxe
class Main {
	static function main() {
		Macro.print('012345\r\n6789');
	}
}

class Macro {
	public static macro function print(e:haxe.macro.Expr) {
		var s = new haxe.macro.Printer().printExpr(e);
		return macro Sys.println($v{s});
	}
}
```

generates:

```js
process.stdout.write("'012345\r\\n6789'");
// what you see in the terminal: \n6789'
```

after fix:

```js
process.stdout.write("'012345\\r\\n6789'");
// what you see in the terminal: '012345\r\n6789'
```