### PR TITLE
sys.Http: fix chunked encoding handling

### DIFF
--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -398,7 +398,7 @@ class Http extends haxe.http.HttpBase {
 				if(p.len <= len) {
 					var cstr = chunk_re.matched(1);
 					chunk_size = Std.parseInt("0x"+cstr);
-					if(cstr == "0") {
+					if(chunk_size == 0) {
 						chunk_size = null;
 						chunk_buf = null;
 						return false;


### PR DESCRIPTION
This url failed to download without this fix
http://taongafarm-dev.akamaized.net/cdn/fac3901fdc2535ee52855ce1cb4cd554/shared/deploy/speech.mpf
For last chunk `cstr` was `'00000000'`, not `'0'`. 