### PR TITLE
add haxe.macro.Context.registerModuleSkipCall

### DIFF
--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -397,6 +397,7 @@ let rec wait_loop process_params verbose accept =
 			| Some m' ->
 				if verbose then process_server_message com2 "" (SkippingDep(m,m'));
 				tcheck();
+				List.iter (MacroContext.call_init_macro ctx) m.m_extra.m_skip_macro_calls;
 				raise Not_found;
 			end;
 			tcheck();

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -322,6 +322,7 @@ and module_def_extra = {
 	mutable m_kind : module_kind;
 	mutable m_binded_res : (string, string) PMap.t;
 	mutable m_reuse_macro_calls : string list;
+	mutable m_skip_macro_calls : string list;
 	mutable m_if_feature : (string *(tclass * tclass_field * bool)) list;
 	mutable m_features : (string,bool) Hashtbl.t;
 }
@@ -427,6 +428,7 @@ let module_extra file sign time kind policy =
 		m_kind = kind;
 		m_binded_res = PMap.empty;
 		m_reuse_macro_calls = [];
+		m_skip_macro_calls = [];
 		m_if_feature = [];
 		m_features = Hashtbl.create 0;
 		m_check_policy = policy;
@@ -1487,6 +1489,7 @@ module Printer = struct
 			"m_kind",s_module_kind me.m_kind;
 			"m_binded_res",""; (* TODO *)
 			"m_reuse_macro_calls",String.concat ", " me.m_reuse_macro_calls;
+			"m_skip_macro_calls",String.concat ", " me.m_skip_macro_calls;
 			"m_if_feature",""; (* TODO *)
 			"m_features",""; (* TODO *)
 		]

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -40,6 +40,7 @@ type 'value compiler_api = {
 	define_module : string -> 'value list -> ((string * Globals.pos) list * Ast.import_mode) list -> Ast.type_path list -> unit;
 	module_dependency : string -> string -> unit;
 	module_reuse_call : string -> string -> unit;
+	module_skip_call : string -> string -> unit;
 	current_module : unit -> module_def;
 	on_reuse : (unit -> bool) -> unit;
 	mutable current_macro_module : unit -> module_def;
@@ -1839,6 +1840,10 @@ let macro_api ccom get_api =
 		);
 		"register_module_reuse_call", vfun2 (fun m mcall ->
 			(get_api()).module_reuse_call (decode_string m) (decode_string mcall);
+			vnull
+		);
+		"register_module_skip_call", vfun2 (fun m mcall ->
+			(get_api()).module_skip_call (decode_string m) (decode_string mcall);
 			vnull
 		);
 		"get_typed_expr", vfun1 (fun e ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -339,6 +339,10 @@ let make_macro_api ctx p =
 			let m = typing_timer ctx false (fun() -> Typeload.load_module ctx (parse_path mpath) p) in
 			m.m_extra.m_reuse_macro_calls <- call :: List.filter ((<>) call) m.m_extra.m_reuse_macro_calls
 		);
+		MacroApi.module_skip_call = (fun mpath call ->
+			let m = typing_timer ctx false (fun() -> Typeload.load_module ctx (parse_path mpath) p) in
+			m.m_extra.m_skip_macro_calls <- call :: List.filter ((<>) call) m.m_extra.m_skip_macro_calls
+		);
 		MacroApi.current_module = (fun() ->
 			ctx.m.curmod
 		);

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -593,6 +593,10 @@ class Context {
 		load("register_module_reuse_call", 2)(modulePath,macroCall);
 	}
 
+	public static function registerModuleSkipCall( modulePath : String, macroCall : String ) {
+		load("register_module_skip_call", 2)(modulePath,macroCall);
+	}
+
 	/**
 		Register a callback function that will be called every time the macro context cached is reused with a new
 		compilation. This enable to reset some static vars since the code might have been changed. If the callback


### PR DESCRIPTION
This allows registering a macro call when skipping module within compilation server (opposite to reusing it, for which we would use `Context.registerModuleReuseCall`).

I'm not sure if that would actually work, but my thoughts is that we can use this to clear cached data about types in a specific changed module instead of clearing all the cache in `onMacroContextReused` callback.

@ncannasse Would that work?