### PR TITLE
[lua] use _hx_string_wrapper helper function instead of string.prototype mod

### DIFF
--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -25,11 +25,17 @@ import lua.Boot;
 @:coreApi class Reflect {
 
 	public inline static function hasField( o : Dynamic, field : String ) : Bool {
-		return untyped o.__fields__ != null ? o.__fields__[field] != null :  o[field] != null;
+		if (Lua.type(o) == "string" && (untyped String.prototype[field] != null || field == "length")){
+			return true;
+		} else return untyped o.__fields__ != null ? o.__fields__[field] != null :  o[field] != null;
 	}
 
 	public static function field( o : Dynamic, field : String ) : Dynamic untyped {
-		return try o[field] catch( e : Dynamic ) null;
+		if (Lua.type(o) == "string"){
+			if (field == "length"){
+				return lua.NativeStringTools.len(o);
+			} else return untyped String.prototype[field];
+		} else return try o[field] catch( e : Dynamic ) null;
 	}
 
 	public inline static function setField( o : Dynamic, field : String, value : Dynamic ) : Void untyped {

--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -26,12 +26,12 @@ import lua.Boot;
 import lua.NativeStringTools;
 
 @:coreApi
+@:extern
 class String {
 	static var __oldindex : String->String->Dynamic;
 	public var length(default,null) : Int;
 
-
-	public function new(string:String) untyped {}
+	public inline function new(string:String) untyped {}
 
 	@:keep
 	static function __index(s:Dynamic, k:Dynamic) : Dynamic {
@@ -48,9 +48,9 @@ class String {
 		else return null;
 	}
 
-	public function toUpperCase() : String return NativeStringTools.upper(this);
-	public function toLowerCase() : String return NativeStringTools.lower(this);
-	public function indexOf( str : String, ?startIndex : Int ) : Int {
+	public inline function toUpperCase() : String return NativeStringTools.upper(this);
+	public inline function toLowerCase() : String return NativeStringTools.lower(this);
+	public inline function indexOf( str : String, ?startIndex : Int ) : Int {
 		if (startIndex == null) startIndex = 1;
 		else startIndex += 1;
 		var r = NativeStringTools.find(this, str, startIndex, true).begin;
@@ -58,18 +58,19 @@ class String {
 		else return -1;
 	}
 
-	public function lastIndexOf( str : String, ?startIndex : Int ) : Int {
+	public inline function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		var i = 0;
 		var ret = -1;
 		if( startIndex == null ) startIndex = length;
 		while( true ) {
 			var p = indexOf(str, ret+1);
-			if( p == -1 || p > startIndex ) return ret;
+			if( p == -1 || p > startIndex ) break;
 			ret = p;
 		}
+		return ret;
 	}
 
-	public function split( delimiter : String ) : Array<String> {
+	public inline function split( delimiter : String ) : Array<String> {
 		var idx = 1;
 		var ret = [];
 		var delim_offset = delimiter.length > 0 ? delimiter.length : 1;
@@ -95,10 +96,10 @@ class String {
 		return ret;
 	}
 
-	public function toString() : String {
+	public inline function toString() : String {
 		return this;
 	}
-	public function substring( startIndex : Int, ?endIndex : Int ) : String {
+	public inline function substring( startIndex : Int, ?endIndex : Int ) : String {
 		if (endIndex == null) endIndex = this.length;
 		if (endIndex < 0) endIndex = 0;
 		if (startIndex < 0) startIndex = 0;
@@ -113,14 +114,14 @@ class String {
 	function get_length() : Int {
 		return NativeStringTools.len(this);
 	}
-	public function charAt( index : Int) : String {
+	public inline function charAt( index : Int) : String {
 		return NativeStringTools.sub(this,index+1, index+1).match;
 	}
-	public function charCodeAt( index : Int) : Null<Int> {
+	public inline function charCodeAt( index : Int) : Null<Int> {
 		return NativeStringTools.byte(this,index+1);
 	}
 
-	public function substr( pos : Int, ?len : Int ) : String {
+	public inline function substr( pos : Int, ?len : Int ) : String {
 		if (len == null || len > pos + this.length) len = this.length;
 		else if (len < 0) len = length + len;
 		if (pos < 0) pos = length + pos;


### PR DESCRIPTION
Here's the third try on the effort to deal with string prototype modification problems.  This PR will subsume the PRs for #6348 and #6347.  

The main trick here is to catch situations where a dynamic or structural type is referencing a field that *might* be a Haxe string field.  In this case, the instance is wrapped in a function that exposes the proper field in the runtime.  The compiler is clever enough to *only* do this if the field name itself matches a known Haxe string method name.  This is the same approach @RealyUniqueName uses in php.

The net result is that dynamic/structural field access incurs a bit of overhead if the field name happens to be "charAt", "indexOf", etc.  Those require runtime logic to resolve fully.

The benefit is that we're not adding additional methods to the string prototype, sidestepping issues where we might clobber a mixin method from another library.

However, note that I didn't completely leave the base string prototype alone.  I still have some modifications to the ``__add`` and`` __concat`` metamethods for string.  This supports concatenation between dynamic instances, where Haxe is uncertain which operator to use (Lua uses ".." for string concatenation, and "+" for integer additions).  I suppose I could wrap that as well, but I thought this was a decent step forward as is.

cc @nadako @ibilon 
