### PR TITLE
support argument names in function type (closes #4799)

### DIFF
--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -425,6 +425,8 @@ and encode_ctype t =
 		4, [encode_array (List.map encode_path tl); encode_array (List.map encode_field fields)]
 	| CTOptional t ->
 		5, [encode_ctype t]
+	| CTNamed (n,t) ->
+		6, [encode_placed_name n; encode_ctype t]
 	in
 	encode_enum ~pos:(Some (pos t)) ICType tag pl
 
@@ -723,6 +725,8 @@ and decode_ctype t =
 		CTExtend (List.map decode_path (decode_array tl), List.map decode_field (decode_array fl))
 	| 5, [t] ->
 		CTOptional (decode_ctype t)
+	| 6, [n;t] ->
+		CTNamed ((decode_string n,p), decode_ctype t)
 	| _ ->
 		raise Invalid_expr),p
 

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -155,6 +155,7 @@ and complex_type =
 	| CTParent of type_hint
 	| CTExtend of placed_type_path list * class_field list
 	| CTOptional of type_hint
+	| CTNamed of placed_name * type_hint
 
 and type_hint = complex_type * pos
 
@@ -550,7 +551,8 @@ let map_expr loop (e,p) =
 			let tl = List.map tpath tl in
 			let fl = List.map cfield fl in
 			CTExtend (tl,fl)
-		| CTOptional t -> CTOptional (type_hint t)),p
+		| CTOptional t -> CTOptional (type_hint t)
+		| CTNamed (n,t) -> CTNamed (n, type_hint t)),p
 	and tparamdecl t =
 		let constraints = List.map type_hint t.tp_constraints in
 		let params = List.map tparamdecl t.tp_params in
@@ -749,6 +751,7 @@ let s_expr e =
 		| CTAnonymous fl -> "{ " ^ String.concat "; " (List.map (s_class_field tabs) fl) ^ "}";
 		| CTParent(t,_) -> "(" ^ s_complex_type tabs t ^ ")"
 		| CTOptional(t,_) -> "?" ^ s_complex_type tabs t
+		| CTNamed ((n,_),(t,_)) -> n ^ " : " ^ s_complex_type tabs t
 		| CTExtend (tl, fl) -> "{> " ^ String.concat " >, " (List.map (s_complex_type_path tabs) tl) ^ ", " ^ String.concat ", " (List.map (s_class_field tabs) fl) ^ " }"
 	and s_class_field tabs f =
 		match f.cff_doc with

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -547,6 +547,7 @@ and load_complex_type ctx allow_display p (t,pn) =
 	| CTParent t -> load_complex_type ctx allow_display p t
 	| CTPath t -> load_instance ~allow_display ctx (t,pn) false p
 	| CTOptional _ -> error "Optional type not allowed here" p
