### PR TITLE
[lua] fix missing close() call in Boot.systemName()

### DIFF
--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -380,7 +380,7 @@ class Boot {
 			var popen_result : lua.FileHandle = null;
 			untyped __lua__("popen_status, popen_result = pcall(_G.io.popen, '')");
 			if (popen_status) {
-				popen_result.close;
+				popen_result.close();
 				os = lua.Io.popen('uname -s','r').read('*l').toLowerCase();
 			} else {
 				os = lua.Os.getenv('OS').toLowerCase();


### PR DESCRIPTION
Thanks to the new diagnostic (#6917). :)

![](https://i.imgur.com/XpSXQhm.png)