### PR TITLE
Add EComplexType expression variant

### DIFF
--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -204,6 +204,7 @@ and expr_def =
 	| ETernary of expr * expr * expr
 	| ECheckType of expr * type_hint
 	| EMeta of metadata_entry * expr
+	| EComplexType of complex_type
 
 and expr = expr_def * pos
 
@@ -585,7 +586,7 @@ let map_expr loop (e,p) =
 	and tpath (t,p) = { t with tparams = List.map tparam t.tparams },p
 	in
 	let e = (match e with
-	| EConst _ -> e
+	| EConst _ | EComplexType _ -> e
 	| EArray (e1,e2) ->
 		let e1 = loop e1 in
 		let e2 = loop e2 in
@@ -670,7 +671,7 @@ let iter_expr loop (e,p) =
 	let opt eo = match eo with None -> () | Some e -> loop e in
 	let exprs = List.iter loop in
 	match e with
-	| EConst _ | EContinue | EBreak | EDisplayNew _ | EReturn None -> ()
+	| EConst _ | EContinue | EBreak | EDisplayNew _ | EReturn None | EComplexType _ -> ()
 	| EParenthesis e1 | EField(e1,_) | EUnop(_,_,e1) | EReturn(Some e1) | EThrow e1 | EMeta(_,e1)
 	| ECheckType(e1,_) | EDisplay(e1,_) | ECast(e1,_) | EUntyped e1 -> loop e1;
 	| EArray(e1,e2) | EBinop(_,e1,e2) | EFor(e1,e2) | EWhile(e1,e2,_) | EIf(e1,e2,None) -> loop e1; loop e2;
@@ -736,6 +737,7 @@ let s_expr e =
 		| ETernary (e1,e2,e3) -> s_expr_inner tabs e1 ^ " ? " ^ s_expr_inner tabs e2 ^ " : " ^ s_expr_inner tabs e3
 		| ECheckType (e,(t,_)) -> "(" ^ s_expr_inner tabs e ^ " : " ^ s_complex_type tabs t ^ ")"
 		| EMeta (m,e) -> s_metadata tabs m ^ " " ^ s_expr_inner tabs e
+		| EComplexType t -> ":" ^ s_complex_type tabs t
 		| EDisplay (e1,iscall) -> Printf.sprintf "#DISPLAY(%s, %b)" (s_expr_inner tabs e1) iscall
 		| EDisplayNew tp -> Printf.sprintf "#DISPLAY_NEW(%s)" (s_complex_type_path tabs tp)
 	and s_expr_list tabs el sep =

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -556,6 +556,8 @@ and encode_expr e =
 				27, [loop e; encode_ctype t]
 			| EMeta (m,e) ->
 				28, [encode_meta_entry m;loop e]
+			| EComplexType t ->
+				30, [encode_ctype (t,p)]
 		in
 		encode_obj OExpr [
 			"pos", encode_pos p;
@@ -827,6 +829,9 @@ and decode_expr v =
 			EMeta (decode_meta_entry m,loop e)
 		| 29, [e;f] ->
 			EField (loop e, decode_string f) (*** deprecated EType, keep until haxe 3 **)
+		| 30, [t] ->
+			let (t,_) = decode_ctype t in
+			EComplexType t
 		| _ ->
 			raise Invalid_expr
 	in

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -966,6 +966,7 @@ and expr = parser
 	| [< '(IntInterval i,p1); e2 = expr >] -> make_binop OpInterval (EConst (Int i),p1) e2
 	| [< '(Kwd Untyped,p1); e = expr >] -> (EUntyped e,punion p1 (pos e))
 	| [< '(Dollar v,p); s >] -> expr_next (EConst (Ident ("$"^v)),p) s
+	| [< '(DblDot,p); (t,_) = parse_complex_type >] -> (EComplexType t),p
 
 and expr_next e1 = parser
 	| [< '(BrOpen,p1) when is_dollar_ident e1; eparam = expr; '(BrClose,p2); s >] ->

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -322,6 +322,8 @@ let reify in_macro =
 			expr "EThrow" [loop e]
 		| ECast (e,ct) ->
 			expr "ECast" [loop e; to_opt to_type_hint ct p]
+		| EComplexType ct ->
+			expr "EComplexType" [to_type_hint (ct,p) p]
 		| EDisplay (e,flag) ->
 			expr "EDisplay" [loop e; to_bool flag p]
 		| EDisplayNew t ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -3597,6 +3597,13 @@ and type_expr ctx (e,p) (with_type:with_type) =
 		in
 		ctx.meta <- old;
 		e
+	| EComplexType t ->
+		let t = Typeload.load_complex_type ctx true p (t,p) in
+		try
+			let mt = module_type_of_type t in
+			type_module_type ctx mt None p
+		with Exit ->
+			error "Type has no runtime value" p
 
 and handle_display ctx e_ast with_type =
 	let old = ctx.in_display,ctx.in_call_args in

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -530,6 +530,11 @@ enum ExprDef {
 		A `@m e` expression.
 	**/
 	EMeta( s : MetadataEntry, e : Expr );
+
+	/**
+		A `:T<P>` complex type.
+	**/
+	EComplexType ( c : ComplexType );
 }
 
 /**

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -73,7 +73,8 @@ class ExprTools {
 			case EConst(_),
 				EContinue,
 				EBreak,
-				EDisplayNew(_):
+				EDisplayNew(_),
+				EComplexType(_):
 			case EField(e, _),
 				EParenthesis(e),
 				EUntyped(e),
@@ -156,7 +157,7 @@ class ExprTools {
 	**/
 	static public function map( e : Expr, f : Expr -> Expr ) : Expr {
 		return {pos: e.pos, expr: switch(e.expr) {
-			case EConst(_): e.expr;
+			case EConst(_), EComplexType(_): e.expr;
 			case EArray(e1, e2): EArray(f(e1), f(e2));
 			case EBinop(op, e1, e2): EBinop(op, f(e1), f(e2));
 			case EField(e, field): EField(f(e), field);

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -242,6 +242,7 @@ class Printer {
 		case ETernary(econd, eif, eelse): '${printExpr(econd)} ? ${printExpr(eif)} : ${printExpr(eelse)}';
 		case ECheckType(e1, ct): '(${printExpr(e1)} : ${printComplexType(ct)})';
 		case EMeta(meta, e1): printMetadata(meta) + " " +printExpr(e1);
+		case EComplexType(ct): ":" + printComplexType(ct);
 	}
 
 	public function printExprs(el:Array<Expr>, sep:String) {

--- a/tests/unit/src/unit/TestBasetypes.hx
+++ b/tests/unit/src/unit/TestBasetypes.hx
@@ -1,5 +1,10 @@
 package unit;
 
+typedef TestArray = Array<Test>;
+private enum TestEnum { V1; V2; }
+
+@:generic private class GenericTestClass<T> {}
+
 class TestBasetypes extends Test {
 
 	function testArray() {
@@ -514,5 +519,22 @@ class TestBasetypes extends Test {
 			var a:{?f:Int} = i; // allowed to fail at runtime
 			unspec(function() a.f);
 		});
+	}
+
+	function testComplexTypeLiteral() {
+		var arrayOfTest = :Array<Test>,
+			testArrayLiteral = :TestArray,
+			qualifiedLiteral = :unit.TestBasetypes.TestArray,
+			testArrayIdentifier = TestArray,
+			generic1 = :GenericTestClass<Int>,
+			generic2 = :GenericTestClass<Float>,
+			enumLiteral = :TestEnum;
+		eq(arrayOfTest, arrayOfTest);
+		eq(arrayOfTest, testArrayLiteral);
+		eq(arrayOfTest, qualifiedLiteral);
+		eq(arrayOfTest, testArrayIdentifier);
+		t((arrayOfTest:Class<Dynamic>) != (generic1:Class<Dynamic>));
+		t((generic1:Class<Dynamic>) != (generic2:Class<Dynamic>));
+		eq(enumLiteral, enumLiteral);
 	}
 }

--- a/tests/unit/src/unit/TestType.hx
+++ b/tests/unit/src/unit/TestType.hx
@@ -809,6 +809,12 @@ class TestType extends Test {
 		typedAs(unit.MyAbstract.GADTEnumAbstract.A, expectedA);
 		typedAs(unit.MyAbstract.GADTEnumAbstract.B, expectedB);
 	}
+
+	function testCreateFromComplexType() {
+		var c = :Array<Int>,
+			v = Type.createInstance(c, []);
+		t(Std.is(v, c));
+	}
 }
 
 typedef TypedefToStringMap<T> = Map<String,T>

--- a/tests/unit/src/unitstd/Type.unit.hx
+++ b/tests/unit/src/unitstd/Type.unit.hx
@@ -71,6 +71,7 @@ c2.b == "bar";
 var c = Type.createEmptyInstance(ClassWithCtorDefaultValues);
 c.a == null;
 c.b == null;
+Std.is(c, ClassWithCtorDefaultValues) == true;
 var c = Type.createEmptyInstance(ClassWithCtorDefaultValuesChild);
 c.a == null;
 c.b == null;


### PR DESCRIPTION
Proposed [here](https://github.com/HaxeFoundation/haxe-evolution/pull/44), this is a way to specify types that can't be parsed as identifiers, e.g. parameterized types:

```haxe
var myType = :Array<MyClass>;

@:meta(:a.b.SomeType<P>) public function myFunction() {}
```