### PR TITLE
[macro] support explicit module dependency for Context.defineType (closes #5613)

### DIFF
--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -36,7 +36,7 @@ type 'value compiler_api = {
 	get_local_vars : unit -> (string, Type.tvar) PMap.t;
 	get_build_fields : unit -> 'value;
 	get_pattern_locals : Ast.expr -> Type.t -> (string,Type.tvar * Globals.pos) PMap.t;
-	define_type : 'value -> unit;
+	define_type : 'value -> string option -> unit;
 	define_module : string -> 'value list -> ((string * Globals.pos) list * Ast.import_mode) list -> Ast.type_path list -> unit;
 	module_dependency : string -> string -> bool -> unit;
 	current_module : unit -> module_def;
@@ -1735,8 +1735,8 @@ let macro_api ccom get_api =
 		"get_build_fields", vfun0 (fun() ->
 			(get_api()).get_build_fields()
 		);
-		"define_type", vfun1 (fun v ->
-			(get_api()).define_type v;
+		"define_type", vfun2 (fun v m ->
+			(get_api()).define_type v (opt decode_string m);
 			vnull
 		);
 		"define_module", vfun4 (fun path vl ui ul ->

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -466,9 +466,13 @@ class Context {
 
 	/**
 		Defines a new type from `TypeDefinition` `t`.
+
+		If `moduleDependency` is given and is not `null`, it should contain
+		a module path that will be used as a dependency for the newly defined module
+		instead of the current module.
 	**/
-	public static function defineType( t : TypeDefinition ) : Void {
-		load("define_type", 1)(t);
+	public static function defineType( t : TypeDefinition, ?moduleDependency : String ) : Void {
+		load("define_type", 2)(t, moduleDependency);
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a second optional argument to `Context.defineType` which allows explicitly controlling module dependency for the newly-created module. If specified, it will be used as a dependency instead of the current module when defining a module for the new type.

This is useful when we define a new type, derived from some existing one from another module, like in a `@:genericBuild Const<T>` macro used in our codebase (it generates "readonly" version of typedef'd structure types). In cases like this it doesn't make sense for a newly created module to depend on the module where the macro was called from (the "current" one) and instead it should depend on a module where the original type is defined.

The current behaviour screws cache server pretty bad in our large codebase, so completion becomes so slow it's basically unusable (because of wrong module invalidations it has to re-run type-building macros a lot and it can spend several seconds to do that). 

This simple change fixes it so `Const<T>` types are not regenerated on each display request and makes IDE support a lot more responsive. So I'd love to merge this ASAP, please review it! :)