### PR TITLE
Typo in dce

### DIFF
--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -592,7 +592,7 @@ and expr dce e =
 		check_and_add_feature dce "dynamic_binop_==";
 		expr dce e1;
 		expr dce e2;
-	| TBinop(OpEq,({ etype = t1} as e1), ({ etype = t2} as e2) ) when is_dynamic t1 || is_dynamic t2 ->
+	| TBinop(OpNotEq,({ etype = t1} as e1), ({ etype = t2} as e2) ) when is_dynamic t1 || is_dynamic t2 ->
 		check_and_add_feature dce "dynamic_binop_!=";
 		expr dce e1;
 		expr dce e2;


### PR DESCRIPTION
The `TBinop(OpEq,_,_)` case is duplicated in the Dce.

It's surprising it even works.