### PR TITLE
Make Sys.print[ln] inline for Python

### DIFF
--- a/std/haxe/unit/TestRunner.hx
+++ b/std/haxe/unit/TestRunner.hx
@@ -95,7 +95,7 @@ class TestRunner {
 			var str:String = v;
 			untyped __java__("java.lang.System.out.print(str)");
 		#elseif python
-			python.Lib.print(v);
+			python.Lib.print_(v);
 		#elseif (hl || lua)
 			Sys.print(Std.string(v));
 		#end

--- a/std/python/Lib.hx
+++ b/std/python/Lib.hx
@@ -36,7 +36,7 @@ class Lib {
 	/**
 		Print the specified value on the default output.
 	**/
-	public static function print(v:Dynamic):Void {
+	public static function print_(v:Dynamic):Void {
 		var str = Std.string(v);
 
 		PySys.stdout.buffer.write( NativeStringTools.encode(str, "utf-8"));

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -46,11 +46,11 @@ class Sys {
 		python.lib.Sys.exit(code);
 	}
 
-	public static function print(v:Dynamic):Void {
-		python.Lib.print(v);
+	public static inline function print(v:Dynamic):Void {
+		python.Lib.print_(v);
 	}
 
-	public static function println(v:Dynamic):Void {
+	public static inline function println(v:Dynamic):Void {
 		python.Lib.println(v);
 	}
 
@@ -146,7 +146,7 @@ class Sys {
 				throw "platform " + x + " not supported";
 		}
 		if (echo) {
-			python.Lib.print(String.fromCharCode(ch));
+			python.Lib.print_(String.fromCharCode(ch));
 		}
 		return ch;
 	}


### PR DESCRIPTION
Makes code more compact, fixes #6184
print_ makes code friendly for Python imports, fixes #6183