### PR TITLE
[typer] more helpful error for invalid usage of @:const type params

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2320,7 +2320,7 @@ and type_ident ctx i p mode =
 				if Typeload.is_generic_parameter ctx c && Meta.has Meta.Const c.cl_meta then
 					AKExpr (type_module_type ctx (TClassDecl c) None p)
 				else begin
-					display_error ctx ("Unless declared on a @:generic class and annotated with @:const, type parameter " ^ i ^ " is not available at runtime") p;
+					display_error ctx ("Only @:const type parameters on @:generic classes can be used as value") p;
 					AKExpr (mk (TConst TNull) t_dynamic p)
 				end
 			with Not_found ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2320,7 +2320,7 @@ and type_ident ctx i p mode =
 				if Typeload.is_generic_parameter ctx c && Meta.has Meta.Const c.cl_meta then
 					AKExpr (type_module_type ctx (TClassDecl c) None p)
 				else begin
-					display_error ctx ("Unless declared on a @:generic class, type parameter " ^ i ^ " is not available at runtime") p;
+					display_error ctx ("Unless declared on a @:generic class and annotated with @:const, type parameter " ^ i ^ " is not available at runtime") p;
 					AKExpr (mk (TConst TNull) t_dynamic p)
 				end
 			with Not_found ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2320,7 +2320,7 @@ and type_ident ctx i p mode =
 				if Typeload.is_generic_parameter ctx c && Meta.has Meta.Const c.cl_meta then
 					AKExpr (type_module_type ctx (TClassDecl c) None p)
 				else begin
-					display_error ctx ("Type parameter " ^ i ^ " is only available at compilation and is not a runtime value") p;
+					display_error ctx ("Unless declared on a @:generic class, type parameter " ^ i ^ " is not available at runtime") p;
 					AKExpr (mk (TConst TNull) t_dynamic p)
 				end
 			with Not_found ->


### PR DESCRIPTION
I initially forgot the `@:generic` when playing around with const type params and had to scratch my head a bit wondering what I was missing. I think mentioning the need for a @:generic class directly in the error is helpful. :)