### PR TITLE
Fix stack overflow with optional parameters

### DIFF
--- a/tests/unit/src/unit/issues/Issue6059.hx
+++ b/tests/unit/src/unit/issues/Issue6059.hx
@@ -1,12 +1,14 @@
 package unit.issues;
 
 class Issue6059 extends Test {
+#if !as3 // See #6891
 	public static inline function foo (name : B, ?id : B, data : Array<String>) : Void { }
 
 	public static function test () : Void {
 		Issue6059.foo ("", []); // -> stackoverflow
 		Issue6059.foo ("", null, []); // ok
 	}
+#end
 }
 
 private abstract A (String) {

--- a/tests/unit/src/unit/issues/Issue6059.hx
+++ b/tests/unit/src/unit/issues/Issue6059.hx
@@ -1,0 +1,34 @@
+package unit.issues;
+
+class Issue6059 extends Test {
+	public static inline function foo (name : B, ?id : B, data : Array<String>) : Void { }
+
+	public static function test () : Void {
+		Issue6059.foo ("", []); // -> stackoverflow
+		Issue6059.foo ("", null, []); // ok
+	}
+}
+
+private abstract A (String) {
+	public inline function new (value : String) {
+		this = value;
+	}
+	@:from
+		public static function fromB (value : B) : A {
+			return new A (Std.string (value));
+		}
+}
+
+private abstract B (String) {
+	public inline function new (value : String) {
+		this = value;
+	}
+	@:from
+		public static function fromString (value : String) : B {
+			return new B (value);
+		}
+	@:from
+		public static function fromA (value : A) : B  {
+			return new B (Std.string (value));
+		}
+}


### PR DESCRIPTION
When calling a function with an optional parameter of an abstract type,
and the abstract type can be inferred in multiple ways, a stack overflow
would occur. This change keeps track of types we have already seen to
avoid the infinite recursion.

Closes #6059