### PR TITLE
[python] Fix stat().atime/.mtime/.ctime

### DIFF
--- a/std/python/_std/sys/FileSystem.hx
+++ b/std/python/_std/sys/FileSystem.hx
@@ -36,9 +36,9 @@ class FileSystem {
 		return {
 			gid : s.st_gid,
 			uid : s.st_uid,
-			atime : Date.fromTime(s.st_atime),
-			mtime : Date.fromTime(s.st_mtime),
-			ctime : Date.fromTime(s.st_ctime),
+			atime : Date.fromTime(1000 * s.st_atime),
+			mtime : Date.fromTime(1000 * s.st_mtime),
+			ctime : Date.fromTime(1000 * s.st_ctime),
 			size : s.st_size,
 			dev : s.st_dev,
 			ino : s.st_ino,


### PR DESCRIPTION
Date.fromTime() expects milliseconds but python.lib.Os.stat() returns seconds since epoch for st_atime/st_mtime/st_ctime.
Thus, before this patch wrong date objects are created for stat results.

https://docs.python.org/3/library/os.html#os.stat_result.st_atime