### PR TITLE
Add a "wildcard*" exclusion option to ignore param in haxe.macro.Compiler's include method

### DIFF
--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -182,12 +182,13 @@ class Compiler {
 		@param strict If true and given package wasn't found in any of class paths, fail with an error.
 	**/
 	public static function include( pack : String, ?rec = true, ?ignore : Array<String>, ?classPaths : Array<String>, strict = false ) {
-		var ignore_wildcard:Bool = false;
+		var ignore_wildcard:Array<String> = [];
 		if(ignore != null) {
-			for (ignore_rule in ignore) {
-				if(StringTools.endsWith(ignore_rule, "*")) {
-					ignore_wildcard = true;
-					break;
+			var i = ignore.length;
+			while (i-- > 0) {
+				if(StringTools.endsWith(ignore[i], "*")) {
+					ignore_wildcard.push(ignore[i].substr(0, ignore[i].length-1));
+					ignore.splice(i, 1);
 				}
 			}
 		}
@@ -195,16 +196,9 @@ class Compiler {
 			function(c) return false;
 		} else {
 			function(c:String) {
-				if(ignore_wildcard) {
-					for (ignore_rule in ignore) {
-						if(StringTools.endsWith(ignore_rule, "*")) {
-							if(StringTools.startsWith(c, ignore_rule.substr(0, ignore_rule.length-1))) {
-								return true;
-							}
-						}
-					}
-				}
-				return Lambda.has(ignore, c);
+				if(Lambda.has(ignore, c)) return true;
+				for (ignore_rule in ignore_wildcard) if(StringTools.startsWith(c, ignore_rule)) return true;
+				return false;
 			}
 		}
 		var displayValue = Context.definedValue("display");

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -183,6 +183,7 @@ class Compiler {
 	**/
 	public static function include( pack : String, ?rec = true, ?ignore : Array<String>, ?classPaths : Array<String>, strict = false ) {
 		var ignoreWildcard:Array<String> = [];
+		var ignoreString:Array<String> = [];
 		if(ignore != null) {
 			for (ignoreRule in ignore) {
 				if(StringTools.endsWith(ignoreRule, "*")) {

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -182,22 +182,22 @@ class Compiler {
 		@param strict If true and given package wasn't found in any of class paths, fail with an error.
 	**/
 	public static function include( pack : String, ?rec = true, ?ignore : Array<String>, ?classPaths : Array<String>, strict = false ) {
-		var ignore_wildcard:Array<String> = [];
+		var ignoreWildcard:Array<String> = [];
 		if(ignore != null) {
-			var i = ignore.length;
-			while (i-- > 0) {
-				if(StringTools.endsWith(ignore[i], "*")) {
-					ignore_wildcard.push(ignore[i].substr(0, ignore[i].length-1));
-					ignore.splice(i, 1);
+			for (ignoreRule in ignore) {
+				if(StringTools.endsWith(ignoreRule, "*")) {
+					ignoreWildcard.push(ignoreRule.substr(0, ignoreRule.length-1));
+				}else{
+					ignoreString.push(ignoreRule);
 				}
-			}
+			} 
 		}
 		var skip = if( ignore == null ) {
 			function(c) return false;
 		} else {
 			function(c:String) {
-				if(Lambda.has(ignore, c)) return true;
-				for (ignore_rule in ignore_wildcard) if(StringTools.startsWith(c, ignore_rule)) return true;
+				if(Lambda.has(ignoreString, c)) return true;
+				for (ignoreRule in ignoreWildcard) if(StringTools.startsWith(c, ignoreRule)) return true;
 				return false;
 			}
 		}

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -176,15 +176,36 @@ class Compiler {
 
 		@param rec If true, recursively adds all sub-packages.
 		@param ignore Array of module names to ignore for inclusion.
+		       You can use `module*` with a * at the end for Wildcard matching
 		@param classPaths An alternative array of paths (directory names) to use to search for modules to include.
 		       Note that if you pass this argument, only the specified paths will be used for inclusion.
 		@param strict If true and given package wasn't found in any of class paths, fail with an error.
 	**/
 	public static function include( pack : String, ?rec = true, ?ignore : Array<String>, ?classPaths : Array<String>, strict = false ) {
+		var ignore_wildcard:Bool = false;
+		if(ignore != null) {
+			for (ignore_rule in ignore) {
+				if(StringTools.endsWith(ignore_rule, "*")) {
+					ignore_wildcard = true;
+					break;
+				}
+			}
+		}
 		var skip = if( ignore == null ) {
 			function(c) return false;
 		} else {
-			function(c) return Lambda.has(ignore, c);
+			function(c:String) {
+				if(ignore_wildcard) {
+					for (ignore_rule in ignore) {
+						if(StringTools.endsWith(ignore_rule, "*")) {
+							if(StringTools.startsWith(c, ignore_rule.substr(0, ignore_rule.length-1))) {
+								return true;
+							}
+						}
+					}
+				}
+				return Lambda.has(ignore, c);
+			}
 		}
 		var displayValue = Context.definedValue("display");
 		if( classPaths == null ) {


### PR DESCRIPTION
Example use case : 

`<haxeflag name="--macro include('package', true, ['package.subclasses*'])" />`

This will allow for a - still basic - but more versatile exclusion matching