### PR TITLE
Add copy() to IMap

### DIFF
--- a/src/macro/eval/evalEncode.ml
+++ b/src/macro/eval/evalEncode.ml
@@ -126,8 +126,14 @@ let encode_rope s =
 let encode_bytes s =
 	encode_instance key_haxe_io_Bytes ~kind:(IBytes s)
 
+let encode_int_map_direct h =
+	encode_instance key_haxe_ds_IntMap ~kind:(IIntMap h)
+	
 let encode_string_map_direct h =
 	encode_instance key_haxe_ds_StringMap ~kind:(IStringMap h)
+	
+let encode_object_map_direct h =
+	encode_instance key_haxe_ds_ObjectMap ~kind:(IObjectMap (Obj.magic h))
 
 let encode_string_map convert m =
 	let h = StringHashtbl.create 0 in

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2598,17 +2598,17 @@ let init_maps builtins =
 		| VInstance {ikind = IIntMap h} -> h
 		| v -> unexpected_value v "int map"
 	in
-	init_fields builtins (["haxe";"ds"],"IntMap") [] (StdIntMap.map_fields vint decode_int (fun i -> Rope.of_string (string_of_int i)) (fun i -> encode_instance key_haxe_ds_IntMap ~kind:(IIntMap (i))) this);
+	init_fields builtins (["haxe";"ds"],"IntMap") [] (StdIntMap.map_fields vint decode_int (fun i -> Rope.of_string (string_of_int i)) encode_int_map_direct this);
 	let this vthis = match vthis with
 		| VInstance {ikind = IStringMap h} -> h
 		| v -> unexpected_value v "string map"
 	in
-	init_fields builtins (["haxe";"ds"],"StringMap") [] (StdStringMap.map_fields vstring_direct decode_rope_string (fun (r,_) -> r) (fun i -> encode_instance key_haxe_ds_StringMap ~kind:(IStringMap (i))) this);
+	init_fields builtins (["haxe";"ds"],"StringMap") [] (StdStringMap.map_fields vstring_direct decode_rope_string (fun (r,_) -> r) encode_string_map_direct this);
 	let this vthis = match vthis with
 		| VInstance {ikind = IObjectMap h} -> Obj.magic h
 		| v -> unexpected_value v "object map"
 	in
-    init_fields builtins (["haxe";"ds"],"ObjectMap") [] (StdObjectMap.map_fields (fun v -> v) (fun v -> v) (fun s -> s_value 0 s) (fun i -> encode_instance key_haxe_ds_ObjectMap ~kind:(IObjectMap (Obj.magic i))) this)
+    init_fields builtins (["haxe";"ds"],"ObjectMap") [] (StdObjectMap.map_fields (fun v -> v) (fun v -> v) (fun s -> s_value 0 s) encode_object_map_direct this)
 
 let init_constructors builtins =
 	let add = Hashtbl.add builtins.constructor_builtins in

