### PR TITLE
* 4x speed Optimization Sha224.hx, Sha256.hx via forced inlining

### DIFF
--- a/std/haxe/crypto/Sha224.hx
+++ b/std/haxe/crypto/Sha224.hx
@@ -148,45 +148,54 @@ class Sha224 {
         return blks;
     }
 
-    static function safeAdd(x, y) {
+    @:extern
+    inline static function safeAdd(x, y) {
         var lsw = (x & 0xFFFF) + (y & 0xFFFF);
         var msw = (x >>> 16) + (y >>> 16) + (lsw >>> 16);
         return ((msw & 0xFFFF) << 16) | (lsw & 0xFFFF);
     }
 
     // ++
-    function ROTR(X, n) {
+    @:extern
+    inline function ROTR(X, n) {
         return ( X >>> n ) | (X << (32 - n));
     }
 
     // ++
-    function SHR(X, n) {
+    @:extern
+    inline function SHR(X, n) {
         return ( X >>> n );
     }
 
     // ++
-    function Ch(x, y, z) {
+    @:extern
+    inline function Ch(x, y, z) {
         return ((x & y) ^ ((~x) & z));
     }
 
     // ++
-    function Maj(x, y, z) {
+    @:extern
+    inline function Maj(x, y, z) {
         return ((x & y) ^ (x & z) ^ (y & z));
     }
 
-    function Sigma0(x) {
+    @:extern
+    inline function Sigma0(x) {
         return ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22);
     }
 
-    function Sigma1(x) {
+    @:extern
+    inline function Sigma1(x) {
         return ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25);
     }
 
-    function Gamma0(x) {
+    @:extern
+    inline function Gamma0(x) {
         return ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3);
     }
 
-    function Gamma1(x) {
+    @:extern
+    inline function Gamma1(x) {
         return ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10);
     }
 

--- a/std/haxe/crypto/Sha256.hx
+++ b/std/haxe/crypto/Sha256.hx
@@ -148,40 +148,48 @@ class Sha256 {
 		blks[nblk * 16 - 1] = b.length * 8;
 		return blks;
 	}
-
-	function S(X, n) {
+	@:extern
+	inline function S(X, n) {
 		return ( X >>> n ) | (X << (32 - n));
 	}
 
-	function R(X, n) {
+	@:extern
+	inline function R(X, n) {
 		return ( X >>> n );
 	}
 
-	function Ch(x, y, z) {
+	@:extern
+	inline function Ch(x, y, z) {
 		return ((x & y) ^ ((~x) & z));
 	}
 
-	function Maj(x, y, z) {
+	@:extern
+	inline function Maj(x, y, z) {
 		return ((x & y) ^ (x & z) ^ (y & z));
 	}
 
-	function Sigma0256(x) {
+	@:extern
+	inline function Sigma0256(x) {
 		return (S(x, 2) ^ S(x, 13) ^ S(x, 22));
 	}
 
-	function Sigma1256(x) {
+	@:extern
+	inline function Sigma1256(x) {
 		return (S(x, 6) ^ S(x, 11) ^ S(x, 25));
 	}
 
-	function Gamma0256(x) {
+	@:extern
+	inline function Gamma0256(x) {
 		return (S(x, 7) ^ S(x, 18) ^ R(x, 3));
 	}
 
-	function Gamma1256(x) {
+	@:extern
+	inline function Gamma1256(x) {
 		return (S(x, 17) ^ S(x, 19) ^ R(x, 10));
 	}
 
-	function safeAdd(x, y) {
+	@:extern
+	inline function safeAdd(x, y) {
 		var lsw = (x & 0xFFFF) + (y & 0xFFFF);
 		var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
 		return (msw << 16) | (lsw & 0xFFFF);


### PR DESCRIPTION
Forced Inline (@:extern) on heavily used internal micro-functions in SHA 224 and 256. Tested against as3 target only.

Inlined code is still not very large, and should have minimal exe bloat tradeoff for a very large speed increase.

