### PR TITLE
Fix for generic function through typedef

### DIFF
--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -397,7 +397,11 @@ let unify_field_call ctx fa el args ret p inline =
 				a.a_path
 			| _ -> c.cl_path
 		in
-		let e = if stat then type_type ctx path p else e in
+		let e = match c.cl_kind with
+			| KAbstractImpl(a) ->
+				type_type ctx a.a_path p
+			| _ -> e
+		in
 		let fa = if stat then FStatic (c,cf2) else FInstance (c,tl,cf2) in
 		let e = mk (TField(e,fa)) cf2.cf_type p in
 		make_call ctx e el ret p

--- a/tests/unit/src/unit/issues/Issue5255.hx
+++ b/tests/unit/src/unit/issues/Issue5255.hx
@@ -1,0 +1,7 @@
+package unit.issues;
+
+class Issue5255 extends Test {
+	function test() {
+		eq(1, unit.issues.misc.Issue5255Class.test(1));
+	}
+}

--- a/tests/unit/src/unit/issues/misc/Issue5255Class.hx
+++ b/tests/unit/src/unit/issues/misc/Issue5255Class.hx
@@ -1,0 +1,9 @@
+package unit.issues.misc;
+
+typedef Issue5255Class<T> = Issue5255Class_<T>;
+
+class Issue5255Class_<T> {
+	@:generic public static function test<T>(arg:T){
+		return arg;
+	}
+}


### PR DESCRIPTION
Fixes #5255 - this `type_type` is trying to load the underlying type's type path in the context of the calling file, which doesn't resolve in this example. For class fields this line doesn't seem necessary at all.