### PR TITLE
Don't allow sibling class access to private constructor

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2965,7 +2965,7 @@ and type_new ctx path el with_type p =
 	let build_constructor_call c tl =
 		let ct, f = get_constructor ctx c tl p in
 		if (Meta.has Meta.CompilerGenerated f.cf_meta) then display_error ctx (error_msg (No_constructor (TClassDecl c))) p;
-		if not (can_access ctx c f true || is_parent c ctx.curclass) && not ctx.untyped then display_error ctx "Cannot access private constructor" p;
+		if not (can_access ctx c f true || is_parent c ctx.curclass) && not ctx.untyped then display_error ctx (Printf.sprintf "Cannot access private constructor of %s" (s_type_path c.cl_path)) p;
 		(match f.cf_kind with
 		| Var { v_read = AccRequire (r,msg) } -> (match msg with Some msg -> error msg p | None -> error_require r p)
 		| _ -> ());

--- a/tests/misc/projects/Issue5871/Main.hx
+++ b/tests/misc/projects/Issue5871/Main.hx
@@ -1,0 +1,14 @@
+class Base {
+	var v = 0;
+}
+
+class Child extends Base {
+	private function new() {}
+}
+
+class Main extends Base {
+	static function main() {
+		// shouldn't be possible; Child's constructor is private
+		new Child();
+	}
+}

--- a/tests/misc/projects/Issue5871/Main2.hx
+++ b/tests/misc/projects/Issue5871/Main2.hx
@@ -1,0 +1,15 @@
+class Base {
+	private function new() {}
+	var v = 0;
+}
+
+class Child extends Base {
+	private function new() super();
+}
+
+class Main2 extends Base {
+	static function main() {
+		// shouldn't be possible; Child's constructor is private
+		new Child();
+	}
+}

--- a/tests/misc/projects/Issue5871/parent-constructor-fail.hxml
+++ b/tests/misc/projects/Issue5871/parent-constructor-fail.hxml
@@ -1,0 +1,2 @@
+-main Main2
+--interp

--- a/tests/misc/projects/Issue5871/parent-constructor-fail.hxml.stderr
+++ b/tests/misc/projects/Issue5871/parent-constructor-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main2.hx:13: characters 3-14 : Cannot access private constructor of Child

--- a/tests/misc/projects/Issue5871/parent-no-constructor-fail.hxml
+++ b/tests/misc/projects/Issue5871/parent-no-constructor-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/Issue5871/parent-no-constructor-fail.hxml.stderr
+++ b/tests/misc/projects/Issue5871/parent-no-constructor-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:12: characters 3-14 : Cannot access private constructor of Child

--- a/tests/unit/src/unit/issues/Issue5323.hx
+++ b/tests/unit/src/unit/issues/Issue5323.hx
@@ -1,6 +1,6 @@
 package unit.issues;
 class Issue5323 extends Test{
-	function new() super();
+	public function new() super();
     function test() {
     	var expected = 1;
         var actual = new Issue5323().doStuff(function() return 0);


### PR DESCRIPTION
Fixes #5871 

A private constructor should only be accessible in the class or its direct descendants.

Found one of these in the tests themselves, so I'm sure people have been relying on this, knowingly or not.