### PR TITLE
Fix enum with argument named index, closes #6299

### DIFF
--- a/src/generators/gencommon/enumToClass2.ml
+++ b/src/generators/gencommon/enumToClass2.ml
@@ -354,7 +354,7 @@ module EnumToClass2Exprf = struct
 				(try
 					let cl = (get_converted_enum_classes f.etype).base in
 					let e_enum = { f with etype = TInst (cl, []) } in
-					Codegen.field e_enum "index" com.basic.tint e.epos
+					Codegen.field e_enum "_hx_index" com.basic.tint e.epos
 				with Not_found ->
 					{ e with eexpr = TCall(left, [f]) })
 			| TEnumParameter(f, ef, i) ->

--- a/std/cs/_std/Type.hx
+++ b/std/cs/_std/Type.hx
@@ -333,7 +333,7 @@ enum ValueType {
 			var values = cs.system.Enum.GetValues(Lib.getNativeType(e));
 			return cs.system.Array.IndexOf(values, e);
 		} else {
-			return cast(e, HxEnum).index;
+			return cast(e, HxEnum)._hx_index;
 		}
 	}
 

--- a/std/cs/internal/HxObject.hx
+++ b/std/cs/internal/HxObject.hx
@@ -86,10 +86,10 @@ class DynamicObject extends HxObject implements Dynamic
 @:meta(System.Serializable)
 #end
 class HxEnum {
-	@:readOnly var index(default,never):Int;
+	@:readOnly var _hx_index(default,never):Int;
 
 	@:protected function new(index:Int) {
-		untyped this.index = index;
+		untyped this._hx_index = index;
 	}
 
 	public function getTag():String {

--- a/tests/unit/src/unit/issues/Issue6299.hx
+++ b/tests/unit/src/unit/issues/Issue6299.hx
@@ -1,0 +1,12 @@
+package unit.issues;
+
+class Issue6299 extends unit.Test {
+    public function test() {
+        t(true);
+    }
+}
+
+@:keep
+enum Expr {
+	EArray( e : Expr, index : Expr );
+}


### PR DESCRIPTION
I modified something in gencommon so I'm not sure if I need to modify something for java too.