### PR TITLE
[lua] fix Compiler.includeFile() with position = Inline

### DIFF
--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -410,7 +410,7 @@ class Compiler {
 
 	#if (js || lua || macro)
 	/**
-		Embed a JavaScript file at compile time (can be called by `--macro` or within an `__init__` method).
+		Embed a JavaScript or Lua file at compile time (can be called by `--macro` or within an `__init__` method).
 	**/
 	public static #if !macro macro #end function includeFile( file : String, position:IncludePosition = Top ) {
 		return switch ((position:String).toLowerCase()) {
@@ -420,7 +420,8 @@ class Compiler {
 
 				var f = try sys.io.File.getContent(Context.resolvePath(file)) catch( e : Dynamic ) Context.error(Std.string(e), Context.currentPos());
 				var p = Context.currentPos();
-				{ expr : EUntyped( { expr : ECall( { expr : EConst(CIdent("__js__")), pos : p }, [ { expr : EConst(CString(f)), pos : p } ]), pos : p } ), pos : p };
+				var magic = if (Context.defined("js")) "__js__" else "__lua__";
+				{ expr : EUntyped( { expr : ECall( { expr : EConst(CIdent(magic)), pos : p }, [ { expr : EConst(CString(f)), pos : p } ]), pos : p } ), pos : p };
 			case Top | Closure:
 				@:privateAccess Context.includeFile(file, position);
 				macro {};


### PR DESCRIPTION
`haxe.macro.Compiler.includeFile("test.lua", "inline");` made `__js__` appear in the Lua output, leading to a rather funny error:

```
attempt to call global '__js__' (a nil value)
```