### PR TITLE
Update haxe.format.JsonParser.hx

### DIFF
--- a/std/haxe/format/JsonParser.hx
+++ b/std/haxe/format/JsonParser.hx
@@ -79,7 +79,7 @@ class JsonParser {
 					case ','.code:
 						if( comma ) comma = false else invalidChar();
 					case '"'.code:
-						if( comma ) invalidChar();
+						if( field != null || comma ) invalidChar();
 						field = parseString();
 					default:
 						invalidChar();


### PR DESCRIPTION
Any strings (empty string for sample), that are not separated by commas not throw an exception:
`haxe.format.JsonParser.parse("{\"\"\"A\":\"B\"}")` 
