### PR TITLE
Fix #6342

### DIFF
--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -496,7 +496,7 @@ let inline_constructors ctx e =
 					loop (el'@acc) el
 			in
 			let el, io = loop [] el in
-			let el = if unwrap_block then el else [mk (TBlock (List.rev el)) e.etype e.epos] in
+			let el = if unwrap_block || Option.is_some io then el else [mk (TBlock (List.rev el)) e.etype e.epos] in
 			el, io
 		| TMeta((Meta.InlineConstructorArgument (_,io_id_start),_,_),e) ->
 			let old_io_id = !current_io_id in

--- a/tests/unit/src/unit/issues/Issue6342.hx
+++ b/tests/unit/src/unit/issues/Issue6342.hx
@@ -1,0 +1,32 @@
+package unit.issues;
+
+class Issue6342 extends unit.Test {
+	@:analyzer(ignore)
+	function test() {
+		var t = new A(1);
+		var tmp1 = t.foo().x;
+		eq(1, tmp1);
+		
+		var tmp2 = ({
+			new A(2);
+		}).x;
+		eq(2, tmp2);
+	}
+}
+
+@:keep
+private class A
+{
+	public var x:Int;
+	
+	@:analyzer(ignore)
+	public inline function new(x) {
+		this.x = x;
+	}
+	
+	@:analyzer(ignore)
+	public inline function foo() {
+		var tmp = x;
+		return new A(x);
+	}
+}

--- a/tests/unit/src/unit/issues/Issue6342.hx
+++ b/tests/unit/src/unit/issues/Issue6342.hx
@@ -1,7 +1,7 @@
 package unit.issues;
 
 class Issue6342 extends unit.Test {
-	@:analyzer(ignore)
+	@:analyzer(no_optimize)
 	function test() {
 		var t = new A(1);
 		var tmp1 = t.foo().x;
@@ -19,12 +19,12 @@ private class A
 {
 	public var x:Int;
 	
-	@:analyzer(ignore)
+	@:analyzer(no_optimize)
 	public inline function new(x) {
 		this.x = x;
 	}
 	
-	@:analyzer(ignore)
+	@:analyzer(no_optimize)
 	public inline function foo() {
 		var tmp = x;
 		return new A(x);


### PR DESCRIPTION
Fix and tests for Issue #6342.

I verified the test fails before without the fix using travis here: https://travis-ci.org/basro/haxe/jobs/240562132

The cpp tests are failing with this PR, however I believe this is a bug in the cpp generator unrelated to the inline constructors bug. I'll open an issue for this soon.

AS3 is failing too because of some 404 request, but this seems to be the case for haxe's development branch too.