### PR TITLE
Reflect.callMethod uses wrong field

### DIFF
--- a/std/php/_std/Reflect.hx
+++ b/std/php/_std/Reflect.hx
@@ -54,7 +54,7 @@
 	}
 
 	public static function callMethod( o : Dynamic, func : haxe.Constraints.Function, args : Array<Dynamic> ) : Dynamic untyped {
-		return __call__("call_user_func_array", __call__("is_callable", func) ? func : __call__("array", o, func), (null == args ? __call__("array") : __field__(args, "a")));
+		return __call__("call_user_func_array", __call__("is_callable", func) ? func : __call__("array", o, func), (null == args ? __call__("array") : args));
 	}
 
 	public static function fields( o : Dynamic ) : Array<String> {


### PR DESCRIPTION
Request.callMethod is supposed to take in the class, the function, and an array of arguments but the function in the php target uses `$array->a` as the input. I think i've fixed it by simply passing the array instead of `array->a`