### PR TITLE
Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -210,4 +210,3 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ matrix:
     #########
     - os: linux
       env:
-        - TEST=macro,neko,js,php,php7,flash9,as3,python,hl,lua,java,cs
+        - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
         - DEPLOY=1
         # - SAUCE=1
         # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
       - $HOME/apt-cache
       - $HOME/hxcache
       - $HOME/_hxbuild
+      - $HOME/lua_env
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 before_cache:
-  - if [ $TRAVIS_OS_NAME = 'linux' ]; then sudo apt-get autoclean; fi
+  - if [ $TRAVIS_OS_NAME = 'linux' ]; then
+      sudo apt-get autoclean;
+      sudo rm -f $HOME/apt-cache/lock || true;
+    fi
   - if [ $TRAVIS_OS_NAME = 'osx' ]; then brew cleanup; fi
-  - sudo rm -f $HOME/apt-cache/lock || true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -233,17 +233,17 @@ matrix:
 
 script:
   - eval `ssh-agent -s` # for deployment to haxe.org
-  - export REQUIRES_CACHE=`test $CACHE_AVAILABLE = 0 && test $TRAVIS_OS_NAME = 'osx'`
-  - if [ $REQUIRES_CACHE ]; then
+  - export CAN_BUILD=`test $CACHE_AVAILABLE = 1 || test $TRAVIS_OS_NAME = 'linux'`
+  - if [ ! $CAN_BUILD ]; then
       echo "No cache available, but initial cache created, please try restarting this job";
     fi
-  - (test $REQUIRES_CACHE) && pushd tests
-  - (test $REQUIRES_CACHE) && mkdir ~/haxelib && haxelib setup ~/haxelib
-  - (test $REQUIRES_CACHE) && haxelib install record-macros
-  - (test $REQUIRES_CACHE) && haxe -version
-  - (test $REQUIRES_CACHE) && haxe RunCi.hxml
-  - (test $REQUIRES_CACHE) && neko RunCi.n
-  - (test $REQUIRES_CACHE) && popd
+  - test $CAN_BUILD && pushd tests
+  - test $CAN_BUILD && mkdir ~/haxelib && haxelib setup ~/haxelib
+  - test $CAN_BUILD && haxelib install record-macros
+  - test $CAN_BUILD && haxe -version
+  - test $CAN_BUILD && haxe RunCi.hxml
+  - test $CAN_BUILD && neko RunCi.n
+  - test $CAN_BUILD && popd
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install_linux: &install_linux
       pushd /home/travis/neko;
     else
       pushd /home/travis/neko;
-      git pull origin master;
+      git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
   - cmake . -DSTATIC_DEPS=all -G Ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,13 @@ addons: &addons
     - api.haxe.org
 
 install_linux: &install_linux
+  - if [ ! -d "$HOME/neko" ]; then
+      export CACHE_AVAILABLE=0;
+    elif [ ! -d "$HOME/neko/.git" ]; then
+      export CACHE_AVAILABLE=0;
+    else
+      export CACHE_AVAILABLE=1;
+    fi
   - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
   # Install dependencies
   - sudo add-apt-repository ppa:haxe/ocaml -y
@@ -111,6 +118,13 @@ install_linux: &install_linux
 
 
 install_osx: &install_osx
+  - if [ ! -d "$HOME/neko" ]; then
+      export CACHE_AVAILABLE=0;
+    elif [ ! -d "$HOME/neko/.git" ]; then
+      export CACHE_AVAILABLE=0;
+    else
+      export CACHE_AVAILABLE=1;
+    fi
   # Install dependencies
   - brew uninstall --force brew-cask # https://github.com/caskroom/homebrew-cask/pull/15381
   - travis_retry brew update
@@ -215,6 +229,10 @@ matrix:
 
 script:
   - eval `ssh-agent -s` # for deployment to haxe.org
+  - if [ $CACHE_AVAILABLE = 0 ]; then
+      echo "No cache available";
+      exit 1;
+  - end
   - pushd tests
   -   mkdir ~/haxelib && haxelib setup ~/haxelib
   -   haxelib install record-macros

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ install_linux: &install_linux
       fi;
       git submodule update --init --recursive;
     fi
-  - cmake . -DSTATIC_DEPS=all -G Ninja || (rm -rf ./build && cmake . -DSTATIC_DEPS=all -G Ninja)
+  - cmake . -DSTATIC_DEPS=all -G Ninja || (git clean -dfx && cmake . -DSTATIC_DEPS=all -G Ninja)
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
   - ninja -j 4
@@ -144,7 +144,7 @@ install_osx: &install_osx
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
-  - cmake . -DSTATIC_DEPS=all -G Ninja || (rm -rf ./build && cmake . -DSTATIC_DEPS=all -G Ninja)
+  - cmake . -DSTATIC_DEPS=all -G Ninja || (git clean -dfx && cmake . -DSTATIC_DEPS=all -G Ninja)
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
   - ninja -j 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
       - $HOME/hxcache
       - $HOME/_hxbuild
       - $HOME/lua_env
-      - /usr/local/Cellar
+      - $HOME/Library/Caches/Homebrew
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,6 @@ install_linux: &install_linux
   - cp -prf ./_build/ ~/_hxbuild/
   - sudo rm -f $APT_CACHE_DIR/lock
 
-
 install_osx: &install_osx
   # Install dependencies
   - brew uninstall --force brew-cask # https://github.com/caskroom/homebrew-cask/pull/15381

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ install_linux: &install_linux
       fi;
       git submodule update --init --recursive;
     fi
-  - cmake . -DSTATIC_DEPS=all -G Ninja
+  - cmake . -DSTATIC_DEPS=all -G Ninja || (rm -rf ./build && cmake . -DSTATIC_DEPS=all -G Ninja)
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
   - ninja -j 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ install_osx: &install_osx
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
-  - cmake . -DSTATIC_DEPS=all -G Ninja
+  - cmake . -DSTATIC_DEPS=all -G Ninja || (rm -rf ./build && cmake . -DSTATIC_DEPS=all -G Ninja)
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
   - ninja -j 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 before_cache:
+  - if [ $TRAVIS_OS_NAME = 'linux' ]; then sudo apt-get autoclean; fi
+  - if [ $TRAVIS_OS_NAME = 'osx' ]; then brew cleanup; fi
   - sudo rm -f $HOME/apt-cache/lock || true
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ cache:
     - $HOME/hxcache
     - $HOME/_hxbuild
     - $HOME/lua_env
+    - $HOME/.luarocks
     - $HOME/Library/Caches/Homebrew
+
 before_cache:
+  - ls -la ~
   - sudo rm -f $HOME/apt-cache/lock || true
 env:
   global:
@@ -159,6 +162,23 @@ matrix:
     #########
     # linux #
     #########
