### PR TITLE
Final

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -5318,7 +5318,8 @@ let access_str a = match a with
    | AccResolve -> "AccResolve"
    | AccCall -> "AccCall"
    | AccInline -> "AccInline"
-   | AccRequire(_,_) -> "AccRequire" ;;
+   | AccRequire(_,_) -> "AccRequire"
+   | AccCtor -> "AccCtor";;
 
 
 let script_type t optional = if optional then begin
@@ -7992,7 +7993,7 @@ let generate_script_class common_ctx script class_def =
          script#writeOpLine IaInline;
       | Var v,_ ->
          let mode_code mode = match mode with
-         | AccNormal -> IaAccessNormal
+         | AccNormal | AccCtor -> IaAccessNormal
          | AccNo -> IaAccessNot
          | AccNever -> IaAccessNot
          | AccResolve -> IaAccessResolve

--- a/src/generators/genxml.ml
+++ b/src/generators/genxml.ml
@@ -132,7 +132,7 @@ and gen_type_decl n t pl =
 and gen_field att f =
 	let add_get_set acc name att =
 		match acc with
-		| AccNormal | AccResolve | AccRequire _ -> att
+		| AccNormal | AccResolve | AccRequire _ | AccCtor -> att
 		| AccNo | AccNever -> (name, "null") :: att
 		| AccCall -> (name,"accessor") :: att
 		| AccInline -> (name,"inline") :: att
@@ -171,7 +171,9 @@ and gen_field att f =
 		with Not_found ->
 			cf.cf_name
 	in
-	node (field_name f) (if f.cf_public then ("public","1") :: att else att) (gen_type ~values:(Some values) f.cf_type :: gen_meta f.cf_meta @ gen_doc_opt f.cf_doc @ overloads)
+	let att = if f.cf_public then ("public","1") :: att else att in
+	let att = if (Meta.has Meta.Final) f.cf_meta then ("final","1") :: att else att in
+	node (field_name f) att (gen_type ~values:(Some values) f.cf_type :: gen_meta f.cf_meta @ gen_doc_opt f.cf_doc @ overloads)
 
 let gen_constr e =
 	let doc = gen_doc_opt e.ef_doc in

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -945,6 +945,7 @@ and encode_var_access a =
 		| AccCall -> 4, []
 		| AccInline	-> 5, []
 		| AccRequire (s,msg) -> 6, [encode_string s; null encode_string msg]
+		| AccCtor -> 7, []
 	) in
 	encode_enum IVarAccess tag pl
 
@@ -1268,6 +1269,7 @@ let decode_var_access v =
 	| 4, [] -> AccCall
 	| 5, [] -> AccInline
 	| 6, [s1;s2] -> AccRequire(decode_string s1, opt decode_string s2)
+	| 7, [] -> AccCtor
 	| _ -> raise Invalid_expr
 
 let decode_method_kind v =

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -387,6 +387,7 @@ and encode_access a =
 		| ADynamic -> 4
 		| AInline -> 5
 		| AMacro -> 6
+		| AFinal -> 7
 	in
 	encode_enum IAccess tag []
 
@@ -685,6 +686,7 @@ and decode_access v =
 	| 4, [] -> ADynamic
 	| 5, [] -> AInline
 	| 6, [] -> AMacro
+	| 7, [] -> AFinal
 	| _ -> raise Invalid_expr
 
 and decode_meta_entry v =

--- a/src/syntax/ast.ml
+++ b/src/syntax/ast.ml
@@ -62,6 +62,7 @@ type keyword =
 	| False
 	| Abstract
 	| Macro
+	| Final
 
 type binop =
 	| OpAdd
@@ -221,6 +222,7 @@ and access =
 	| ADynamic
 	| AInline
 	| AMacro
+	| AFinal
 
 and class_field_kind =
 	| FVar of type_hint option * expr option
@@ -362,6 +364,7 @@ let s_access = function
 	| ADynamic -> "dynamic"
 	| AInline -> "inline"
 	| AMacro -> "macro"
+	| AFinal -> "final"
 
 let s_keyword = function
 	| Function -> "function"
@@ -406,6 +409,7 @@ let s_keyword = function
 	| False -> "false"
 	| Abstract -> "abstract"
 	| Macro -> "macro"
