### PR TITLE
Tests for #6135 and #6169

### DIFF
--- a/tests/unit/src/unit/issues/Issue6135.hx
+++ b/tests/unit/src/unit/issues/Issue6135.hx
@@ -1,0 +1,10 @@
+package unit.issues;
+
+class Issue6135 extends unit.Test {
+	@:analyzer(ignore)
+	function test() {
+		var x:Array<Dynamic> = [1];
+		x[0] = "hi";
+		t(x[0] == "hi");
+	}
+}

--- a/tests/unit/src/unit/issues/Issue6169.hx
+++ b/tests/unit/src/unit/issues/Issue6169.hx
@@ -1,0 +1,17 @@
+package unit.issues;
+
+class Rec {
+	var x : Int = 0;
+	public inline function new(rec:Bool) {
+		if ( rec ) {
+			var r = new Rec(false);
+			x = r.x;
+		}
+	}
+}
+
+class Issue6169 extends unit.Test {
+	function test() {
+		var r = new Rec(false);
+	}
+}


### PR DESCRIPTION
I tried the tests individually with the old inline constructors to confirm they fail.
The test for #6135 fails on static typed platforms only.