### PR TITLE
Fix cpp compilation with HXCPP_SCRIPTABLE undefined

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -6049,7 +6049,7 @@ let generate_class_files baseCtx super_deps constructor_deps class_def inScripta
          )
       in
 
-      output_cpp "#if HXCPP_SCRIPTABLE\n";
+      output_cpp "#ifdef HXCPP_SCRIPTABLE\n";
 
       let stored_fields = List.filter is_data_member implemented_instance_fields in
       if ( (List.length stored_fields) > 0) then begin


### PR DESCRIPTION
Fix inconsistency in cpp generation. HXCPP_SCRIPTABLE should be using #ifdef and not #if