### PR TITLE
Clean up CLI usage/help output, standardize flag naming

### DIFF
--- a/extra/all.hxml
+++ b/extra/all.hxml
@@ -15,7 +15,7 @@
 
 -swf all9.swf
 -xml flash9.xml
--swf-version 11.4
+--swf-version 11.4
 
 --next
 

--- a/extra/doc.hxml
+++ b/extra/doc.hxml
@@ -1,6 +1,6 @@
 --no-output
 --macro ImportAll.run()
--dce no
+--dce no
 -D doc-gen
 
 --each
@@ -17,7 +17,7 @@
 
 -swf all9.swf
 -xml doc/flash.xml
--swf-version 11.4
+--swf-version 11.4
 
 --next
 

--- a/extra/extract.hxml
+++ b/extra/extract.hxml
@@ -4,9 +4,9 @@
 # - Run haxe extract.hxml
 # - Restore removed haxe/std/flash/DIR directories
 # - Copy directories from hxclasses/flash to haxe/std/flash, overwriting restored ones
--debug
--swf-lib library.swf
+--debug
+--swf-lib library.swf
 -swf test.swf
--swf-version 15
+--swf-version 15
 --macro patchTypes("../extra/extract.patch")
 --gen-hx-classes

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -581,7 +581,7 @@ try
 			message ctx (CMInfo(s_version,null_pos));
 			did_something := true;
 		),"","print version and exit");
