### PR TITLE
File.update should create file if it doesn't exist

### DIFF
--- a/std/cpp/_std/sys/io/File.hx
+++ b/std/cpp/_std/sys/io/File.hx
@@ -60,6 +60,9 @@ class File {
 	}
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		return untyped new FileOutput(NativeFile.file_open(path,(if( binary ) "rb+" else "r+")));
 	}
 

--- a/std/cs/_std/sys/io/File.hx
+++ b/std/cs/_std/sys/io/File.hx
@@ -86,6 +86,9 @@ class File {
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput
 	{
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		#if std_buffer //standardize 4kb buffers
 		var stream = new cs.system.io.FileStream(path, OpenOrCreate, Write, ReadWrite, 4096);
 		#else

--- a/std/hl/_std/sys/io/File.hx
+++ b/std/hl/_std/sys/io/File.hx
@@ -74,6 +74,9 @@ typedef FileHandle = hl.Abstract<"hl_fdesc">;
 	}
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		var f = file_open(Sys.getPath(path),3,binary);
 		if( f == null ) throw new Sys.SysError("Can't open "+path+" for update");
 		return @:privateAccess new FileOutput(f);

--- a/std/lua/_std/sys/io/File.hx
+++ b/std/lua/_std/sys/io/File.hx
@@ -41,6 +41,9 @@ class File {
 	}
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		return new FileOutput(Io.open(path, binary ? "r+b" : "r+"));
 	}
 

--- a/std/neko/_std/sys/io/File.hx
+++ b/std/neko/_std/sys/io/File.hx
@@ -59,6 +59,9 @@ enum FileHandle {
 	}
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		return untyped new FileOutput(file_open(path.__s,(if( binary ) "rb+" else "r+").__s));
 	}
 

--- a/std/php/_std/sys/io/File.hx
+++ b/std/php/_std/sys/io/File.hx
@@ -57,6 +57,9 @@ import php.Global;
 	}
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		return untyped new FileOutput(fopen(path, binary ? "rb+" : "r+"));
 	}
 

--- a/std/python/_std/sys/io/File.hx
+++ b/std/python/_std/sys/io/File.hx
@@ -78,6 +78,9 @@ class File {
 	}
 
 	public static function update( path : String, binary : Bool = true ) : FileOutput {
+		if (!FileSystem.exists(path)) {
+			write(path).close();
+		}
 		var mode = if (binary) "rb+" else "r+";
 		var f = python.lib.Builtins.open(path, mode, -1, null, null, binary ? null : "");
 

--- a/tests/unit/src/unitstd/sys/io/File.unit.hx
+++ b/tests/unit/src/unitstd/sys/io/File.unit.hx
@@ -1,9 +1,11 @@
 #if sys
 var filename = '.sys.io.file.testfile';
 if (sys.FileSystem.exists(filename)) sys.FileSystem.deleteFile(filename);
+sys.FileSystem.exists(filename) == false;
 
 // test file write
 var fw = sys.io.File.write(filename);
+sys.FileSystem.exists(filename) == true;
 fw.writeString("apple\n");
 fw.close();
 sys.io.File.getContent(filename) == "apple\n";
@@ -30,6 +32,12 @@ fu.seek(7, sys.io.FileSeek.SeekBegin);
 fu.writeString("banana\n");
 fu.close();
 sys.io.File.getContent(filename) == "cherry\nbanana\n";
+
+// File.update should create the file if it doesn't exist
+sys.FileSystem.deleteFile(filename);
+var fu = sys.io.File.update(filename);
+fu.close();
+sys.FileSystem.exists(filename) == true;
 
 sys.FileSystem.deleteFile(filename);
 #end


### PR DESCRIPTION
On some targets this is the current behavior, but for most `File.update` fails if the file doesn't already exist. As `File.update` is documented to behave similar to `File.append` we should guarantee that the file will be created if it doesn't exist on all targets.