### PR TITLE
Mask values to prevent overflow in bytes.setInt32

### DIFF
--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -331,10 +331,10 @@ class Bytes {
 		#if neko_v21
 		untyped $sset32(b, pos, v, false);
 		#else
-		set(pos, v);
-		set(pos + 1, v >> 8);
-		set(pos + 2, v >> 16);
-		set(pos + 3, v >>> 24);
+		set(pos, v & 0xFF);
+		set(pos + 1, v >> 8 & 0xFF);
+		set(pos + 2, v >> 16 & 0xFF);
+		set(pos + 3, v >>> 24 & 0xFF);
 		#end
 	}
 


### PR DESCRIPTION
I was just comparing differences in our versions of Haxe standard classes with the current development here, and noticed this change in our source. This change fixes compile warnings on the C++ target, and may resolve some bad values at runtime