+	| Final -> "final"
 
 let rec s_binop = function
 	| OpAdd -> "+"

--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -84,7 +84,7 @@ let keywords =
 		Switch;Case;Default;Public;Private;Try;Untyped;
 		Catch;New;This;Throw;Extern;Enum;In;Interface;
 		Cast;Override;Dynamic;Typedef;Package;
-		Inline;Using;Null;True;False;Abstract;Macro];
+		Inline;Using;Null;True;False;Abstract;Macro;Final];
 	h
 
 let init file do_add =

--- a/src/syntax/parser.mly
+++ b/src/syntax/parser.mly
@@ -941,11 +941,11 @@ and parse_complex_type_inner = parser
 	| [< '(POpen,p1); t = parse_complex_type; '(PClose,p2) >] -> CTParent t,punion p1 p2
 	| [< '(BrOpen,p1); s >] ->
 		(match s with parser
-		| [< l,p2 = parse_type_anonymous false >] -> CTAnonymous l,punion p1 p2
+		| [< l,p2 = parse_type_anonymous false false >] -> CTAnonymous l,punion p1 p2
 		| [< t = parse_structural_extension; s>] ->
 			let tl = t :: plist parse_structural_extension s in
 			(match s with parser
-			| [< l,p2 = parse_type_anonymous false >] -> CTExtend (tl,l),punion p1 p2
+			| [< l,p2 = parse_type_anonymous false false >] -> CTExtend (tl,l),punion p1 p2
 			| [< l,p2 = parse_class_fields true p1 >] -> CTExtend (tl,l),punion p1 p2)
 		| [< l,p2 = parse_class_fields true p1 >] -> CTAnonymous l,punion p1 p2
 		| [< >] -> serror())
@@ -1019,8 +1019,9 @@ and parse_complex_type_next (t : type_hint) = parser
 			CTFunction ([t] , (t2,p2)),punion (pos t) p2)
 	| [< >] -> t
 
-and parse_type_anonymous opt = parser
-	| [< '(Question,_) when not opt; s >] -> parse_type_anonymous true s
+and parse_type_anonymous opt final = parser
+	| [< '(Question,_) when not opt; s >] -> parse_type_anonymous true final s
+	| [< '(Kwd Final,_) when not opt && not final; s >] -> parse_type_anonymous opt true s
 	| [< name, p1 = ident; t = parse_type_hint_with_pos; s >] ->
 		let p2 = pos (last_token s) in
 		let next acc =
@@ -1029,7 +1030,7 @@ and parse_type_anonymous opt = parser
 				cff_meta = if opt then [Meta.Optional,[],null_pos] else [];
 				cff_access = [];
 				cff_doc = None;
-				cff_kind = FVar (Some t,None);
+				cff_kind = if final then FProp(("default",null_pos),("never",null_pos),Some t,None) else FVar (Some t,None);
 				cff_pos = punion p1 p2;
 			} :: acc
 		in
@@ -1038,7 +1039,7 @@ and parse_type_anonymous opt = parser
 		| [< '(Comma,p2) >] ->
 			(match s with parser
 			| [< '(BrClose,p2) >] -> next [],p2
-			| [< l,p2 = parse_type_anonymous false >] -> next l,punion p1 p2
+			| [< l,p2 = parse_type_anonymous false false >] -> next l,punion p1 p2
 			| [< >] -> serror());
 		| [< >] -> serror()
 

--- a/src/syntax/parser.mly
+++ b/src/syntax/parser.mly
@@ -338,6 +338,7 @@ let reify in_macro =
 			| ADynamic -> "ADynamic"
 			| AInline -> "AInline"
 			| AMacro -> "AMacro"
+			| AFinal -> "AFinal"
 			) in
 			mk_enum "Access" n [] p
 		in
@@ -848,7 +849,7 @@ and parse_class_field_resume tdecl s =
 			| Kwd New :: Kwd Function :: _ ->
 				junk_tokens (k - 2);
 				parse_class_field_resume tdecl s
-			| Kwd Macro :: _ | Kwd Public :: _ | Kwd Static :: _ | Kwd Var :: _ | Kwd Override :: _ | Kwd Dynamic :: _ | Kwd Inline :: _ ->
+			| Kwd Macro :: _ | Kwd Public :: _ | Kwd Static :: _ | Kwd Var :: _ | Kwd Final :: _ | Kwd Override :: _ | Kwd Dynamic :: _ | Kwd Inline :: _ ->
 				junk_tokens (k - 1);
 				parse_class_field_resume tdecl s
 			| BrClose :: _ when tdecl ->
@@ -1069,43 +1070,54 @@ and parse_enum_param = parser
 	| [< '(Question,_); name, _ = ident; t = parse_type_hint_with_pos >] -> (name,true,t)
 	| [< name, _ = ident; t = parse_type_hint_with_pos >] -> (name,false,t)
 
+and parse_function_field doc meta al = parser
+	| [< '(Kwd Function,p1); name = parse_fun_name; pl = parse_constraint_params; '(POpen,_); args = psep Comma parse_fun_param; '(PClose,_); t = popt parse_type_hint_with_pos; s >] ->
+		let e, p2 = (match s with parser
+			| [< e = toplevel_expr; s >] ->
+				(try ignore(semicolon s) with Error (Missing_semicolon,p) -> !display_error Missing_semicolon p);
+				Some e, pos e
+			| [< p = semicolon >] -> None, p
+			| [< >] -> serror()
+		) in
+		let f = {
+			f_params = pl;
+			f_args = args;
+			f_type = t;
+			f_expr = e;
+		} in
+		name, punion p1 p2, FFun f, al
+
+and parse_var_field_assignment = parser
+	| [< '(Binop OpAssign,_); e = toplevel_expr; p2 = semicolon >] -> Some e , p2
+	| [< p2 = semicolon >] -> None , p2
+	| [< >] -> serror()
+
 and parse_class_field s =
 	let doc = get_doc s in
 	match s with parser
 	| [< meta = parse_meta; al = parse_cf_rights true []; s >] ->
-		let name, pos, k = (match s with parser
+		let name, pos, k, al = (match s with parser
 		| [< '(Kwd Var,p1); name = dollar_ident; s >] ->
-			(match s with parser
+			begin match s with parser
 			| [< '(POpen,_); i1 = property_ident; '(Comma,_); i2 = property_ident; '(PClose,_) >] ->
 				let t = popt parse_type_hint_with_pos s in
-				let e , p2 = (match s with parser
-				| [< '(Binop OpAssign,_); e = toplevel_expr; p2 = semicolon >] -> Some e , p2
-				| [< p2 = semicolon >] -> None , p2
-				| [< >] -> serror()
-				) in
-				name, punion p1 p2, FProp (i1,i2,t, e)
+				let e,p2 = parse_var_field_assignment s in
+				name, punion p1 p2, FProp (i1,i2,t, e), al
 			| [< t = popt parse_type_hint_with_pos; s >] ->
-				let e , p2 = (match s with parser
-				| [< '(Binop OpAssign,_); e = toplevel_expr; p2 = semicolon >] -> Some e , p2
-				| [< p2 = semicolon >] -> None , p2
-				| [< >] -> serror()
-				) in
-				name, punion p1 p2, FVar (t,e))
-		| [< '(Kwd Function,p1); name = parse_fun_name; pl = parse_constraint_params; '(POpen,_); al = psep Comma parse_fun_param; '(PClose,_); t = popt parse_type_hint_with_pos; s >] ->
-			let e, p2 = (match s with parser
-				| [< e = toplevel_expr; s >] ->
-					(try ignore(semicolon s) with Error (Missing_semicolon,p) -> !display_error Missing_semicolon p);
-					Some e, pos e
-				| [< p = semicolon >] -> None, p
-				| [< >] -> serror()
-			) in
-			let f = {
-				f_params = pl;
-				f_args = al;
-				f_type = t;
-				f_expr = e;
-			} in
-			name, punion p1 p2, FFun f
+				let e,p2 = parse_var_field_assignment s in
+				name, punion p1 p2, FVar (t,e), al
+			end
+		| [< '(Kwd Final,p1) >] ->
+			begin match s with parser
+			| [< name = dollar_ident; t = popt parse_type_hint_with_pos; e,p2 = parse_var_field_assignment >] ->
+				name,punion p1 p2,FVar(t,e),(AFinal :: al)
+			| [< al = parse_cf_rights (not (List.mem AStatic al)) (AFinal :: al); f = parse_function_field doc meta al >] ->
+				f
+			| [< >] ->
+				serror()
+			end
+		| [< f = parse_function_field doc meta al >] ->
+			f
 		| [< >] ->
 			if al = [] then raise Stream.Failure else serror()
 		) in

--- a/src/typing/type.ml
+++ b/src/typing/type.ml
@@ -33,11 +33,12 @@ and var_kind = {
 
 and var_access =
 	| AccNormal
-	| AccNo				(* can't be accessed outside of the class itself and its subclasses *)
-	| AccNever			(* can't be accessed, even in subclasses *)
-	| AccResolve		(* call resolve("field") when accessed *)
-	| AccCall			(* perform a method call when accessed *)
-	| AccInline			(* similar to Normal but inline when accessed *)
+	| AccNo             (* can't be accessed outside of the class itself and its subclasses *)
+	| AccNever          (* can't be accessed, even in subclasses *)
+	| AccCtor           (* can only be accessed from the constructor *)
+	| AccResolve        (* call resolve("field") when accessed *)
+	| AccCall           (* perform a method call when accessed *)
+	| AccInline         (* similar to Normal but inline when accessed *)
 	| AccRequire of string * string option (* set when @:require(cond) fails *)
 
 and method_kind =
@@ -974,6 +975,7 @@ let s_access is_read = function
 	| AccCall -> if is_read then "get" else "set"
 	| AccInline	-> "inline"
 	| AccRequire (n,_) -> "require " ^ n
+	| AccCtor -> "ctor"
 
 let s_kind = function
 	| Var { v_read = AccNormal; v_write = AccNormal } -> "var"
@@ -1627,7 +1629,7 @@ let unify_access a1 a2 =
 	| _ -> false
 
 let direct_access = function
-	| AccNo | AccNever | AccNormal | AccInline | AccRequire _ -> true
+	| AccNo | AccNever | AccNormal | AccInline | AccRequire _ | AccCtor -> true
 	| AccResolve | AccCall -> false
 
 let unify_kind k1 k2 =

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -1638,7 +1638,28 @@ let type_function ctx args ret fmode f do_display p =
 	in
 	let e = if fmode <> FunConstructor then
 		e
-	else match has_super_constr() with
+	else begin
+		let final_vars = Hashtbl.create 0 in
+		List.iter (fun cf -> match cf.cf_kind with
+			| Var _ when Meta.has Meta.Final cf.cf_meta && cf.cf_expr = None ->
+				Hashtbl.add final_vars cf.cf_name cf
+			| _ ->
+				()
+		) ctx.curclass.cl_ordered_fields;
+		if Hashtbl.length final_vars > 0 then begin
+			let rec find_inits e = match e.eexpr with
+				| TBinop(OpAssign,{eexpr = TField({eexpr = TConst TThis},fa)},e2) ->
+					Hashtbl.remove final_vars (field_name fa);
+					find_inits e2;
+				| _ ->
+					Type.iter find_inits e
+			in
+			find_inits e;
+			Hashtbl.iter (fun _ cf ->
+				display_error ctx ("final field " ^ cf.cf_name ^ " must be initialized immediately or in the constructor") cf.cf_pos;
+			) final_vars
+		end;
+		match has_super_constr() with
 		| Some (was_forced,t_super) ->
 			(try
 				loop e;
@@ -1654,7 +1675,7 @@ let type_function ctx args ret fmode f do_display p =
 				Exit -> e);
 		| None ->
 			e
-	in
+	end in
 	locals();
 	let e = match ctx.curfun, ctx.vthis with
 		| (FunMember|FunConstructor), Some v ->

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -620,7 +620,7 @@ and load_complex_type ctx allow_display p (t,pn) =
 				| APublic -> ()
 				| APrivate -> pub := false;
 				| ADynamic when (match f.cff_kind with FFun _ -> true | _ -> false) -> dyn := true
-				| AStatic | AOverride | AInline | ADynamic | AMacro -> error ("Invalid access " ^ Ast.s_access a) p
+				| AStatic | AOverride | AInline | ADynamic | AMacro | AFinal -> error ("Invalid access " ^ Ast.s_access a) p
 			) f.cff_access;
 			let t , access = (match f.cff_kind with
 				| FVar (Some (CTPath({tpackage=[];tname="Void"}),_), _)  | FProp (_,_,Some (CTPath({tpackage=[];tname="Void"}),_),_) ->
@@ -2733,7 +2733,7 @@ module ClassInitializer = struct
 		if name.[0] = '$' then display_error ctx "Field names starting with a dollar are not allowed" p;
 		List.iter (fun acc ->
 			match (acc, f.cff_kind) with
-			| APublic, _ | APrivate, _ | AStatic, _ -> ()
+			| APublic, _ | APrivate, _ | AStatic, _ | AFinal, _ -> ()
 			| ADynamic, FFun _ | AOverride, FFun _ | AMacro, FFun _ | AInline, FFun _ | AInline, FVar _ -> ()
 			| _, FVar _ -> error ("Invalid accessor '" ^ Ast.s_access acc ^ "' for variable " ^ name) p
 			| _, FProp _ -> error ("Invalid accessor '" ^ Ast.s_access acc ^ "' for property " ^ name) p

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1088,6 +1088,8 @@ let field_access ctx mode f fmode t e p =
 			if ctx.untyped then normal() else AKNo f.cf_name
 		| AccInline ->
 			AKInline (e,f,fmode,t)
+		| AccCtor ->
+			if ctx.curfun = FunConstructor then normal() else AKNo f.cf_name
 		| AccRequire (r,msg) ->
 			match msg with
 			| None -> error_require r p

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -772,6 +772,12 @@ enum Access {
 		normal functions which are executed as soon as they are typed.
 	**/
 	AMacro;
+
+	/**
+		Final access modifier. For functions, they can not be overridden. For
+		variables, it means they can be assigned to only once.
+	**/
+	AFinal;
 }
 
 /**

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -135,6 +135,7 @@ class Printer {
 		case AInline: "inline";
 		case ADynamic: "dynamic";
 		case AMacro: "macro";
+		case AFinal: "final";
 	}
 
 	public function printField(field:Field) return

--- a/std/haxe/macro/Type.hx
+++ b/std/haxe/macro/Type.hx
@@ -628,6 +628,11 @@ enum VarAccess {
 		Failed access due to a `@:require` metadata.
 	**/
 	AccRequire( r : String, ?msg : String );
+
+	/**
+		Access is only allowed from the constructor.
+	**/
+	AccCtor;
 }
 
 /**

--- a/std/haxe/macro/TypeTools.hx
+++ b/std/haxe/macro/TypeTools.hx
@@ -43,7 +43,7 @@ class TypeTools {
 	static function toField(cf : ClassField) : Field return {
 		function varAccessToString(va : VarAccess, getOrSet : String) : String return {
 			switch (va) {
-				case AccNormal: "default";
+				case AccNormal | AccCtor: "default";
 				case AccNo: "null";
 				case AccNever: "never";
 				case AccResolve: throw "Invalid TAnonymous";
@@ -52,10 +52,14 @@ class TypeTools {
 				case AccRequire(_, _): "default";
 			}
 		}
+		var access = cf.isPublic ? [ APublic ] : [ APrivate ];
+		if (cf.meta.has(":final")) {
+			access.push(AFinal);
+		}
 		if (cf.params.length == 0) {
 			name: cf.name,
 			doc: cf.doc,
-			access: cf.isPublic ? [ APublic ] : [ APrivate ],
+			access: access,
 			kind: switch([ cf.kind, cf.type ]) {
 				case [ FVar(read, write), ret ]:
 					FProp(

--- a/std/haxe/rtti/CType.hx
+++ b/std/haxe/rtti/CType.hx
@@ -66,7 +66,7 @@ typedef PathParams = {
 }
 
 /**
-	An array of strings representing the names of the type parameters the type 
+	An array of strings representing the names of the type parameters the type
 	has. As of Haxe 3.2.0, this does not include the constraints.
 **/
 typedef TypeParams = Array<String> // no constraints
@@ -90,7 +90,7 @@ typedef MetaData = Array<{ name : String, params : Array<String> }>;
 
 /**
 	The runtime class field information.
-	
+
 	@see <https://haxe.org/manual/cr-rtti-structure.html#class-field-information>
 **/
 typedef ClassField = {
@@ -110,19 +110,24 @@ typedef ClassField = {
 	var isPublic : Bool;
 
 	/**
+		Whether or not the field is final.
+	**/
+	var isFinal : Bool;
+
+	/**
 		Whether or not the field overrides another field.
 	**/
 	var isOverride : Bool;
 
 	/**
-		The documentation of the field. This information is only available 
-		if the compiler flag `-D use_rtti_doc` was in place. Otherwise, or 
+		The documentation of the field. This information is only available
+		if the compiler flag `-D use_rtti_doc` was in place. Otherwise, or
 		if the field has no documentation, the value is `null`.
 	**/
 	var doc : Null<String>;
 
 	/**
-		The [read access](https://haxe.org/manual/dictionary.html#define-read-access) 
+		The [read access](https://haxe.org/manual/dictionary.html#define-read-access)
 		behavior of the field.
 	**/
 	var get : Rights;
@@ -134,8 +139,8 @@ typedef ClassField = {
 	var set : Rights;
 
 	/**
-		An array of strings representing the names of the type parameters 
-		the field has. 
+		An array of strings representing the names of the type parameters
+		the field has.
 	**/
 	var params : TypeParams;
 
@@ -150,20 +155,20 @@ typedef ClassField = {
 	var meta : MetaData;
 
 	/**
-		The line number where the field is defined. This information is only 
-		available if the field has an expression. 
+		The line number where the field is defined. This information is only
+		available if the field has an expression.
 		Otherwise the value is `null`.
 	**/
 	var line : Null<Int>;
 
 	/**
-		The list of available overloads for the fields or `null` if no overloads 
+		The list of available overloads for the fields or `null` if no overloads
 		exists.
 	**/
 	var overloads : Null<List<ClassField>>;
 
 	/**
-		The actual expression of the field or `null` if there is no expression. 
+		The actual expression of the field or `null` if there is no expression.
 	**/
 	var expr : Null<String>;
 }
@@ -183,15 +188,15 @@ typedef TypeInfos = {
 	var module : Path;
 
 	/**
-		The full slash path of the .hx file containing the type. 
+		The full slash path of the .hx file containing the type.
 		This might be `null` in case there is no such file, e.g. if the
 		type is defined through a macro.
 	**/
 	var file : Null<String>;
 
 	/**
-		An array of strings representing the names of the type parameters the 
-		type has. 
+		An array of strings representing the names of the type parameters the
+		type has.
 	**/
 	var params : TypeParams;
 
@@ -213,7 +218,7 @@ typedef TypeInfos = {
 	var platforms : Platforms;
 
 	/**
-		The [metadata](https://haxe.org/manual/lf-metadata.html) the type was 
+		The [metadata](https://haxe.org/manual/lf-metadata.html) the type was
 		annotated with.
 	**/
 	var meta : MetaData;
@@ -234,13 +239,13 @@ typedef Classdef = {> TypeInfos,
 	var isInterface : Bool;
 
 	/**
-		The class' parent class defined by its type path and list of type 
+		The class' parent class defined by its type path and list of type
 		parameters.
 	**/
 	var superClass : Null<PathParams>;
 
 	/**
-		The list of interfaces defined by their type path and list of type 
+		The list of interfaces defined by their type path and list of type
 		parameters.
 	**/
 	var interfaces : List<PathParams>;
@@ -264,7 +269,7 @@ typedef Classdef = {> TypeInfos,
 
 /**
 	The runtime enum constructor information.
-	
+
 	@see <https://haxe.org/manual/cr-rtti-structure.html#enum-constructor-information>
 **/
 typedef EnumField = {
@@ -274,7 +279,7 @@ typedef EnumField = {
 	var name : String;
 
 	/**
-		The list of arguments the constructor has or `null` if no arguments are 
+		The list of arguments the constructor has or `null` if no arguments are
 		available.
 	**/
 	var args : Null<List<{ name : String, opt : Bool, t : CType }>>;
@@ -300,7 +305,7 @@ typedef EnumField = {
 
 /**
 	The enum runtime type information.
-	
+
 	@see <https://haxe.org/manual/cr-rtti-structure.html#enum-type-information>
 **/
 typedef Enumdef = {> TypeInfos,
@@ -332,7 +337,7 @@ typedef Typedef = {> TypeInfos,
 
 /**
 	The abstract type runtime information.
-	
+
 	@see <https://haxe.org/manual/cr-rtti-structure.html#abstract-type-information>
 **/
 typedef Abstractdef = {> TypeInfos,
@@ -401,7 +406,7 @@ class TypeApi {
 	}
 
 	/**
-		Unlike `r1 == r2`, this function performs a deep equality check on 
+		Unlike `r1 == r2`, this function performs a deep equality check on
 		the given `Rights` instances.
 
 		If `r1` or `r2` are `null`, the result is unspecified.
@@ -422,7 +427,7 @@ class TypeApi {
 	}
 
 	/**
-		Unlike `t1 == t2`, this function performs a deep equality check on 
+		Unlike `t1 == t2`, this function performs a deep equality check on
 		the given `CType` instances.
 
 		If `t1` or `t2` are `null`, the result is unspecified.
@@ -481,7 +486,7 @@ class TypeApi {
 	}
 
 	/**
-		Unlike `f1 == f2`, this function performs a deep equality check on 
+		Unlike `f1 == f2`, this function performs a deep equality check on
 		the given `ClassField` instances.
 
 		If `f1` or `f2` are `null`, the result is unspecified.
@@ -507,7 +512,7 @@ class TypeApi {
 	}
 
 	/**
-		Unlike `c1 == c2`, this function performs a deep equality check on 
+		Unlike `c1 == c2`, this function performs a deep equality check on
 		the arguments of the enum constructors, if exists.
 
 		If `c1` or `c2` are `null`, the result is unspecified.

--- a/std/haxe/rtti/XmlParser.hx
+++ b/std/haxe/rtti/XmlParser.hx
@@ -26,7 +26,7 @@ import haxe.xml.Fast;
 /**
 	XmlParser processes the runtime type information (RTTI) which
 	is stored as a XML string in a static field `__rtti`.
-	
+
 	@see <https://haxe.org/manual/cr-rtti.html>
 **/
 class XmlParser {
@@ -416,6 +416,7 @@ class XmlParser {
 			name : x.name,
 			type : t,
 			isPublic : x.x.exists("public") || defPublic,
+			isFinal : x.x.exists("final"),
 			isOverride : x.x.exists("override"),
 			line : if( x.has.line ) Std.parseInt(x.att.line) else null,
 			doc : doc,

--- a/std/haxe/zip/InflateImpl.hx
+++ b/std/haxe/zip/InflateImpl.hx
@@ -98,7 +98,7 @@ class InflateImpl {
 	var nbits : Int;
 	var bits : Int;
 	var state : State;
-	var final : Bool;
+	var isFinal : Bool;
 	var huffman : Huffman;
 	var huffdist : Null<Huffman>;
 	var htools : HuffTools;
@@ -114,7 +114,7 @@ class InflateImpl {
 	static var FIXED_HUFFMAN = null;
 
 	public function new( i, ?header = true, ?crc = true ) {
-		final = false;
+		isFinal = false;
 		htools = new HuffTools();
 		huffman = buildFixedHuffman();
 		huffdist = null;
@@ -279,7 +279,7 @@ class InflateImpl {
 			// nothing
 			return false;
 		case Block:
-			final = getBit();
+			isFinal = getBit();
 			switch( getBits(2) ) {
 			case 0: // no compression
 				len = input.readUInt16();
@@ -319,7 +319,7 @@ class InflateImpl {
 			var bytes = input.read(rlen);
 			len -= rlen;
 			addBytes(bytes,0,rlen);
-			if( len == 0 ) state = final ? Crc : Block;
+			if( len == 0 ) state = isFinal ? Crc : Block;
 			return needed > 0;
 		case DistOne:
 			var rlen = (len < needed) ? len : needed;
@@ -342,7 +342,7 @@ class InflateImpl {
 				addByte(n);
 				return needed > 0;
 			} else if( n == 256 ) {
-				state = final ? Crc : Block;
+				state = isFinal ? Crc : Block;
 				return true;
 			} else {
 				n -= 257;

--- a/tests/misc/projects/Issue6584/Main1.hx
+++ b/tests/misc/projects/Issue6584/Main1.hx
@@ -1,0 +1,3 @@
+class Main {
+	static final v;
+}

--- a/tests/misc/projects/Issue6584/Main2.hx
+++ b/tests/misc/projects/Issue6584/Main2.hx
@@ -1,0 +1,7 @@
+class Main {
+	static final v = 1;
+
+	static function f() {
+		v = 2;
+	}
+}

--- a/tests/misc/projects/Issue6584/Main3.hx
+++ b/tests/misc/projects/Issue6584/Main3.hx
@@ -1,0 +1,11 @@
+class Main {
+	final v:Int;
+
+	function new() {
+		v = 1;
+	}
+
+	function f() {
+		v = 2;
+	}
+}

--- a/tests/misc/projects/Issue6584/Main4.hx
+++ b/tests/misc/projects/Issue6584/Main4.hx
@@ -1,0 +1,10 @@
+class Main {
+	final y:Int;
+	static public function main() {
+		new Main();
+	}
+
+	function new() {
+
+	}
+}

--- a/tests/misc/projects/Issue6584/Main5.hx
+++ b/tests/misc/projects/Issue6584/Main5.hx
@@ -1,0 +1,6 @@
+class Main {
+	final v:Int;
+	static public function main() {
+
+	}
+}

--- a/tests/misc/projects/Issue6584/compile1-fail.hxml
+++ b/tests/misc/projects/Issue6584/compile1-fail.hxml
@@ -1,0 +1,2 @@
+Main1
+--interp

--- a/tests/misc/projects/Issue6584/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6584/compile1-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main1.hx:2: characters 9-17 : v: Static final variable must be initialized

--- a/tests/misc/projects/Issue6584/compile2-fail.hxml
+++ b/tests/misc/projects/Issue6584/compile2-fail.hxml
@@ -1,0 +1,2 @@
+Main2
+--interp

--- a/tests/misc/projects/Issue6584/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6584/compile2-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main2.hx:5: characters 3-8 : Cannot access field or identifier v for writing

--- a/tests/misc/projects/Issue6584/compile3-fail.hxml
+++ b/tests/misc/projects/Issue6584/compile3-fail.hxml
@@ -1,0 +1,2 @@
+Main3
+--interp

--- a/tests/misc/projects/Issue6584/compile3-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6584/compile3-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main3.hx:9: characters 3-8 : Cannot access field or identifier v for writing

--- a/tests/misc/projects/Issue6584/compile4-fail.hxml
+++ b/tests/misc/projects/Issue6584/compile4-fail.hxml
@@ -1,0 +1,2 @@
+Main4
+--interp

--- a/tests/misc/projects/Issue6584/compile4-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6584/compile4-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main4.hx:2: characters 2-14 : final field y must be initialized in the constructor
+Main4.hx:2: characters 2-14 : final field y must be initialized immediately or in the constructor

--- a/tests/misc/projects/Issue6584/compile4-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6584/compile4-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main4.hx:2: characters 2-14 : final field y must be initialized in the constructor

--- a/tests/misc/projects/Issue6584/compile5-fail.hxml
+++ b/tests/misc/projects/Issue6584/compile5-fail.hxml
@@ -1,0 +1,2 @@
+Main5
+--interp

--- a/tests/misc/projects/Issue6584/compile5-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6584/compile5-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main5.hx:1: lines 1-6 : This class has uninitialized final vars, which requires a constructor
+Main5.hx:2: characters 2-14 : Example of an uninitialized final var


### PR DESCRIPTION
This adds `final` as a keyword and allows using it in two places:

* As modifier to a method, like in Java.
* As replacement for `var` when declaring fields.

The semantics of the latter are as follows:

* `static final` vars have to be initialized immediately
* if a class has non-static `final` vars which are not initialized immediately, it requires a constructor which has to assign to all such fields
* `static inline final` works, but has the same semantics as `static inline var`
* visibility is orthogonal and not affected
* property syntax is not supported

## Implementation details

I added a new `var_access` variant `AccCtor` which is used as the `v_write` value for non-static final vars. For static vars, we simply use `AccNo`. We internally add the `@:final` metadata to `final` fields (both vars and methods) in order to recognize final fields for the XML export. This also makes it automatically work with the already implemented `@:final` parts of the compiler.

Parsing is a bit funky: We can't parse `final` as a field modifier because it is also used for `final x` fields. We also have to consider that field modifiers may appear both before and after the `final`, which requires a call to `parse_cf_rights` twice.