### PR TITLE
[lua] add special markup + handling for extern closure instances

### DIFF
--- a/src/context/meta.ml
+++ b/src/context/meta.ml
@@ -89,7 +89,7 @@ type strict_meta =
 	| LibType
 	| LoopLabel
 	| LuaRequire
-	| LuaDotAccess
+	| LuaDotMethod 
 	| Meta
 	| Macro
 	| MaybeUsed
@@ -282,7 +282,7 @@ let get_info = function
 	| JavaNative -> ":javaNative",("Automatically added by -java-lib on classes generated from JAR/class files",[Platform Java; UsedOnEither[TClass;TEnum]; UsedInternally])
 	| JsRequire -> ":jsRequire",("Generate javascript module require expression for given extern",[Platform Js; UsedOn TClass])
 	| LuaRequire -> ":luaRequire",("Generate lua module require expression for given extern",[Platform Lua; UsedOn TClass])
-	| LuaDotAccess -> ":luaDotAccess",("Indicates that the given extern type instance should have dot-style access for methods.",[Platform Lua; UsedOnEither[TClass;TClassField]])
+	| LuaDotMethod -> ":luaDotMethod",("Indicates that the given extern type instance should have dot-style invocation for methods instead of colon.",[Platform Lua; UsedOnEither[TClass;TClassField]])
 	| Keep -> ":keep",("Causes a field or type to be kept by DCE",[])
 	| KeepInit -> ":keepInit",("Causes a class to be kept by DCE even if all its field are removed",[UsedOn TClass])
 	| KeepSub -> ":keepSub",("Extends @:keep metadata to all implementing and extending classes",[UsedOn TClass])

--- a/src/context/meta.ml
+++ b/src/context/meta.ml
@@ -89,6 +89,7 @@ type strict_meta =
 	| LibType
 	| LoopLabel
 	| LuaRequire
+	| LuaClosureInstance
 	| Meta
 	| Macro
 	| MaybeUsed
@@ -281,6 +282,7 @@ let get_info = function
 	| JavaNative -> ":javaNative",("Automatically added by -java-lib on classes generated from JAR/class files",[Platform Java; UsedOnEither[TClass;TEnum]; UsedInternally])
 	| JsRequire -> ":jsRequire",("Generate javascript module require expression for given extern",[Platform Js; UsedOn TClass])
 	| LuaRequire -> ":luaRequire",("Generate lua module require expression for given extern",[Platform Lua; UsedOn TClass])
+	| LuaClosureInstance -> ":luaClosureInstance",("Indicates that the given extern type instance should have closure-style methods (dot access rather than colon).",[Platform Lua; UsedOn TClass])
 	| Keep -> ":keep",("Causes a field or type to be kept by DCE",[])
 	| KeepInit -> ":keepInit",("Causes a class to be kept by DCE even if all its field are removed",[UsedOn TClass])
 	| KeepSub -> ":keepSub",("Extends @:keep metadata to all implementing and extending classes",[UsedOn TClass])

--- a/src/context/meta.ml
+++ b/src/context/meta.ml
@@ -89,7 +89,7 @@ type strict_meta =
 	| LibType
 	| LoopLabel
 	| LuaRequire
-	| LuaClosureInstance
+	| LuaDotAccess
 	| Meta
 	| Macro
 	| MaybeUsed
@@ -282,7 +282,7 @@ let get_info = function
 	| JavaNative -> ":javaNative",("Automatically added by -java-lib on classes generated from JAR/class files",[Platform Java; UsedOnEither[TClass;TEnum]; UsedInternally])
 	| JsRequire -> ":jsRequire",("Generate javascript module require expression for given extern",[Platform Js; UsedOn TClass])
 	| LuaRequire -> ":luaRequire",("Generate lua module require expression for given extern",[Platform Lua; UsedOn TClass])
-	| LuaClosureInstance -> ":luaClosureInstance",("Indicates that the given extern type instance should have closure-style methods (dot access rather than colon).",[Platform Lua; UsedOn TClass])
+	| LuaDotAccess -> ":luaDotAccess",("Indicates that the given extern type instance should have dot-style access for methods.",[Platform Lua; UsedOnEither[TClass;TClassField]])
 	| Keep -> ":keep",("Causes a field or type to be kept by DCE",[])
 	| KeepInit -> ":keepInit",("Causes a class to be kept by DCE even if all its field are removed",[UsedOn TClass])
 	| KeepSub -> ":keepSub",("Extends @:keep metadata to all implementing and extending classes",[UsedOn TClass])

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -200,6 +200,13 @@ let open_block ctx =
 
 let this ctx = match ctx.in_value with None -> "self" | Some _ -> "self"
 
