### PR TITLE
AS3 target Compile error with missing iterators.

### DIFF
--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -81,7 +81,7 @@ class ObjectMap<K:{},V> extends flash.utils.Dictionary implements haxe.Constrain
 		return s + "}";
 	}
 }
-
+#if !as3
 private class NativePropertyIterator {
 	var collection:Dynamic;
 	var index:Int = 0;
@@ -139,3 +139,4 @@ private class NativeValueIterator {
 		return result;
 	}
 }
+#end

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -81,7 +81,7 @@ class WeakMap<K:{},V> extends flash.utils.Dictionary implements haxe.Constraints
 		return s + "}";
 	}
 }
-
+#if !as3
 private class NativePropertyIterator {
 	var collection:Dynamic;
 	var index:Int = 0;
@@ -139,3 +139,4 @@ private class NativeValueIterator {
 		return result;
 	}
 }
+#end


### PR DESCRIPTION
Error when targeting as3. Generates NativePropertyIterator.as and NativeValueIterator.as but __foreach__ __forin__ missing.  Better to not generate at all, since those impl are not used.

Minor issue that is solved by not generating the above classes, and therefore bypassing any missing function dependencies.

Note that no test can be written because of differences in developer as3 compilation context. This error was detected during use of the generated as3 code in a FlashBuilder environment where the haxe-generated as3 code was included as an additional source directory. 