### PR TITLE
make `in` a Binop and remove `EIn` (closes #6224)

### DIFF
--- a/src/display/display.ml
+++ b/src/display/display.ml
@@ -239,7 +239,7 @@ module DocumentSymbols = struct
 			| EFunction(Some s,f) ->
 				add s Function p;
 				func parent f
-			| EIn((EConst(Ident s),p),e2) ->
+			| EBinop(OpIn,(EConst(Ident s),p),e2) ->
 				add s Variable p;
 				expr parent e2;
 			| _ ->

--- a/src/generators/gencommon/dynamicOperators.ml
+++ b/src/generators/gencommon/dynamicOperators.ml
@@ -118,7 +118,7 @@ let init com handle_strings (should_change:texpr->bool) (equals_handler:texpr->t
 				{ e with eexpr = TBinop (op, mk_cast com.basic.tbool (run e1), mk_cast com.basic.tbool (run e2)) }
 			| OpAnd | OpOr | OpXor | OpShl | OpShr | OpUShr ->
 				{ e with eexpr = TBinop (op, mk_cast com.basic.tint (run e1), mk_cast com.basic.tint (run e2)) }
-			| OpAssign | OpAssignOp _ | OpInterval | OpArrow ->
+			| OpAssign | OpAssignOp _ | OpInterval | OpArrow | OpIn ->
 				assert false)
 
 		| TUnop (Increment as op, flag, e1)

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4092,6 +4092,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
       | OpMod -> "%"
       | OpInterval -> "..."
       | OpArrow -> "->"
+      | OpIn -> " in "
       | OpAssign | OpAssignOp _ -> abort "Unprocessed OpAssign" pos
    and string_of_path path =
       "::" ^ (join_class_path_remap path "::") ^ "_obj"
@@ -7035,6 +7036,7 @@ let cppia_op_info = function
 	| IaBinOp OpMod -> ("%", 120)
 	| IaBinOp OpInterval -> ("...", 121)
 	| IaBinOp OpArrow -> ("=>", 122)
+	| IaBinOp OpIn -> (" in ", 123)
 	| IaBinOp OpAssignOp OpAdd -> ("+=", 201)
 	| IaBinOp OpAssignOp OpMult -> ("*=", 202)
 	| IaBinOp OpAssignOp OpDiv -> ("/=", 203)
@@ -7051,6 +7053,7 @@ let cppia_op_info = function
 	| IaBinOp OpAssignOp OpShl -> ("<<=", 219)
 	| IaBinOp OpAssignOp OpMod -> ("%=", 220)
 
+	| IaBinOp OpAssignOp OpIn
 	| IaBinOp OpAssignOp OpInterval
 	| IaBinOp OpAssignOp OpAssign
 	| IaBinOp OpAssignOp OpEq

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2316,7 +2316,7 @@ and eval_expr ctx e =
 					free ctx r;
 					binop r r b;
 					r))
-		| OpInterval | OpArrow ->
+		| OpInterval | OpArrow | OpIn ->
 			assert false)
 	| TUnop (Not,_,v) ->
 		let tmp = alloc_tmp ctx HBool in

--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -1053,7 +1053,7 @@ module Printer = struct
 		| OpShr -> ">>"
 		| OpUShr -> ">>"
 		| OpMod -> "%"
-		| OpInterval | OpArrow | OpAssignOp _ -> assert false
+		| OpInterval | OpArrow | OpIn | OpAssignOp _ -> assert false
 
 	let print_string s =
 		Printf.sprintf "\"%s\"" (Ast.s_escape s)

--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -1691,7 +1691,7 @@ and gen_binop ctx retval op e1 e2 t p =
 		gen_op A3OLt
 	| OpLte ->
 		gen_op A3OLte
-	| OpInterval | OpArrow ->
+	| OpInterval | OpArrow | OpIn ->
 		assert false
 
 and gen_expr ctx retval e =

--- a/src/macro/eval/evalJit.ml
+++ b/src/macro/eval/evalJit.ml
@@ -64,7 +64,7 @@ let get_binop_fun op p = match op with
 	| OpShr -> op_shr p
 	| OpUShr -> op_ushr p
 	| OpMod -> op_mod p
