### PR TITLE
[java] Fix array of generic enum creation

### DIFF
--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -131,7 +131,7 @@ let rec t_has_type_param_shallow last t = match follow t with
 
 let rec replace_type_param t = match follow t with
 	| TInst({ cl_kind = KTypeParameter _ }, []) -> t_dynamic
-	| TEnum(e, params) -> TEnum(e, List.map replace_type_param params)
+	| TEnum(e, params) -> t_dynamic
 	| TAbstract(a, params) -> TAbstract(a, List.map replace_type_param params)
 	| TInst(cl, params) -> TInst(cl, List.map replace_type_param params)
 	| _ -> t

--- a/tests/unit/src/unit/issues/Issue4595.hx
+++ b/tests/unit/src/unit/issues/Issue4595.hx
@@ -1,0 +1,14 @@
+package unit.issues;
+
+private enum Either<A> {
+	Left(a:A);
+}
+
+class Issue4595 extends Test {
+	function test() {
+		var a = example(1); 
+	}
+	static function example<A>(a:A):Array<Array<Either<A>>>{
+		return [];
+	}
+}


### PR DESCRIPTION
When instantiating an array of a generic enum type, do not output the
type parameters when targeting Java.

Closes #4595