### PR TITLE
[js] rework exception handling (closes #6458)

### DIFF
--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -23,6 +23,7 @@ open Type
 open Typecore
 open Error
 open Globals
+open FiltersCommon
 
 (** retrieve string from @:native metadata or raise Not_found *)
 let get_native_name meta =
@@ -414,25 +415,6 @@ let save_class_state ctx t = match t with
 
 (* PASS 2 begin *)
 
-let rec is_removable_class c =
-	match c.cl_kind with
-	| KGeneric ->
-		(Meta.has Meta.Remove c.cl_meta ||
-		(match c.cl_super with
-			| Some (c,_) -> is_removable_class c
-			| _ -> false) ||
-		List.exists (fun (_,t) -> match follow t with
-			| TInst(c,_) ->
-				has_ctor_constraint c || Meta.has Meta.Const c.cl_meta
-			| _ ->
-				false
-		) c.cl_params)
-	| KTypeParameter _ ->
-		(* this shouldn't happen, have to investigate (see #4092) *)
-		true
-	| _ ->
-		false
-
 let remove_generic_base ctx t = match t with
 	| TClassDecl c when is_removable_class c ->
 		c.cl_extern <- true
@@ -749,37 +731,6 @@ let check_reserved_type_paths ctx t =
 
 (* PASS 3 end *)
 
-let run_expression_filters ctx filters t =
-	let run e =
-		List.fold_left (fun e f -> f e) e filters
-	in
-	match t with
-	| TClassDecl c when is_removable_class c -> ()
-	| TClassDecl c ->
-		ctx.curclass <- c;
-		let rec process_field f =
-			ctx.curfield <- f;
-			(match f.cf_expr with
-			| Some e when not (is_removable_field ctx f) ->
-				AbstractCast.cast_stack := f :: !AbstractCast.cast_stack;
-				f.cf_expr <- Some (run e);
-				AbstractCast.cast_stack := List.tl !AbstractCast.cast_stack;
-			| _ -> ());
-			List.iter process_field f.cf_overloads
-		in
-		List.iter process_field c.cl_ordered_fields;
-		List.iter process_field c.cl_ordered_statics;
-		(match c.cl_constructor with
-		| None -> ()
-		| Some f -> process_field f);
-		(match c.cl_init with
-		| None -> ()
-		| Some e ->
-			c.cl_init <- Some (run e));
-	| TEnumDecl _ -> ()
-	| TTypeDecl _ -> ()
-	| TAbstractDecl _ -> ()
-
 let pp_counter = ref 1
 
 let is_cached t =
@@ -923,6 +874,7 @@ let run com tctx main =
 	] in
 	let type_filters = match com.platform with
 		| Cs -> type_filters @ [ fun _ t -> InterfaceProps.run t ]
+		| Js -> JsExceptions.inject_callstack com type_filters
 		| _ -> type_filters
 	in
 	let t = filter_timer detail_times ["type 3"] in

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -1,0 +1,70 @@
+(*
+	The Haxe Compiler
+	Copyright (C) 2005-2017  Haxe Foundation
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*)
+open Type
+open Typecore
+
+let rec is_removable_class c =
+	match c.cl_kind with
+	| KGeneric ->
+		(Meta.has Meta.Remove c.cl_meta ||
+		(match c.cl_super with
+			| Some (c,_) -> is_removable_class c
+			| _ -> false) ||
+		List.exists (fun (_,t) -> match follow t with
+			| TInst(c,_) ->
+				has_ctor_constraint c || Meta.has Meta.Const c.cl_meta
+			| _ ->
+				false
+		) c.cl_params)
+	| KTypeParameter _ ->
+		(* this shouldn't happen, have to investigate (see #4092) *)
+		true
+	| _ ->
+		false
+
+let run_expression_filters ctx filters t =
+	let run e =
+		List.fold_left (fun e f -> f e) e filters
+	in
+	match t with
+	| TClassDecl c when is_removable_class c -> ()
+	| TClassDecl c ->
+		ctx.curclass <- c;
+		let rec process_field f =
+			ctx.curfield <- f;
+			(match f.cf_expr with
+			| Some e when not (is_removable_field ctx f) ->
+				AbstractCast.cast_stack := f :: !AbstractCast.cast_stack;
+				f.cf_expr <- Some (run e);
+				AbstractCast.cast_stack := List.tl !AbstractCast.cast_stack;
+			| _ -> ());
+			List.iter process_field f.cf_overloads
+		in
+		List.iter process_field c.cl_ordered_fields;
+		List.iter process_field c.cl_ordered_statics;
+		(match c.cl_constructor with
+		| None -> ()
+		| Some f -> process_field f);
+		(match c.cl_init with
+		| None -> ()
+		| Some e ->
+			c.cl_init <- Some (run e));
+	| TEnumDecl _ -> ()
+	| TTypeDecl _ -> ()
+	| TAbstractDecl _ -> ()

--- a/src/filters/jsExceptions.ml
+++ b/src/filters/jsExceptions.ml
@@ -1,0 +1,183 @@
+(*
+	The Haxe Compiler
+	Copyright (C) 2005-2017  Haxe Foundation
+
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *)
+
+(*
+	This filter handles everything related to expressions for the JavaScript target:
+
+	- wrapping non-js.Error types in HaxeError on throwing
+	- unwrapping HaxeError on catch
+	- transforming series of catches into a single catch with Std.is checks (optimized)
+	- re-throwing caught exception with js.Lib.rethrow
+	- storing caught exception in haxe.CallStack.lastException (if haxe.CallStack is used)
+
+	Basically it translates this:
+
+	 try throw "fail"
+	 catch (e:String) { trace(e); js.Lib.rethrow(); }
+	 catch (e:Bool) {}
+
+	into something like this (JS):
+
+	 try {
+		 throw new HaxeError("fail");
+	 } catch (e) {
+		 haxe.CallStack.lastException = e;
+		 var e1 = (e instanceof HaxeError) e.val : e;
+		 if (typeof e1 == "string") {
+			 trace(e1);
+			 throw e;
+		 } else if (typeof e1 == "boolean") {
+		 } else {
+			 throw e;
+		 }
+	 }
+*)
+
+open Common
+open Type
+open Typecore
+open Texpr.Builder
+
+let follow = Abstract.follow_with_abstracts
+
+let rec is_js_error t =
+	match t with
+	| TInst ({ cl_path = ["js"],"Error" },_) -> true
+	| TInst ({ cl_super = Some (csup,tl) },_) -> is_js_error (TInst (csup,tl))
+	| _ -> false
+
+let find_cl ctx path =
+	ExtList.List.find_map (function
+		| TClassDecl c when c.cl_path = path -> Some c
+		| _ -> None
+	) ctx.com.types
+
+let init ctx =
+	let cJsError = find_cl ctx (["js"],"Error") in
+	let cHaxeError = find_cl ctx (["js";"_Boot"],"HaxeError") in
+	let cStd = find_cl ctx ([],"Std") in
+	let cBoot = find_cl ctx (["js"],"Boot") in
+	let cSyntax = find_cl ctx (["js"],"Syntax") in
+	let cCallStack = try Some (find_cl ctx (["haxe"],"CallStack")) with Not_found -> None in
+
+	let dynamic_wrap e =
+		let eHaxeError = make_static_this cHaxeError e.epos in
+		fcall eHaxeError "wrap" [e] (TInst (cJsError, [])) e.epos
+	in
+
+	let static_wrap e =
+		{ e with eexpr = TNew (cHaxeError,[],[e]); etype = TInst (cHaxeError,[]) }
+	in
+
+	let rec loop vrethrow e =
+		match e.eexpr with
+		| TThrow eexc ->
+			let eexc = loop vrethrow eexc in
+			let eexc =
+				match follow eexc.etype with
+				| TDynamic _ | TMono _ ->
+					(match eexc.eexpr with
+					| TConst (TInt _ | TFloat _ | TString _ | TBool _ | TNull) -> static_wrap eexc
+					| _ -> dynamic_wrap eexc)
+				| t when not (is_js_error t) ->
+					static_wrap eexc
+				| _ ->
+					eexc
+			in
+			{ e with eexpr = TThrow eexc }
+
+		| TCall ({ eexpr = TField (_, FStatic ({ cl_path = ["js"],"Lib" }, { cf_name = "rethrow" })) }, _) ->
+			(match vrethrow with
+			| Some erethrowvar -> { e with eexpr = TThrow erethrowvar }
+			| None -> abort "js.Lib.rethrow can only be called inside a catch block" e.epos)
+
+		| TTry (etry, catches) ->
+			let etry = loop vrethrow etry in
+
+			let catchall_name = match catches with [(v,_)] -> v.v_name | _ -> "e" in
+			let vcatchall = alloc_var catchall_name t_dynamic e.epos in
+			let ecatchall = make_local vcatchall e.epos in
+			let erethrow = mk (TThrow ecatchall) t_dynamic e.epos in
+
+			let eSyntax = make_static_this cSyntax e.epos in
+			let eHaxeError = make_static_this cHaxeError e.epos in
+			let eInstanceof = fcall eSyntax "instanceof" [ecatchall;eHaxeError] ctx.com.basic.tbool e.epos in
+			let eVal = field { ecatchall with etype = TInst (cHaxeError,[]) } "val" t_dynamic e.epos in
+			let eunwrap = mk (TIf (eInstanceof, eVal, Some (ecatchall))) t_dynamic e.epos in
+
+			let vunwrapped = alloc_var catchall_name t_dynamic e.epos in
+			let eunwrapped = make_local vunwrapped e.epos in
+
+			let ecatch = List.fold_left (fun acc (v,ecatch) ->
+				let ecatch = loop (Some ecatchall) ecatch in
+
+				match follow v.v_type with
+				| TDynamic _ ->
+					{ ecatch with
+						eexpr = TBlock [
+							mk (TVar (v, Some eunwrapped)) ctx.com.basic.tvoid ecatch.epos;
+							ecatch;
+						]
+					}
+				| t ->
+					let etype = make_typeexpr (module_type_of_type t) e.epos in
+					let args = [eunwrapped;etype] in
+					let echeck =
+						match Optimizer.api_inline ctx cStd "is" args e.epos with
+						| Some e -> e
+						| None ->
+							let eBoot = make_static_this cBoot e.epos in
+							fcall eBoot "__instanceof" [eunwrapped;etype] ctx.com.basic.tbool e.epos
+					in
+					let ecatch = { ecatch with
+						eexpr = TBlock [
+							mk (TVar (v, Some eunwrapped)) ctx.com.basic.tvoid ecatch.epos;
+							ecatch;
+						]
+					} in
+					mk (TIf (echeck, ecatch, Some acc)) e.etype e.epos
+			) erethrow (List.rev catches) in
+
+			let ecatch_block = [
+				mk (TVar (vunwrapped, Some eunwrap)) ctx.com.basic.tvoid e.epos;
+				ecatch;
+			] in
+
+			let ecatch_block =
+				match cCallStack with
+				| None -> ecatch_block
+				| Some c ->
+					(*
+						TODO: we should use `__feature__` here, but analyzer won't like an unbound identifier,
+						so let's wait for some proper way to deal with feature-conditional expressions (@:ifFeature maybe?)
+
+						Alternatively, we could run an additional post-analyzer/dce filter that adds these assignments.
+					*)
+					let eCallStack = make_static_this c ecatch.epos in
+					let elastException = field eCallStack "lastException" t_dynamic ecatch.epos in
+					let estore = mk (TBinop (Ast.OpAssign, elastException, ecatchall)) ecatch.etype ecatch.epos in
+					estore :: ecatch_block
+			in
+
+			let ecatch = { ecatch with eexpr = TBlock ecatch_block } in
+			{ e with eexpr = TTry (etry, [(vcatchall,ecatch)]) }
+		| _ ->
+			Type.map_expr (loop vrethrow) e
+	in
+	loop None

--- a/src/filters/jsExceptions.ml
+++ b/src/filters/jsExceptions.ml
@@ -186,6 +186,9 @@ let inject_callstack com type_filters =
 		let rec loop e =
 			match e.eexpr with
 			| TTry (etry,[(v,ecatch)]) ->
+				let etry = loop etry in
+				let ecatch = loop ecatch in
+
 				let eCallStack = make_static_this cCallStack ecatch.epos in
 				let elastException = field eCallStack "lastException" t_dynamic ecatch.epos in
 				let elocal = make_local v ecatch.epos in

--- a/src/filters/jsExceptions.ml
+++ b/src/filters/jsExceptions.ml
@@ -102,6 +102,11 @@ let init ctx =
 			in
 			{ e with eexpr = TThrow eexc }
 
+		| TCall ({ eexpr = TField (_, FStatic ({ cl_path = ["js"],"Lib" }, { cf_name = "getOriginalException" })) }, _) ->
+			(match vrethrow with
+			| Some erethrowvar -> erethrowvar
+			| None -> abort "js.Lib.getOriginalException can only be called inside a catch block" e.epos)
+
 		| TCall ({ eexpr = TField (_, FStatic ({ cl_path = ["js"],"Lib" }, { cf_name = "rethrow" })) }, _) ->
 			(match vrethrow with
 			| Some erethrowvar -> { e with eexpr = TThrow erethrowvar }

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -24,17 +24,17 @@ package js;
 import js.Syntax; // import it here so it's always available in the compiler
 
 private class HaxeError extends js.Error {
-
 	var val:Dynamic;
 
-	public function new(val:Dynamic) untyped {
+	@:pure
+	public function new(val:Dynamic) {
 		super();
-		this.val = __define_feature__("js.Boot.HaxeError", val);
-		this.message = String(val);
-		if (js.Error.captureStackTrace) js.Error.captureStackTrace(this, HaxeError);
+		this.val = val;
+		this.message = (cast String)(val);
+		if ((cast js.Error).captureStackTrace) (cast js.Error).captureStackTrace(this, HaxeError);
 	}
 
-	public static function wrap(val:Dynamic):Dynamic {
+	public static function wrap(val:Dynamic):js.Error {
 		return if (js.Syntax.instanceof(val, js.Error)) val else new HaxeError(val);
 	}
 }
@@ -168,7 +168,7 @@ class Boot {
 		return __interfLoop(cc.__super__,cl);
 	}
 
-	@:ifFeature("typed_catch") private static function __instanceof(o : Dynamic,cl : Dynamic) {
+	@:ifFeature("typed_catch") @:pure private static function __instanceof(o : Dynamic,cl : Dynamic) {
 		if( cl == null )
 			return false;
 		switch( cl ) {

--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -117,9 +117,9 @@ class Lib {
 	/**
 		Re-throw last cathed exception, preserving original stack information.
 
-		Calling this only makes sense inside a catch statement.
+		Calling this is only possible inside a catch statement.
 	**/
-	@:extern public static inline function rethrow() {
-		untyped __define_feature__("js.Lib.rethrow", __rethrow__());
+	@:pure(false) public static function rethrow() {
+		// function is implemented in the compiler
 	}
 }

--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -122,4 +122,15 @@ class Lib {
 	@:pure(false) public static function rethrow() {
 		// function is implemented in the compiler
 	}
+
+	/**
+		Get original caught exception object, before unwrapping the `js.Boot.HaxeError`.
+
+		Can be useful if we want to redirect the original error into some external API (e.g. Promise or node.js callbacks).
+
+		Calling this is only possible inside a catch statement.
+	**/
+	public static function getOriginalException():Dynamic {
+		return null; // function is implemented in the compiler
+	}
 }

--- a/std/js/_std/Reflect.hx
+++ b/std/js/_std/Reflect.hx
@@ -26,6 +26,7 @@
 		return js.Object.prototype.hasOwnProperty.call(o, field);
 	}
 
+	@:pure
 	public static function field( o : Dynamic, field : String ) : Dynamic {
 		try return o[cast field] catch( e : Dynamic ) return null;
 	}

--- a/tests/optimization/src/TestJs.hx
+++ b/tests/optimization/src/TestJs.hx
@@ -62,7 +62,7 @@ class TestJs {
 		return v + v2;
 	}
 
-	@:js("var a = [];var tmp;try {tmp = a[0];} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;var e2 = e1;tmp = null;}tmp;")
+	@:js("var a = [];var tmp;try {tmp = a[0];} catch( e ) {(e instanceof js__$Boot_HaxeError);tmp = null;}tmp;")
 	@:analyzer(no_local_dce)
 	static function testInlineWithComplexExpr() {
 		var a = [];
@@ -172,22 +172,22 @@ class TestJs {
 		try throw false catch (e:Dynamic) {}
 	}
 
-	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;var e2 = e1;TestJs.use(e2);}')
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {TestJs.use((e instanceof js__$Boot_HaxeError) ? e.val : e);}')
 	static function testHaxeErrorUnwrappingWhenUsed() {
 		try throw false catch (e:Dynamic) use(e);
 	}
 
-	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;if(typeof(e1) != "boolean") {throw e;}}')
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {if(typeof((e instanceof js__$Boot_HaxeError) ? e.val : e) != "boolean") {throw e;}}')
 	static function testHaxeErrorUnwrappingWhenTypeChecked() {
 		try throw false catch (e:Bool) {};
 	}
 
-	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;if(typeof(e1) == "boolean") {TestJs.use(e);} else {throw e;}}')
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {if(typeof((e instanceof js__$Boot_HaxeError) ? e.val : e) == "boolean") {TestJs.use(e);} else {throw e;}}')
 	static function testGetOriginalException() {
 		try throw false catch (e:Bool) use(js.Lib.getOriginalException());
 	}
 
-	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;if(typeof(e1) == "boolean") {throw e;} else {throw e;}}')
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {if(typeof((e instanceof js__$Boot_HaxeError) ? e.val : e) == "boolean") {throw e;} else {throw e;}}')
 	static function testRethrow() {
 		try throw false catch (e:Bool) js.Lib.rethrow();
 	}

--- a/tests/optimization/src/TestJs.hx
+++ b/tests/optimization/src/TestJs.hx
@@ -182,6 +182,15 @@ class TestJs {
 		try throw false catch (e:Bool) {};
 	}
 
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;if(typeof(e1) == "boolean") {TestJs.use(e);} else {throw e;}}')
+	static function testGetOriginalException() {
+		try throw false catch (e:Bool) use(js.Lib.getOriginalException());
+	}
+
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;if(typeof(e1) == "boolean") {throw e;} else {throw e;}}')
+	static function testRethrow() {
+		try throw false catch (e:Bool) js.Lib.rethrow();
+	}
 
 	@:js('TestJs.use(2);')
 	static function testIssue3938() {

--- a/tests/optimization/src/TestJs.hx
+++ b/tests/optimization/src/TestJs.hx
@@ -62,7 +62,7 @@ class TestJs {
 		return v + v2;
 	}
 
-	@:js("var a = [];var tmp;try {tmp = a[0];} catch( e ) {tmp = null;}tmp;")
+	@:js("var a = [];var tmp;try {tmp = a[0];} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;var e2 = e1;tmp = null;}tmp;")
 	@:analyzer(no_local_dce)
 	static function testInlineWithComplexExpr() {
 		var a = [];
@@ -172,12 +172,12 @@ class TestJs {
 		try throw false catch (e:Dynamic) {}
 	}
 
-	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {if (e instanceof js__$Boot_HaxeError) e = e.val;TestJs.use(e);}')
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;var e2 = e1;TestJs.use(e2);}')
 	static function testHaxeErrorUnwrappingWhenUsed() {
 		try throw false catch (e:Dynamic) use(e);
 	}
 
-	@:js("try {throw new js__$Boot_HaxeError(false);} catch( e ) {if (e instanceof js__$Boot_HaxeError) e = e.val;if( js_Boot.__instanceof(e,Bool) ) {} else throw(e);}")
+	@:js('try {throw new js__$Boot_HaxeError(false);} catch( e ) {var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;if(typeof(e1) != "boolean") {throw e;}}')
 	static function testHaxeErrorUnwrappingWhenTypeChecked() {
 		try throw false catch (e:Bool) {};
 	}


### PR DESCRIPTION
This reworks JS exception handling in a pre-analyzer/pre-dce filter that handles wrapping/unwrapping, single-catch + Std.is transformation, rethrowing, haxe.CallStack, etc.

E.g.
```haxe
try {
    throw "epuc fial";
} catch (e:String) {
    trace(e);
} catch (e:Bool) {
    trace(e);
    js.Lib.rethrow();
}
```
is now generated as
```js
try {
    throw new js__$Boot_HaxeError("epuc fial");
} catch( e ) {
    var e1 = (e instanceof js__$Boot_HaxeError) ? e.val : e;
    if(typeof(e1) == "string") {
        console.log("Main.hx:7:",e1);
    } else if(typeof(e1) == "boolean") {
        console.log("Main.hx:9:",e1);
        throw e;
    } else {
        throw e;
    }
}
```

Let's see what travis has to say about this...