### PR TITLE
Never parseInt(null) to avoid null pointer exception

### DIFF
--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -43,6 +43,9 @@ import js.Boot;
 
 	@:pure
 	public static function parseInt( x : String ) : Null<Int> {
+		if ( x == null ) {
+			return null;
+		}
 		var v = untyped __js__("parseInt")(x, 10);
 		// parse again if hexadecimal
 		if( v == 0 && (x.charCodeAt(1) == 'x'.code || x.charCodeAt(1) == 'X'.code) )


### PR DESCRIPTION
Docs say "If the input cannot be recognized, the result is null." - So just never parse null strings in the first place.

Why: I ran into an rare issue where the google closure compiler did restructure the current generated code

```
Std.parseInt = function(x) {
	var v = parseInt(x,10);
	if(v == 0 && (HxOverrides.cca(x,1) == 120 || HxOverrides.cca(x,1) == 88)) {
		v = parseInt(x);
	}
	if(isNaN(v)) {
		return null;
	}
	return v;
};
```

to

```
r.v = function (a) {
        var b = parseInt(a, 10);
        b || 120 != I.Lb(a) && 88 != I.Lb(a) || (b = parseInt(a));
        return isNaN(b) ? null : b
    };

```
and therefore did throw an null pointer exception while calling HxOverrides.cca(x,1) { x.charCodeAt()... because x was actually null.