### PR TITLE
fix bytes.setUInt16 in IE8/9

### DIFF
--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -60,7 +60,7 @@ class FPHelper {
 		static inline var LN2 = 0.6931471805599453; // Math.log(2)
 
 		static inline function _i32ToFloat(i: Int): Float {
-			var sign = 0x80000000 & i == 0 ? 1.0 : -1.0;
+			var sign = 1 - ((i >>> 31) << 1);
 			var e = (i >> 23) & 0xff;
 			if (e == 255)
 				return i & 0x7fffff == 0
@@ -71,7 +71,7 @@ class FPHelper {
 		}
 
 		static inline function _i64ToDouble(lo: Int, hi: Int): Float {
-			var sign = 0x80000000 & hi == 0 ? 1.0 : -1.0;
+			var sign = 1 - ((hi >>> 31) << 1);
 			var e = (hi >> 20) & 0x7ff;
 			if (e == 2047)
 				return lo == 0 && (hi & 0xFFFFF) == 0
@@ -91,7 +91,7 @@ class FPHelper {
 			} else {
 				if (exp <= -127 ) {
 					exp = -127;
-					af *= 7.1362384635298e+44;
+					af *= 7.1362384635298e+44;  // af * 0.5 * 0x800000 / Math.pow(2, -127)
 				} else {
 					af = (af / Math.pow(2, exp) - 1.0) * 0x800000;
 				}
@@ -116,7 +116,7 @@ class FPHelper {
 				} else {
 					if (exp <= -1023) {
 						exp = -1023;
-						av = av / 2.2250738585072014e-308;  // av * 0.5 / Math.pow(2, -1023)
+						av = av / 2.2250738585072014e-308;
 					} else {
 						av = av / Math.pow(2, exp) - 1.0;
 					}

--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -59,7 +59,7 @@ class FPHelper {
 	#if !(neko || cpp || cs || java || flash || (js && nodejs))
 		static inline var LN2 = 0.6931471805599453; // Math.log(2)
 
-		static inline function i2f(i: Int): Float {
+		static inline function _i32ToFloat(i: Int): Float {
 			var sign = 0x80000000 & i == 0 ? 1.0 : -1.0;
 			var e = (i >> 23) & 0xff;
 			if (e == 255)
@@ -70,7 +70,7 @@ class FPHelper {
 			return sign * m * Math.pow(2, e - 150);
 		}
 
-		static inline function ii2d(lo: Int, hi: Int): Float {
+		static inline function _i64ToDouble(lo: Int, hi: Int): Float {
 			var sign = 0x80000000 & hi == 0 ? 1.0 : -1.0;
 			var e = (hi >> 20) & 0x7ff;
 			if (e == 2047)
@@ -82,7 +82,7 @@ class FPHelper {
 			return sign * m * Math.pow(2, e - 1023);
 		}
 
-		static inline function f2i(f: Float): Int {
+		static inline function _floatToI32(f: Float): Int {
 			if( f == 0 ) return 0;
 			var af = f < 0 ? -f : f;
 			var exp = Math.floor(Math.log(af) / LN2);
@@ -100,7 +100,7 @@ class FPHelper {
 			}
 		}
 
-		static inline function d2ii(v: Float): Int64 @:privateAccess {
+		static inline function _doubleToI64(v: Float): Int64 @:privateAccess {
 			var i64 = i64tmp;
 			if( v == 0 ) {
 				i64.set_low(0);
@@ -172,7 +172,7 @@ class FPHelper {
 			helper.setInt32(0, i, true);
 			return helper.getFloat32(0, true);
 		#else
-			return i2f(i);
+			return _i32ToFloat(i);
 		#end
 	}
 
@@ -208,7 +208,7 @@ class FPHelper {
 			helper.setFloat32(0, f, true);
 			return helper.getInt32(0,true);
 		#else
-			return f2i(f);
+			return _floatToI32(f);
 		#end
 	}
 
@@ -267,7 +267,7 @@ class FPHelper {
 				return Math.NEGATIVE_INFINITY;
 			}
 			#end
-			return ii2d(low, high);
+			return _i64ToDouble(low, high);
 		#end
 	}
 
@@ -341,7 +341,7 @@ class FPHelper {
 			}
 			return i64;
 		#else
-			return d2ii(v);
+			return _doubleToI64(v);
 		#end
 	}
 

--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -77,7 +77,7 @@ class FPHelper {
 				return lo == 0 && (hi & 0xFFFFF) == 0
 					? (sign > 0 ? Math.POSITIVE_INFINITY : Math.NEGATIVE_INFINITY)
 					: Math.NaN;
-			var m = Math.pow(2, -52) * ((hi & 0xFFFFF) * 4294967296. + (lo >>> 31) * 2147483648. + (lo & 0x7FFFFFFF));
+			var m = 2.220446049250313e-16 * ((hi & 0xFFFFF) * 4294967296. + (lo >>> 31) * 2147483648. + (lo & 0x7FFFFFFF));
 			m = e == 0 ? m * 2.0 : m + 1.0;
 			return sign * m * Math.pow(2, e - 1023);
 		}
@@ -91,12 +91,11 @@ class FPHelper {
 			} else {
 				if (exp <= -127 ) {
 					exp = -127;
-					af = af / Math.pow(2, exp) * 0.5;
+					af *= 7.1362384635298e+44;
 				} else {
-					af = af / Math.pow(2, exp) - 1.0;
+					af = (af / Math.pow(2, exp) - 1.0) * 0x800000;
 				}
-				var sig = Math.round(af * 0x800000);
-				return (f < 0 ? 0x80000000 : 0) | ((exp + 127) << 23) | sig;
+				return (f < 0 ? 0x80000000 : 0) | ((exp + 127) << 23) | Math.round(af);
 			}
 		}
 
@@ -117,7 +116,7 @@ class FPHelper {
 				} else {
 					if (exp <= -1023) {
 						exp = -1023;
-						av = av / Math.pow(2, exp) * 0.5;
+						av = av / 2.2250738585072014e-308;  // av * 0.5 / Math.pow(2, -1023)
 					} else {
 						av = av / Math.pow(2, exp) - 1.0;
 					}

--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -52,11 +52,10 @@ class FPHelper {
 			b.endian = flash.utils.Endian.LITTLE_ENDIAN;
 			b;
 		}
-	#elseif js
+	#else
+		#if js
 		static var helper = new js.html.DataView(new js.html.ArrayBuffer(8));
-	#end
-
-	#if !(neko || cpp || cs || java || flash || (js && nodejs))
+		#end
 		static inline var LN2 = 0.6931471805599453; // Math.log(2)
 
 		static inline function _i32ToFloat(i: Int): Float {
@@ -259,13 +258,6 @@ class FPHelper {
 			helper.setInt32(4, high, true);
 			return helper.getFloat64(0,true);
 		#else
-			#if python
-			if (low == 0 && high == 2146435072) {
-				return Math.POSITIVE_INFINITY;
-			} else if (low == 0 && high == -1048576 ) {
-				return Math.NEGATIVE_INFINITY;
-			}
-			#end
 			return _i64ToDouble(low, high);
 		#end
 	}

--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -56,7 +56,7 @@ class FPHelper {
 		static var helper = new js.html.DataView(new js.html.ArrayBuffer(8));
 	#end
 
-	#if !(neko || cpp || cs || java || flash || nodejs)
+	#if !(neko || cpp || cs || java || flash || (js && nodejs))
 		static inline var LN2 = 0.6931471805599453; // Math.log(2)
 
 		static inline function i2f(i: Int): Float {

--- a/std/js/html/compat/DataView.hx
+++ b/std/js/html/compat/DataView.hx
@@ -80,13 +80,13 @@ class DataView {
 	}
 
 	public function getFloat32( byteOffset : Int, ?littleEndian : Bool ) : Float {
-		return @:privateAccess haxe.io.FPHelper.i2f(getInt32(byteOffset, littleEndian));
+		return @:privateAccess haxe.io.FPHelper._i32ToFloat(getInt32(byteOffset, littleEndian));
 	}
 
 	public function getFloat64( byteOffset : Int, ?littleEndian : Bool ) : Float {
 		var a = getInt32(byteOffset, littleEndian);
 		var b = getInt32(byteOffset + 4, littleEndian);
-		return @:privateAccess haxe.io.FPHelper.ii2d(littleEndian ? a : b, littleEndian ? b : a);
+		return @:privateAccess haxe.io.FPHelper._i64ToDouble(littleEndian ? a : b, littleEndian ? b : a);
 	}
 
 	public function setInt8( byteOffset : Int, value : Int ) : Void {
@@ -133,11 +133,11 @@ class DataView {
 
 	static inline var LN2 = 0.6931471805599453;
 	public function setFloat32( byteOffset : Int, value : Float, ?littleEndian : Bool ) : Void {
-		setUint32(byteOffset, @:privateAccess haxe.io.FPHelper.f2i(value), littleEndian);
+		setUint32(byteOffset, @:privateAccess haxe.io.FPHelper._floatToI32(value), littleEndian);
 	}
 
 	public function setFloat64( byteOffset : Int, value : Float, ?littleEndian : Bool ) : Void {
-		var i64 = @:privateAccess haxe.io.FPHelper.d2ii(value);
+		var i64 = @:privateAccess haxe.io.FPHelper._doubleToI64(value);
 		if( littleEndian ) {
 			setUint32(byteOffset,     i64.low , true);
 			setUint32(byteOffset + 4, i64.high, true);

--- a/std/js/html/compat/DataView.hx
+++ b/std/js/html/compat/DataView.hx
@@ -131,7 +131,6 @@ class DataView {
 		}
 	}
 
-	static inline var LN2 = 0.6931471805599453;
 	public function setFloat32( byteOffset : Int, value : Float, ?littleEndian : Bool ) : Void {
 		setUint32(byteOffset, @:privateAccess haxe.io.FPHelper._floatToI32(value), littleEndian);
 	}

--- a/std/js/html/compat/DataView.hx
+++ b/std/js/html/compat/DataView.hx
@@ -80,13 +80,29 @@ class DataView {
 	}
 
 	public function getFloat32( byteOffset : Int, ?littleEndian : Bool ) : Float {
-		return haxe.io.FPHelper.i32ToFloat(getInt32(byteOffset,littleEndian));
+		var i = getInt32(byteOffset, littleEndian);
+		var sign = 0x80000000 & i == 0 ? 1.0 : -1.0;
+		var e = (i >> 23) & 0xff;
+		if (e == 255)
+			return i & 0x7fffff == 0
+				? (sign > 0 ? Math.POSITIVE_INFINITY : Math.NEGATIVE_INFINITY)
+				: Math.NaN;
+		var m = e == 0 ? (i & 0x7fffff) << 1 : (i & 0x7fffff) | 0x800000;
+		return sign * m * Math.pow(2, e - 150);
 	}
 
 	public function getFloat64( byteOffset : Int, ?littleEndian : Bool ) : Float {
-		var a = getInt32(byteOffset, littleEndian);
-		var b = getInt32(byteOffset + 4, littleEndian);
-		return haxe.io.FPHelper.i64ToDouble(littleEndian?a:b,littleEndian?b:a);
+		var lo = getInt32(byteOffset, littleEndian);
+		var hi = getInt32(byteOffset + 4, littleEndian);
+		var sign = 0x80000000 & hi == 0 ? 1.0 : -1.0;
+		var e = (hi >> 20) & 0x7ff;
+		if (e == 2047)
+			return lo == 0 && (hi & 0xFFFFF) == 0
+				? (sign > 0 ? Math.POSITIVE_INFINITY : Math.NEGATIVE_INFINITY)
+				: Math.NaN;
+		var m = Math.pow(2, -52) * ((hi & 0xFFFFF) * 4294967296. + (lo >>> 31) * 2147483648. + (lo & 0x7FFFFFFF));
+		m = e == 0 ? m * 2.0 : m + 1.0;
+		return sign * m * Math.pow(2, e - 1023);
 	}
 
 	public function setInt8( byteOffset : Int, value : Int ) : Void {
@@ -131,18 +147,55 @@ class DataView {
 		}
 	}
 
-	public function setFloat32( byteOffset : Int, value : Float, ?littleEndian : Bool ) : Void {
-		setUint32(byteOffset, haxe.io.FPHelper.floatToI32(value),littleEndian);
+	static inline var LN2 = 0.6931471805599453;
+	public function setFloat32( byteOffset : Int, f : Float, ?littleEndian : Bool ) : Void {
+		if( f == 0 ) setUint32(byteOffset, 0, littleEndian);
+		var af = f < 0 ? -f : f;
+		var exp = Math.floor(Math.log(af) / LN2);
+		if ( exp <= -127 ) {
+			exp = -127;
+			af = af / Math.pow(2, exp) * 0.5;
+		}else if ( exp > 127 ) {
+			setUint32(byteOffset, 0x7F800000, littleEndian);
+		} else {
+			af = af / Math.pow(2, exp) - 1.0;
+		}
+		var sig = Math.round(af * 0x800000);
+		setUint32(byteOffset, (f < 0 ? 0x80000000 : 0) | ((exp + 127) << 23) | sig , littleEndian);
 	}
 
-	public function setFloat64( byteOffset : Int, value : Float, ?littleEndian : Bool ) : Void {
-		var i64 = haxe.io.FPHelper.doubleToI64(value);
+	public function setFloat64( byteOffset : Int, v : Float, ?littleEndian : Bool ) : Void {
+		var lo = 0;
+		var hi = 0;
+		if (!Math.isFinite(v)) {
+			lo = 0;
+			hi = v > 0 ? 0x7FF00000 : 0xFFF00000;
+		} else if (v != 0) {
+			var av = v < 0 ? -v : v;
+			var exp = Math.floor(Math.log(av) / LN2);
+			if (exp > 1023) {  // MAX_VALUE
+				lo = 0xFFFFFFFF;
+				hi = 0x7FEFFFFF;
+			} else {
+				 if (exp <= -1023) {
+					exp = -1023;
+					av = av / Math.pow(2, exp) * 0.5;
+				 } else {
+					av = av / Math.pow(2, exp) - 1.0;
+				 }
+				var sig = Math.fround(av * 4503599627370496.); // 2^52
+				// Note: If "sig" is outside of the signed Int32 range, or is NaN, NEGATIVE_INFINITY or POSITIVE_INFINITY, the result is unspecified.
+				// Works in JS, Lua, Flash, Python and Cpp
+				lo = Std.int(sig);
+				hi = (v < 0 ? 0x80000000 : 0) | ((exp + 1023) << 20) | Std.int(sig / 4294967296.0);
+			}
+		}
 		if( littleEndian ) {
-			setUint32(byteOffset, i64.low);
-			setUint32(byteOffset + 4, i64.high);
+			setUint32(byteOffset,     lo, true);
+			setUint32(byteOffset + 4, hi, true);
 		} else {
-			setUint32(byteOffset, i64.high);
-			setUint32(byteOffset + 4, i64.low);
+			setUint32(byteOffset,     hi, false);
+			setUint32(byteOffset + 4, lo, false);
 		}
 	}
 

--- a/std/js/html/compat/DataView.hx
+++ b/std/js/html/compat/DataView.hx
@@ -92,8 +92,15 @@ class DataView {
 	}
 
 	public function getFloat64( byteOffset : Int, ?littleEndian : Bool ) : Float {
-		var lo = getInt32(byteOffset, littleEndian);
-		var hi = getInt32(byteOffset + 4, littleEndian);
+		var lo = 0;
+		var hi = 0;
+		if (littleEndian) {
+			lo = getInt32(byteOffset    , true);
+			hi = getInt32(byteOffset + 4, true);
+		} else {
+			hi = getInt32(byteOffset    , false);
+			lo = getInt32(byteOffset + 4, false);
+		}
 		var sign = 0x80000000 & hi == 0 ? 1.0 : -1.0;
 		var e = (hi >> 20) & 0x7ff;
 		if (e == 2047)


### PR DESCRIPTION
```hx
class Main {
    static function main() {
        var b = haxe.io.Bytes.alloc(128);
        var v = 101;
        b.setUInt16(0, v);
        trace(b.get(0) == v);
        trace(b.getUInt16(0) == v);
        trace(b.getInt32(0) == v);
    }
}
```