-		("Miscellaneous", ["help";"-h";"--help"], ["-help"], Arg.Unit (fun () ->
+		("Miscellaneous", ["-h";"--help"], ["-help"], Arg.Unit (fun () ->
 			raise (Arg.Help "")
 		),"","show extended help information");
 		("Miscellaneous",["--help-defines"],[], Arg.Unit (fun() ->

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -680,7 +680,16 @@ try
 		),"<command>","run the specified command after successful compilation");
 		(* FIXME: replace with -D define *)
 		("Optimization",["--no-traces"],[], define Define.NoTraces, "","don't compile trace calls in the program");
-		("Debug",["--gen-hx-classes"],[], Arg.Unit (fun() ->
+		("Batch",["--next"],[], Arg.Unit (fun() -> assert false), "","separate several haxe compilations");
+		("Batch",["--each"],[], Arg.Unit (fun() -> assert false), "","append preceding parameters to all haxe compilations separated by --next");
+		("Services",["--display"],[], Arg.String (fun file_pos ->
+			DisplayOutput.handle_display_argument com file_pos pre_compilation did_something;
+		),"","display code tips");
+		("Services",["--xml"],["-xml"],Arg.String (fun file ->
+			Parser.use_doc := true;
+			xml_out := Some file
+		),"<file>","generate XML types description");
+		("Services",["--gen-hx-classes"],[], Arg.Unit (fun() ->
 			force_typing := true;
 			pre_compilation := (fun() ->
 				List.iter (fun (_,_,extract) ->
@@ -697,15 +706,6 @@ try
 			) :: !pre_compilation;
 			xml_out := Some "hx"
 		),"","generate hx headers for all input classes");
-		("Batch",["--next"],[], Arg.Unit (fun() -> assert false), "","separate several haxe compilations");
-		("Batch",["--each"],[], Arg.Unit (fun() -> assert false), "","append preceding parameters to all haxe compilations separated by --next");
-		("Services",["--display"],[], Arg.String (fun file_pos ->
-			DisplayOutput.handle_display_argument com file_pos pre_compilation did_something;
-		),"","display code tips");
-		("Services",["--xml"],["-xml"],Arg.String (fun file ->
-			Parser.use_doc := true;
-			xml_out := Some file
-		),"<file>","generate XML types description");
 		("Optimization",["--no-output"],[], Arg.Unit (fun() -> no_output := true),"","compiles but does not generate any file");
 		("Debug",["--times"],[], Arg.Unit (fun() -> measure_times := true),"","measure compilation times");
 		("Optimization",["--no-inline"],[], define Define.NoInline, "","disable inlining");

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -405,7 +405,11 @@ let rec process_params create pl =
 		| arg :: l ->
 			match List.rev (ExtString.String.nsplit arg ".") with
 			| "hxml" :: _ when (match acc with "-cmd" :: _ -> false | _ -> true) ->
-				let acc, l = (try acc, parse_hxml arg @ l with Not_found -> (arg ^ " (file not found)") :: acc, l) in
+				let acc, l =
+					(try
+						let parsed = parse_hxml arg in
+						if (List.mem "--" parsed) then raise (Arg.Bad "Rest arguments (--) are not allowed in hxml files") else (acc, parsed @ l)
+					with Not_found -> (arg ^ " (file not found)") :: acc, l) in
 				loop acc l
 			| _ -> loop (arg :: acc) l
 	in
@@ -592,7 +596,7 @@ try
 			List.iter (fun msg -> ctx.com.print (msg ^ "\n")) all;
 			did_something := true
 		),"","print help for all compiler metadatas");
-		("Misc",["--run"],[], Arg.Unit (fun() -> assert false), "","TODO");
+		("Misc",["--run"],[], Arg.Unit (fun() -> assert false), "<module> [args...]","compile and execute a Haxe module with command line arguments");
 		("Miscellaneous",["--"],[], Arg.Rest (fun arg ->
 			com.sys_args <- com.sys_args @ [arg];
 		),"[args...]","args that will be passed to the macro interpreter");

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -548,11 +548,11 @@ try
 			com.main_class <- Some cpath;
 			classes := cpath :: !classes
 		),"<class>","select startup class");
-		("Compilation",["-l";"--lib"],["-lib"],Arg.String (fun l ->
+		("Compilation",["-L";"--lib"],["-lib"],Arg.String (fun l ->
 			cp_libs := l :: !cp_libs;
 			Common.raw_define com l;
 		),"<library[:version]>","use a haxelib library");
-		("Compilation",["-D"],[],Arg.String (fun var ->
+		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
 			begin match var with
 				| "no_copt" | "no-copt" -> com.foptimize <- false;
 				| "use_rtti_doc" | "use-rtti-doc" -> Parser.use_doc := true;

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -588,7 +588,7 @@ try
 		),"","print help for all compiler metadatas");
 	] in
 	let adv_args_spec = [
-		("Optimization",["--dce"],["-dce"],Arg.String (fun mode ->
+		("Optimization",["--dce";"--dead-code-elimination"],["-dce"],Arg.String (fun mode ->
 			(match mode with
 			| "std" | "full" | "no" -> ()
 			| _ -> raise (Arg.Bad "Invalid DCE mode, expected std | full | no"));

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -427,10 +427,14 @@ and process_args arg_spec =
 		(List.map (fun (arg) -> (arg, spec, doc)) ok) @
 		(* deprecated argument names *)
 		let dep_msg arg = (Printf.sprintf "WARNING: %s is deprecated" arg) ^ (if List.length ok > 0 then (Printf.sprintf ". Use %s instead" (String.concat "/" ok)) else "") in
+		(* For now, these warnings are a noop. Can replace this function to
+		enable error output: *)
+		(* let dep_fun = prerr_endline (dep_msg arg) in *)
+		let dep_fun arg spec = () in
 		let dep_spec arg spec = match spec with
-			| Arg.String f -> Arg.String (fun x -> prerr_endline (dep_msg arg); f x)
-			| Arg.Unit f -> Arg.Unit (fun x -> prerr_endline (dep_msg arg); f x)
-			| Arg.Bool f -> Arg.Bool (fun x -> prerr_endline (dep_msg arg); f x)
+			| Arg.String f -> Arg.String (fun x -> dep_fun arg spec; f x)
+			| Arg.Unit f -> Arg.Unit (fun x -> dep_fun arg spec; f x)
+			| Arg.Bool f -> Arg.Bool (fun x -> dep_fun arg spec; f x)
 			| _ -> spec in
 		(List.map (fun (arg) -> (arg, dep_spec arg spec, doc)) dep)
 	) arg_spec)

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -51,6 +51,7 @@ open Globals
 open Filename
 
 exception Abort
+exception HelpMessage of string
 
 let executable_path() =
 	Extc.executable_path()
@@ -108,7 +109,7 @@ let add_libs com libs =
 		let ret = Unix.close_process_full (pin,pout,perr) in
 		if ret <> Unix.WEXITED 0 then failwith (match lines, err with
 			| [], [] -> "Failed to call haxelib (command not found ?)"
-			| [], [s] when ExtString.String.ends_with (ExtString.String.strip s) "Module not found : path" -> "The haxelib command has been strip'ed, please install it again"
+			| [], [s] when ExtString.String.ends_with (ExtString.String.strip s) "Module not found: path" -> "The haxelib command has been strip'ed, please install it again"
 			| _ -> String.concat "\n" (lines@err));
 		t();
 		lines
@@ -416,9 +417,38 @@ let rec process_params create pl =
 	) in
 	loop [] pl
 
+and process_args arg_spec =
+	(* Takes a list of arg specs including some custom info, and generates a
+	list in the format Arg.parse_argv wants. Handles multiple official or
+	deprecated names for the same arg; deprecated versions will display a
+	warning. *)
+	List.flatten(List.map (fun (cat, ok, dep, spec, hint, doc) ->
+		(* official argument names *)
+		(List.map (fun (arg) -> (arg, spec, doc)) ok) @
+		(* deprecated argument names *)
+		let dep_msg arg = (Printf.sprintf "WARNING: %s is deprecated" arg) ^ (if List.length ok > 0 then (Printf.sprintf ". Use %s instead" (String.concat "/" ok)) else "") in
+		let dep_spec arg spec = match spec with
+			| Arg.String f -> Arg.String (fun x -> prerr_endline (dep_msg arg); f x)
+			| Arg.Unit f -> Arg.Unit (fun x -> prerr_endline (dep_msg arg); f x)
+			| Arg.Bool f -> Arg.Bool (fun x -> prerr_endline (dep_msg arg); f x)
+			| _ -> spec in
+		(List.map (fun (arg) -> (arg, dep_spec arg spec, doc)) dep)
+	) arg_spec)
+
+and usage_string arg_spec usage =
+	let make_label = fun names hint -> Printf.sprintf "%s %s" (String.concat ", " names) hint in
+	let args = (List.filter (fun (cat, ok, dep, spec, hint, doc) -> (List.length ok) > 0) arg_spec) in
+	let cat_order = ["Target";"Compilation";"Optimization";"Debug";"Batch";"Compilation Server";"Target-specific";"Miscellaneous"] in
+	let cats = List.filter (fun x -> List.mem x (List.map (fun (cat, _, _, _, _, _) -> cat) args)) cat_order in
+	let max_length = List.fold_left max 0 (List.map String.length (List.map (fun (_, ok, _, _, hint, _) -> make_label ok hint) args)) in
+	usage ^ (String.concat "\n" (List.flatten (List.map (fun cat -> [cat] @ (List.map (fun (cat, ok, dep, spec, hint, doc) ->
+		let label = make_label ok hint in
+		Printf.sprintf "  %s%s  %s" label (String.make (max_length - (String.length label)) ' ') doc
+	) (List.filter (fun (cat', _, _, _, _, _) -> (if List.mem cat' cat_order then cat' else "Miscellaneous") = cat) args))) cats)))
+
 and init ctx =
 	let usage = Printf.sprintf
-		"Haxe Compiler %s - (C)2005-2018 Haxe Foundation\n Usage : haxe%s -main <class> [-swf|-js|-neko|-php|-cpp|-cppia|-as3|-cs|-java|-python|-hl|-lua] <output> [options]\n Options :"
+		"Haxe Compiler %s - (C)2005-2018 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files...]\n\n"
 		s_version (if Sys.os_type = "Win32" then ".exe" else "")
 	in
 	let com = ctx.com in
@@ -458,87 +488,114 @@ try
 		| args -> (!process_ref) args
 	in
 	let arg_delays = ref [] in
+	(* category, official names, deprecated names, arg spec, usage hint, doc *)
 	let basic_args_spec = [
-		("-cp",Arg.String (fun path ->
-			process_libs();
-			com.class_path <- Path.add_trailing_slash path :: com.class_path
-		),"<path> : add a directory to find source files");
-		("-js",Arg.String (Initialize.set_platform com Js),"<file> : compile code to JavaScript file");
-		("-lua",Arg.String (Initialize.set_platform com Lua),"<file> : compile code to Lua file");
-		("-swf",Arg.String (Initialize.set_platform com Flash),"<file> : compile code to Flash SWF file");
-		("-as3",Arg.String (fun dir ->
+		("Target",["-js"],[],Arg.String (Initialize.set_platform com Js),"<file>","compile code to JavaScript file");
+		("Target",["-lua"],[],Arg.String (Initialize.set_platform com Lua),"<file>","compile code to Lua file");
+		("Target",["-swf"],[],Arg.String (Initialize.set_platform com Flash),"<file>","compile code to Flash SWF file");
+		("Target",["-as3"],[],Arg.String (fun dir ->
 			Initialize.set_platform com Flash dir;
 			Common.define com Define.As3;
 			Common.define com Define.NoInline;
-		),"<directory> : generate AS3 code into target directory");
-		("-neko",Arg.String (Initialize.set_platform com Neko),"<file> : compile code to Neko Binary");
-		("-php",Arg.String (fun dir ->
+		),"<directory>","generate AS3 code into target directory");
+		("Target",["-neko"],[],Arg.String (Initialize.set_platform com Neko),"<file>","compile code to Neko Binary");
+		("Target",["-php"],[],Arg.String (fun dir ->
 			classes := (["php"],"Boot") :: !classes;
 			Initialize.set_platform com Php dir;
-		),"<directory> : generate PHP code into target directory");
-		("-cpp",Arg.String (fun dir ->
+		),"<directory>","generate PHP code into target directory");
+		("Target",["-cpp"],[],Arg.String (fun dir ->
 			Initialize.set_platform com Cpp dir;
-		),"<directory> : generate C++ code into target directory");
-		("-cppia",Arg.String (fun file ->
+		),"<directory>","generate C++ code into target directory");
+		("Target",["-cppia"],[],Arg.String (fun file ->
 			Initialize.set_platform com Cpp file;
 			Common.define com Define.Cppia;
-		),"<file> : generate Cppia code into target file");
-		("-cs",Arg.String (fun dir ->
+		),"<file>","generate Cppia code into target file");
+		("Target",["-cs"],[],Arg.String (fun dir ->
 			cp_libs := "hxcs" :: !cp_libs;
 			Initialize.set_platform com Cs dir;
-		),"<directory> : generate C# code into target directory");
-		("-java",Arg.String (fun dir ->
+		),"<directory>","generate C# code into target directory");
+		("Target",["-java"],[],Arg.String (fun dir ->
 			cp_libs := "hxjava" :: !cp_libs;
 			Initialize.set_platform com Java dir;
-		),"<directory> : generate Java code into target directory");
-		("-python",Arg.String (fun dir ->
+		),"<directory>","generate Java code into target directory");
+		("Target",["-python"],[],Arg.String (fun dir ->
 			Initialize.set_platform com Python dir;
-		),"<file> : generate Python code as target file");
-		("-hl",Arg.String (fun file ->
+		),"<file>","generate Python code as target file");
+		("Target",["-hl"],[],Arg.String (fun file ->
 			Initialize.set_platform com Hl file;
-		),"<file> : compile HL code as target file");
-		("-xml",Arg.String (fun file ->
+		),"<file>","compile HL code as target file");
+		("Target",["-xml"],[],Arg.String (fun file ->
 			Parser.use_doc := true;
 			xml_out := Some file
-		),"<file> : generate XML types description");
-		("-main",Arg.String (fun cl ->
-			if com.main_class <> None then raise (Arg.Bad "Multiple -main");
+		),"<file>","generate XML types description");
+		("Target",["-interp"],["--interp"], Arg.Unit (fun() ->
+			Common.define com Define.Interp;
+			Initialize.set_platform com (!Globals.macro_platform) "";
+			interp := true;
+		),"","interpret the program using internal macro system");
+
+		("Compilation",["-c";"--cp"],["-cp"],Arg.String (fun path ->
+			process_libs();
+			com.class_path <- Path.add_trailing_slash path :: com.class_path
+		),"<path>","add a directory to find source files");
+		("Compilation",["-m";"--main"],["-main"],Arg.String (fun cl ->
+			if com.main_class <> None then raise (Arg.Bad "Multiple --main classes specified");
 			let cpath = Path.parse_type_path cl in
 			com.main_class <- Some cpath;
 			classes := cpath :: !classes
-		),"<class> : select startup class");
-		("-lib",Arg.String (fun l ->
+		),"<class>","select startup class");
+		("Compilation",["-l";"--lib"],["-lib"],Arg.String (fun l ->
 			cp_libs := l :: !cp_libs;
 			Common.raw_define com l;
-		),"<library[:version]> : use a haxelib library");
-		("-D",Arg.String (fun var ->
+		),"<library[:version]>","use a haxelib library");
+		("Compilation",["-D"],[],Arg.String (fun var ->
 			begin match var with
 				| "no_copt" | "no-copt" -> com.foptimize <- false;
 				| "use_rtti_doc" | "use-rtti-doc" -> Parser.use_doc := true;
 				| _ -> 	if List.mem var reserved_flags then raise (Arg.Bad (var ^ " is a reserved compiler flag and cannot be defined from command line"));
 			end;
 			Common.raw_define com var;
-		),"<var[=value]> : define a conditional compilation flag");
-		("-v",Arg.Unit (fun () ->
+		),"<var[=value]>","define a conditional compilation flag");
+		("Debug",["-v";"--verbose"],[],Arg.Unit (fun () ->
 			com.verbose <- true
-		),": turn on verbose mode");
-		("-debug", Arg.Unit (fun() ->
+		),"","turn on verbose mode");
+		("Debug",["--debug"],["-debug"], Arg.Unit (fun() ->
 			Common.define com Define.Debug;
 			com.debug <- true;
-		), ": add debug information to the compiled code");
+		),"","add debug information to the compiled code");
+		("Miscellaneous",["--version"],["-version"],Arg.Unit (fun() ->
+			message ctx (CMInfo(s_version,null_pos));
+			did_something := true;
+		),"","print version and exit");
+		("Miscellaneous", ["-h";"--help"], ["-help"], Arg.Unit (fun () ->
+			raise (Arg.Help "")
+		),"","show extended help information");
+		("Miscellaneous",["--help-defines"],[], Arg.Unit (fun() ->
+			let all,max_length = Define.get_documentation_list() in
+			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
+			List.iter (fun msg -> ctx.com.print (msg ^ "\n")) all;
+			did_something := true
+		),"","print help for all compiler specific defines");
+		("Miscellaneous",["--help-metas"],[], Arg.Unit (fun() ->
+			let all,max_length = Meta.get_documentation_list() in
+			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
+			List.iter (fun msg -> ctx.com.print (msg ^ "\n")) all;
+			did_something := true
+		),"","print help for all compiler metadatas");
 	] in
 	let adv_args_spec = [
-		("-dce", Arg.String (fun mode ->
+		("Optimization",["--dce"],["-dce"],Arg.String (fun mode ->
 			(match mode with
 			| "std" | "full" | "no" -> ()
 			| _ -> raise (Arg.Bad "Invalid DCE mode, expected std | full | no"));
 			Common.define_value com Define.Dce mode
-		),"[std|full|no] : set the dead code elimination mode (default std)");
-		("-swf-version",Arg.Float (fun v ->
+		),"[std|full|no]","set the dead code elimination mode (default std)");
+		("Target-specific",["--swf-version"],["-swf-version"],Arg.Float (fun v ->
 			if not !swf_version || com.flash_version < v then com.flash_version <- v;
 			swf_version := true;
-		),"<version> : change the SWF version");
-		("-swf-header",Arg.String (fun h ->
+		),"<version>","change the SWF version");
+		(* FIXME: replace with -D define *)
+		("Target-specific",["--swf-header"],["-swf-header"],Arg.String (fun h ->
 			try
 				swf_header := Some (match ExtString.String.nsplit h ":" with
 				| [width; height; fps] ->
@@ -549,19 +606,22 @@ try
 				| _ -> raise Exit)
 			with
 				_ -> raise (Arg.Bad "Invalid SWF header format, expected width:height:fps[:color]")
-		),"<header> : define SWF header (width:height:fps:color)");
-		("-swf-lib",Arg.String (fun file ->
+		),"<header>","define SWF header (width:height:fps:color)");
+		(* FIXME: replace with -D define *)
+		("Target-specific",["--swf-lib"],["-swf-lib"],Arg.String (fun file ->
 			process_libs(); (* linked swf order matters, and lib might reference swf as well *)
 			SwfLoader.add_swf_lib com file false
-		),"<file> : add the SWF library to the compiled SWF");
-		("-swf-lib-extern",Arg.String (fun file ->
+		),"<file>","add the SWF library to the compiled SWF");
+		(* FIXME: replace with -D define *)
+		("Target-specific",["--swf-lib-extern"],["-swf-lib-extern"],Arg.String (fun file ->
 			SwfLoader.add_swf_lib com file true
-		),"<file> : use the SWF library for type checking");
-		("-java-lib",Arg.String (fun file ->
+		),"<file>","use the SWF library for type checking");
+		("Target-specific",["--flash-strict"],[], define Define.FlashStrict, "","more type strict flash API");
+		("Target-specific",["--java-lib"],["-java-lib"],Arg.String (fun file ->
 			let std = file = "lib/hxjava-std.jar" in
 			arg_delays := (fun () -> Java.add_java_lib com file std) :: !arg_delays;
-		),"<file> : add an external JAR or class directory library");
-		("-net-lib",Arg.String (fun file ->
+		),"<file>","add an external JAR or class directory library");
+		("Target-specific",["--net-lib"],["-net-lib"],Arg.String (fun file ->
 			let file, is_std = match ExtString.String.nsplit file "@" with
 				| [file] ->
 					file,false
@@ -570,14 +630,15 @@ try
 				| _ -> raise Exit
 			in
 			arg_delays := (fun () -> Dotnet.add_net_lib com file is_std) :: !arg_delays;
-		),"<file>[@std] : add an external .NET DLL file");
-		("-net-std",Arg.String (fun file ->
+		),"<file>[@std]","add an external .NET DLL file");
+		("Target-specific",["--net-std"],["-net-std"],Arg.String (fun file ->
 			Dotnet.add_net_std com file
-		),"<file> : add a root std .NET DLL search path");
-		("-c-arg",Arg.String (fun arg ->
+		),"<file>","add a root std .NET DLL search path");
+		(* FIXME: replace with -D define *)
+		("Target-specific",["--c-arg"],["-c-arg"],Arg.String (fun arg ->
 			com.c_args <- arg :: com.c_args
-		),"<arg> : pass option <arg> to the native Java/C# compiler");
-		("-x", Arg.String (fun file ->
+		),"<arg>","pass option <arg> to the native Java/C# compiler");
+		("Target-specific",["-x"],[], Arg.String (fun file ->
 			let neko_file = file ^ ".n" in
 			Initialize.set_platform com Neko neko_file;
 			if com.main_class = None then begin
@@ -586,8 +647,8 @@ try
 				classes := cpath :: !classes
 			end;
 			cmds := ("neko " ^ neko_file) :: !cmds;
-		),"<file> : shortcut for compiling and executing a neko file");
-		("-resource",Arg.String (fun res ->
+		),"<file>","shortcut for compiling and executing a neko file");
+		("Compilation",["-r";"--resource"],["-resource"],Arg.String (fun res ->
 			let file, name = (match ExtString.String.nsplit res "@" with
 				| [file; name] -> file, name
 				| [file] -> file, file
@@ -599,19 +660,19 @@ try
 				if String.length s > 12000000 then raise Exit;
 				s;
 			with
-				| Sys_error _ -> failwith ("Resource file not found : " ^ file)
+				| Sys_error _ -> failwith ("Resource file not found: " ^ file)
 				| _ -> failwith ("Resource '" ^ file ^ "' excess the maximum size of 12MB")
 			) in
 			if Hashtbl.mem com.resources name then failwith ("Duplicate resource name " ^ name);
 			Hashtbl.add com.resources name data
-		),"<file>[@name] : add a named resource file");
-		("-prompt", Arg.Unit (fun() -> prompt := true),": prompt on error");
-		("-cmd", Arg.String (fun cmd ->
+		),"<file>[@name]","add a named resource file");
+		("Debug",["--prompt"],["-prompt"], Arg.Unit (fun() -> prompt := true),"","prompt on error");
+		("Compilation",["--cmd"],["-cmd"], Arg.String (fun cmd ->
 			cmds := DisplayOutput.unquote cmd :: !cmds
-		),": run the specified command after successful compilation");
-		("--flash-strict", define Define.FlashStrict, ": more type strict flash API");
-		("--no-traces", define Define.NoTraces, ": don't compile trace calls in the program");
-		("--gen-hx-classes", Arg.Unit (fun() ->
+		),"<command>","run the specified command after successful compilation");
+		(* FIXME: replace with -D define *)
+		("Optimization",["--no-traces"],[], define Define.NoTraces, "","don't compile trace calls in the program");
+		("Debug",["--gen-hx-classes"],[], Arg.Unit (fun() ->
 			force_typing := true;
 			pre_compilation := (fun() ->
 				List.iter (fun (_,_,extract) ->
@@ -627,33 +688,28 @@ try
 				) com.net_libs;
 			) :: !pre_compilation;
 			xml_out := Some "hx"
-		),": generate hx headers for all input classes");
-		("--next", Arg.Unit (fun() -> assert false), ": separate several haxe compilations");
-		("--each", Arg.Unit (fun() -> assert false), ": append preceding parameters to all haxe compilations separated by --next");
-		("--display", Arg.String (fun file_pos ->
+		),"","generate hx headers for all input classes");
+		("Batch",["--next"],[], Arg.Unit (fun() -> assert false), "","separate several haxe compilations");
+		("Batch",["--each"],[], Arg.Unit (fun() -> assert false), "","append preceding parameters to all haxe compilations separated by --next");
+		("Compilation Server",["--display"],[], Arg.String (fun file_pos ->
 			DisplayOutput.handle_display_argument com file_pos pre_compilation did_something;
-		),": display code tips");
-		("--no-output", Arg.Unit (fun() -> no_output := true),": compiles but does not generate any file");
-		("--times", Arg.Unit (fun() -> measure_times := true),": measure compilation times");
-		("--no-inline", define Define.NoInline, ": disable inlining");
-		("--no-opt", Arg.Unit (fun() ->
+		),"","display code tips");
+		("Optimization",["--no-output"],[], Arg.Unit (fun() -> no_output := true),"","compiles but does not generate any file");
+		("Debug",["--times"],[], Arg.Unit (fun() -> measure_times := true),"","measure compilation times");
+		("Optimization",["--no-inline"],[], define Define.NoInline, "","disable inlining");
+		("Optimization",["--no-opt"],[], Arg.Unit (fun() ->
 			com.foptimize <- false;
 			Common.define com Define.NoOpt;
-		), ": disable code optimizations");
-		("--remap", Arg.String (fun s ->
+		), "","disable code optimizations");
+		("Compilation",["--remap"],[], Arg.String (fun s ->
 			let pack, target = (try ExtString.String.split s ":" with _ -> raise (Arg.Bad "Invalid remap format, expected source:target")) in
 			com.package_rules <- PMap.add pack (Remap target) com.package_rules;
-		),"<package:target> : remap a package to another one");
-		("--interp", Arg.Unit (fun() ->
-			Common.define com Define.Interp;
-			Initialize.set_platform com (!Globals.macro_platform) "";
-			interp := true;
-		),": interpret the program using internal macro system");
-		("--macro", Arg.String (fun e ->
+		),"<package:target>","remap a package to another one");
+		("Compilation",["--macro"],[], Arg.String (fun e ->
 			force_typing := true;
 			config_macros := e :: !config_macros
-		)," : call the given macro before typing anything else");
-		("--wait", Arg.String (fun hp ->
+		),"<macro>","call the given macro before typing anything else");
+		("Compilation Server",["--wait"],[], Arg.String (fun hp ->
 			let accept = match hp with
 				| "stdio" ->
 					Server.init_wait_stdio()
@@ -663,29 +719,13 @@ try
 					init_wait_socket com.verbose host port
 			in
 			wait_loop process_params com.verbose accept
-		),"[[host:]port]|stdio] : wait on the given port (or use standard i/o) for commands to run)");
-		("--connect",Arg.String (fun _ ->
+		),"[[host:]port]|stdio]","wait on the given port (or use standard i/o) for commands to run)");
+		("Compilation Server",["--connect"],[],Arg.String (fun _ ->
 			assert false
-		),"<[host:]port> : connect on the given port and run commands there)");
-		("--cwd", Arg.String (fun dir ->
+		),"<[host:]port>","connect on the given port and run commands there)");
+		("Compilation",["--cwd"],[], Arg.String (fun dir ->
 			assert false
-		),"<dir> : set current working directory");
-		("-version",Arg.Unit (fun() ->
-			message ctx (CMInfo(s_version,null_pos));
-			did_something := true;
-		),": print version and exit");
-		("--help-defines", Arg.Unit (fun() ->
-			let all,max_length = Define.get_documentation_list() in
-			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-			List.iter (fun msg -> ctx.com.print (msg ^ "\n")) all;
-			did_something := true
-		),": print help for all compiler specific defines");
-		("--help-metas", Arg.Unit (fun() ->
-			let all,max_length = Meta.get_documentation_list() in
-			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-			List.iter (fun msg -> ctx.com.print (msg ^ "\n")) all;
-			did_something := true
-		),": print help for all compiler metadatas");
+		),"<dir>","set current working directory");
 	] in
 	let args_callback cl =
 		let path,name = Path.parse_path cl in
@@ -696,13 +736,19 @@ try
 			config_macros := (Printf.sprintf "include('%s', true, null, null, true)" cl) :: !config_macros;
 		end
 	in
-	let all_args_spec = basic_args_spec @ adv_args_spec in
+	let all_args = (basic_args_spec @ adv_args_spec) in
+	let all_args_spec = process_args all_args in
 	let process args =
 		let current = ref 0 in
 		(try
-			Arg.parse_argv ~current (Array.of_list ("" :: List.map expand_env args)) all_args_spec args_callback usage;
+			Arg.parse_argv ~current (Array.of_list ("" :: List.map expand_env args)) all_args_spec args_callback "";
 			List.iter (fun fn -> fn()) !arg_delays
-		with (Arg.Bad msg) as exc ->
+		with
+		| Arg.Help _ ->
+			raise (HelpMessage (usage_string all_args usage))
+		| Arg.Bad msg ->
+			let first_line = List.nth (Str.split (Str.regexp "\n") msg) 0 in
+			let new_msg = (Printf.sprintf "%s\n\n%s" first_line (usage_string all_args usage)) in
 			let r = Str.regexp "unknown option `\\([-A-Za-z]+\\)'" in
 			try
 				ignore(Str.search_forward r msg 0);
@@ -711,7 +757,7 @@ try
 				let msg = StringError.string_error_raise s sl (Printf.sprintf "Invalid command: %s" s) in
 				raise (Arg.Bad msg)
 			with Not_found ->
-				raise exc);
+				raise (Arg.Bad new_msg));
 		arg_delays := []
 	in
 	process_ref := process;
@@ -745,18 +791,11 @@ try
 	com.config <- get_config com; (* make sure to adapt all flags changes defined after platform *)
 	List.iter (fun f -> f()) (List.rev (!pre_compilation));
 	if !classes = [([],"Std")] && not !force_typing then begin
-		let help_spec = basic_args_spec @ [
-			("-help", Arg.Unit (fun () -> ()),": show extended help information");
-			("--help", Arg.Unit (fun () -> ()),": show extended help information");
-			("--help-defines", Arg.Unit (fun () -> ()),": print help for all compiler specific defines");
-			("--help-metas", Arg.Unit (fun () -> ()),": print help for all compiler metadatas");
-			("<dot-path>", Arg.Unit (fun () -> ()),": compile the module specified by dot-path");
-		] in
-		if !cmds = [] && not !did_something then print_endline (Arg.usage_string help_spec usage);
+		if !cmds = [] && not !did_something then raise (HelpMessage (usage_string basic_args_spec usage));
 	end else begin
 		ctx.setup();
-		Common.log com ("Classpath : " ^ (String.concat ";" com.class_path));
-		Common.log com ("Defines : " ^ (String.concat ";" (PMap.foldi (fun k v acc -> (match v with "1" -> k | _ -> k ^ "=" ^ v) :: acc) com.defines.Define.values [])));
+		Common.log com ("Classpath: " ^ (String.concat ";" com.class_path));
+		Common.log com ("Defines: " ^ (String.concat ";" (PMap.foldi (fun k v acc -> (match v with "1" -> k | _ -> k ^ "=" ^ v) :: acc) com.defines.Define.values [])));
 		let t = Timer.timer ["typing"] in
 		Typecore.type_expr_ref := (fun ctx e with_type -> Typer.type_expr ctx e with_type);
 		let tctx = Typer.create com in
@@ -785,7 +824,7 @@ try
 		| Some "hx" ->
 			Genxml.generate_hx com
 		| Some file ->
-			Common.log com ("Generating xml : " ^ file);
+			Common.log com ("Generating xml: " ^ file);
 			Path.mkdir_from_path file;
 			Genxml.generate com file);
 		if not !no_output then generate tctx ext !xml_out !interp !swf_header;
@@ -829,7 +868,7 @@ with
 		error ctx ("Error: " ^ msg) null_pos
 	| Failure msg when not (is_debug_run()) ->
 		error ctx ("Error: " ^ msg) null_pos
-	| Arg.Help msg ->
+	| HelpMessage msg ->
 		message ctx (CMInfo(msg,null_pos))
 	| Display.DisplayPackage pack ->
 		raise (DisplayOutput.Completion (String.concat "." pack))

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -618,7 +618,7 @@ let create version s_version args =
 			unresolved_identifiers = [];
 			interface_field_implementations = [];
 		};
-		sys_args = args;
+		sys_args = [];
 		debug = false;
 		display = DisplayMode.create !display_default;
 		verbose = false;

--- a/tests/RunCi.hxml
+++ b/tests/RunCi.hxml
@@ -1,2 +1,2 @@
--main RunCi
+--main RunCi
 --interp

--- a/tests/TestMakefile.hxml
+++ b/tests/TestMakefile.hxml
@@ -1,2 +1,2 @@
--main TestMakefile
+--main TestMakefile
 -neko TestMakefile.n

--- a/tests/benchs/ds/tests.hxml
+++ b/tests/benchs/ds/tests.hxml
@@ -1,3 +1,3 @@
--cp src
--main Main
+-p src
+--main Main
 -lib thx.benchmark

--- a/tests/benchs/mandelbrot/compile-cpp.hxml
+++ b/tests/benchs/mandelbrot/compile-cpp.hxml
@@ -1,7 +1,7 @@
--main Mandelbrot
+--main Mandelbrot
 -cpp bin/cpp
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -cpp bin/cpp-anon
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-cppia.hxml
+++ b/tests/benchs/mandelbrot/compile-cppia.hxml
@@ -1,9 +1,9 @@
--main Mandelbrot
+--main Mandelbrot
 -cpp bin/Mandelbrot.cppia
 -D cppia
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -cpp bin/Mandelbrot-anon.cppia
 -D cppia
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-hl.hxml
+++ b/tests/benchs/mandelbrot/compile-hl.hxml
@@ -1,9 +1,9 @@
--main Mandelbrot
+--main Mandelbrot
 -hl bin/mandelbrot.hl
 -D interp
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -hl bin/mandelbrot-anon.hl
 -D interp
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-java.hxml
+++ b/tests/benchs/mandelbrot/compile-java.hxml
@@ -1,7 +1,7 @@
--main Mandelbrot
+--main Mandelbrot
 -java bin/java
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -java bin/java-anon
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-js.hxml
+++ b/tests/benchs/mandelbrot/compile-js.hxml
@@ -1,7 +1,7 @@
--main Mandelbrot
+--main Mandelbrot
 -js bin/Mandelbrot.js
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -js bin/Mandelbrot-anon.js
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-macro.hxml
+++ b/tests/benchs/mandelbrot/compile-macro.hxml
@@ -1,7 +1,7 @@
--main Mandelbrot
+--main Mandelbrot
 --interp
 
 --next
--main Mandelbrot
+--main Mandelbrot
 --interp
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-neko.hxml
+++ b/tests/benchs/mandelbrot/compile-neko.hxml
@@ -1,7 +1,7 @@
--main Mandelbrot
+--main Mandelbrot
 -neko bin/Mandelbrot.n
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -neko bin/Mandelbrot-anon.n
 -D anon_objects

--- a/tests/benchs/mandelbrot/compile-php.hxml
+++ b/tests/benchs/mandelbrot/compile-php.hxml
@@ -1,7 +1,7 @@
--main Mandelbrot
+--main Mandelbrot
 -php bin/php
 
 --next
--main Mandelbrot
+--main Mandelbrot
 -php bin/php-anon
 -D anon_objects

--- a/tests/display/build.hxml
+++ b/tests/display/build.hxml
@@ -1,4 +1,4 @@
--cp src
--main Main
+-p src
+--main Main
 --interp
 -D use-rtti-doc

--- a/tests/misc/compile.hxml
+++ b/tests/misc/compile.hxml
@@ -1,3 +1,3 @@
--cp src
+-p src
 #-D MISC_TEST_FILTER=3802
 --run Main

--- a/tests/misc/cppObjc/build.hxml
+++ b/tests/misc/cppObjc/build.hxml
@@ -1,5 +1,5 @@
 -D source-header=''
--main TestObjc
+--main TestObjc
 -cpp bin
--debug
+--debug
 -D objc

--- a/tests/misc/csTwoLibs/compile-1.hxml
+++ b/tests/misc/csTwoLibs/compile-1.hxml
@@ -1,15 +1,15 @@
 cs.Boot
--dce no
+--dce no
 -cs bin/haxeboot
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 Lib1
 -cs bin/lib1
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
--main Main
+--main Main
 -cs bin/main

--- a/tests/misc/csTwoLibs/compile-2.hxml
+++ b/tests/misc/csTwoLibs/compile-2.hxml
@@ -1,18 +1,18 @@
 cs.Boot
--dce no
+--dce no
 -cs bin/haxeboot
 -D no_root
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 -D no_root
 Lib1
 -cs bin/lib1
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 -D no_root
--main Main
+--main Main
 -cs bin/main

--- a/tests/misc/csTwoLibs/compile-3.hxml
+++ b/tests/misc/csTwoLibs/compile-3.hxml
@@ -1,18 +1,18 @@
 cs.Boot
--dce no
+--dce no
 -cs bin/haxeboot
 -D erase_generics
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 -D erase_generics
 Lib1
 -cs bin/lib1
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 -D erase_generics
--main Main
+--main Main
 -cs bin/main

--- a/tests/misc/csTwoLibs/compile-4.hxml
+++ b/tests/misc/csTwoLibs/compile-4.hxml
@@ -1,21 +1,21 @@
 cs.Boot
--dce no
+--dce no
 -cs bin/haxeboot
 -D erase_generics
 -D no_root
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 -D erase_generics
 -D no_root
 Lib1
 -cs bin/lib1
 --next
--net-lib bin/haxeboot/bin/haxeboot.dll
--dce no
+--net-lib bin/haxeboot/bin/haxeboot.dll
+--dce no
 -D dll_import
 -D erase_generics
 -D no_root
--main Main
+--main Main
 -cs bin/main

--- a/tests/misc/eventLoop/all.hxml
+++ b/tests/misc/eventLoop/all.hxml
@@ -1,8 +1,8 @@
--main Main
--dce full
+--main Main
+--dce full
 --each
 -swf eventLoop.swf
--swf-version 14
+--swf-version 14
 --next
 -neko eventLoop.n
 --next

--- a/tests/misc/luaDeadCode/stringReflection/compile.hxml
+++ b/tests/misc/luaDeadCode/stringReflection/compile.hxml
@@ -1,5 +1,5 @@
--main Issue6276
+--main Issue6276
 -lua issue6276.lua
 -cmd lua issue6276.lua
--cp tests/misc/luaDeadCode/issue6276
+-p tests/misc/luaDeadCode/issue6276
 

--- a/tests/misc/projects/Issue1138/compile1.hxml
+++ b/tests/misc/projects/Issue1138/compile1.hxml
@@ -1,4 +1,4 @@
--cp src1
--cp src2
--main C
+-p src1
+-p src2
+--main C
 --interp

--- a/tests/misc/projects/Issue1138/compile2.hxml
+++ b/tests/misc/projects/Issue1138/compile2.hxml
@@ -1,4 +1,4 @@
--cp src1
--cp src2
--main p2.C2
+-p src1
+-p src2
+--main p2.C2
 --interp

--- a/tests/misc/projects/Issue1138/compile3-fail.hxml
+++ b/tests/misc/projects/Issue1138/compile3-fail.hxml
@@ -1,4 +1,4 @@
--cp src1
--cp src2
--main D
+-p src1
+-p src2
+--main D
 --interp

--- a/tests/misc/projects/Issue1138/compile4-fail.hxml
+++ b/tests/misc/projects/Issue1138/compile4-fail.hxml
@@ -1,3 +1,3 @@
--cp src3
--main Main
+-p src3
+--main Main
 --interp

--- a/tests/misc/projects/Issue1310/compile1-fail.hxml
+++ b/tests/misc/projects/Issue1310/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue2087/compile-fail.hxml
+++ b/tests/misc/projects/Issue2087/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue2148/compile1-fail.hxml
+++ b/tests/misc/projects/Issue2148/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue2232/compile1-fail.hxml
+++ b/tests/misc/projects/Issue2232/compile1-fail.hxml
@@ -1,3 +1,3 @@
--main Main1
+--main Main1
 -swf swf.swf
 --no-output

--- a/tests/misc/projects/Issue2232/compile2-fail.hxml
+++ b/tests/misc/projects/Issue2232/compile2-fail.hxml
@@ -1,3 +1,3 @@
--main Main2
+--main Main2
 -swf swf.swf
 --no-output

--- a/tests/misc/projects/Issue2508/compile.hxml
+++ b/tests/misc/projects/Issue2508/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue2538/compile-fail.hxml
+++ b/tests/misc/projects/Issue2538/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 -neko neko.n
 --no-output

--- a/tests/misc/projects/Issue3102/compile-each.hxml
+++ b/tests/misc/projects/Issue3102/compile-each.hxml
@@ -1,3 +1,4 @@
--dce full
--main Main
--x test
+--dce full
+-m Main
+-neko test.n
+--cmd "neko test.n"

--- a/tests/misc/projects/Issue3102/compile2-each.hxml
+++ b/tests/misc/projects/Issue3102/compile2-each.hxml
@@ -1,3 +1,4 @@
--dce full
--main Main2
--x test
+--dce full
+-m Main2
+-neko test.n
+-cmd "neko test.n"

--- a/tests/misc/projects/Issue3129/compile.hxml
+++ b/tests/misc/projects/Issue3129/compile.hxml
@@ -1,3 +1,2 @@
 --macro addGlobalMetadata('Main', '@:build(Build.build())')
--main Main
--x test
+-x Main

--- a/tests/misc/projects/Issue3192/compile1-fail.hxml
+++ b/tests/misc/projects/Issue3192/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue3542/compile.hxml
+++ b/tests/misc/projects/Issue3542/compile.hxml
@@ -1,4 +1,4 @@
--main Main
+--main Main
 -js js.js
 --no-output
 --no-inline

--- a/tests/misc/projects/Issue3621/compile-fail.hxml
+++ b/tests/misc/projects/Issue3621/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main1
+--main Main1
 --no-output
 -js js.js

--- a/tests/misc/projects/Issue3714/compile-fail.hxml
+++ b/tests/misc/projects/Issue3714/compile-fail.hxml
@@ -1,1 +1,1 @@
--main Main
+--main Main

--- a/tests/misc/projects/Issue3783/compile-fail.hxml
+++ b/tests/misc/projects/Issue3783/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue3830/compile-fail.hxml
+++ b/tests/misc/projects/Issue3830/compile-fail.hxml
@@ -1,2 +1,2 @@
--main MainFail
+--main MainFail
 --no-output

--- a/tests/misc/projects/Issue3830/compile.hxml
+++ b/tests/misc/projects/Issue3830/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --display Main.hx@0

--- a/tests/misc/projects/Issue3956/compile.hxml
+++ b/tests/misc/projects/Issue3956/compile.hxml
@@ -1,3 +1,2 @@
--main Main
 -D analyzer
--x neko.n
+-x Main

--- a/tests/misc/projects/Issue3975/compile-fail.hxml
+++ b/tests/misc/projects/Issue3975/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4114/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4114/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4114/compile2-fail.hxml
+++ b/tests/misc/projects/Issue4114/compile2-fail.hxml
@@ -1,2 +1,2 @@
--main Main2
+--main Main2
 --interp

--- a/tests/misc/projects/Issue4160/compile.hxml
+++ b/tests/misc/projects/Issue4160/compile.hxml
@@ -1,2 +1,2 @@
--main test.Main
+--main test.Main
 --interp

--- a/tests/misc/projects/Issue4218/build.hxml
+++ b/tests/misc/projects/Issue4218/build.hxml
@@ -1,3 +1,3 @@
 -python Test.py
--main Main
+--main Main
 -cmd python3 Test.py

--- a/tests/misc/projects/Issue4247/compile-fail.hxml
+++ b/tests/misc/projects/Issue4247/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4250/compile-fail.hxml
+++ b/tests/misc/projects/Issue4250/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4265/compile.hxml
+++ b/tests/misc/projects/Issue4265/compile.hxml
@@ -1,3 +1,2 @@
--main Main
 -D analyzer
--x neko.n
+-x Main

--- a/tests/misc/projects/Issue4364/compile-fail.hxml
+++ b/tests/misc/projects/Issue4364/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 -neko neko.n
 --no-output

--- a/tests/misc/projects/Issue4378/compile-fail.hxml
+++ b/tests/misc/projects/Issue4378/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4399/compile.hxml
+++ b/tests/misc/projects/Issue4399/compile.hxml
@@ -1,3 +1,2 @@
--main Main
 -D analyzer
--x neko.n
+-x Main

--- a/tests/misc/projects/Issue4404/compile1.hxml
+++ b/tests/misc/projects/Issue4404/compile1.hxml
@@ -1,4 +1,4 @@
--cp src
--main Main
+-p src
+--main Main
 -js js.js
 --no-output

--- a/tests/misc/projects/Issue4448/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4448/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4454/compile.hxml
+++ b/tests/misc/projects/Issue4454/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4456/compile.hxml
+++ b/tests/misc/projects/Issue4456/compile.hxml
@@ -1,3 +1,2 @@
--main Main
 -D analyzer
--x neko.n
+-x Main

--- a/tests/misc/projects/Issue4466/compile-fail.hxml
+++ b/tests/misc/projects/Issue4466/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4540/compile-fail.hxml
+++ b/tests/misc/projects/Issue4540/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 -js Main.js

--- a/tests/misc/projects/Issue4563/compile.hxml
+++ b/tests/misc/projects/Issue4563/compile.hxml
@@ -1,3 +1,2 @@
--main Main
 -D analyzer
--x neko.n
+-x Main

--- a/tests/misc/projects/Issue4580/compile-fail.hxml
+++ b/tests/misc/projects/Issue4580/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4671/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4671/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4671/compile2-fail.hxml
+++ b/tests/misc/projects/Issue4671/compile2-fail.hxml
@@ -1,2 +1,2 @@
--main Main2
+--main Main2
 --interp

--- a/tests/misc/projects/Issue4679/compile.hxml
+++ b/tests/misc/projects/Issue4679/compile.hxml
@@ -1,2 +1,3 @@
--main Main
--x test
+-m Main
+-neko test.n
+--cmd "neko test.n"

--- a/tests/misc/projects/Issue4689/compile-fail.hxml
+++ b/tests/misc/projects/Issue4689/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4712/compile.hxml
+++ b/tests/misc/projects/Issue4712/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4720/compile.hxml
+++ b/tests/misc/projects/Issue4720/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4742/compile-fail.hxml
+++ b/tests/misc/projects/Issue4742/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 -neko neko.n
 --no-output

--- a/tests/misc/projects/Issue4754/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4754/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4761/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4761/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4764/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4764/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4766/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4766/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4775/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4775/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4803/compile-fail.hxml
+++ b/tests/misc/projects/Issue4803/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 -js js.js
 --no-output

--- a/tests/misc/projects/Issue4816/compile1-fail.hxml
+++ b/tests/misc/projects/Issue4816/compile1-fail.hxml
@@ -1,2 +1,2 @@
--main Main1
+--main Main1
 --interp

--- a/tests/misc/projects/Issue4825/compile.hxml
+++ b/tests/misc/projects/Issue4825/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4904/compile-fail.hxml
+++ b/tests/misc/projects/Issue4904/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4907/compile-fail.hxml
+++ b/tests/misc/projects/Issue4907/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4954/compile-fail.hxml
+++ b/tests/misc/projects/Issue4954/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4957/compile-fail.hxml
+++ b/tests/misc/projects/Issue4957/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue4982/compile-fail.hxml
+++ b/tests/misc/projects/Issue4982/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5005/compile.hxml
+++ b/tests/misc/projects/Issue5005/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5010/compile-fail.hxml
+++ b/tests/misc/projects/Issue5010/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5126/compile-fail.hxml
+++ b/tests/misc/projects/Issue5126/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 -neko neko.n
 --no-output

--- a/tests/misc/projects/Issue5145/compile.hxml
+++ b/tests/misc/projects/Issue5145/compile.hxml
@@ -1,2 +1,2 @@
 
--main Main
+--main Main

--- a/tests/misc/projects/Issue5206/compile-fail.hxml
+++ b/tests/misc/projects/Issue5206/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5268/compile-fail.hxml
+++ b/tests/misc/projects/Issue5268/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5321/compile.hxml
+++ b/tests/misc/projects/Issue5321/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5375/compile-fail.hxml
+++ b/tests/misc/projects/Issue5375/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue5559/build.hxml
+++ b/tests/misc/projects/Issue5559/build.hxml
@@ -1,4 +1,4 @@
--main Main
--cp source
+--main Main
+-p source
 --macro addMetadata('@:build(Build.build())', 'Main')
 -neko run.n

--- a/tests/misc/projects/Issue5644/compile-fail.hxml
+++ b/tests/misc/projects/Issue5644/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 --no-output
 -js js.js

--- a/tests/misc/projects/Issue5833/compile-fail.hxml
+++ b/tests/misc/projects/Issue5833/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 --no-output
 -js js.js

--- a/tests/misc/projects/Issue5856/compile.hxml
+++ b/tests/misc/projects/Issue5856/compile.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 --no-output
 -js js.js

--- a/tests/misc/projects/Issue5888/compile-fail.hxml
+++ b/tests/misc/projects/Issue5888/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 --no-output
 -js js.js

--- a/tests/misc/projects/Issue5940/compile-fail.hxml
+++ b/tests/misc/projects/Issue5940/compile-fail.hxml
@@ -1,1 +1,1 @@
--main Main
+--main Main

--- a/tests/misc/projects/Issue6030/compile-fail.hxml
+++ b/tests/misc/projects/Issue6030/compile-fail.hxml
@@ -1,3 +1,3 @@
--main Main1
+--main Main1
 --no-output
 -js js.js

--- a/tests/misc/projects/Issue6402/compile.hxml
+++ b/tests/misc/projects/Issue6402/compile.hxml
@@ -1,1 +1,1 @@
--main Main
+--main Main

--- a/tests/misc/projects/Issue6445/compile-fail.hxml
+++ b/tests/misc/projects/Issue6445/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue6542/compile-fail.hxml
+++ b/tests/misc/projects/Issue6542/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue6550/compile-fail.hxml
+++ b/tests/misc/projects/Issue6550/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue6583/compile.hxml
+++ b/tests/misc/projects/Issue6583/compile.hxml
@@ -1,1 +1,1 @@
--main Main
+--main Main

--- a/tests/misc/projects/Issue6699/compile-fail.hxml
+++ b/tests/misc/projects/Issue6699/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue6757/compile-fail.hxml
+++ b/tests/misc/projects/Issue6757/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Test
+--main Test
 --interp

--- a/tests/misc/projects/Issue6765/compile-fail.hxml
+++ b/tests/misc/projects/Issue6765/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/Issue6826/compile-fail.hxml
+++ b/tests/misc/projects/Issue6826/compile-fail.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --interp

--- a/tests/misc/projects/display-package/compile1.hxml
+++ b/tests/misc/projects/display-package/compile1.hxml
@@ -1,2 +1,2 @@
--cp src
+-p src
 --display src/C1.hx@0@package

--- a/tests/misc/projects/display-package/compile2.hxml
+++ b/tests/misc/projects/display-package/compile2.hxml
@@ -1,2 +1,2 @@
--cp src
+-p src
 --display src/pack/C2.hx@0@package

--- a/tests/misc/projects/display-type/compile.hxml
+++ b/tests/misc/projects/display-type/compile.hxml
@@ -1,2 +1,2 @@
--main Main
+--main Main
 --display Main.hx@52@type

--- a/tests/misc/pythonImport/compile.hxml
+++ b/tests/misc/pythonImport/compile.hxml
@@ -1,3 +1,3 @@
--main Main
+--main Main
 -python test.py
 -lib utest

--- a/tests/misc/weakmap/compile-cs.hxml
+++ b/tests/misc/weakmap/compile-cs.hxml
@@ -1,3 +1,3 @@
--main TestWeakMap
+--main TestWeakMap
 -cs cs
--debug
+--debug

--- a/tests/misc/weakmap/compile-java.hxml
+++ b/tests/misc/weakmap/compile-java.hxml
@@ -1,2 +1,2 @@
--main TestWeakMap
+--main TestWeakMap
 -java java

--- a/tests/optimization/run.hxml
+++ b/tests/optimization/run.hxml
@@ -1,13 +1,13 @@
--cp src
+-p src
 -D analyzer-optimize
 -D analyzer-user-var-fusion
 --each
 
--main TestAnalyzer
+--main TestAnalyzer
 --interp
 
 --next
--main TestNullChecker
+--main TestNullChecker
 -D analyzer-check-null
 --interp
 
@@ -17,4 +17,4 @@
 --macro Macro.register('TestJs')
 --macro Macro.register('TestLocalDce')
 --macro Macro.register('issues')
--dce std
+--dce std

--- a/tests/server/build.hxml
+++ b/tests/server/build.hxml
@@ -1,5 +1,5 @@
--cp src
--main Main
+-p src
+--main Main
 -js test.js
 -lib hxnodejs
 -lib utest

--- a/tests/sys/compile-cpp.hxml
+++ b/tests/sys/compile-cpp.hxml
@@ -1,13 +1,13 @@
 compile-each.hxml
--main Main
+--main Main
 -cpp bin/cpp
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -cpp bin/cpp
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -cpp bin/cpp

--- a/tests/sys/compile-cs.hxml
+++ b/tests/sys/compile-cs.hxml
@@ -1,13 +1,13 @@
 compile-each.hxml
--main Main
+--main Main
 -cs bin/cs
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -cs bin/cs
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -cs bin/cs

--- a/tests/sys/compile-each.hxml
+++ b/tests/sys/compile-each.hxml
@@ -1,11 +1,11 @@
--cp src
--main ExitCode
+-p src
+--main ExitCode
 -neko bin/neko/ExitCode.n
 -lib utest
 -cmd nekotools boot bin/neko/ExitCode.n
 
 --next
 -D source-header=''
--debug
+--debug
 -lib utest
--cp src
+-p src

--- a/tests/sys/compile-hl.hxml
+++ b/tests/sys/compile-hl.hxml
@@ -1,13 +1,13 @@
 compile-each.hxml
--main Main
+--main Main
 -hl bin/hl/sys.hl
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -hl bin/hl/TestArguments.hl
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -hl bin/hl/ExitCode.hl

--- a/tests/sys/compile-java.hxml
+++ b/tests/sys/compile-java.hxml
@@ -1,13 +1,13 @@
 compile-each.hxml
--main Main
+--main Main
 -java bin/java
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -java bin/java
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -java bin/java

--- a/tests/sys/compile-lua.hxml
+++ b/tests/sys/compile-lua.hxml
@@ -1,14 +1,14 @@
 
 compile-each.hxml
--main Main
+--main Main
 -lua bin/lua/sys.lua
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -lua bin/lua/TestArguments.lua
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -lua bin/lua/ExitCode.lua

--- a/tests/sys/compile-macro.hxml
+++ b/tests/sys/compile-macro.hxml
@@ -1,3 +1,3 @@
 compile-each.hxml
--main Main
+--main Main
 --interp

--- a/tests/sys/compile-neko.hxml
+++ b/tests/sys/compile-neko.hxml
@@ -1,10 +1,10 @@
 compile-each.hxml
--main Main
+--main Main
 -neko bin/neko/sys.n
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -neko bin/neko/TestArguments.n
 
 # --next

--- a/tests/sys/compile-php.hxml
+++ b/tests/sys/compile-php.hxml
@@ -1,13 +1,13 @@
 compile-each.hxml
--main Main
+--main Main
 -php bin/php/Main
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -php bin/php/TestArguments
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -php bin/php/ExitCode

--- a/tests/sys/compile-python.hxml
+++ b/tests/sys/compile-python.hxml
@@ -1,13 +1,13 @@
 compile-each.hxml
--main Main
+--main Main
 -python bin/python/sys.py
 
 --next
 compile-each.hxml
--main TestArguments
+--main TestArguments
 -python bin/python/TestArguments.py
 
 --next
 compile-each.hxml
--main ExitCode
+--main ExitCode
 -python bin/python/ExitCode.py

--- a/tests/unit/compile-as3.hxml
+++ b/tests/unit/compile-as3.hxml
@@ -1,4 +1,4 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -as3 bin/as3
 -cmd mxmlc -static-link-runtime-shared-libraries=true -debug bin/as3/__main__.as --output bin/unit9_as3.swf

--- a/tests/unit/compile-cpp.hxml
+++ b/tests/unit/compile-cpp.hxml
@@ -1,4 +1,4 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -cpp bin/cpp
 -D HXCPP_NO_DEBUG_LINK

--- a/tests/unit/compile-cppia-host.hxml
+++ b/tests/unit/compile-cppia-host.hxml
@@ -1,9 +1,9 @@
--main cpp.cppia.Host
+--main cpp.cppia.Host
 -D source-header=''
 -D scriptable
 -D dll_export=bin/cppia.classes
--debug
--dce no
+--debug
+--dce no
 -cpp bin/cppia
--cp src
+-p src
 --macro include("scripthost")

--- a/tests/unit/compile-cppia.hxml
+++ b/tests/unit/compile-cppia.hxml
@@ -1,3 +1,3 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -cppia bin/unit.cppia

--- a/tests/unit/compile-cs-travis.hxml
+++ b/tests/unit/compile-cs-travis.hxml
@@ -1,7 +1,7 @@
 compile-cs.hxml
 
--net-lib cs_drivers/System.Data.dll
--net-lib cs_drivers/System.Xml.dll@std
--net-lib cs_drivers/Mono.Data.Sqlite.dll
+--net-lib cs_drivers/System.Data.dll
+--net-lib cs_drivers/System.Xml.dll@std
+--net-lib cs_drivers/Mono.Data.Sqlite.dll
 
 -D travis

--- a/tests/unit/compile-cs-unsafe-travis.hxml
+++ b/tests/unit/compile-cs-unsafe-travis.hxml
@@ -1,7 +1,7 @@
 compile-cs-unsafe.hxml
 
--net-lib cs_drivers/System.Data.dll
--net-lib cs_drivers/System.Xml.dll@std
--net-lib cs_drivers/Mono.Data.Sqlite.dll
+--net-lib cs_drivers/System.Data.dll
+--net-lib cs_drivers/System.Xml.dll@std
+--net-lib cs_drivers/Mono.Data.Sqlite.dll
 
 -D travis

--- a/tests/unit/compile-cs-unsafe.hxml
+++ b/tests/unit/compile-cs-unsafe.hxml
@@ -4,7 +4,7 @@
 --next
 
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -D unsafe
 -cs bin/cs_unsafe
--net-lib native_cs/bin/native_cs.dll
+--net-lib native_cs/bin/native_cs.dll

--- a/tests/unit/compile-cs.hxml
+++ b/tests/unit/compile-cs.hxml
@@ -4,6 +4,6 @@
 --next
 
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -cs bin/cs
--net-lib native_cs/bin/native_cs.dll
+--net-lib native_cs/bin/native_cs.dll

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -1,9 +1,9 @@
 -D source-header=''
--debug
--cp src
+--debug
+-p src
 # -cp "C:\Program Files\The Haxe Effect\src/dev/null"
--resource res1.txt@re/s?!%[]))("'1.txt
--resource res2.bin@re/s?!%[]))("'1.bin
--dce full
+--resource res1.txt@re/s?!%[]))("'1.txt
+--resource res2.bin@re/s?!%[]))("'1.bin
+--dce full
 -D analyzer-optimize
 -D analyzer-user-var-fusion

--- a/tests/unit/compile-exe-runner.hxml
+++ b/tests/unit/compile-exe-runner.hxml
@@ -1,3 +1,3 @@
--cp src
--main RunExe
+-p src
+--main RunExe
 -neko bin/runexe.n

--- a/tests/unit/compile-flash9.hxml
+++ b/tests/unit/compile-flash9.hxml
@@ -1,4 +1,4 @@
 compile-each.hxml
--main unit.TestMain
--swf-version 11
+--main unit.TestMain
+--swf-version 11
 -swf bin/unit9.swf

--- a/tests/unit/compile-hl.hxml
+++ b/tests/unit/compile-hl.hxml
@@ -1,5 +1,5 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -hl bin/unit.hl
 #-D interp
 -D hl-check

--- a/tests/unit/compile-java-runner.hxml
+++ b/tests/unit/compile-java-runner.hxml
@@ -1,3 +1,3 @@
--cp src
--main RunJava
+-p src
+--main RunJava
 -neko bin/runjava.n

--- a/tests/unit/compile-java.hxml
+++ b/tests/unit/compile-java.hxml
@@ -4,8 +4,8 @@
 --next
 
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -java bin/java
--java-lib native_java/native.jar
--java-lib java_drivers/mysql-connector-java-5.1.32-bin.jar
--java-lib java_drivers/sqlite-jdbc-3.7.2.jar
+--java-lib native_java/native.jar
+--java-lib java_drivers/mysql-connector-java-5.1.32-bin.jar
+--java-lib java_drivers/sqlite-jdbc-3.7.2.jar

--- a/tests/unit/compile-js.hxml
+++ b/tests/unit/compile-js.hxml
@@ -1,5 +1,5 @@
--cp src
--main unit.issues.Issue4138
+-p src
+--main unit.issues.Issue4138
 -js bin/Issue4138_Worker.js
 -D worker
 

--- a/tests/unit/compile-lua.hxml
+++ b/tests/unit/compile-lua.hxml
@@ -1,3 +1,3 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -lua bin/unit.lua

--- a/tests/unit/compile-macro.hxml
+++ b/tests/unit/compile-macro.hxml
@@ -1,3 +1,3 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 --interp

--- a/tests/unit/compile-neko.hxml
+++ b/tests/unit/compile-neko.hxml
@@ -1,4 +1,4 @@
 compile-each.hxml
 -D neko_v2
--main unit.TestMain
+--main unit.TestMain
 -neko bin/unit.n

--- a/tests/unit/compile-php.hxml
+++ b/tests/unit/compile-php.hxml
@@ -1,3 +1,3 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -php bin/php

--- a/tests/unit/compile-python.hxml
+++ b/tests/unit/compile-python.hxml
@@ -1,3 +1,3 @@
 compile-each.hxml
--main unit.TestMain
+--main unit.TestMain
 -python bin/unit.py

--- a/tests/unit/compile-remoting.hxml
+++ b/tests/unit/compile-remoting.hxml
@@ -1,3 +1,3 @@
--cp src
--main unit.RemotingServer
+-p src
+--main unit.RemotingServer
 -neko remoting.n

--- a/tests/unit/compile-saucelabs-runner.hxml
+++ b/tests/unit/compile-saucelabs-runner.hxml
@@ -1,5 +1,5 @@
--cp src
+-p src
 -js bin/RunSauceLabs.js
--main RunSauceLabs
+--main RunSauceLabs
 -lib hxnodejs
--debug
+--debug


### PR DESCRIPTION
Implements parts of https://github.com/HaxeFoundation/haxe/issues/6613

- Standardizes flags: `-` for targets or single letter flags, `--` for everything else.
- Allow multiple variants of some flags, and support deprecated versions which will show a warning when used.
- Groups flags by function.
- Cleans up/aligns the output.

There should be no change in behavior, although everyone will start getting compiler warnings on `-main`, `-cp` etc. which are deprecated in favor of the standardized versions. The warnings go to stderr so it shouldn't impact tools consuming haxe's stdout.

Example output:

```
Haxe Compiler 4.0.0 - (C)2005-2018 Haxe Foundation
Usage: haxe <target> [options] [hxml files...]

Target
  --js <file>                                   compile code to JavaScript file
  --lua <file>                                  compile code to Lua file
  --swf <file>                                  compile code to Flash SWF file
  --as3 <directory>                             generate AS3 code into target directory
  --neko <file>                                 compile code to Neko Binary
  --php <directory>                             generate PHP code into target directory
  --cpp <directory>                             generate C++ code into target directory
  --cppia <file>                                generate Cppia code into target file
  --cs <directory>                              generate C# code into target directory
  --java <directory>                            generate Java code into target directory
  --python <file>                               generate Python code as target file
  --hl <file>                                   compile HL code as target file
  -x, --execute <class>                         interpret the program using internal macro system
Compilation
  -p, --class-path <path>                       add a directory to find source files
  -m, --main <class>                            select startup class
  -L, --library <library[:version]>             use a haxelib library
  -D, --define <var[=value]>                    define a conditional compilation flag
  -r, --resource <file>[@name]                  add a named resource file
  --cmd <command>                               run the specified command after successful compilation
  --remap <package:target>                      remap a package to another one
  --macro <macro>                               call the given macro before typing anything else
  -C, --cwd <dir>                               set current working directory
Optimization
  --dce, --dead-code-elimination [std|full|no]  set the dead code elimination mode (default std)
  --no-traces                                   don't compile trace calls in the program
  --no-output                                   compiles but does not generate any file
  --no-inline                                   disable inlining
  --no-opt                                      disable code optimizations
Debug
  -v, --verbose                                 turn on verbose mode
  --debug                                       add debug information to the compiled code
  --prompt                                      prompt on error
  --times                                       measure compilation times
Batch
  --next                                        separate several haxe compilations
  --each                                        append preceding parameters to all haxe compilations separated by --next
Services
  --display                                     display code tips
  --xml <file>                                  generate XML types description
  --gen-hx-classes                              generate hx headers for all input classes
Compilation Server
  --wait [[host:]port]|stdio]                   wait on the given port (or use standard i/o) for commands to run)
  --connect <[host:]port>                       connect on the given port and run commands there)
Target-specific
  --swf-version <version>                       change the SWF version
  --swf-header <header>                         define SWF header (width:height:fps:color)
  --swf-lib <file>                              add the SWF library to the compiled SWF
  --swf-lib-extern <file>                       use the SWF library for type checking
  --flash-strict                                more type strict flash API
  --java-lib <file>                             add an external JAR or class directory library
  --net-lib <file>[@std]                        add an external .NET DLL file
  --net-std <file>                              add a root std .NET DLL search path
  --c-arg <arg>                                 pass option <arg> to the native Java/C# compiler
Miscellaneous
  --version                                     print version and exit
  help, -h, --help                              show extended help information
  --help-defines                                print help for all compiler specific defines
  --help-metas                                  print help for all compiler metadatas
  --run <module> [args...]                      compile and execute a Haxe module with command line arguments
  -- [args...]                                  args that will be passed to the macro interpreter
```