### PR TITLE
[java/php7] fix FileSystem.createDirectory() for dirs that exist, closes #6268

### DIFF
--- a/std/java/_std/sys/FileSystem.hx
+++ b/std/java/_std/sys/FileSystem.hx
@@ -83,7 +83,8 @@ class FileSystem {
 
 	public static function createDirectory( path : String ) : Void
 	{
-		if (!new File(path).mkdirs())
+		var f = new File(path);
+		if (!f.isDirectory() && !f.mkdirs())
 			throw "Cannot create dir " + path;
 	}
 

--- a/std/php7/_std/sys/FileSystem.hx
+++ b/std/php7/_std/sys/FileSystem.hx
@@ -86,7 +86,8 @@ class FileSystem {
 	}
 
 	public static inline function createDirectory( path : String ) : Void {
-		Global.mkdir(path, 493, true);
+		if (!Global.is_dir(path))
+			Global.mkdir(path, 493, true);
 	}
 
 	public static inline function deleteFile( path : String ) : Void {

--- a/tests/sys/src/TestFileSystem.hx
+++ b/tests/sys/src/TestFileSystem.hx
@@ -113,4 +113,11 @@ class TestFileSystem extends haxe.unit.TestCase {
 		var stat = FileSystem.stat(dir);
 		assertTrue(stat != null);
 	}
+
+	function testCreateExistingDirectory() {
+		var testDir = dir + "exists";
+		FileSystem.createDirectory(testDir);
+		FileSystem.createDirectory(testDir); // shouldn't throw
+		assertTrue(FileSystem.isDirectory(testDir));
+	}
 }


### PR DESCRIPTION
Simply check whether there's already a directory with the same name to avoid the exception.