+let is_closure_instance_type e =
+    match follow(e.etype) with
+        | TInst (c,_) when Meta.has Meta.LuaClosureInstance c.cl_meta ->
+                true;
+        | _ ->
+                false
+
 let is_dynamic_iterator ctx e =
 	let check x =
 		has_feature ctx "HxOverrides.iter" && (match follow x.etype with
@@ -436,7 +443,10 @@ let rec gen_call ctx e el in_value =
 		    spr ctx ")";
 		end else begin
 		    gen_value ctx e;
-		    print ctx ":%s" (field_name ef);
+                    if is_closure_instance_type e then
+                        print ctx ".%s" (field_name ef)
+                    else
+                        print ctx ":%s" (field_name ef);
                     gen_paren ctx el;
 		end;
 	| _ ->
@@ -1690,6 +1700,8 @@ let generate_type ctx = function
 		(* A special case for Std because we do not want to generate it if it's empty. *)
 		if p = "Std" && c.cl_ordered_statics = [] then
 			()
+		else if (not c.cl_extern) && Meta.has Meta.LuaClosureInstance c.cl_meta then
+                    abort "LuaClosureInstance is valid for externs only" c.cl_pos
 		else if not c.cl_extern then
 			generate_class ctx c
 		else if Meta.has Meta.InitPackage c.cl_meta then

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -202,7 +202,7 @@ let this ctx = match ctx.in_value with None -> "self" | Some _ -> "self"
 
 let is_dot_access e cf =
     match follow(e.etype), cf with
-        | TInst (c,_), FInstance(_,_,icf)  when (Meta.has Meta.LuaDotAccess c.cl_meta || Meta.has Meta.LuaDotAccess icf.cf_meta)->
+        | TInst (c,_), FInstance(_,_,icf)  when (Meta.has Meta.LuaDotMethod c.cl_meta || Meta.has Meta.LuaDotMethod icf.cf_meta)->
                 true;
         | _ ->
                 false
@@ -1700,8 +1700,8 @@ let generate_type ctx = function
 		(* A special case for Std because we do not want to generate it if it's empty. *)
 		if p = "Std" && c.cl_ordered_statics = [] then
 			()
-		else if (not c.cl_extern) && Meta.has Meta.LuaDotAccess c.cl_meta then
-                    abort "LuaDotAccess is valid for externs only" c.cl_pos
+		else if (not c.cl_extern) && Meta.has Meta.LuaDotMethod c.cl_meta then
+                    abort "LuaDotMethod is valid for externs only" c.cl_pos
 		else if not c.cl_extern then
 			generate_class ctx c
 		else if Meta.has Meta.InitPackage c.cl_meta then


### PR DESCRIPTION
Here's a simple POC for supporting closure-style extern instances, as described in #6411.

The main idea is to provide special metadata that changes how an extern behaves:

```haxe
@:luaClosureInstance
extern class Bar {
	public function new(){ }
	public function bar(a:Int, b:String) : Int;
}
```

Field method invocations on this instance will be simple "dot" style, rather than the colon.

There's a lot of advantages to this approach... It's restricted to extern only, and I can keep most of the code nicely isolated.  Still, I don't think I can make this perfect.

There's ways this could break... it mostly would involve situations with dynamic, reflect, etc... also I guess this breaks if you pass it as a structural type, or try to use inheritance with this.  Some of that I can guard against.

The other alternative is to wrap each instance in some kind of proxy that substitutes a dummy "self" argument where necessary.  This makes the extern instances easier to pass around through the other type signatures.  However, I couldn't think of a good way of doing this automatically (abstracts, etc.).  @Simn you have ideas there?  Also, I'm guessing the wrapping would add some overhead, which is not really ideal.

I'm leaning more towards the first option, which is what I have here.  I have a utility method to support the second approach, but I can't figure out how to automatically apply it.