### PR TITLE
[js] fixed js syntax on `value.iterator--` (fixes #6637)

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -24,6 +24,7 @@
 	php/python : fixed some bit operators for Int32 (#5938)
 	php : fixed accessing `static inline var` via reflection (#6630)
 	php : fixed Math.min() and Math.max() for NAN on PHP 7.1.9 and 7.1.10
+	js : fixed js syntax error for `value.iterator--` (#6637)
 
 2017-09-12: 4.0.0-preview.1
 

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -490,6 +490,17 @@ and gen_expr ctx e =
 		print ctx "$iterator(";
 		gen_value ctx x;
 		print ctx ")";
+	(* Don't generate `$iterator(value)` for exprs like `value.iterator--` *)
+	| TUnop (op,flag,({eexpr = TField (x,f)} as fe)) when field_name f = "iterator" && is_dynamic_iterator ctx fe ->
+		(match flag with
+			| Prefix ->
+				spr ctx (Ast.s_unop op);
+				gen_value ctx x;
+				spr ctx ".iterator"
+			| Postfix ->
+				gen_value ctx x;
+				spr ctx ".iterator";
+				spr ctx (Ast.s_unop op))
 	| TField (x,FClosure (Some ({cl_path=[],"Array"},_), {cf_name="push"})) ->
 		(* see https://github.com/HaxeFoundation/haxe/issues/1997 *)
 		add_feature ctx "use.$arrayPush";

--- a/tests/unit/src/unit/issues/Issue6637.hx
+++ b/tests/unit/src/unit/issues/Issue6637.hx
@@ -1,0 +1,18 @@
+package unit.issues;
+
+class Issue6637 extends unit.Test {
+	function test() {
+		//this is required to enable HxOverrides.iter on js
+		([]:Iterable<Int>);
+
+		var value = {iterator:10};
+		decrease(value);
+
+		eq(value.iterator, 8);
+	}
+
+	static public function decrease<T:{iterator:Int}>(v:T) {
+		v.iterator--;
+		--v.iterator;
+	}
+}


### PR DESCRIPTION
See #6637 
Created a PR to check CI.