### PR TITLE
[js] generate faster code for `x.iterator()` calls

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -444,6 +444,11 @@ let rec gen_call ctx e el in_value =
 			gen_value ctx e;
 			spr ctx ")";
 		end
+	| TField (x,f), [] when field_name f = "iterator" && is_dynamic_iterator ctx e ->
+		add_feature ctx "use.$getIterator";
+		print ctx "$getIterator(";
+		gen_value ctx x;
+		print ctx ")";
 	| _ ->
 		gen_value ctx e;
 		spr ctx "(";
@@ -1525,6 +1530,10 @@ let generate com =
 	if has_feature ctx "use.$iterator" then begin
 		add_feature ctx "use.$bind";
 		print ctx "function $iterator(o) { if( o instanceof Array ) return function() { return HxOverrides.iter(o); }; return typeof(o.iterator) == 'function' ? $bind(o,o.iterator) : o.iterator; }";
+		newline ctx;
+	end;
+	if has_feature ctx "use.$getIterator" then begin
+		print ctx "function $getIterator(o) { if( o instanceof Array ) return HxOverrides.iter(o); else return o.iterator(); }";
 		newline ctx;
 	end;
 	if has_feature ctx "use.$bind" then begin


### PR DESCRIPTION
This makes genjs generate more efficient code for `x.iterator()` calls, which is a much more common case than just getting `x.iterator`, because it's used for iteration:

```haxe
class Main {
	static function main() {
		for (v in ([1,2,3] : Iterable<Int>)) {
			trace(v);
		}
	}
}
```

BEFORE:
```js
Test.main = function() {
	var v = $iterator([1,2,3])();
	while(v.hasNext()) console.log(v.next());
};
function $iterator(o) { if( o instanceof Array ) return function() { return HxOverrides.iter(o); }; return typeof(o.iterator) == 'function' ? $bind(o,o.iterator) : o.iterator; }
var $_, $fid = 0;
function $bind(o,m) { if( m == null ) return null; if( m.__id__ == null ) m.__id__ = $fid++; var f; if( o.hx__closures__ == null ) o.hx__closures__ = {}; else f = o.hx__closures__[m.__id__]; if( f == null ) { f = function(){ return f.method.apply(f.scope, arguments); }; f.scope = o; f.method = m; o.hx__closures__[m.__id__] = f; } return f; }
```

AFTER:
```js
Main.main = function() {
	var v = $getIterator([1,2,3]);
	while(v.hasNext()) console.log("Main.hx:4:",v.next());
};
function $getIterator(o) { if( o instanceof Array ) return HxOverrides.iter(o); else return o.iterator(); }
```

Basically this eliminates the closure creation and extra call (and also `$bind` call for non-array iterables like `Map`).
