### PR TITLE
Forbid (never, never)

### DIFF
--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -2735,7 +2735,7 @@ module ClassInitializer = struct
 				if not cctx.is_lib then delay_check (fun() -> check_method set t_set (if set <> "set" && set <> "set_" ^ name then Some ("set_" ^ name) else None));
 				AccCall
 		) in
-		if set = AccNormal && (match get with AccCall -> true | _ -> false) then error (name ^ ": Unsupported property combination") p;
+		if (set = AccNormal && (match get with AccCall -> true | _ -> false)) || (set = AccNever && (match get with AccNever -> true | _ -> false))  then error (name ^ ": Unsupported property combination") p;
 		let cf = {
 			(mk_field name ret f.cff_pos (pos f.cff_name)) with
 			cf_doc = f.cff_doc;

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -2735,7 +2735,7 @@ module ClassInitializer = struct
 				if not cctx.is_lib then delay_check (fun() -> check_method set t_set (if set <> "set" && set <> "set_" ^ name then Some ("set_" ^ name) else None));
 				AccCall
 		) in
-		if (set = AccNormal && (match get with AccCall -> true | _ -> false)) || (set = AccNever && (match get with AccNever -> true | _ -> false))  then error (name ^ ": Unsupported property combination") p;
+		if (set = AccNormal && get = AccCall) || (set = AccNever && get = AccNever)  then error (name ^ ": Unsupported property combination") p;
 		let cf = {
 			(mk_field name ret f.cff_pos (pos f.cff_name)) with
 			cf_doc = f.cff_doc;


### PR DESCRIPTION
At the moment, it is possible to compile code with variable that can be never read nor set.

`var useless (never, never) : Int`

I propose to make it raise compilation error in the same way as:

`var forbidden (get, default) : Int`