### PR TITLE
[lua] hide ProcessInput/Output from the API

### DIFF
--- a/std/lua/_std/sys/io/Process.hx
+++ b/std/lua/_std/sys/io/Process.hx
@@ -122,7 +122,7 @@ class Process {
 	}
 }
 
-class ProcessInput extends haxe.io.Input {
+private class ProcessInput extends haxe.io.Input {
 	var b : Pipe;
 	var buf : String;
 	var idx : Int;
@@ -170,7 +170,7 @@ class ProcessInput extends haxe.io.Input {
 
 }
 
-class ProcessOutput extends haxe.io.Output {
+private class ProcessOutput extends haxe.io.Output {
 	var b : Pipe;
 
 	public function new(pipe:Pipe) {


### PR DESCRIPTION
These show up as part of the general Haxe `sys.io` API:

https://api.haxe.org/sys/io/ProcessInput.html

I don't think that's the intention here, these two classes just seem to be implementation details.

@jdonaldson 