### PR TITLE
Type array access on Array<T> as Null<T>

### DIFF
--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -1641,6 +1641,18 @@ let has_meta m ml = List.exists (fun (m2,_,_) -> m = m2) ml
 let get_meta m ml = List.find (fun (m2,_,_) -> m = m2) ml
 let no_meta = []
 
+(**
+	Check if type `t` has meta `m`.
+	Does not follow typedefs, monomorphs etc.
+*)
+let type_has_meta t m =
+	match t with
+		| TMono _ | TFun _ | TAnon _ | TDynamic _ | TLazy _ -> false
+		| TEnum ({ e_meta = metadata }, _)
+		| TInst ({ cl_meta = metadata }, _)
+		| TType ({ t_meta = metadata }, _)
+		| TAbstract ({ a_meta = metadata }, _) -> has_meta m metadata
+
 (*
 	we can restrict access as soon as both are runtime-compatible
 *)

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2595,11 +2595,7 @@ and should_be_nullable_array_access ctx array_type access_mode =
 	else
 		match array_type with
 		| TInst ({ cl_path = [],"Array"},[t]) ->
-			let t = Abstract.follow_with_abstracts t in
-			if (Common.defined ctx.com Define.Static) && (type_has_meta t Meta.NotNull) then
-				false
-			else
-				true
+			not ((Common.defined ctx.com Define.Static) && (type_has_meta (Abstract.follow_with_abstracts t) Meta.NotNull))
 		| _ -> false
 
 and type_array_access ctx e1 e2 p mode =

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2622,14 +2622,17 @@ and type_array_access ctx e1 e2 p mode =
 				loop (apply_params a.a_params tl a.a_this)
 			| t ->
 				let pt =
-					match t with
-					| TInst ({ cl_path = [],"Array"},[t]) ->
-						let t = Abstract.follow_with_abstracts t in
-						if (Common.defined ctx.com Define.Static) && (t = ctx.t.tint || t = ctx.t.tfloat || t = ctx.t.tbool) then
-							mk_mono()
-						else
-							ctx.t.tnull (mk_mono())
-					| _ -> mk_mono()
+					if mode = MSet then
+						mk_mono()
+					else
+						match t with
+						| TInst ({ cl_path = [],"Array"},[t]) ->
+							let t = Abstract.follow_with_abstracts t in
+							if (Common.defined ctx.com Define.Static) && (t = ctx.t.tint || t = ctx.t.tfloat || t = ctx.t.tbool) then
+								mk_mono()
+							else
+								ctx.t.tnull (mk_mono())
+						| _ -> mk_mono()
 				in
 				let t = ctx.t.tarray pt in
 				(try unify_raise ctx et t p

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2628,7 +2628,7 @@ and type_array_access ctx e1 e2 p mode =
 						match t with
 						| TInst ({ cl_path = [],"Array"},[t]) ->
 							let t = Abstract.follow_with_abstracts t in
-							if (Common.defined ctx.com Define.Static) && (t = ctx.t.tint || t = ctx.t.tfloat || t = ctx.t.tbool) then
+							if (Common.defined ctx.com Define.Static) && (t == ctx.t.tint || t == ctx.t.tfloat || t == ctx.t.tbool) then
 								mk_mono()
 							else
 								ctx.t.tnull (mk_mono())

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2596,7 +2596,7 @@ and should_be_nullable_array_access ctx array_type access_mode =
 		match array_type with
 		| TInst ({ cl_path = [],"Array"},[t]) ->
 			let t = Abstract.follow_with_abstracts t in
-			if (Common.defined ctx.com Define.Static) && (t == ctx.t.tint || t == ctx.t.tfloat || t == ctx.t.tbool) then
+			if (Common.defined ctx.com Define.Static) && (type_has_meta t Meta.NotNull) then
 				false
 			else
 				true

--- a/std/haxe/io/BufferInput.hx
+++ b/std/haxe/io/BufferInput.hx
@@ -43,7 +43,7 @@ class BufferInput extends haxe.io.Input {
 		available += i.readBytes(buf, available, buf.length - available);
 	}
 
-	override function readByte() {
+	override function readByte():Int {
 		if( available == 0 ) refill();
 		var c = buf.get(pos);
 		pos++;


### PR DESCRIPTION
Current behavior
```haxe
var a = ['hello'];
$type(a[1000]); // String
trace(a[1000]); //null
```
Behavior of this PR:
```haxe
var a = ['hello'];
$type(a[1000]); // Null<String>
trace(a[1000]); //null
```
This PR adds `Null<>` for array read access on all platforms except `Int`, `Bool`, `Float` on static targets.
In addition to proper typing it also makes possible to check array access for null safety (i'm making a plugin for that).