--- a/std/Map.hx
+++ b/std/Map.hx
@@ -123,6 +123,15 @@ abstract Map<K,V>(IMap<K,V> ) {
 	}
 
 	/**
+		Returns a shallow copy of `this` map.
+
+		The order of values is undefined.
+	**/
+	public inline function copy():Map<K,V> {
+		return cast this.copy();
+	}
+
+	/**
 		Returns a String representation of `this` Map.
 
 		The exact representation depends on the platform and key-type.

--- a/std/cpp/_std/haxe/ds/IntMap.hx
+++ b/std/cpp/_std/haxe/ds/IntMap.hx
@@ -77,6 +77,12 @@ package haxe.ds;
 		var a:Array<Dynamic> = untyped __global__.__int_hash_values(h);
 		return a.iterator();
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		return untyped __global__.__int_hash_to_string(h);

--- a/std/cpp/_std/haxe/ds/ObjectMap.hx
+++ b/std/cpp/_std/haxe/ds/ObjectMap.hx
@@ -76,6 +76,12 @@ class ObjectMap<K:{},V> implements haxe.Constraints.IMap<K,V> {
 		var a:Array<Dynamic> = untyped __global__.__object_hash_values(h);
 		return a.iterator();
 	}
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		return untyped __global__.__object_hash_to_string(h);

--- a/std/cpp/_std/haxe/ds/StringMap.hx
+++ b/std/cpp/_std/haxe/ds/StringMap.hx
@@ -76,6 +76,12 @@ package haxe.ds;
 		var a:Array<Dynamic> = untyped __global__.__string_hash_values(h);
 		return a.iterator();
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		return untyped __global__.__string_hash_to_string(h);

--- a/std/cpp/_std/haxe/ds/WeakMap.hx
+++ b/std/cpp/_std/haxe/ds/WeakMap.hx
@@ -74,6 +74,13 @@ class WeakMap<K:{},V> implements haxe.Constraints.IMap<K,V> {
 		var a:Array<Dynamic> = untyped __global__.__object_hash_values(h);
 		return a.iterator();
 	}
+	
+	public function copy() : WeakMap<K,V> {
+		var copied = new WeakMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
+
 
 	public function toString() : String {
 		return untyped __global__.__object_hash_to_string(h);

--- a/std/cs/_std/haxe/ds/IntMap.hx
+++ b/std/cs/_std/haxe/ds/IntMap.hx
@@ -362,6 +362,12 @@ import cs.NativeArray;
 	{
 		return new IntMapValueIterator(this);
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap<T>();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	/**
 		Returns an displayable representation of the hashtable content.

--- a/std/cs/_std/haxe/ds/ObjectMap.hx
+++ b/std/cs/_std/haxe/ds/ObjectMap.hx
@@ -392,6 +392,12 @@ import cs.NativeArray;
 	{
 		return new ObjectMapValueIterator(this);
 	}
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap<K, V>();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	/**
 		Returns an displayable representation of the hashtable content.

--- a/std/cs/_std/haxe/ds/StringMap.hx
+++ b/std/cs/_std/haxe/ds/StringMap.hx
@@ -388,6 +388,12 @@ import cs.NativeArray;
 		return new StringMapValueIterator(this);
 	}
 
+	public function copy() : StringMap<T> {
+		var copied = new StringMap<T>();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
+
 	/**
 		Returns an displayable representation of the hashtable content.
 	**/

--- a/std/flash/_std/haxe/ds/IntMap.hx
+++ b/std/flash/_std/haxe/ds/IntMap.hx
@@ -76,6 +76,12 @@ package haxe.ds;
 
 	#end
 	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
+	
 	public function toString() : String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -69,6 +69,12 @@ class ObjectMap<K:{},V> extends flash.utils.Dictionary implements haxe.Constrain
 	}
 
 	#end
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = "";

--- a/std/flash/_std/haxe/ds/StringMap.hx
+++ b/std/flash/_std/haxe/ds/StringMap.hx
@@ -111,6 +111,12 @@ package haxe.ds;
 	}
 
 	#end
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/flash/_std/haxe/ds/UnsafeStringMap.hx
+++ b/std/flash/_std/haxe/ds/UnsafeStringMap.hx
@@ -80,6 +80,12 @@ class UnsafeStringMap<T> implements haxe.Constraints.IMap<String,T> {
 	}
 
 	#end
+	
+	public function copy() : UnsafeStringMap<T> {
+		var copied = new UnsafeStringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -69,6 +69,12 @@ class WeakMap<K:{},V> extends flash.utils.Dictionary implements haxe.Constraints
 	}
 
 	#end
