### PR TITLE
[python] allow array access on Python Map classes from Python code

### DIFF
--- a/std/python/_std/haxe/ds/IntMap.hx
+++ b/std/python/_std/haxe/ds/IntMap.hx
@@ -57,7 +57,7 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	public function iterator() : Iterator<T> {
 		return h.values().iter();
 	}
-	
+
 	public function copy() : IntMap<T> {
 		var copied = new IntMap();
 		for(key in keys()) copied.set(key, get(key));
@@ -77,5 +77,21 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		}
 		s.add("}");
 		return s.toString();
+	}
+
+	@:keep function __getitem__( key : Int ) : T {
+		return get(key);
+	}
+
+	@:keep function __setitem__( key : Int, value : T ) : Void {
+		set(key, value);
+	}
+
+	@:keep function __delitem__( key : Int ) : Void {
+		remove(key);
+	}
+
+	@:keep function __contains__( key : Int ) : Bool {
+		return exists(key);
 	}
 }

--- a/std/python/_std/haxe/ds/ObjectMap.hx
+++ b/std/python/_std/haxe/ds/ObjectMap.hx
@@ -58,7 +58,7 @@ class ObjectMap<K:{},V> implements haxe.Constraints.IMap<K, V> {
 	public function iterator() : Iterator<V> {
 		return h.values().iter();
 	}
-	
+
 	public function copy() : ObjectMap<K,V> {
 		var copied = new ObjectMap();
 		for(key in keys()) copied.set(key, get(key));
@@ -78,5 +78,21 @@ class ObjectMap<K:{},V> implements haxe.Constraints.IMap<K, V> {
 		}
 		s.add("}");
 		return s.toString();
+	}
+
+	@:keep function __getitem__( key : K ) : V {
+		return get(key);
+	}
+
+	@:keep function __setitem__( key : K, value : V ) : Void {
+		set(key, value);
+	}
+
+	@:keep function __delitem__( key : K ) : Void {
+		remove(key);
+	}
+
+	@:keep function __contains__( key : K ) : Bool {
+		return exists(key);
 	}
 }

--- a/std/python/_std/haxe/ds/StringMap.hx
+++ b/std/python/_std/haxe/ds/StringMap.hx
@@ -57,7 +57,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 	public function iterator() : Iterator<T> {
 		return h.values().iter();
 	}
-	
+
 	public function copy() : StringMap<T> {
 		var copied = new StringMap();
 		for(key in keys()) copied.set(key, get(key));
@@ -79,5 +79,21 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		}
 		s.add("}");
 		return s.toString();
+	}
+
+	@:keep function __getitem__( key : String ) : T {
+		return get(key);
+	}
+
+	@:keep function __setitem__( key : String, value : T ) : Void {
+		set(key, value);
+	}
+
+	@:keep function __delitem__( key : String ) : Void {
+		remove(key);
+	}
+
+	@:keep function __contains__( key : String ) : Bool {
+		return exists(key);
 	}
 }


### PR DESCRIPTION
Add some magic methods to Map classes so they can be used idiomatically from Python, i.e. `map[key]` instead of `map.h[key]`.