### PR TITLE
when checking for casts between two abstract, check for direct to/from first and then for @:to/@:from field casts (closes #6751)

### DIFF
--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -369,10 +369,7 @@ module AbstractCast = struct
 		else begin
 			let rec loop tleft tright = match follow tleft,follow tright with
 			| TAbstract(a1,tl1),TAbstract(a2,tl2) ->
-				begin try find a2 tl2 (fun () -> Abstract.find_to a2 tl2 tleft)
-				with Not_found -> try find a1 tl1 (fun () -> Abstract.find_from a1 tl1 eright.etype tleft)
-				with Not_found -> raise Not_found
-				end
+				Abstract.find_to_from find a1 tl1 a2 tl2 tleft eright.etype
 			| TAbstract(a,tl),_ ->
 				begin try find a tl (fun () -> Abstract.find_from a tl eright.etype tleft)
 				with Not_found ->

--- a/tests/unit/src/unit/issues/Issue6751.hx
+++ b/tests/unit/src/unit/issues/Issue6751.hx
@@ -1,0 +1,21 @@
+package unit.issues;
+
+import unit.HelperMacros.typedAs;
+
+private abstract O(String) {
+	public function new(s) this = s;
+	@:to function toInt() return 42;
+}
+
+private abstract A<T>(T) from T {}
+
+class Issue6751 extends Test {
+	function test() {
+		function make<T>(o:A<T>) return o;
+
+		var o = new O("hello");
+		var a = make(o);
+		typedAs(a, (null : A<O>));
+		eq(Std.string(a), "hello");
+	}
+}


### PR DESCRIPTION
(also refactor related code a little bit)