### PR TITLE
[lua] do not modify base string prototype

### DIFF
--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -63,6 +63,7 @@ class Boot {
 	*/
 	static inline public function getClass(o:Dynamic) : Class<Dynamic> {
 		if (Std.is(o, Array)) return Array;
+		else if (Std.is(o, String)) return String;
 		else {
 			var cl = untyped __define_feature__("lua.Boot.getClass", o.__class__);
 			if (cl != null) return cl;

--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -25,11 +25,16 @@ import lua.Boot;
 @:coreApi class Reflect {
 
 	public inline static function hasField( o : Dynamic, field : String ) : Bool {
-		return untyped o.__fields__ != null ? o.__fields__[field] != null :  o[field] != null;
+		return  Std.is(o,String) && field == "length" ? true :
+			untyped o.__fields__ != null ? o.__fields__[field] != null :  o[field] != null;
 	}
 
-	public static function field( o : Dynamic, field : String ) : Dynamic untyped {
-		return try o[field] catch( e : Dynamic ) null;
+	public static function field( o : Dynamic, field : String ) : Dynamic {
+		if (Std.is(o, String)){
+			if (field == "length") return lua.NativeStringTools.len(o);
+			else return untyped String.prototype[field];
+		}
+		else return try untyped o[field] catch( e : Dynamic ) null;
 	}
 
 	public inline static function setField( o : Dynamic, field : String, value : Dynamic ) : Void untyped {

--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -31,19 +31,11 @@ class String {
 	public var length(default,null) : Int;
 
 
-	public function new(string:String) untyped {}
+	public inline function new(string:String) untyped {}
 
-	@:keep
-	static function __index(s:Dynamic, k:Dynamic) : Dynamic {
-		if (k == "length") return NativeStringTools.len(s);
-		else if (Reflect.hasField(untyped String.prototype, k)) return untyped String.prototype[k];
-		else if (__oldindex != null) return  __oldindex[k];
-		else return null;
-	}
-
-	public function toUpperCase() : String return NativeStringTools.upper(this);
-	public function toLowerCase() : String return NativeStringTools.lower(this);
-	public function indexOf( str : String, ?startIndex : Int ) : Int {
+	public inline function toUpperCase() : String return NativeStringTools.upper(this);
+	public inline function toLowerCase() : String return NativeStringTools.lower(this);
+	public inline function indexOf( str : String, ?startIndex : Int ) : Int {
 		if (startIndex == null) startIndex = 1;
 		else startIndex += 1;
 		var r = NativeStringTools.find(this, str, startIndex, true).begin;
@@ -51,18 +43,19 @@ class String {
 		else return -1;
 	}
 
-	public function lastIndexOf( str : String, ?startIndex : Int ) : Int {
+	public inline function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		var i = 0;
 		var ret = -1;
 		if( startIndex == null ) startIndex = length;
 		while( true ) {
 			var p = indexOf(str, ret+1);
-			if( p == -1 || p > startIndex ) return ret;
+			if( p == -1 || p > startIndex ) break;
 			ret = p;
 		}
+		return ret;
 	}
 
-	public function split( delimiter : String ) : Array<String> {
+	public inline function split( delimiter : String ) : Array<String> {
 		var idx = 1;
 		var ret = [];
 		var delim_offset = delimiter.length > 0 ? delimiter.length : 1;
@@ -88,10 +81,10 @@ class String {
 		return ret;
 	}
 
-	public function toString() : String {
+	public inline function toString() : String {
 		return this;
 	}
-	public function substring( startIndex : Int, ?endIndex : Int ) : String {
+	public inline function substring( startIndex : Int, ?endIndex : Int ) : String {
 		if (endIndex == null) endIndex = this.length;
 		if (endIndex < 0) endIndex = 0;
 		if (startIndex < 0) startIndex = 0;
@@ -103,17 +96,14 @@ class String {
 		}
 	}
 
-	function get_length() : Int {
-		return NativeStringTools.len(this);
-	}
-	public function charAt( index : Int) : String {
+	public inline function charAt( index : Int) : String {
 		return NativeStringTools.sub(this,index+1, index+1).match;
 	}
-	public function charCodeAt( index : Int) : Null<Int> {
+	public inline function charCodeAt( index : Int) : Null<Int> {
 		return NativeStringTools.byte(this,index+1);
 	}
 
-	public function substr( pos : Int, ?len : Int ) : String {
+	public inline function substr( pos : Int, ?len : Int ) : String {
 		if (len == null || len > pos + this.length) len = this.length;
 		else if (len < 0) len = length + len;
 		if (pos < 0) pos = length + pos;
@@ -121,7 +111,7 @@ class String {
 		return NativeStringTools.sub(this, pos + 1, pos+len).match;
 	}
 
-	public inline static function fromCharCode( code : Int ) : String {
+	public inline static inline function fromCharCode( code : Int ) : String {
 		return NativeStringTools.char(code);
 	}
 

--- a/tests/unit/src/unit/TestSpecification.hx
+++ b/tests/unit/src/unit/TestSpecification.hx
@@ -40,7 +40,7 @@ typedef T = {
 		return "1";
 	}
 
-	public function set_propAcc(v) {
+	public function set_propAcc(v:String) {
 		return this.propAcc = v.toUpperCase();
 	}
 }

--- a/tests/unit/src/unit/issues/Issue6259.hx
+++ b/tests/unit/src/unit/issues/Issue6259.hx
@@ -3,7 +3,7 @@ class Issue6259 extends Test{
 	function test(){
 #if !python
 		function f(a) return a.b;
-		var res = f({b: (s) -> s.length})("6259");
+		var res = f({b: (s : String) -> s.length})("6259");
 		eq(res,4);
 #end
 	}

--- a/tests/unit/src/unit/issues/Issue6298.hx
+++ b/tests/unit/src/unit/issues/Issue6298.hx
@@ -1,0 +1,7 @@
+package unit.issues;
+class Issue6298 extends Test {
+	function test(){
+
+	}
+}
+

--- a/tests/unit/src/unitstd/Array.unit.hx
+++ b/tests/unit/src/unitstd/Array.unit.hx
@@ -255,7 +255,7 @@ a != b;
 b.length == a.length;
 a[0] == b[0];
 a[1] == b[1];
-var func = function(s) return s.toUpperCase();
+var func = function(s:String) return s.toUpperCase();
 ["foo", "bar"].map(func) == ["FOO", "BAR"];
 [].map(func) == [];
 


### PR DESCRIPTION
Here's a pull request for a version of genlua that does not need to modify the base string type.

There's some caveats here... namely the compiler needs to be told explicitly that it is working with a string.  It won't be able to rely on untyped field access on strings.  E.g.:

```haxe
var f = function(x) return x.length;  // x is typed as { length : Unknown<A>}
trace(f("a string"));
```

The compiler will allow this, but inside of the ``f`` function, the argument type will be anonymous.  The expression will generate as a plain field access, instead of referencing the correct String length method, and that field access will fail in the runtime.

I'm wondering if this will cause more confusion for developers... String is such a basic type, and I can imagine people use it in functions without specifying argument type (I found a few of these cases already in the unit tests).

Would it be possible to detect when a string function is passed as a structural type?  I could catch those cases and try and create an anonymous object where it is needed.


cc @ibilon @nadako 