### PR TITLE
HL SSL fixes

### DIFF
--- a/std/hl/_std/sys/ssl/Certificate.hx
+++ b/std/hl/_std/sys/ssl/Certificate.hx
@@ -78,17 +78,17 @@ class Certificate {
 
 	function get_altNames() : Array<String> {
 		var a = cert_get_altnames(__x);
-		return [for( e in a ) @:privateAccess String.fromUTF8(e)];
+		return [for( e in a ) @:privateAccess String.fromUCS2(e)];
 	}
 	
 	public function subject( field : String ) : Null<String> {
 		var s = cert_get_subject(__x, @:privateAccess field.toUtf8() );
-		return s==null ? null : new String( cast s );
+		return s==null ? null : @:privateAccess String.fromUCS2( cast s );
 	}
 	
 	public function issuer( field : String ) : Null<String> {
 		var s = cert_get_issuer(__x, @:privateAccess field.toUtf8());
-		return s==null ? null : new String( cast s );
+		return s==null ? null : @:privateAccess String.fromUCS2( cast s );
 	}
 
 	function get_notBefore() : Date {

--- a/std/hl/_std/sys/ssl/Socket.hx
+++ b/std/hl/_std/sys/ssl/Socket.hx
@@ -35,6 +35,8 @@ private class SocketInput extends haxe.io.Input {
 	}
 
 	public override function readBytes( buf : haxe.io.Bytes, pos : Int, len : Int ) : Int {
+		if( pos < 0 || len < 0 || ((pos+len):UInt) > (buf.length : UInt) )
+			throw haxe.io.Error.OutsideBounds;
 		__s.handshake();
 		var r = ssl_recv(  @:privateAccess __s.ssl, @:privateAccess buf.b, pos, len );
 		if( r == -1 )
@@ -70,6 +72,8 @@ private class SocketOutput extends haxe.io.Output {
 	}
 
 	public override function writeBytes( buf : haxe.io.Bytes, pos : Int, len : Int) : Int {
+		if( pos < 0 || len < 0 || ((pos+len):UInt) > (buf.length : UInt) )
+			throw haxe.io.Error.OutsideBounds;
 		__s.handshake();
 		var r = ssl_send( @:privateAccess __s.ssl, @:privateAccess buf.b, pos, len);
 		if( r == -1 )


### PR DESCRIPTION
- Fixed double utf8 to ucs2 conversion in ssl.Certificate.altNames (https://github.com/HaxeFoundation/hashlink/issues/115)
- Added boundary check in ssl.Socket readBytes/writeBytes