### PR TITLE
Add a platform-dependent `newLine` constant to StringTools.

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -509,6 +509,15 @@ class StringTools {
 	*/
 	public static var winMetaCharacters = [" ".code, "(".code, ")".code, "%".code, "!".code, "^".code, "\"".code, "<".code, ">".code, "&".code, "|".code, "\n".code, "\r".code, ",".code, ";".code];
 
+    /**
+        The newline character, depending on the system. On unix-like systems, this will be `\n`, while on Windows it will be `\r\n`.
+     */
+    public static var newLine:String = {
+        #if sys
+        if(Sys.systemName() == "Windows") '\r\n';
+        else #end '\n';
+    };
+
 	/**
 		Returns a String that can be used as a single command line argument
 		on Windows.


### PR DESCRIPTION
On numerous occasions I've found myself needing the current platform's new line character(s) (i.e. `\n` or `\r\n`). This is the code that I usually include somewhere to do that and although it's rather trivial it's always felt like something that the standard library should include, so happy to put this up for consideration!

Usage boils down to:

```haxe
var twoLines:String = 'Line one' + StringTools.newLine + 'Line two';
```