### PR TITLE
apply FD_OUTPUT filter to unix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,17 @@ else
 	MODULE_EXT = cmx
 endif
 
+ifeq (${FD_OUTPUT}, 1)
+FILTER=sed -e 's/_build\/src\//src\//' tmp.cmi
+endif
+
 CC_CMD = $(COMPILER) $(ALL_CFLAGS) -c $<
+
+ifdef FILTER
+CC_CMD=($(COMPILER) $(ALL_CFLAGS) -c $< 2>tmp.cmi && $(FILTER)) || ($(FILTER) && exit 1)
+CC_PARSER_CMD=($(COMPILER) -pp camlp4o $(ALL_CFLAGS) -c src/syntax/parser.ml 2>tmp.cmi && $(FILTER)) || ($(FILTER) && exit 1)
+endif
+
 
 # Meta information
 


### PR DESCRIPTION
Here's a real quick patch to make the _build/src/* filtering available on the base MAKEFILE.  Is this sufficient for vscode?