-	| OpAssign | OpBoolAnd | OpBoolOr | OpAssignOp _ | OpInterval | OpArrow -> assert false
+	| OpAssign | OpBoolAnd | OpBoolOr | OpAssignOp _ | OpInterval | OpArrow | OpIn -> assert false
 
 open EvalJitContext
 

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -620,6 +620,7 @@ module Fusion = struct
 		| OpBoolOr
 		| OpAssignOp _
 		| OpInterval
+		| OpIn
 		| OpArrow ->
 			false
 

--- a/src/optimization/analyzerTexprTransformer.ml
+++ b/src/optimization/analyzerTexprTransformer.ml
@@ -731,7 +731,7 @@ and func ctx i =
 				| OpAdd | OpMult | OpDiv | OpSub | OpAnd
 				| OpOr | OpXor | OpShl | OpShr | OpUShr | OpMod ->
 					true
-				| OpAssignOp _ | OpInterval | OpArrow | OpAssign | OpEq
+				| OpAssignOp _ | OpInterval | OpArrow | OpIn | OpAssign | OpEq
 				| OpNotEq | OpGt | OpGte | OpLt | OpLte | OpBoolAnd | OpBoolOr ->
 					false
 			in

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -916,6 +916,7 @@ let standard_precedence op =
 	| OpArrow -> 16, left
 	| OpAssignOp OpAssign -> 17, right (* mimics ?: *)
 	| OpAssign | OpAssignOp _ -> 18, right
+	| OpIn -> 19, right
 
 let rec need_parent e =
 	match e.eexpr with
@@ -1503,18 +1504,18 @@ let optimize_completion_expr e =
 			let e = map e in
 			old();
 			e
-		| EFor ((EIn ((EConst (Ident n),_) as id,it),p),efor) ->
+		| EFor ((EBinop (OpIn,((EConst (Ident n),_) as id),it),p),efor) ->
 			let it = loop it in
 			let old = save() in
 			let etmp = (EConst (Ident "$tmp"),p) in
 			decl n None (Some (EBlock [
 				(EVars [("$tmp",null_pos),None,None],p);
-				(EFor ((EIn (id,it),p),(EBinop (OpAssign,etmp,(EConst (Ident n),p)),p)),p);
+				(EFor ((EBinop (OpIn,id,it),p),(EBinop (OpAssign,etmp,(EConst (Ident n),p)),p)),p);
 				etmp
 			],p));
 			let efor = loop efor in
 			old();
-			(EFor ((EIn (id,it),p),efor),p)
+			(EFor ((EBinop (OpIn,id,it),p),efor),p)
 		| EReturn _ ->
 			typing_side_effect := true;
 			map e

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -914,9 +914,9 @@ let standard_precedence op =
 	| OpBoolAnd -> 14, left
 	| OpBoolOr -> 15, left
 	| OpArrow -> 16, left
-	| OpAssignOp OpAssign -> 17, right (* mimics ?: *)
-	| OpAssign | OpAssignOp _ -> 18, right
-	| OpIn -> 19, right
+	| OpIn -> 17, right
+	| OpAssignOp OpAssign -> 18, right (* mimics ?: *)
+	| OpAssign | OpAssignOp _ -> 19, right
 
 let rec need_parent e =
 	match e.eexpr with

