### PR TITLE
Add an OCaml native SHA1 implementation in macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ STATICLINK?=0
 HAXE_DIRECTORIES=core syntax context codegen codegen/gencommon generators optimization filters macro macro/eval typing compiler
 EXTLIB_LIBS=extlib-leftovers extc neko javalib swflib ttflib ilib objsize pcre ziplib
 OCAML_LIBS=unix str threads dynlink
-OPAM_LIBS=sedlex xml-light extlib rope ptmap
+OPAM_LIBS=sedlex xml-light extlib rope ptmap sha
 
 FINDLIB_LIBS=$(OCAML_LIBS)
 FINDLIB_LIBS+=$(OPAM_LIBS)

--- a/opam
+++ b/opam
@@ -20,6 +20,7 @@ depends: [
   "extlib"       {build & >= "1.7"}
   "rope"         {build}
   "ptmap"        {build}
+  "sha"
   "conf-libpcre"
   "conf-zlib"
   "conf-neko"

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -1689,6 +1689,18 @@ module StdResource = struct
 	)
 end
 
+module StdSha1 = struct
+	let encode = vfun1 (fun s ->
+		let s = decode_string s in
+		encode_string (Sha1.to_hex (Sha1.string s))
+	)
+
+	let make = vfun1 (fun b ->
+		let b = decode_bytes b in
+		encode_bytes (Bytes.unsafe_of_string (Sha1.to_bin (Sha1.string (Bytes.unsafe_to_string b))))
+	)
+end
+
 module StdSocket = struct
 	open Unix
 
@@ -2954,6 +2966,10 @@ let init_standard_library builtins =
 		"listNames",StdResource.listNames;
 		"getString",StdResource.getString;
 		"getBytes",StdResource.getBytes;
+	] [];
+	init_fields builtins (["haxe";"crypto"],"Sha1") [
+		"encode",StdSha1.encode;
+		"make",StdSha1.make;
 	] [];
 	init_fields builtins (["sys";"net";"_Socket"],"NativeSocket") [
 		"select",StdSocket.select;


### PR DESCRIPTION
Fixes #6773 

Note that this requires a new opam package (not sure if that may be a problem for Windows, please let me know if I'm missing something).

I used the following sample for a quick bit of benchmarking:

```haxe
class Main {
    public static function main() {
        var buf = new StringBuf();
        for (i in 1...100000) buf.addChar(97);
        var s = buf.toString();
        var x = haxe.Timer.stamp();
        for (i in 1...10) haxe.crypto.Sha1.encode(s);
        trace(haxe.Timer.stamp() - x);
    }
}
```

The results look good. Before these changes:

```
$ > haxe --interp -main Main.hx
Main.hx:8: 8.20536017417907715
```

After these changes:

```
$ > haxe --interp -main Main.hx
Main.hx:8: 0.00219798088073730469
```