+    - os: linux
+      env:
+        - TEST=lua
+        # - SAUCE=1
+        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+      # addons:
+      #   <<: *addons
+      #  sauce_connect: true
+      before_install:
+        - sudo apt-get update -y || true
+        - "export DISPLAY=:99.0"
+        - "sh -e /etc/init.d/xvfb start"
+        - "export AUDIODEV=null"
+      install: *install_linux
     - os: linux
       env:
         - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ cache:
     - $HOME/_hxbuild
     - $HOME/lua_env
     - $HOME/Library/Caches/Homebrew
+before_cache:
+  - sudo rm -f $HOME/apt-cache/lock
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,24 +141,24 @@ matrix:
     #########
     # linux #
     #########
-    #- os: linux
-    #  env:
-    #    - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
-    #    - DEPLOY=1
-    #    # - SAUCE=1
-    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-    #  # addons:
-    #  #   <<: *addons
-    #  #  sauce_connect: true
-    #  before_install:
-    #    - sudo apt-get update -y || true
-    #    - "export DISPLAY=:99.0"
-    #    - "sh -e /etc/init.d/xvfb start"
-    #    - "export AUDIODEV=null"
-    #  install: *install_linux
+    - os: linux
+      env:
+        - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
+        - DEPLOY=1
+        # - SAUCE=1
+        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+      # addons:
+      #   <<: *addons
+      #  sauce_connect: true
+      before_install:
+        - sudo apt-get update -y || true
+        - "export DISPLAY=:99.0"
+        - "sh -e /etc/init.d/xvfb start"
+        - "export AUDIODEV=null"
+      install: *install_linux
 
     - os: linux
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 cache:
-    directories:
-      - $HOME/.opam
-      - $HOME/neko
-      - $HOME/apt-cache
-      - $HOME/hxcache
-      - $HOME/_hxbuild
-      - $HOME/lua_env
+  timeout: 1000
+  directories:
+    - $HOME/.opam
+    - $HOME/neko
+    - $HOME/apt-cache
+    - $HOME/hxcache
+    - $HOME/_hxbuild
+    - $HOME/lua_env
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ install_linux: &install_linux
   - cp -prf ./_build/* ~/_hxbuild/
   - sudo rm -f $APT_CACHE_DIR/lock
 
+
 install_osx: &install_osx
   # Install dependencies
   - brew uninstall --force brew-cask # https://github.com/caskroom/homebrew-cask/pull/15381

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,19 +38,19 @@ install_linux: &install_linux
   # Install dependencies
   - sudo add-apt-repository ppa:haxe/ocaml -y
   - sudo apt-get update
-  #- sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
-  #    ocaml
-  #    ocaml-native-compilers
-  #    ocaml-findlib
-  #    camlp4
-  #    libpcre3-dev
-  #    zlib1g-dev
-  #    libgtk2.0-dev
-  #    ninja-build
-  #    awscli
-  #- wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sh -s /usr/local/bin system
+  - sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
+      ocaml
+      ocaml-native-compilers
+      ocaml-findlib
+      camlp4
+      libpcre3-dev
+      zlib1g-dev
+      libgtk2.0-dev
+      ninja-build
+      awscli
+  - wget https://raw.github.com/ocaml/opam/master/shell/opam_installer.sh -O - | sh -s /usr/local/bin system
   - export OPAMYES=1
-  #- opam install sedlex xml-light extlib rope ptmap
+  - opam install sedlex xml-light extlib rope ptmap
   # Install neko
   - if [ ! -d "../../neko" ]; then
       mkdir ../../neko;
@@ -61,11 +61,11 @@ install_linux: &install_linux
       git pull origin master;
       git submodule update --init --recursive;
     fi
-  #- cmake . -DSTATIC_DEPS=all -G Ninja
+  - cmake . -DSTATIC_DEPS=all -G Ninja
   # download static dependencies before actual build, with 3 chances to deal with network issues
-  #- ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
-  #- ninja -j 4
-  #- sudo ninja install
+  - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
+  - ninja -j 4
+  - sudo ninja install
   - popd
   # Setup database
   - travis_retry sudo apt-get install mysql-server-5.6 -y
@@ -80,16 +80,16 @@ install_linux: &install_linux
       echo "/home/travis/_hxbuild exists";
       cp -pr ~/_hxbuild ./_build;
     fi
-  #- make package_src -s
-  #- opam config exec -- make -s STATICLINK=1
-  #- make package_bin -s
+  - make package_src -s
+  - opam config exec -- make -s STATICLINK=1
+  - make package_bin -s
   - ls -la ~
   - ls -la .
   - echo $PWD
-  - mkdir -p ./_build
-  #- ls -l out
-  #- ldd -v ./haxe
-  #- ldd -v ./haxelib
+  #- mkdir -p ./_build
+  - ls -l out
+  - ldd -v ./haxe
+  - ldd -v ./haxelib
   - export PATH="$PATH:$TRAVIS_BUILD_DIR"
   - export HAXE_STD_PATH="$TRAVIS_BUILD_DIR/std"
   - if [ ! -d "/home/travis/_hxbuild" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ cache:
     - $HOME/Library/Caches/Homebrew
 
 before_cache:
-  - ls -la ~
   - sudo rm -f $HOME/apt-cache/lock || true
+
 env:
   global:
     # make variables
@@ -59,12 +59,12 @@ install_linux: &install_linux
   - export OPAMYES=1
   - opam install sedlex xml-light extlib rope ptmap
   # Install neko
-  - if [ ! -d "/home/travis/neko" ]; then
-      mkdir /home/travis/neko;
-      pushd /home/travis/neko;
+  - if [ ! -d "$HOME/neko" ]; then
+      mkdir $HOME/neko;
+      pushd $HOME/neko;
       git clone https://github.com/HaxeFoundation/neko.git .;
     else
-      pushd /home/travis/neko;
+      pushd $HOME/neko;
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
@@ -83,23 +83,19 @@ install_linux: &install_linux
   - jdk_switcher use oraclejdk7
   - java -version
   # Build haxe
-  - if [ -d "/home/travis/_hxbuild" ]; then
-      echo "/home/travis/_hxbuild exists";
+  - if [ -d "$HOME/_hxbuild" ]; then
+      echo "$HOME/_hxbuild exists";
       cp -pr ~/_hxbuild ./_build;
     fi
   - make package_src -s
   - opam config exec -- make -s STATICLINK=1
   - make package_bin -s
-  - ls -la ~
-  - ls -la .
-  - echo $PWD
-  #- mkdir -p ./_build
   - ls -l out
   - ldd -v ./haxe
   - ldd -v ./haxelib
   - export PATH="$PATH:$TRAVIS_BUILD_DIR"
   - export HAXE_STD_PATH="$TRAVIS_BUILD_DIR/std"
-  - if [ ! -d "/home/travis/_hxbuild" ]; then
+  - if [ ! -d "$HOME/_hxbuild" ]; then
         mkdir ~/_hxbuild;
     fi
   - cp -prf ./_build/* ~/_hxbuild/
@@ -117,12 +113,12 @@ install_osx: &install_osx
   - eval `opam config env`
   # Install neko
   - brew upgrade cmake # we need a recent cmake to use CMAKE_OSX_DEPLOYMENT_TARGET
-  - if [ ! -d "/Users/travis/neko" ]; then
-      mkdir /Users/travis/neko;
-      pushd /Users/travis/neko;
+  - if [ ! -d "$HOME/neko" ]; then
+      mkdir $HOME/neko;
+      pushd $HOME/neko;
       git clone https://github.com/HaxeFoundation/neko.git .;
     else
-      pushd /Users/travis/neko;
+      pushd $HOME/neko;
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
@@ -140,8 +136,8 @@ install_osx: &install_osx
   - mysql -u root -e "grant all on haxe_test.* to travis@localhost;"
   # Build haxe
   - travis_retry brew install zlib pcre
-  - if [ -d "/Users/travis/_hxbuild" ]; then
-      echo "/Users/travis/_hxbuild exists";
+  - if [ -d "$HOME/_hxbuild" ]; then
+      echo "$HOME/_hxbuild exists";
       cp -pr ~/_hxbuild ./_build;
     fi
   - make package_src -s
@@ -152,7 +148,7 @@ install_osx: &install_osx
   - otool -L ./haxelib
   - export PATH="$PATH:$TRAVIS_BUILD_DIR"
   - export HAXE_STD_PATH="$TRAVIS_BUILD_DIR/std"
-  - if [ ! -d "/Users/travis/_hxbuild" ]; then
+  - if [ ! -d "$HOME/_hxbuild" ]; then
         mkdir ~/_hxbuild;
     fi
   - cp -prf ./_build/* ~/_hxbuild/

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install_linux: &install_linux
   - if [ ! -d "/home/travis/_hxbuild" ]; then
         mkdir ~/_hxbuild;
     fi
-  - cp -prf ./_build/ ~/_hxbuild/
+  - cp -prf ./_build/* ~/_hxbuild/
   - sudo rm -f $APT_CACHE_DIR/lock
 
 install_osx: &install_osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -242,15 +242,14 @@ script:
   - eval `ssh-agent -s` # for deployment to haxe.org
   - if [ $CACHE_AVAILABLE = 0 ]; then
       echo "No cache available, but initial cache created, try restarting this job";
-      exit 200;
     fi
-  - pushd tests
-  - mkdir ~/haxelib && haxelib setup ~/haxelib
-  - haxelib install record-macros
-  - haxe -version
-  - haxe RunCi.hxml
-  - neko RunCi.n
-  - popd
+  - [ $CACHE_AVAILABLE = 1 ] && pushd tests
+  - [ $CACHE_AVAILABLE = 1 ] && mkdir ~/haxelib && haxelib setup ~/haxelib
+  - [ $CACHE_AVAILABLE = 1 ] && haxelib install record-macros
+  - [ $CACHE_AVAILABLE = 1 ] && haxe -version
+  - [ $CACHE_AVAILABLE = 1 ] && haxe RunCi.hxml
+  - [ $CACHE_AVAILABLE = 1 ] && neko RunCi.n
+  - [ $CACHE_AVAILABLE = 1 ] && popd
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -205,7 +205,6 @@ matrix:
         - TEST=cpp
         - HXCPP_COMPILE_THREADS=4
         - HXCPP_COMPILE_CACHE=~/hxcache
-        - HXCPP_VERBOSE
       before_install:
         - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
         - sudo apt-get update -y || true
@@ -228,7 +227,6 @@ matrix:
         - TEST=cpp
         - HXCPP_COMPILE_CACHE=~/hxcache
         - HXCPP_COMPILE_THREADS=4
-        - HXCPP_VERBOSE
       install: *install_osx
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
     - $HOME/hxcache
     - $HOME/_hxbuild
     - $HOME/lua_env
+    - /usr/local/Cellar
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,35 +141,36 @@ matrix:
     #########
     # linux #
     #########
-    - os: linux
-      env:
-        - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
-        - DEPLOY=1
-        # - SAUCE=1
-        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-      # addons:
-      #   <<: *addons
-      #  sauce_connect: true
-      before_install:
-        - sudo apt-get update -y || true
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - "export AUDIODEV=null"
-      install: *install_linux
-
     #- os: linux
     #  env:
-    #    - TEST=cpp
-    #    - HXCPP_COMPILE_CACHE=~/hxcache
+    #    - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
+    #    - DEPLOY=1
+    #    # - SAUCE=1
+    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+    #  # addons:
+    #  #   <<: *addons
+    #  #  sauce_connect: true
     #  before_install:
     #    - sudo apt-get update -y || true
-    #    - travis_retry sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
-    #        gcc-multilib
-    #        g++-multilib
+    #    - "export DISPLAY=:99.0"
+    #    - "sh -e /etc/init.d/xvfb start"
+    #    - "export AUDIODEV=null"
     #  install: *install_linux
+
+    - os: linux
+      env:
+        - TEST=cpp
+        - HXCPP_COMPILE_CACHE=~/hxcache
+      before_install:
+        - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
+        - sudo apt-get update -y || true
+        - travis_retry sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
+            gcc-multilib
+            g++-multilib
+      install: *install_linux
 
     #######
     # osx #

--- a/.travis.yml
+++ b/.travis.yml
@@ -242,7 +242,7 @@ script:
   - eval `ssh-agent -s` # for deployment to haxe.org
   - if [ $CACHE_AVAILABLE = 0 ]; then
       echo "No cache available, but initial cache created, try restarting this job";
-      exit 200
+      exit 200;
     fi
   - pushd tests
   - mkdir ~/haxelib && haxelib setup ~/haxelib

--- a/.travis.yml
+++ b/.travis.yml
@@ -233,16 +233,17 @@ matrix:
 
 script:
   - eval `ssh-agent -s` # for deployment to haxe.org
-  - if [ $CACHE_AVAILABLE = 0 ]; then
-      echo "No cache available, but initial cache created, try restarting this job";
+  - export REQUIRES_CACHE=`test $CACHE_AVAILABLE = 0 && test $TRAVIS_OS_NAME = 'osx'`
+  - if [ $REQUIRES_CACHE ]; then
+      echo "No cache available, but initial cache created, please try restarting this job";
     fi
-  - test $CACHE_AVAILABLE = 1 && pushd tests
-  - test $CACHE_AVAILABLE = 1 && mkdir ~/haxelib && haxelib setup ~/haxelib
-  - test $CACHE_AVAILABLE = 1 && haxelib install record-macros
-  - test $CACHE_AVAILABLE = 1 && haxe -version
-  - test $CACHE_AVAILABLE = 1 && haxe RunCi.hxml
-  - test $CACHE_AVAILABLE = 1 && neko RunCi.n
-  - test $CACHE_AVAILABLE = 1 && popd
+  - (test $REQUIRES_CACHE) && pushd tests
+  - (test $REQUIRES_CACHE) && mkdir ~/haxelib && haxelib setup ~/haxelib
+  - (test $REQUIRES_CACHE) && haxelib install record-macros
+  - (test $REQUIRES_CACHE) && haxe -version
+  - (test $REQUIRES_CACHE) && haxe RunCi.hxml
+  - (test $REQUIRES_CACHE) && neko RunCi.n
+  - (test $REQUIRES_CACHE) && popd
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ install_linux: &install_linux
   # Install neko
   - if [ ! -d "/home/travis/neko" ]; then
       mkdir /home/travis/neko;
-      git clone https://github.com/HaxeFoundation/neko.git /home/travis/neko;
       pushd /home/travis/neko;
+      git clone https://github.com/HaxeFoundation/neko.git .;
     else
       pushd /home/travis/neko;
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/lua_env
     - $HOME/Library/Caches/Homebrew
 before_cache:
-  - sudo rm -f $HOME/apt-cache/lock
+  - sudo rm -f $HOME/apt-cache/lock || true
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,11 @@ install_linux: &install_linux
       git clone https://github.com/HaxeFoundation/neko.git .;
     else
       pushd $HOME/neko;
-      git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
+      if [ ! -d "$HOME/neko/.git" ]; then
+        git clone https://github.com/HaxeFoundation/neko.git .;
+      else
+        git fetch --all; git reset --hard origin/master;
+      fi;
       git submodule update --init --recursive;
     fi
   - cmake . -DSTATIC_DEPS=all -G Ninja

--- a/.travis.yml
+++ b/.travis.yml
@@ -243,13 +243,13 @@ script:
   - if [ $CACHE_AVAILABLE = 0 ]; then
       echo "No cache available, but initial cache created, try restarting this job";
     fi
-  - [ $CACHE_AVAILABLE = 1 ] && pushd tests
-  - [ $CACHE_AVAILABLE = 1 ] && mkdir ~/haxelib && haxelib setup ~/haxelib
-  - [ $CACHE_AVAILABLE = 1 ] && haxelib install record-macros
-  - [ $CACHE_AVAILABLE = 1 ] && haxe -version
-  - [ $CACHE_AVAILABLE = 1 ] && haxe RunCi.hxml
-  - [ $CACHE_AVAILABLE = 1 ] && neko RunCi.n
-  - [ $CACHE_AVAILABLE = 1 ] && popd
+  - test $CACHE_AVAILABLE = 1 && pushd tests
+  - test $CACHE_AVAILABLE = 1 && mkdir ~/haxelib && haxelib setup ~/haxelib
+  - test $CACHE_AVAILABLE = 1 && haxelib install record-macros
+  - test $CACHE_AVAILABLE = 1 && haxe -version
+  - test $CACHE_AVAILABLE = 1 && haxe RunCi.hxml
+  - test $CACHE_AVAILABLE = 1 && neko RunCi.n
+  - test $CACHE_AVAILABLE = 1 && popd
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
       - $HOME/hxcache
       - $HOME/_hxbuild
       - $HOME/lua_env
+      - /usr/local/Cellar
 env:
   global:
     # make variables
@@ -110,8 +111,15 @@ install_osx: &install_osx
   - eval `opam config env`
   # Install neko
   - brew upgrade cmake # we need a recent cmake to use CMAKE_OSX_DEPLOYMENT_TARGET
-  - git clone https://github.com/HaxeFoundation/neko.git ../neko
-  - pushd ../neko
+  - if [ ! -d "/home/travis/neko" ]; then
+      mkdir /home/travis/neko;
+      pushd /home/travis/neko;
+      git clone https://github.com/HaxeFoundation/neko.git .;
+    else
+      pushd /home/travis/neko;
+      git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
+      git submodule update --init --recursive;
+    fi
   - cmake . -DSTATIC_DEPS=all -G Ninja
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
@@ -126,6 +134,10 @@ install_osx: &install_osx
   - mysql -u root -e "grant all on haxe_test.* to travis@localhost;"
   # Build haxe
   - travis_retry brew install zlib pcre
+  - if [ -d "/home/travis/_hxbuild" ]; then
+      echo "/home/travis/_hxbuild exists";
+      cp -pr ~/_hxbuild ./_build;
+    fi
   - make package_src -s
   - make -s STATICLINK=1 "LIB_PARAMS=/usr/local/opt/zlib/lib/libz.a /usr/local/lib/libpcre.a"
   - make package_bin -s
@@ -134,6 +146,10 @@ install_osx: &install_osx
   - otool -L ./haxelib
   - export PATH="$PATH:$TRAVIS_BUILD_DIR"
   - export HAXE_STD_PATH="$TRAVIS_BUILD_DIR/std"
+  - if [ ! -d "/home/travis/_hxbuild" ]; then
+        mkdir ~/_hxbuild;
+    fi
+  - cp -prf ./_build/* ~/_hxbuild/
   - travis_retry brew install awscli
 
 matrix:
@@ -141,40 +157,81 @@ matrix:
     #########
     # linux #
     #########
-    - os: linux
-      env:
-        - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
-        - DEPLOY=1
-        # - SAUCE=1
-        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-      # addons:
-      #   <<: *addons
-      #  sauce_connect: true
-      before_install:
-        - sudo apt-get update -y || true
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - "export AUDIODEV=null"
-      install: *install_linux
-
-    - os: linux
-      env:
-        - TEST=cpp
-        - HXCPP_COMPILE_CACHE=~/hxcache
-      before_install:
-        - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
-        - sudo apt-get update -y || true
-        - travis_retry sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
-            gcc-multilib
-            g++-multilib
-      install: *install_linux
+    #- os: linux
+    #  env:
+    #    - TEST=macro
+    #    - DEPLOY=1
+    #    # - SAUCE=1
+    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+    #  # addons:
+    #  #   <<: *addons
+    #  #  sauce_connect: true
+    #  before_install:
+    #    - sudo apt-get update -y || true
+    #    - "export DISPLAY=:99.0"
+    #    - "sh -e /etc/init.d/xvfb start"
+    #    - "export AUDIODEV=null"
+    #  install: *install_linux
+    #- os: linux
+    #  env:
+    #    - TEST=macro,neko,js,php,php7,flash9,as3,python,hl,lua
+    #    - DEPLOY=1
+    #    # - SAUCE=1
+    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+    #  # addons:
+    #  #   <<: *addons
+    #  #  sauce_connect: true
+    #  before_install:
+    #    - sudo apt-get update -y || true
+    #    - "export DISPLAY=:99.0"
+    #    - "sh -e /etc/init.d/xvfb start"
+    #    - "export AUDIODEV=null"
+    #  install: *install_linux
+    #- os: linux
+    #  env:
+    #    - TEST=java,cs
+    #    - DEPLOY=1
+    #    # - SAUCE=1
+    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+    #  # addons:
+    #  #   <<: *addons
+    #  #  sauce_connect: true
+    #  before_install:
+    #    - sudo apt-get update -y || true
+    #    - "export DISPLAY=:99.0"
+    #    - "sh -e /etc/init.d/xvfb start"
+    #    - "export AUDIODEV=null"
+    #  install: *install_linux
+#
+    #- os: linux
+    #  env:
+    #    - TEST=cpp
+    #    - HXCPP_COMPILE_CACHE=~/hxcache
+    #  before_install:
+    #    - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
+    #    - sudo apt-get update -y || true
+    #    - travis_retry sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
+    #        gcc-multilib
+    #        g++-multilib
+    #  install: *install_linux
 
     #######
     # osx #
     #######
+    - os: osx
+      env:
+        - TEST=macro,neko
+        - DEPLOY=1
+      install: *install_osx
     #- os: osx
     #  env:
     #    - TEST=macro,neko,js,php,flash9,as3,java,cs,python,hl,lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,12 @@ install_linux: &install_linux
   - export OPAMYES=1
   - opam install sedlex xml-light extlib rope ptmap
   # Install neko
-  - if [ ! -d "../../neko" ]; then
-      mkdir ../../neko;
-      git clone https://github.com/HaxeFoundation/neko.git ../../neko;
-      pushd ../../neko;
+  - if [ ! -d "/home/travis/neko" ]; then
+      mkdir /home/travis/neko;
+      git clone https://github.com/HaxeFoundation/neko.git /home/travis/neko;
+      pushd /home/travis/neko;
     else
-      pushd ../../neko;
+      pushd /home/travis/neko;
       git pull origin master;
       git submodule update --init --recursive;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,7 @@ install_linux: &install_linux
   - cp -prf ./_build/ ~/_hxbuild/
   - sudo rm -f $APT_CACHE_DIR/lock
 
+
 install_osx: &install_osx
   # Install dependencies
   - brew uninstall --force brew-cask # https://github.com/caskroom/homebrew-cask/pull/15381

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
     - $HOME/hxcache
     - $HOME/_hxbuild
     - $HOME/lua_env
-    - /usr/local/Cellar
+    - $HOME/Library/Caches/Homebrew
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,13 @@ matrix:
     #########
     - os: linux
       env:
+        - TEST=Quick
+      install:
+        - export CACHE_AVAILABLE=0
+        - mkdir $HOME/neko || true
+        - mkdir $HOME/neko/.git || true
+    - os: linux
+      env:
         - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
         - DEPLOY_API_DOCS=1
         - DEPLOY_NIGHTLIES=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,7 +166,8 @@ matrix:
     - os: linux
       env:
         - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
-        - DEPLOY=1
+        - DEPLOY_API_DOCS=1
+        - DEPLOY_NIGHTLIES=1
         # - SAUCE=1
         # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
         - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
@@ -199,6 +200,7 @@ matrix:
     - os: osx
       env:
         - TEST=macro,neko,js,php,flash9,as3,java,cs,python,hl,lua
+        - DEPLOY_NIGHTLIES=1
       install: *install_osx
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -210,3 +210,4 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ addons: &addons
     - haxe.org
     - api.haxe.org
 
+
 install_linux: &install_linux
   - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
   # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,25 +159,7 @@ matrix:
     #########
     - os: linux
       env:
-        - TEST=macro,neko,js,php,php7,flash9,as3,python,hl,lua
-        - DEPLOY=1
-        # - SAUCE=1
-        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-      # addons:
-      #   <<: *addons
-      #  sauce_connect: true
-      before_install:
-        - sudo apt-get update -y || true
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - "export AUDIODEV=null"
-      install: *install_linux
-    - os: linux
-      env:
-        - TEST=java,cs
+        - TEST=macro,neko,js,php,php7,flash9,as3,python,hl,lua,java,cs
         - DEPLOY=1
         # - SAUCE=1
         # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,72 +157,53 @@ matrix:
     #########
     # linux #
     #########
-    #- os: linux
-    #  env:
-    #    - TEST=macro
-    #    - DEPLOY=1
-    #    # - SAUCE=1
-    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-    #  # addons:
-    #  #   <<: *addons
-    #  #  sauce_connect: true
-    #  before_install:
-    #    - sudo apt-get update -y || true
-    #    - "export DISPLAY=:99.0"
-    #    - "sh -e /etc/init.d/xvfb start"
-    #    - "export AUDIODEV=null"
-    #  install: *install_linux
-    #- os: linux
-    #  env:
-    #    - TEST=macro,neko,js,php,php7,flash9,as3,python,hl,lua
-    #    - DEPLOY=1
-    #    # - SAUCE=1
-    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-    #  # addons:
-    #  #   <<: *addons
-    #  #  sauce_connect: true
-    #  before_install:
-    #    - sudo apt-get update -y || true
-    #    - "export DISPLAY=:99.0"
-    #    - "sh -e /etc/init.d/xvfb start"
-    #    - "export AUDIODEV=null"
-    #  install: *install_linux
-    #- os: linux
-    #  env:
-    #    - TEST=java,cs
-    #    - DEPLOY=1
-    #    # - SAUCE=1
-    #    # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-    #    - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-    #    # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-    #    - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-    #  # addons:
-    #  #   <<: *addons
-    #  #  sauce_connect: true
-    #  before_install:
-    #    - sudo apt-get update -y || true
-    #    - "export DISPLAY=:99.0"
-    #    - "sh -e /etc/init.d/xvfb start"
-    #    - "export AUDIODEV=null"
-    #  install: *install_linux
-#
-    #- os: linux
-    #  env:
-    #    - TEST=cpp
-    #    - HXCPP_COMPILE_CACHE=~/hxcache
-    #  before_install:
-    #    - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
-    #    - sudo apt-get update -y || true
-    #    - travis_retry sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
-    #        gcc-multilib
-    #        g++-multilib
-    #  install: *install_linux
+    - os: linux
+      env:
+        - TEST=macro,neko,js,php,php7,flash9,as3,python,hl,lua
+        - DEPLOY=1
+        # - SAUCE=1
+        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+      # addons:
+      #   <<: *addons
+      #  sauce_connect: true
+      before_install:
+        - sudo apt-get update -y || true
+        - "export DISPLAY=:99.0"
+        - "sh -e /etc/init.d/xvfb start"
+        - "export AUDIODEV=null"
+      install: *install_linux
+    - os: linux
+      env:
+        - TEST=java,cs
+        - DEPLOY=1
+        # - SAUCE=1
+        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
+        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
+        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
+        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
+      # addons:
+      #   <<: *addons
+      #  sauce_connect: true
+      before_install:
+        - sudo apt-get update -y || true
+        - "export DISPLAY=:99.0"
+        - "sh -e /etc/init.d/xvfb start"
+        - "export AUDIODEV=null"
+      install: *install_linux
+    - os: linux
+      env:
+        - TEST=cpp
+        - HXCPP_COMPILE_CACHE=~/hxcache
+      before_install:
+        - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
+        - sudo apt-get update -y || true
+        - travis_retry sudo apt-get -o dir::cache::archives="$APT_CACHE_DIR" install -y
+            gcc-multilib
+            g++-multilib
+      install: *install_linux
 
     #######
     # osx #

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,13 +183,6 @@ matrix:
     #########
     - os: linux
       env:
-        - TEST=Quick
-      install:
-        - export CACHE_AVAILABLE=0
-        - mkdir $HOME/neko || true
-        - mkdir $HOME/neko/.git || true
-    - os: linux
-      env:
         - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
         - DEPLOY_API_DOCS=1
         - DEPLOY_NIGHTLIES=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -203,7 +203,9 @@ matrix:
     - os: linux
       env:
         - TEST=cpp
+        - HXCPP_COMPILE_THREADS=4
         - HXCPP_COMPILE_CACHE=~/hxcache
+        - HXCPP_VERBOSE
       before_install:
         - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
         - sudo apt-get update -y || true
@@ -225,14 +227,16 @@ matrix:
       env:
         - TEST=cpp
         - HXCPP_COMPILE_CACHE=~/hxcache
+        - HXCPP_COMPILE_THREADS=4
+        - HXCPP_VERBOSE
       install: *install_osx
 
 script:
   - eval `ssh-agent -s` # for deployment to haxe.org
   - if [ $CACHE_AVAILABLE = 0 ]; then
-      echo "No cache available";
+      echo "No cache available, but initial cache created, try restarting this job";
       exit 1;
-  - end
+    fi
   - pushd tests
   -   mkdir ~/haxelib && haxelib setup ~/haxelib
   -   haxelib install record-macros

--- a/.travis.yml
+++ b/.travis.yml
@@ -150,6 +150,7 @@ install_osx: &install_osx
     fi
   - cp -prf ./_build/* ~/_hxbuild/
   - travis_retry brew install awscli
+  - travis_retry brew cleanup
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -244,12 +244,12 @@ script:
       echo "No cache available, but initial cache created, try restarting this job";
       exit 200
     fi
-  - pushd tests &&
-  - mkdir ~/haxelib && haxelib setup ~/haxelib &&
-  - haxelib install record-macros &&
-  - haxe -version &&
-  - haxe RunCi.hxml &&
-  - neko RunCi.n &&
+  - pushd tests
+  - mkdir ~/haxelib && haxelib setup ~/haxelib
+  - haxelib install record-macros
+  - haxe -version
+  - haxe RunCi.hxml
+  - neko RunCi.n
   - popd
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,15 +235,16 @@ script:
   - eval `ssh-agent -s` # for deployment to haxe.org
   - if [ $CACHE_AVAILABLE = 0 ]; then
       echo "No cache available, but initial cache created, try restarting this job";
-      exit 1;
+      echo 2;
+    else
+      pushd tests &&
+      mkdir ~/haxelib && haxelib setup ~/haxelib &&
+      haxelib install record-macros &&
+      haxe -version &&
+      haxe RunCi.hxml &&
+      neko RunCi.n &&
+      popd;
     fi
-  - pushd tests
-  -   mkdir ~/haxelib && haxelib setup ~/haxelib
-  -   haxelib install record-macros
-  -   haxe -version
-  -   haxe RunCi.hxml
-  -   neko RunCi.n
-  - popd
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,13 +77,16 @@ install_linux: &install_linux
   - java -version
   # Build haxe
   - if [ -d "/home/travis/_hxbuild" ]; then
+      echo "/home/travis/_hxbuild exists";
       cp -pr ~/_hxbuild ./_build;
     fi
   #- make package_src -s
   #- opam config exec -- make -s STATICLINK=1
   #- make package_bin -s
+  - ls -la ~
+  - ls -la .
   - echo $PWD
-  - mkdir ./_build
+  - mkdir -p ./_build
   #- ls -l out
   #- ldd -v ./haxe
   #- ldd -v ./haxelib

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,6 @@ install_osx: &install_osx
     fi
   - cp -prf ./_build/* ~/_hxbuild/
   - travis_retry brew install awscli
-  - travis_retry brew cleanup
 
 matrix:
   include:
@@ -228,14 +227,9 @@ matrix:
     #######
     - os: osx
       env:
-        - TEST=macro,neko
+        - TEST=macro,neko,js,php,flash9,as3,java,cs,python,hl,lua
         - DEPLOY=1
       install: *install_osx
-    #- os: osx
-    #  env:
-    #    - TEST=macro,neko,js,php,flash9,as3,java,cs,python,hl,lua
-    #    - DEPLOY=1
-    #  install: *install_osx
 
     - os: osx
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,11 +237,11 @@ matrix:
     #    - DEPLOY=1
     #  install: *install_osx
 
-    #- os: osx
-    #  env:
-    #    - TEST=cpp
-    #    - HXCPP_COMPILE_CACHE=~/hxcache
-    #  install: *install_osx
+    - os: osx
+      env:
+        - TEST=cpp
+        - HXCPP_COMPILE_CACHE=~/hxcache
+      install: *install_osx
 
 script:
   - eval `ssh-agent -s` # for deployment to haxe.org

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
       - $HOME/hxcache
       - $HOME/_hxbuild
       - $HOME/lua_env
-      - $HOME/Library/Caches/Homebrew
 env:
   global:
     # make variables

--- a/.travis.yml
+++ b/.travis.yml
@@ -242,16 +242,15 @@ script:
   - eval `ssh-agent -s` # for deployment to haxe.org
   - if [ $CACHE_AVAILABLE = 0 ]; then
       echo "No cache available, but initial cache created, try restarting this job";
-      echo 2;
-    else
-      pushd tests &&
-      mkdir ~/haxelib && haxelib setup ~/haxelib &&
-      haxelib install record-macros &&
-      haxe -version &&
-      haxe RunCi.hxml &&
-      neko RunCi.n &&
-      popd;
+      exit 200
     fi
+  - pushd tests &&
+  - mkdir ~/haxelib && haxelib setup ~/haxelib &&
+  - haxelib install record-macros &&
+  - haxe -version &&
+  - haxe RunCi.hxml &&
+  - neko RunCi.n &&
+  - popd
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,7 +199,6 @@ matrix:
     - os: osx
       env:
         - TEST=macro,neko,js,php,flash9,as3,java,cs,python,hl,lua
-        - DEPLOY=1
       install: *install_osx
 
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -165,23 +165,6 @@ matrix:
     #########
     - os: linux
       env:
-        - TEST=lua
-        # - SAUCE=1
-        # haxeci_decrypt (Deploy source package to ppa:haxe/snapshots.)
-        - secure: "Mw3p6bDZuqVQ6u7GrwLQfje5hhIOA4+mdqqLXYHP79UKdhgqb91Dn6IbG9vQ1VXVe64W4YZbQAMBMMRX5kEPDl6JvTVGSBhg00Mi69oO5qrCMcBI6f9FntG72YaVvLf+PA7co+vKrnJzaP2M9pe4SH9Ztbhy0YNxULp7NQ8FLsM="
-        # deploy_key_decrypt (Deploy doc to api.haxe.org.)
-        - secure: "A75uYqU0Xz6plIgSewEs0QQWe472dCMb9kf3j7Hx0DS7dApXgx8++189sw9Sv0wam5KPtbcIM292MucjGCb5zocVj9xCUVgajhEA0QpTuDMBjk/cg3ClWCGjfybaCl2E5LLdUs7Zy4b4oNWtVikOWLWJ4sC1kaarR9p6kv8yYZg="
-      # addons:
-      #   <<: *addons
-      #  sauce_connect: true
-      before_install:
-        - sudo apt-get update -y || true
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - "export AUDIODEV=null"
-      install: *install_linux
-    - os: linux
-      env:
         - TEST=macro,neko,js,php,php7,flash9,as3,java,cs,python,hl,lua
         - DEPLOY=1
         # - SAUCE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,12 +111,12 @@ install_osx: &install_osx
   - eval `opam config env`
   # Install neko
   - brew upgrade cmake # we need a recent cmake to use CMAKE_OSX_DEPLOYMENT_TARGET
-  - if [ ! -d "/home/travis/neko" ]; then
-      mkdir /home/travis/neko;
-      pushd /home/travis/neko;
+  - if [ ! -d "/Users/travis/neko" ]; then
+      mkdir /Users/travis/neko;
+      pushd /Users/travis/neko;
       git clone https://github.com/HaxeFoundation/neko.git .;
     else
-      pushd /home/travis/neko;
+      pushd /Users/travis/neko;
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
@@ -134,8 +134,8 @@ install_osx: &install_osx
   - mysql -u root -e "grant all on haxe_test.* to travis@localhost;"
   # Build haxe
   - travis_retry brew install zlib pcre
-  - if [ -d "/home/travis/_hxbuild" ]; then
-      echo "/home/travis/_hxbuild exists";
+  - if [ -d "/Users/travis/_hxbuild" ]; then
+      echo "/Users/travis/_hxbuild exists";
       cp -pr ~/_hxbuild ./_build;
     fi
   - make package_src -s
@@ -146,7 +146,7 @@ install_osx: &install_osx
   - otool -L ./haxelib
   - export PATH="$PATH:$TRAVIS_BUILD_DIR"
   - export HAXE_STD_PATH="$TRAVIS_BUILD_DIR/std"
-  - if [ ! -d "/home/travis/_hxbuild" ]; then
+  - if [ ! -d "/Users/travis/_hxbuild" ]; then
         mkdir ~/_hxbuild;
     fi
   - cp -prf ./_build/* ~/_hxbuild/

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install_linux: &install_linux
         mkdir ~/_hxbuild;
     fi
   - cp -prf ./_build/ ~/_hxbuild/
-  - sudo rmf $APT_CACHE_DIR/lock
+  - sudo rm -f $APT_CACHE_DIR/lock
 
 install_osx: &install_osx
   # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ addons: &addons
     - haxe.org
     - api.haxe.org
 
-
 install_linux: &install_linux
   - export APT_CACHE_DIR=~/apt-cache && mkdir -pv $APT_CACHE_DIR
   # Install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -233,7 +233,7 @@ matrix:
 
 script:
   - eval `ssh-agent -s` # for deployment to haxe.org
-  - export CAN_BUILD=`test $CACHE_AVAILABLE = 1 || test $TRAVIS_OS_NAME = 'linux'`
+  - export CAN_BUILD=`(test $CACHE_AVAILABLE = 1 || test $TRAVIS_OS_NAME = 'linux') && echo 1`
   - if [ ! $CAN_BUILD ]; then
       echo "No cache available, but initial cache created, please try restarting this job";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 cache:
     directories:
       - $HOME/.opam
-      - $HOME/Library/Caches/Homebrew
       - $HOME/neko
       - $HOME/apt-cache
       - $HOME/hxcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ install_linux: &install_linux
       fi;
       git submodule update --init --recursive;
     fi
-  - cmake . -DSTATIC_DEPS=all -G Ninja || (git clean -dfx && cmake . -DSTATIC_DEPS=all -G Ninja)
+  - cmake . -DSTATIC_DEPS=all -G Ninja || (git clean -dfx && export CACHE_AVAILABLE=0 && cmake . -DSTATIC_DEPS=all -G Ninja)
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
   - ninja -j 4
@@ -144,7 +144,7 @@ install_osx: &install_osx
       git pull origin master || git clone https://github.com/HaxeFoundation/neko.git .;
       git submodule update --init --recursive;
     fi
-  - cmake . -DSTATIC_DEPS=all -G Ninja || (git clean -dfx && cmake . -DSTATIC_DEPS=all -G Ninja)
+  - cmake . -DSTATIC_DEPS=all -G Ninja || (git clean -dfx && export CACHE_AVAILABLE=0 && cmake . -DSTATIC_DEPS=all -G Ninja)
   # download static dependencies before actual build, with 3 chances to deal with network issues
   - ninja download_static_deps || ninja download_static_deps || ninja download_static_deps
   - ninja -j 4

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -104,8 +104,16 @@ class RunCi {
 
 	static function requireAptPackages(packages:Array<String>):Void {
 		var notYetInstalled = [for (p in packages) if (!isAptPackageInstalled(p)) p];
-		if (notYetInstalled.length > 0)
-			runCommand("sudo", ["apt-get", "install", "-y"].concat(notYetInstalled), true);
+		if (notYetInstalled.length > 0) {
+			var aptCacheDir = Sys.getEnv("APT_CACHE_DIR");
+			var baseCommand = if (aptCacheDir != null) {
+				["apt-get", "-o", 'dir::cache::archives=${aptCacheDir}', "install", "-y"];
+			} else {
+				["apt-get", "install", "-y"];
+			};
+			runCommand("sudo", baseCommand.concat(notYetInstalled), true);
+		}
+
 	}
 
 	static function haxelibInstallGit(account:String, repository:String, ?branch:String, ?srcPath:String, useRetry:Bool = false, ?altName:String):Void {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -355,7 +355,7 @@ class RunCi {
 			haxelibInstallGit("HaxeFoundation", "hxcpp", true);
 			var oldDir = Sys.getCwd();
 			changeDirectory(getHaxelibPath("hxcpp") + "tools/hxcpp/");
-			runCommand("haxe", ["compile.hxml"]);
+			runCommand("haxe", ["-D", "source-header=''", "compile.hxml"]);
 			changeDirectory(oldDir);
 		}
 

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -410,13 +410,23 @@ class RunCi {
 	}
 
 	static function installLuaVersionDependencies(lv:String){
-	  if (lv == "-l5.1"){
-	    runCommand("luarocks", ["install", "luabitop", "1.0.2-3", "--server=https://luarocks.org/dev"]);
-	  }
-	  runCommand("luarocks", ["install", "lrexlib-pcre", "2.8.0-1", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "luv", "1.9.1-0", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "luasocket", "3.0rc1-2", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "environ", "0.1.0-1", "--server=https://luarocks.org/dev"]);
+		if (lv == "-l5.1"){
+			if (!commandSucceed("luarocks", ["show", "luabit"])) {
+	    		runCommand("luarocks", ["install", "luabitop", "1.0.2-3", "--server=https://luarocks.org/dev"]);
+		  	}
+	  	}
+		if (!commandSucceed("luarocks", ["show", "lrexlib-pcre"])) {
+	  		runCommand("luarocks", ["install", "lrexlib-pcre", "2.8.0-1", "--server=https://luarocks.org/dev"]);
+		}
+		if (!commandSucceed("luarocks", ["show", "luv"])) {
+	  		runCommand("luarocks", ["install", "luv", "1.9.1-0", "--server=https://luarocks.org/dev"]);
+		}
+		if (!commandSucceed("luarocks", ["show", "luasocket"])) {
+	  		runCommand("luarocks", ["install", "luasocket", "3.0rc1-2", "--server=https://luarocks.org/dev"]);
+		}
+		if (!commandSucceed("luarocks", ["show", "environ"])) {
+	  		runCommand("luarocks", ["install", "environ", "0.1.0-1", "--server=https://luarocks.org/dev"]);
+		}
 	}
 
 	static function getCsDependencies() {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -411,12 +411,12 @@ class RunCi {
 
 	static function installLuaVersionDependencies(lv:String){
 	  if (lv == "-l5.1"){
-	    runCommand("luarocks", ["install", "--local", "luabitop", "1.0.2-3", "--server=https://luarocks.org/dev"]);
+	    runCommand("luarocks", ["install", "luabitop", "1.0.2-3", "--server=https://luarocks.org/dev"]);
 	  }
-	  runCommand("luarocks", ["install", "--local", "lrexlib-pcre", "2.8.0-1", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "--local", "luv", "1.9.1-0", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "--local", "luasocket", "3.0rc1-2", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "--local", "environ", "0.1.0-1", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "lrexlib-pcre", "2.8.0-1", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "luv", "1.9.1-0", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "luasocket", "3.0rc1-2", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "environ", "0.1.0-1", "--server=https://luarocks.org/dev"]);
 	}
 
 	static function getCsDependencies() {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -576,10 +576,13 @@ class RunCi {
 			if (Sys.systemName() != 'Windows') {
 				// generate doc
 				runCommand("make", ["-s", "install_dox"]);
-				runCommand("make", ["-s", "package_doc"]);
+				if (gitInfo.branch == "development") {
+					runCommand("make", ["-s", "package_doc"]);
 
-				// deployBintray();
-				deployApiDoc();
+
+					// deployBintray();
+					deployApiDoc();
+				}
 
 				// disable deployment to ppa:haxe/snapshots for now
 				// because there is no debian sedlex package...

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -411,12 +411,12 @@ class RunCi {
 
 	static function installLuaVersionDependencies(lv:String){
 	  if (lv == "-l5.1"){
-	    runCommand("luarocks", ["install", "luabitop", "1.0.2-3", "--server=https://luarocks.org/dev"]);
+	    runCommand("luarocks", ["install", "--local", "luabitop", "1.0.2-3", "--server=https://luarocks.org/dev"]);
 	  }
-	  runCommand("luarocks", ["install", "lrexlib-pcre", "2.8.0-1", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "luv", "1.9.1-0", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "luasocket", "3.0rc1-2", "--server=https://luarocks.org/dev"]);
-	  runCommand("luarocks", ["install", "environ", "0.1.0-1", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "--local", "lrexlib-pcre", "2.8.0-1", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "--local", "luv", "1.9.1-0", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "--local", "luasocket", "3.0rc1-2", "--server=https://luarocks.org/dev"]);
+	  runCommand("luarocks", ["install", "--local", "environ", "0.1.0-1", "--server=https://luarocks.org/dev"]);
 	}
 
 	static function getCsDependencies() {

--- a/tests/misc/cppObjc/build.hxml
+++ b/tests/misc/cppObjc/build.hxml
@@ -1,3 +1,4 @@
+-D source-header=''
 -main TestObjc
 -cpp bin
 -debug

--- a/tests/sys/compile-each.hxml
+++ b/tests/sys/compile-each.hxml
@@ -4,6 +4,6 @@
 -cmd nekotools boot bin/neko/ExitCode.n
 
 --next
-
+-D source-header=''
 -debug
 -cp src

--- a/tests/unit/compile-cppia-host.hxml
+++ b/tests/unit/compile-cppia-host.hxml
@@ -1,4 +1,5 @@
 -main cpp.cppia.Host
+-D source-header=''
 -D scriptable
 -D dll_export=bin/cppia.classes
 -debug

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -1,3 +1,4 @@
+-D source-header=''
 -debug
 -cp src
 -cp "C:\Program Files\The Haxe Effect\src/dev/null"


### PR DESCRIPTION
this PR enabled caching for some folders during the build process, the following folders are cached and reused between builds
- .opam - opam files
- neko - the neko folder including compiled files
- apt-cache - downloaded apt-get files (linux)
- hxcache - hxcpp cache
- _hxbuild - the compiler _build folder
- lua_env - lua files
- .luarocks - .luarocks folder (@jdonaldson please check)
- Library/Caches/Homebrew - downloaded homebrew files (osx)

Although it is not recommended to cache apt-get or homebrew files, it seems to make a difference in my tests.

Sorry for the stupid commits, but it's hard to test travis files ;)