### PR TITLE
[lua] `sys.LFileSystem` as import, not as typedef

### DIFF
--- a/std/lua/_std/sys/FileSystem.hx
+++ b/std/lua/_std/sys/FileSystem.hx
@@ -26,7 +26,7 @@ import lua.Os;
 import lua.Lib;
 import lua.Table;
 import haxe.io.Path;
-typedef LFileSystem = lua.lib.luv.fs.FileSystem;
+import lua.lib.luv.fs.FileSystem as LFileSystem;
 
 class FileSystem {
 	public static function exists( path : String ) : Bool {


### PR DESCRIPTION
Goal is to hide [this](http://api.haxe.org/sys/LFileSystem.html) confusing typedef from the API docs.

(I hope) It is only used in this class.