### PR TITLE
[flash] `haxe.io.Bytes.toString()` stops on zero-byte

### DIFF
--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -425,7 +425,7 @@ class Bytes {
 		return new String(untyped __dollar__ssub(b,0,length));
 		#elseif flash
 		b.position = 0;
-		return b.readUTFBytes(length);
+		return b.toString();
 		#elseif php
 		return b.toString();
 		#elseif cs


### PR DESCRIPTION
Current implementation of `Bytes.toString()` returns a string from the first byte to the last or tol the first null-byte. While e.g. on JS it always return from the first byte to the last byte.
This PR makes Flash implementation behave the same way with JS one.