### PR TITLE
[lua] alias string methods with -d lua-alias-string

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -253,19 +253,19 @@ let mk_mr_box ctx e =
 	mk_lua_code ctx.com code [e] e.etype e.epos
 
 (* create a multi-return select call for given expr and field name *)
-let mk_mr_select com e name =
+let mk_mr_select com e ecall name =
 	let i =
-		match follow e.etype with
+		match follow ecall.etype with
 		| TInst (c,_) ->
 			index_of (fun f -> f.cf_name = name) c.cl_ordered_fields
 		| _ ->
 			assert false
 	in
 	if i == 0 then
-	    e
+	    mk_lua_code com "{0}" [ecall] e.etype e.epos
 	else
 	    let code = Printf.sprintf "_G.select(%i, {0})" (i + 1) in
-	    mk_lua_code com code [e] e.etype e.epos
+	    mk_lua_code com code [ecall] e.etype e.epos
 
 (* from genphp *)
 let rec is_string_type t =
@@ -1786,7 +1786,7 @@ let transform_multireturn ctx = function
 					(* if we found a field access for the multi-return call, generate select call *)
 					| TField ({ eexpr = TCall _ } as ecall, f) when is_multireturn ecall.etype ->
 						let ecall = Type.map_expr loop ecall in
-						mk_mr_select ctx.com ecall (field_name f)
+						mk_mr_select ctx.com e ecall (field_name f)
 
 					(* if we found a multi-return call used as a value, box it *)
 					| TCall _ when is_multireturn e.etype ->

--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -41,8 +41,11 @@ class String {
 		else return null;
 	}
 
-	public function toUpperCase() : String return NativeStringTools.upper(this);
-	public function toLowerCase() : String return NativeStringTools.lower(this);
+#if lua_alias_string @:native("_hx_toUpperCase") #end
+	public inline function toUpperCase() : String return NativeStringTools.upper(this);
+#if lua_alias_string @:native("_hx_toLowerCase") #end
+	public inline function toLowerCase() : String return NativeStringTools.lower(this);
+#if lua_alias_string @:native("_hx_indexOf") #end
 	public function indexOf( str : String, ?startIndex : Int ) : Int {
 		if (startIndex == null) startIndex = 1;
 		else startIndex += 1;
@@ -51,6 +54,7 @@ class String {
 		else return -1;
 	}
 
+#if lua_alias_string @:native("_hx_lastIndexOf") #end
 	public function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		var i = 0;
 		var ret = -1;
@@ -62,6 +66,7 @@ class String {
 		}
 	}
 
+#if lua_alias_string @:native("_hx_split") #end
 	public function split( delimiter : String ) : Array<String> {
 		var idx = 1;
 		var ret = [];
@@ -88,9 +93,12 @@ class String {
 		return ret;
 	}
 
-	public function toString() : String {
+#if lua_alias_string @:native("_hx_toString") #end
+	public inline function toString() : String {
 		return this;
 	}
+
+#if lua_alias_string @:native("_hx_substring") #end
 	public function substring( startIndex : Int, ?endIndex : Int ) : String {
 		if (endIndex == null) endIndex = this.length;
 		if (endIndex < 0) endIndex = 0;
@@ -103,16 +111,17 @@ class String {
 		}
 	}
 
-	function get_length() : Int {
-		return NativeStringTools.len(this);
-	}
-	public function charAt( index : Int) : String {
+#if lua_alias_string @:native("_hx_charAt") #end
+	public inline function charAt( index : Int) : String {
 		return NativeStringTools.sub(this,index+1, index+1).match;
 	}
-	public function charCodeAt( index : Int) : Null<Int> {
+	
+#if lua_alias_string @:native("_hx_charCodeAt") #end
+	public inline function charCodeAt( index : Int) : Null<Int> {
 		return NativeStringTools.byte(this,index+1);
 	}
 
+#if lua_alias_string @:native("_hx_substr") #end
 	public function substr( pos : Int, ?len : Int ) : String {
 		if (len == null || len > pos + this.length) len = this.length;
 		else if (len < 0) len = length + len;
@@ -121,6 +130,7 @@ class String {
 		return NativeStringTools.sub(this, pos + 1, pos+len).match;
 	}
 
+#if lua_alias_string @:native("_hx_fromCharCode") #end
 	public inline static function fromCharCode( code : Int ) : String {
 		return NativeStringTools.char(code);
 	}


### PR DESCRIPTION
String methods are commonly patched in lua libraries.  This can cause problems with haxe generated code, since it relies on specific patches for strings.

This branch provides a ``-D lua-alias-string`` directive that applies ``@:native`` metadata to all string methods.

cc @ibilon