### PR TITLE
Fix Browser.supported for Node.js and --no-inline

### DIFF
--- a/std/js/Browser.hx
+++ b/std/js/Browser.hx
@@ -52,7 +52,7 @@ class Browser {
 	 * environment such as node.js.
 	 */
 	public static var supported(get, never):Bool;
-	inline static function get_supported() return js.Syntax.typeof(window) != "undefined";
+	inline static function get_supported() return untyped __js__("typeof window != undefined");
 
 	/**
 	 * Safely gets the browser's local storage, or returns null if localStorage is unsupported or


### PR DESCRIPTION
I am testing using a recent version of Node.js, along with Webpack to compile my assets, and I found that using `Browser.supported` crashes out with an undefined reference error.

On Haxe 3.4.4, the generated code `typeof (Browser.get_window())` was resulting in an error, but changing it to a simpler `typeof window` works fine. Oh, I should also mention, I am using `--no-inline` when I compile, so this is probably why others have not seen this problem.

Thanks :smile: