### PR TITLE
Flatten blocks in inline constructors. Fixes #6229

### DIFF
--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -489,10 +489,10 @@ let inline_constructors ctx e =
 			let rec loop acc el = match el with
 				| [] -> acc, None
 				| [e] ->
-					let el',io = final_map e in
+					let el',io = final_map ~unwrap_block:unwrap_block e in
 					(el'@acc), io
 				| e::el ->
-					let el',_ = final_map e in
+					let el',_ = final_map ~unwrap_block:unwrap_block e in
 					loop (el'@acc) el
 			in
 			let el, io = loop [] el in

--- a/tests/optimization/src/issues/Issue6229.hx
+++ b/tests/optimization/src/issues/Issue6229.hx
@@ -1,0 +1,27 @@
+package issues;
+
+class Vec {
+    public var x:Float;
+	public var y:Float;
+    public inline function new(x) {
+        this.x = x;
+		this.y = x;
+    }
+}
+
+class Issue6229 {
+    static inline function mkVec(x) {
+		{
+			{
+				return new Vec(x);
+			}
+		}
+	}
+
+	@:js('var a = 1 + 1;')
+	@:analyzer(no_local_dce)
+    static function test() {
+        var v = mkVec(1);
+		var a = v.x + v.y;
+    }
+}


### PR DESCRIPTION
The reworked constructor inliner was already unwrapping blocks inserted by constructor inlining, this change will make it also unwrap any nested block inside of an unwrapped block.

This should fix #6229