### PR TITLE
Improve variable names in inline constructors rework.

### DIFF
--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -526,8 +526,8 @@ let inline_constructors ctx e =
 		let rec get_pretty_name iv = match iv.iv_kind with
 			| IVKField(io,fname,None) ->
 				begin try
-					let is_user_variable v = Meta.has Meta.UserVariable v.v_meta in
-					let iv = List.find (fun iv -> is_user_variable iv.iv_var) io.io_aliases in
+					let is_user_variable iv = Meta.has Meta.UserVariable iv.iv_var.v_meta in
+					let iv = List.find is_user_variable io.io_aliases in
 					(get_pretty_name iv) ^ "_" ^ fname;
 				with Not_found ->
 					(get_pretty_name (List.hd io.io_aliases)) ^ "_" ^ fname;

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -525,7 +525,13 @@ let inline_constructors ctx e =
 		let e = make_expr_for_rev_list el e.etype e.epos in
 		let rec get_pretty_name iv = match iv.iv_kind with
 			| IVKField(io,fname,None) ->
-				(get_pretty_name (List.hd io.io_aliases)) ^ "_" ^ fname;
+				begin try
+					let is_user_variable v = Meta.has Meta.UserVariable v.v_meta in
+					let iv = List.find (fun iv -> is_user_variable iv.iv_var) io.io_aliases in
+					(get_pretty_name iv) ^ "_" ^ fname;
+				with Not_found ->
+					(get_pretty_name (List.hd io.io_aliases)) ^ "_" ^ fname;
+				end
 			| _ -> iv.iv_var.v_name
 		in
 		IntMap.iter (fun _ iv ->


### PR DESCRIPTION
When there are multiple aliasing variables this change will give priority to names of variables that are user created. (By finding variables that have the UserVariable metadata)

This improves the situation described by nadako here: https://github.com/HaxeFoundation/haxe/pull/6230#issuecomment-298713427