### PR TITLE
Fix inconsistent treatment of Null<T> in unify_min

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -309,7 +309,7 @@ let rec unify_min_raise ctx (el:texpr list) : t =
 	| [] -> mk_mono()
 	| [e] -> e.etype
 	| _ ->
-		let rec chk_null e = is_null e.etype ||
+		let rec chk_null e = is_null e.etype || is_explicit_null e.etype ||
 			match e.eexpr with
 			| TConst TNull -> true
 			| TBlock el ->

--- a/tests/unit/src/unit/issues/Issue6836.hx
+++ b/tests/unit/src/unit/issues/Issue6836.hx
@@ -1,0 +1,19 @@
+package unit.issues;
+
+import unit.HelperMacros.typeString;
+
+class Issue6836 extends Test {
+	function test() {
+		var v:Null<Int> = 1;
+		var e1 = Std.random(2) == 1 ? 2 : v;
+		eq(typeString(e1), "Null<Int>");
+		var e2 = Std.random(2) == 1 ? v : 2;
+		eq(typeString(e1), "Null<Int>");
+
+		var v:Null<String> = "abc";
+		var e1 = Std.random(2) == 1 ? "def" : v;
+		eq(typeString(e1), "Null<String>");
+		var e2 = Std.random(2) == 1 ? v : "def";
+		eq(typeString(e1), "Null<String>");
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/haxe/issues/6836. Ternary and if expressions both call `unify_min` to determine their type. For types which are nullable by default (String, classes) `unify_raise` never raises when mixing `Null<T>` and `T` in either order, so whichever comes first in the list wins. Types that are *not* nullable by default such as `Int` don't show this behavior, always returning `Null<Int>`.

This fix is pretty on the nose; maybe there's a more general solution?