### PR TITLE
Fix overflow (and subsequent compiler warnings) in haxe.io.Bytes

### DIFF
--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -331,10 +331,10 @@ class Bytes {
 		#if neko_v21
 		untyped $sset32(b, pos, v, false);
 		#else
-		set(pos, v);
-		set(pos + 1, v >> 8);
-		set(pos + 2, v >> 16);
-		set(pos + 3, v >>> 24);
+		set(pos, v & 0xFF);
+		set(pos + 1, v >> 8 & 0xFF);
+		set(pos + 2, v >> 16 & 0xFF);
+		set(pos + 3, v >>> 24 & 0xFF);
 		#end
 	}
 


### PR DESCRIPTION
Setting large `Int` 32-bit values directly were resulting in compiler warnings (such as https://github.com/openfl/lime/blob/develop/lime/graphics/format/BMP.hx#L89), and probably caused bad inlined values in C++ generated code due to wrapping. 