+	
+	public function copy() : WeakMap<K,V> {
+		var copied = new WeakMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = "";

--- a/std/haxe/Constraints.hx
+++ b/std/haxe/Constraints.hx
@@ -62,5 +62,6 @@ interface IMap<K,V> {
 	public function remove(k:K):Bool;
 	public function keys():Iterator<K>;
 	public function iterator():Iterator<V>;
+	public function copy():IMap<K,V>;
 	public function toString():String;
 }

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -128,6 +128,12 @@ class BalancedTree<K,V> implements haxe.Constraints.IMap<K,V> {
 		keysLoop(root, ret);
 		return ret.iterator();
 	}
+	
+	public function copy():BalancedTree<K, V> {
+		var copied = new BalancedTree<K, V>();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	function setLoop(k:K, v:V, node:TreeNode<K,V>) {
 		if (node == null) return new TreeNode<K,V>(null, k, v, null);

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -131,7 +131,7 @@ class BalancedTree<K,V> implements haxe.Constraints.IMap<K,V> {
 	
 	public function copy():BalancedTree<K, V> {
 		var copied = new BalancedTree<K, V>();
-		for(key in keys()) copied.set(key, get(key));
+		copied.root = root;
 		return copied;
 	}
 

--- a/std/haxe/ds/HashMap.hx
+++ b/std/haxe/ds/HashMap.hx
@@ -72,6 +72,16 @@ abstract HashMap<K:{ function hashCode():Int; }, V >(HashMapData<K,V>) {
 	public inline function keys() {
 		return this.keys.iterator();
 	}
+	
+	/**
+		See `Map.copy`
+	**/
+	public function copy() : HashMap<K, V> {
+		var copied = new HashMapData();
+		copied.keys = this.keys.copy();
+		copied.values = this.values.copy();
+		return cast copied;
+	}
 
 	/**
 		See `Map.iterator`

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -66,6 +66,11 @@ extern class IntMap<T> implements haxe.Constraints.IMap<Int,T> {
 	public function iterator() : Iterator<T>;
 
 	/**
+		See `Map.copy`
+	**/
+	public function copy() : IntMap<T>;
+	
+	/**
 		See `Map.toString`
 	**/
 	public function toString() : String;

--- a/std/haxe/ds/ObjectMap.hx
+++ b/std/haxe/ds/ObjectMap.hx
@@ -68,6 +68,11 @@ extern class ObjectMap < K: { }, V > implements haxe.Constraints.IMap<K,V> {
 		See `Map.iterator`
 	**/
 	public function iterator():Iterator<V>;
+	
+	/**
+		See `Map.copy`
+	**/
+	public function copy() : ObjectMap<K,V>;
 
 	/**
 		See `Map.toString`

--- a/std/haxe/ds/StringMap.hx
+++ b/std/haxe/ds/StringMap.hx
@@ -67,6 +67,11 @@ extern class StringMap<T> implements haxe.Constraints.IMap<String,T> {
 	public function iterator() : Iterator<T>;
 
 	/**
+		See `Map.copy`
+	**/
+	public function copy() : StringMap<T>;
+	
+	/**
 		See `Map.toString`
 	**/
 	public function toString() : String;

--- a/std/haxe/ds/WeakMap.hx
+++ b/std/haxe/ds/WeakMap.hx
@@ -80,6 +80,13 @@ class WeakMap<K: { },V> implements haxe.Constraints.IMap<K,V> {
 	public function iterator():Iterator<V> {
 		return null;
 	}
+	
+	/**
+		See `Map.copy`
+	**/
+	public function copy() : WeakMap<K,V> {
+		return null;
+	}
 
 	/**
 		See `Map.toString`

--- a/std/hl/_std/haxe/ds/IntMap.hx
+++ b/std/hl/_std/haxe/ds/IntMap.hx
@@ -54,6 +54,12 @@ class IntMap<T> implements haxe.Constraints.IMap<Int,T> {
 	public function iterator() : Iterator<T> {
 		return h.iterator();
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/hl/_std/haxe/ds/ObjectMap.hx
+++ b/std/hl/_std/haxe/ds/ObjectMap.hx
@@ -54,6 +54,12 @@ class ObjectMap<K:{},T> implements haxe.Constraints.IMap<K,T> {
 	public function iterator() : Iterator<T> {
 		return h.iterator();
 	}
+	
+	public function copy() : ObjectMap<K,T> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -79,6 +79,12 @@ class StringMap<T> implements haxe.Constraints.IMap<String,T> {
 	public function iterator() : Iterator<T> {
 		return h.iterator();
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/java/_std/haxe/ds/IntMap.hx
+++ b/std/java/_std/haxe/ds/IntMap.hx
@@ -385,6 +385,12 @@ import java.NativeArray;
 			}
 		};
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	/**
 		Returns an displayable representation of the hashtable content.

--- a/std/java/_std/haxe/ds/ObjectMap.hx
+++ b/std/java/_std/haxe/ds/ObjectMap.hx
@@ -409,6 +409,13 @@ import java.NativeArray;
 			}
 		};
 	}
+	
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	/**
 		Returns an displayable representation of the hashtable content.

--- a/std/java/_std/haxe/ds/StringMap.hx
+++ b/std/java/_std/haxe/ds/StringMap.hx
@@ -409,6 +409,12 @@ import java.NativeArray;
 			}
 		};
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	/**
 		Returns an displayable representation of the hashtable content.

--- a/std/java/_std/haxe/ds/WeakMap.hx
+++ b/std/java/_std/haxe/ds/WeakMap.hx
@@ -447,6 +447,13 @@ import java.lang.ref.ReferenceQueue;
 			}
 		};
 	}
+	
+	
+	public function copy() : WeakMap<K,V> {
+		var copied = new WeakMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	/**
 		Returns an displayable representation of the hashtable content.

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -61,6 +61,12 @@ package haxe.ds;
 			next : function() { var i = __this__.it.next(); return __this__.ref[i]; }
 		};
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -82,6 +82,12 @@ class ObjectMap<K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 			next : function() { var i = __this__.it.next(); return __this__.ref[getId(i)]; }
 		};
 	}
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -124,6 +124,12 @@ private class StringMapIterator<T> {
 	public inline function iterator() : Iterator<T> {
 		return new StringMapIterator(this, arrayKeys());
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/lua/_std/haxe/ds/IntMap.hx
+++ b/std/lua/_std/haxe/ds/IntMap.hx
@@ -66,6 +66,12 @@ class IntMap<T> implements haxe.Constraints.IMap<Int,T> {
 			next : function() return h[it.next()]
 		};
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/lua/_std/haxe/ds/ObjectMap.hx
+++ b/std/lua/_std/haxe/ds/ObjectMap.hx
@@ -79,6 +79,12 @@ class ObjectMap<A,B> implements haxe.Constraints.IMap<A,B> {
 			next : function() return h[itr.next()]
 		};
 	}
+	
+	public function copy() : ObjectMap<A,B> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/lua/_std/haxe/ds/StringMap.hx
+++ b/std/lua/_std/haxe/ds/StringMap.hx
@@ -75,6 +75,12 @@ class StringMap<T> implements haxe.Constraints.IMap<String,T> {
 			next : function() return untyped __lua__("{0}[{1}]", v, it.next())
 		};
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/neko/_std/haxe/ds/IntMap.hx
+++ b/std/neko/_std/haxe/ds/IntMap.hx
@@ -56,6 +56,12 @@ package haxe.ds;
 		untyped __dollar__hiter(h,function(_,v) { l.push(v); });
 		return l.iterator();
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/neko/_std/haxe/ds/ObjectMap.hx
+++ b/std/neko/_std/haxe/ds/ObjectMap.hx
@@ -75,6 +75,12 @@ class ObjectMap<K:{},V> implements haxe.Constraints.IMap<K,V> {
 		untyped __dollar__hiter(h,function(_,v) { l.push(v); });
 		return l.iterator();
 	}
+	
+	public function copy() : ObjectMap<K, V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/neko/_std/haxe/ds/StringMap.hx
+++ b/std/neko/_std/haxe/ds/StringMap.hx
@@ -56,6 +56,12 @@ package haxe.ds;
 		untyped __dollar__hiter(h,function(_,v) { l.push(v); });
 		return l.iterator();
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -59,6 +59,12 @@ package haxe.ds;
 	public function iterator() : Iterator<T> {
 		return untyped __call__("new _hx_array_iterator", __call__("array_values", h));
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = "{";

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -62,7 +62,7 @@ package haxe.ds;
 	
 	public function copy() : IntMap<T> {
 		var copied = new IntMap();
-		for(key in keys()) copied.set(key, get(key));
+		copied.h = h;
 		return copied;
 	}
 

--- a/std/php/_std/haxe/ds/ObjectMap.hx
+++ b/std/php/_std/haxe/ds/ObjectMap.hx
@@ -76,7 +76,8 @@ class ObjectMap <K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 	
 	public function copy() : ObjectMap<K,V> {
 		var copied = new ObjectMap();
-		for(key in keys()) copied.set(key, get(key));
+		copied.h = h;
+		copied.hk = hk;
 		return copied;
 	}
 

--- a/std/php/_std/haxe/ds/ObjectMap.hx
+++ b/std/php/_std/haxe/ds/ObjectMap.hx
@@ -73,6 +73,12 @@ class ObjectMap <K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 	public inline function iterator() : Iterator<V> {
 		return untyped __call__("new _hx_array_iterator", __call__("array_values", h));
 	}
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = "{";

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -62,7 +62,7 @@ package haxe.ds;
 	
 	public function copy() : StringMap<T> {
 		var copied = new StringMap();
-		for(key in keys()) copied.set(key, get(key));
+		copied.h = h;
 		return copied;
 	}
 

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -59,6 +59,12 @@ package haxe.ds;
 	public function iterator() : Iterator<T> {
 		return untyped __call__("new _hx_array_iterator", __call__("array_values", h));
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = "{";

--- a/std/php7/_std/haxe/ds/IntMap.hx
+++ b/std/php7/_std/haxe/ds/IntMap.hx
@@ -86,7 +86,7 @@ import php.NativeIndexedArray;
 
 	public function copy() : IntMap<T> {
 		var copied = new IntMap();
-		for(key in keys()) copied.set(key, get(key));
+		copied.data = data;
 		return copied;
 	}
 

--- a/std/php7/_std/haxe/ds/IntMap.hx
+++ b/std/php7/_std/haxe/ds/IntMap.hx
@@ -84,6 +84,12 @@ import php.NativeIndexedArray;
 		return Global.array_values(data).iterator();
 	}
 
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
+
 	/**
 		See `Map.toString`
 	**/

--- a/std/php7/_std/haxe/ds/ObjectMap.hx
+++ b/std/php7/_std/haxe/ds/ObjectMap.hx
@@ -66,6 +66,12 @@ class ObjectMap <K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 	public inline function iterator() : Iterator<V> {
 		return _values.iterator();
 	}
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = "{";

--- a/std/php7/_std/haxe/ds/ObjectMap.hx
+++ b/std/php7/_std/haxe/ds/ObjectMap.hx
@@ -69,7 +69,8 @@ class ObjectMap <K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 	
 	public function copy() : ObjectMap<K,V> {
 		var copied = new ObjectMap();
-		for(key in keys()) copied.set(key, get(key));
+		copied._values = _values;
+		copied._keys = _keys;
 		return copied;
 	}
 

--- a/std/php7/_std/haxe/ds/StringMap.hx
+++ b/std/php7/_std/haxe/ds/StringMap.hx
@@ -65,7 +65,7 @@ import haxe.Constraints;
 	
 	public function copy() : StringMap<T> {
 		var copied = new StringMap();
-		for(key in keys()) copied.set(key, get(key));
+		copied.data = data;
 		return copied;
 	}
 

--- a/std/php7/_std/haxe/ds/StringMap.hx
+++ b/std/php7/_std/haxe/ds/StringMap.hx
@@ -62,6 +62,12 @@ import haxe.Constraints;
 	public inline function iterator() : Iterator<T> {
 		return data.iterator();
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var parts = new NativeArray();

--- a/std/python/_std/haxe/ds/IntMap.hx
+++ b/std/python/_std/haxe/ds/IntMap.hx
@@ -57,6 +57,12 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	public function iterator() : Iterator<T> {
 		return h.values().iter();
 	}
+	
+	public function copy() : IntMap<T> {
+		var copied = new IntMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/python/_std/haxe/ds/ObjectMap.hx
+++ b/std/python/_std/haxe/ds/ObjectMap.hx
@@ -58,6 +58,12 @@ class ObjectMap<K:{},V> implements haxe.Constraints.IMap<K, V> {
 	public function iterator() : Iterator<V> {
 		return h.values().iter();
 	}
+	
+	public function copy() : ObjectMap<K,V> {
+		var copied = new ObjectMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 		var s = new StringBuf();

--- a/std/python/_std/haxe/ds/StringMap.hx
+++ b/std/python/_std/haxe/ds/StringMap.hx
@@ -57,6 +57,12 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 	public function iterator() : Iterator<T> {
 		return h.values().iter();
 	}
+	
+	public function copy() : StringMap<T> {
+		var copied = new StringMap();
+		for(key in keys()) copied.set(key, get(key));
+		return copied;
+	}
 
 	public function toString() : String {
 

--- a/tests/unit/src/unitstd/Map.unit.hx
+++ b/tests/unit/src/unitstd/Map.unit.hx
@@ -22,6 +22,16 @@ map3.exists("foo") == true;
 map3.get("foo") == 1;
 map4.exists("foo") == true;
 map4.get("foo") == 1;
+
+var copied = map.copy();
+copied != map;
+copied.exists("foo") == map.exists("foo");
+copied.exists("bar") == map.exists("bar");
+copied.exists("baz") == map.exists("baz");
+copied.get("foo") == map.get("foo");
+copied.get("bar") == map.get("bar");
+copied.get("baz") == map.get("baz");
+
 var values = [];
 for (val in map) {
 	values.push(val);
@@ -56,6 +66,16 @@ map.exists(3) == true;
 map.get(1) == 1;
 map.get(2) == 2;
 map.get(3) == 3;
+
+var copied = map.copy();
+copied != map;
+copied.exists(1) == map.exists(1);
+copied.exists(2) == map.exists(2);
+copied.exists(3) == map.exists(3);
+copied.get(1) == map.get(1);
+copied.get(2) == map.get(2);
+copied.get(3) == map.get(3);
+
 var values = [];
 for (val in map) {
 	values.push(val);
@@ -92,6 +112,16 @@ map.exists(c) == true;
 map.get(a) == 1;
 map.get(b) == 2;
 map.get(c) == 3;
+
+var copied = map.copy();
+copied != map;
+copied.exists(a) == map.exists(a);
+copied.exists(b) == map.exists(b);
+copied.exists(c) == map.exists(c);
+copied.get(a) == map.get(a);
+copied.get(b) == map.get(b);
+copied.get(c) == map.get(c);
+
 var values = [];
 for (val in map) {
 	values.push(val);
@@ -128,6 +158,16 @@ map.exists(c) == true;
 map.get(a) == 1;
 map.get(b) == 2;
 map.get(c) == 3;
+
+var copied = map.copy();
+copied != map;
+copied.exists(a) == map.exists(a);
+copied.exists(b) == map.exists(b);
+copied.exists(c) == map.exists(c);
+copied.get(a) == map.get(a);
+copied.get(b) == map.get(b);
+copied.get(c) == map.get(c);
+
 var values = [];
 for (val in map) {
 	values.push(val);

--- a/tests/unit/src/unitstd/Map.unit.hx
+++ b/tests/unit/src/unitstd/Map.unit.hx
@@ -32,6 +32,10 @@ copied.get("foo") == map.get("foo");
 copied.get("bar") == map.get("bar");
 copied.get("baz") == map.get("baz");
 
+copied.set("foo", 4);
+copied.get("foo") == 4;
+map.get("foo") == 1;
+
 var values = [];
 for (val in map) {
 	values.push(val);
@@ -75,6 +79,10 @@ copied.exists(3) == map.exists(3);
 copied.get(1) == map.get(1);
 copied.get(2) == map.get(2);
 copied.get(3) == map.get(3);
+
+copied.set(1, 4);
+copied.get(1) == 4;
+map.get(1) == 1;
 
 var values = [];
 for (val in map) {
@@ -122,6 +130,10 @@ copied.get(a) == map.get(a);
 copied.get(b) == map.get(b);
 copied.get(c) == map.get(c);
 
+copied.set(a, 4);
+copied.get(a) == 4;
+map.get(a) == 1;
+
 var values = [];
 for (val in map) {
 	values.push(val);
@@ -167,6 +179,10 @@ copied.exists(c) == map.exists(c);
 copied.get(a) == map.get(a);
 copied.get(b) == map.get(b);
 copied.get(c) == map.get(c);
+
+copied.set(a, 4);
+copied.get(a) == 4;
+map.get(a) == 1;
 
 var values = [];
 for (val in map) {

--- a/tests/unit/src/unitstd/haxe/ds/BalancedTree.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/BalancedTree.unit.hx
@@ -31,6 +31,16 @@ for (k in test.keys()) {
 for (k in otherKeys) {
 	eq(false, m.exists(k));
 }
+
+var copied = m.copy();
+copied != m;
+for(k in m.keys()) {
+	eq(test[k], copied.get(k));
+	copied.set(k, copied.get(k) + 1);
+	eq(test[k] + 1, copied.get(k));
+	eq(test[k], m.get(k));
+}
+
 var r = [for (key in m.keys()) key];
 arrEq(r, [1,6,8,11,13,15,17,22,25,27]);
 var r = [for (val in m) val];


### PR DESCRIPTION
This adds a new method to `IMap` so it is a breaking change.

I put a naive implementation to the platform classes (loop through the keys and copy) which can be later optimized.

See also: https://github.com/HaxeFoundation/haxe/pull/5863