--- a/src/syntax/parser.mly
+++ b/src/syntax/parser.mly
@@ -1515,7 +1515,7 @@ and expr_next e1 = parser
 	| [< '(Question,_); e2 = expr; '(DblDot,_); e3 = expr >] ->
 		(ETernary (e1,e2,e3),punion (pos e1) (pos e3))
 	| [< '(Kwd In,_); e2 = expr >] ->
-		(EBinop (OpIn,e1,e2), punion (pos e1) (pos e2))
+		make_binop OpIn e1 e2
 	| [< >] -> e1
 
 and parse_guard = parser

--- a/src/syntax/parser.mly
+++ b/src/syntax/parser.mly
@@ -120,8 +120,8 @@ let precedence op =
 	| OpBoolAnd -> 7, left
 	| OpBoolOr -> 8, left
 	| OpArrow -> 9, right
-	| OpAssign | OpAssignOp _ -> 10, right
-	| OpIn -> 11, right
+	| OpIn -> 10, right
+	| OpAssign | OpAssignOp _ -> 11, right
 
 let is_not_assign = function
 	| OpAssign | OpAssignOp _ -> false

--- a/src/syntax/parser.mly
+++ b/src/syntax/parser.mly
@@ -121,6 +121,7 @@ let precedence op =
 	| OpBoolOr -> 8, left
 	| OpArrow -> 9, right
 	| OpAssign | OpAssignOp _ -> 10, right
+	| OpIn -> 11, right
 
 let is_not_assign = function
 	| OpAssign | OpAssignOp _ -> false
@@ -210,6 +211,7 @@ let reify in_macro =
 		| OpAssignOp o -> mk_enum "Binop" "OpAssignOp" [to_binop o p] p
 		| OpInterval -> op "OpInterval"
 		| OpArrow -> op "OpArrow"
+		| OpIn -> op "OpIn"
 	in
 	let to_string s p =
 		let len = String.length s in
@@ -432,8 +434,6 @@ let reify in_macro =
 			expr "EBlock" [to_expr_array el p]
 		| EFor (e1,e2) ->
 			expr "EFor" [loop e1;loop e2]
-		| EIn (e1,e2) ->
-			expr "EIn" [loop e1;loop e2]
 		| EIf (e1,e2,eelse) ->
 			expr "EIf" [loop e1;loop e2;to_opt to_expr eelse p]
 		| EWhile (e1,e2,flag) ->
@@ -1515,7 +1515,7 @@ and expr_next e1 = parser
 	| [< '(Question,_); e2 = expr; '(DblDot,_); e3 = expr >] ->
 		(ETernary (e1,e2,e3),punion (pos e1) (pos e3))
 	| [< '(Kwd In,_); e2 = expr >] ->
-		(EIn (e1,e2), punion (pos e1) (pos e2))
+		(EBinop (OpIn,e1,e2), punion (pos e1) (pos e2))
 	| [< >] -> e1
 
 and parse_guard = parser

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -2540,7 +2540,7 @@ module TExprToExpr = struct
 			EVars ([(v.v_name,v.v_pos), mk_type_hint v.v_type v.v_pos, eopt eo])
 		| TBlock el -> EBlock (List.map convert_expr el)
 		| TFor (v,it,e) ->
-			let ein = (EIn ((EConst (Ident v.v_name),it.epos),convert_expr it),it.epos) in
+			let ein = (EBinop (OpIn,(EConst (Ident v.v_name),it.epos),convert_expr it),it.epos) in
 			EFor (ein,convert_expr e)
 		| TIf (e,e1,e2) -> EIf (convert_expr e,convert_expr e1,eopt e2)
 		| TWhile (e1,e2,flag) -> EWhile (convert_expr e1, convert_expr e2, flag)

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2166,6 +2166,8 @@ and type_binop2 ctx op (e1 : texpr) (e2 : Ast.expr) is_assign_op wt p =
 		mk (TNew ((match t with TInst (c,[]) -> c | _ -> assert false),[],[e1;e2])) t p
 	| OpArrow ->
 		error "Unexpected =>" p
+	| OpIn ->
+		error "Unexpected in" p
 	| OpAssign
 	| OpAssignOp _ ->
 		assert false
@@ -3381,7 +3383,7 @@ and type_expr ctx (e,p) (with_type:with_type) =
 			| _ -> error "Identifier expected" (pos e1)
 		in
 		let rec loop display e1 = match fst e1 with
-			| EIn(e1,e2) -> loop_ident display e1,e2
+			| EBinop(OpIn,e1,e2) -> loop_ident display e1,e2
 			| EDisplay(e1,_) -> loop true e1
 			| _ -> error "For expression should be 'v in expr'" (snd it)
 		in
@@ -3428,8 +3430,6 @@ and type_expr ctx (e,p) (with_type:with_type) =
 		ctx.in_loop <- old_loop;
 		old_locals();
 		e
-	| EIn _ ->
-		error "This expression is not allowed outside a for loop" p
 	| ETernary (e1,e2,e3) ->
 		type_expr ctx (EIf (e1,e2,Some e3),p) with_type
 	| EIf (e,e1,e2) ->

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -212,6 +212,11 @@ enum Binop {
 		`=>`
 	**/
 	OpArrow;
+
+	/**
+		`in`
+	**/
+	OpIn;
 }
 
 /**
@@ -412,11 +417,6 @@ enum ExprDef {
 		A `for` expression.
 	**/
 	EFor( it : Expr, expr : Expr );
-
-	/**
-		A `(e1 in e2)` expression.
-	**/
-	EIn( e1 : Expr, e2 : Expr );
 
 	/**
 		An `if(econd) eif` or `if(econd) eif else eelse` expression.

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -87,8 +87,7 @@ class ExprTools {
 			case EArray(e1, e2),
 				EWhile(e1, e2, _),
 				EBinop(_, e1, e2),
-				EFor(e1, e2),
-				EIn(e1, e2):
+				EFor(e1, e2):
 					f(e1);
 					f(e2);
 			case EVars(vl):
@@ -178,7 +177,6 @@ class ExprTools {
 				EVars(ret);
 			case EBlock(el): EBlock(ExprArrayTools.map(el, f));
 			case EFor(it, expr): EFor(f(it), f(expr));
-			case EIn(e1, e2): EIn(f(e1), f(e2));
 			case EIf(econd, eif, eelse): EIf(f(econd), f(eif), opt(eelse, f));
 			case EWhile(econd, e, normalWhile): EWhile(f(econd), f(e), normalWhile);
 			case EReturn(e): EReturn(opt(e,f));

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -70,6 +70,7 @@ class Printer {
 		case OpMod: "%";
 		case OpInterval: "...";
 		case OpArrow: "=>";
+		case OpIn: " in ";
 		case OpAssignOp(op):
 			printBinop(op)
 			+ "=";
@@ -196,7 +197,6 @@ class Printer {
 			tabs = old;
 			s + ';\n$tabs}';
 		case EFor(e1, e2): 'for (${printExpr(e1)}) ${printExpr(e2)}';
-		case EIn(e1, e2): '${printExpr(e1)} in ${printExpr(e2)}';
 		case EIf(econd, eif, null): 'if (${printExpr(econd)}) ${printExpr(eif)}';
 		case EIf(econd, eif, eelse): 'if (${printExpr(econd)}) ${printExpr(eif)} else ${printExpr(eelse)}';
 		case EWhile(econd, e1, true): 'while (${printExpr(econd)}) ${printExpr(e1)}';

--- a/tests/optimization/src/TestAnalyzer.hx
+++ b/tests/optimization/src/TestAnalyzer.hx
@@ -738,7 +738,7 @@ class TestAnalyzer extends TestBase {
 		assertEqualsConst("A", fromCharCode);
 
 		var enumIndex = Type.enumIndex(eBreak);
-		assertEqualsConst(20, enumIndex);
+		assertEqualsConst(19, enumIndex);
 	}
 
 	function testWhilePrune1() {

--- a/tests/unit/src/unit/TestMatch.hx
+++ b/tests/unit/src/unit/TestMatch.hx
@@ -46,7 +46,7 @@ class TestMatch extends Test {
 				s;
 			case EArray(_, { expr : EConst(CInt(i) | CFloat(i)) } ):
 				Std.string(i);
-			case EIn(_, { expr : e, pos : _ }) :
+			case EBinop(OpIn, _, { expr : e, pos : _ }) :
 				Std.string(e);
 			case _:
 				"not_found";

--- a/tests/unit/src/unit/UnitBuilder.hx
+++ b/tests/unit/src/unit/UnitBuilder.hx
@@ -147,7 +147,7 @@ class UnitBuilder {
 						}
 					case EThrow(e):
 						macro exc(function() $e);
-					case EIn(e1, {expr:EArrayDecl(el) }):
+					case EBinop(OpIn, e1, {expr:EArrayDecl(el) }):
 						var el2 = [];
 						for (e in el)
 							el2.push(macro $e1 == $e);

--- a/tests/unit/src/unit/issues/Issue6224.hx
+++ b/tests/unit/src/unit/issues/Issue6224.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+private abstract S(String) from String {
+	inline function asString() return this;
+	@:op(a in b) inline static function contains(a:S, b:S) return b.asString().indexOf(a.asString()) != -1;
+}
+
+class Issue6224 extends unit.Test {
+	function test() {
+		var s:S = "hello";
+		t("hell" in s);
+	}
+}


### PR DESCRIPTION
Since @Simn said "sounds good" to this, I'm preparing this PR :-P

This removes the `EIn` expression kind and instead adds `OpIn` binary operator (adapting other code accordingly).

I believe this makes sense because `in` is basically _is_ a binary operator, and even though in basic Haxe it's only used in `for` expressions, `in` often processed as a binop by macros.

This is obviously a macro breaking change, so consistency alone wouldn't be enough to make it. Having `in` as a binop also makes it automatically overloadable by abstracts through the `@:op` metadata, which is a nice feature for building DSLs. See #6224 for more info (also see test case included in this PR for an example).