### PR TITLE
[cs/lua] overwrite contents in File.copy(), closes #6278

### DIFF
--- a/std/cs/_std/sys/io/File.hx
+++ b/std/cs/_std/sys/io/File.hx
@@ -86,6 +86,6 @@ class File {
 
 	public static function copy( srcPath : String, dstPath : String ) : Void
 	{
-		cs.system.io.File.Copy(srcPath, dstPath);
+		cs.system.io.File.Copy(srcPath, dstPath, true);
 	}
 }

--- a/std/lua/_std/sys/io/File.hx
+++ b/std/lua/_std/sys/io/File.hx
@@ -44,7 +44,7 @@ class File {
 	public static function copy( srcPath : String, dstPath : String ) : Void {
 		switch (Sys.systemName()) {
 			case "Windows" : Os.execute('copy ${StringTools.quoteWinArg(srcPath, true)} ${StringTools.quoteWinArg(dstPath,true)}');
-			default : Os.execute('copy ${StringTools.quoteUnixArg(srcPath)} ${StringTools.quoteUnixArg(dstPath)}');
+			default : Os.execute('cp ${StringTools.quoteUnixArg(srcPath)} ${StringTools.quoteUnixArg(dstPath)}');
 		};
 	}
 

--- a/tests/sys/src/ExitCode.hx
+++ b/tests/sys/src/ExitCode.hx
@@ -3,7 +3,7 @@ import sys.io.*;
 import haxe.io.*;
 
 /**
-	This is intented to be used by TestSys and io.TestProcess.
+	This is intended to be used by TestSys and io.TestProcess.
 */
 class ExitCode {
 	static public var bin:String =

--- a/tests/sys/src/Main.hx
+++ b/tests/sys/src/Main.hx
@@ -3,6 +3,7 @@ class Main {
 		var runner = new haxe.unit.TestRunner();
 		runner.add(new TestSys());
 		runner.add(new TestFileSystem());
+		runner.add(new io.TestFile());
 		runner.add(new io.TestFileInput());
 		runner.add(new io.TestProcess());
 		var code = runner.run() ? 0 : 1;

--- a/tests/sys/src/io/TestFile.hx
+++ b/tests/sys/src/io/TestFile.hx
@@ -1,0 +1,21 @@
+package io;
+
+import sys.io.File;
+import sys.FileSystem;
+
+class TestFile extends haxe.unit.TestCase {
+	public function testCopyOverwrite() {
+		var fileA = "temp/a.txt";
+		var fileB = "temp/b.txt";
+		File.saveContent(fileA, "a");
+		File.saveContent(fileB, "b");
+
+		assertEquals("b", File.getContent(fileB));
+		File.copy(fileA, fileB);
+		assertEquals("a", File.getContent(fileB));
+
+		// cleanup
+		FileSystem.deleteFile(fileA);
+		FileSystem.deleteFile(fileB);
+	}
+}


### PR DESCRIPTION
Basically, I just changed it to use the overload of `File.Copy()` with an `overwrite` parameter:

https://msdn.microsoft.com/en-us/library/9706cfs5(v=vs.110).aspx