### PR TITLE
Travis hack

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -524,9 +524,8 @@ and gen_expr ?(local=true) ctx e = begin
 		gen_value ctx x;
 		print ctx ")";
 	| TField (e, f) when is_string_expr e ->
-                spr ctx "(";
-                gen_value ctx e;
-                print ctx ").%s" (field_name f);
+                gen_paren ctx [e];
+                print ctx ".%s" (field_name f);
 	| TField (x,FClosure (_,f)) ->
 		add_feature ctx "use._hx_bind";
 		(match x.eexpr with

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -746,6 +746,24 @@ class RunCi {
 		}
 	}
 
+	static function getMatches(ereg:EReg, input:String, index:Int = 0):Array<String> {
+	  var matches = [];
+	  while (ereg.match(input)) {
+	    matches.push(ereg.matched(index));
+	    input = ereg.matchedRight();
+	  }
+	  return matches;
+	}
+
+	static function filterTests(tests:Array<TEST>){
+	  var commit = Sys.getEnv("TRAVIS_COMMIT_MESSAGE");
+	  var test_tags = getMatches(~/\[([^\]]+)\]/m, commit,1);
+	  Sys.println('test tags : $test_tags');
+	  test_tags = [for (tag in test_tags) tag.toLowerCase()];
+	  if (test_tags.length > 0) tests = test_tags;
+	  return tests;
+	}
+
 	static function main():Void {
 		Sys.putEnv("OCAMLRUNPARAM", "b");
 
@@ -755,6 +773,9 @@ class RunCi {
 			case env:
 				[for (v in env.split(",")) v.trim().toLowerCase()];
 		}
+
+		tests = filterTests(tests);
+
 		Sys.println('Going to test: $tests');
 
 		for (test in tests) {
@@ -1086,5 +1107,6 @@ class RunCi {
 			Sys.exit(1);
 		}
 	}
+
 }
 


### PR DESCRIPTION
Here's a quick pull request showing an illustration of "travis focusing" by using the commit message to select the targets to run.

Several core developers use a bracket tag to denote commits pertaining to a specific target.  E.g.:

```[lua] fix some stuff```

In this target focus branch, the RunCI will look for tags like that, and extract them.  It will use them to filter the list of standard targets it uses for running unit tests.

You can see the result on the following travis run, where only the [lua tests were run](https://s3.amazonaws.com/archive.travis-ci.org/jobs/242232835/log.txt?X-Amz-Expires=30&X-Amz-Date=20170613T001804Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJRYRXRSVGNKPKO5A/20170613/us-east-1/s3/aws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=e068b2b2083c47d705ff03b25aa9eb73bbada90edf7dca12ade4a966c34f3dcc) for https://github.com/HaxeFoundation/haxe/commit/0a7375848e4e73d9ba2dc63f8973719935ae5965 .