+	| CTNamed _ -> error "Named type not allowed here" p
 	| CTExtend (tl,l) ->
 		(match load_complex_type ctx allow_display p (CTAnonymous l,p) with
 		| TAnon a as ta ->
@@ -687,7 +688,8 @@ and load_complex_type ctx allow_display p (t,pn) =
 		| _ ->
 			TFun (List.map (fun t ->
 				let t, opt = (match fst t with CTOptional t -> t, true | _ -> t,false) in
-				"",opt,load_complex_type ctx allow_display p t
+				let t, n = (match fst t with CTNamed (n,t) -> t,fst n | _ -> t,"") in
+				n,opt,load_complex_type ctx allow_display p t
 			) args,load_complex_type ctx allow_display p r)
 
 and init_meta_overloads ctx co cf =

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -535,6 +535,11 @@ enum ComplexType {
 		Represents an optional type.
 	**/
 	TOptional( t : ComplexType );
+
+	/**
+		Represents a named type.
+	**/
+	TNamed( n : String, t : ComplexType );
 }
 
 /**

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -119,6 +119,7 @@ class Printer {
 		case TAnonymous(fields): "{ " + [for (f in fields) printField(f) + "; "].join("") + "}";
 		case TParent(ct): "(" + printComplexType(ct) + ")";
 		case TOptional(ct): "?" + printComplexType(ct);
+		case TNamed(n,ct): n + ":" + printComplexType(ct);
 		case TExtend(tpl, fields): '{> ${tpl.map(printTypePath).join(" >, ")}, ${fields.map(printField).join(", ")} }';
 	}
 

--- a/tests/unit/src/unit/HelperMacros.hx
+++ b/tests/unit/src/unit/HelperMacros.hx
@@ -7,6 +7,12 @@ class HelperMacros {
 		return macro $v { Std.string(Date.now()) };
 	}
 
+	static public macro function typeString(e) {
+		var typed = haxe.macro.Context.typeExpr(e);
+		var s = haxe.macro.TypeTools.toString(typed.t);
+		return macro $v{s};
+	}
+
 	static public macro function typedAs(actual:haxe.macro.Expr, expected:haxe.macro.Expr) {
 		var tExpected = haxe.macro.Context.typeof(expected);
 		var tActual = haxe.macro.Context.typeof(actual);

--- a/tests/unit/src/unit/issues/Issue2958.hx
+++ b/tests/unit/src/unit/issues/Issue2958.hx
@@ -1,5 +1,7 @@
 package unit.issues;
 
+import unit.HelperMacros.typeString;
+
 private typedef Asset<@:const T> = String;
 
 class Issue2958 extends Test {
@@ -8,12 +10,5 @@ class Issue2958 extends Test {
 		   typeString((null : Asset<["test", 1]>)),
 		   "unit.issues._Issue2958.Asset<[\"test\", 1]>"
 		);
-	}
-
-	static macro function typeString(e)
-	{
-		var typed = haxe.macro.Context.typeExpr(e);
-		var s = haxe.macro.TypeTools.toString(typed.t);
-		return macro $v{s};
 	}
 }

--- a/tests/unit/src/unit/issues/Issue4799.hx
+++ b/tests/unit/src/unit/issues/Issue4799.hx
@@ -1,0 +1,16 @@
+package unit.issues;
+
+import unit.HelperMacros.typeErrorText;
+import unit.HelperMacros.typeString;
+
+class Issue4799 extends Test {
+	function test() {
+		var f : arg1:Int->?arg2:String->Float->Void;
+		eq(typeString(f), "arg1 : Int -> ?arg2 : String -> Float -> Void");
+
+		eq(typeErrorText((null : arg:Int)), "Named type not allowed here");
+
+		// TODO: maybe we could actually allow this?
+		eq(typeErrorText((null : Int->returnValue:Int)), "Named type not allowed here");
+	}
+}


### PR DESCRIPTION
This PR adds support for specifying argument names in a function type with the following syntax:

```haxe
arg1:Type1 -> arg2:Type2 -> Ret
```
This syntax is the most obvious choice as people are already familiar with it because Haxe prints function type with argument names like that.

The parsing part is super-easy and the change is tiny: we parse an identifier, then check if it's followed by a colon (`:`), then we parse a named argument, otherwise we continue parsing as a type path.

The AST representation takes the same approach as optional args: we add a `CTNamed` variant next to `CTOptional` and handle it similarly.

The typing part is the smallest change: when we loop through `CTFunction` arguments, we filter out `CTNamed` and extract name from it (again, similar to how we extract optional-ness `CTOptional`).

---

Here's why I believe adding this is a good idea, considering how non-invasive this change is:

Self-documenting code. Just compare these two:
```haxe
typedef GetUserCallback = Int -> String -> Int -> Void;
// vs
typedef GetUserCallback = id:Int -> name:String -> age:Int -> Void;
```

Good signature hints for callbacks:

![](http://i.imgur.com/a2XfL0U.png)

IDEs have the info to autogenerate a callback function/method with sensible argument names:

![](http://i.imgur.com/IEpnGIV.png)

It's useful when we want to generate a function type from a macro. For example, latest node.js API have this [`util.promisify`](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original) function that transform a callback-style function into a promise-returning one. With the information about argument names, we can provide a type-safe way of dealing with it:

![](http://i.imgur.com/1LRqGJ4.png)
(note how we transform `stdout/stderr` from argument names to promise object fields, and how we have the same `command` argument name for the generated function).

---

The only thing that's breaking about this change I think is the added `ComplexType.TNamed` constructor, which I think is fine, considering all the gained benefits and that we're aiming at Haxe 4 which already breaks macros in worse ways :)