### PR TITLE
Add a VSCode settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+	"files.associations": {
+		"*.mly": "ocaml",
+		"*.ml": "ocaml"
+	},
+	"[ocaml]": {
+		"editor.tabSize": 4
+	},
+	"files.exclude": {
+		"**/_build": true
+	}
+}


### PR DESCRIPTION
It's common practice to commit .vscode settings (eventually, it might be good to have a tasks.json and a launch.json too).

The first two are necessary to work with the vscode-ocaml extension. The files.exclude pattern prevents always ending up in _build files instead of the actual source files by accident (for instance via Ctrl+P, which used to show both).
Note that F1 -> Clear Editor History might be necessary for Ctrl+P not to show _build files anymore since it shows recently opened files regardless of the files.exclude setting.

[skip ci]