### PR TITLE
[std] remove some unused variables

### DIFF
--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -299,7 +299,6 @@ abstract Vector<T>(VectorData<T>) {
 		return this.join(sep);
 		#else
 		var b = new StringBuf();
-		var i = 0;
 		var len = length;
 		for(i in 0...len) {
 			b.add( Std.string(get(i)) );
@@ -324,7 +323,6 @@ abstract Vector<T>(VectorData<T>) {
 		#else
 		var length = length;
 		var r = new Vector<S>(length);
-		var i = 0;
 		var len = length;
 		for(i in 0...len) {
 			var v = f(get(i));

--- a/std/haxe/io/Path.hx
+++ b/std/haxe/io/Path.hx
@@ -223,8 +223,6 @@ class Path {
 		}
 
 		var tmp = target.join(slash);
-		var regex = ~/([^:])\/+/g;
-		var result = regex.replace(tmp, "$1" +slash);
 		var acc = new StringBuf();
 		var colon = false;
 		var slashes = false;

--- a/std/haxe/rtti/XmlParser.hx
+++ b/std/haxe/rtti/XmlParser.hx
@@ -220,7 +220,6 @@ class XmlParser {
 				cur = pk;
 			}
 		}
-		var prev = null;
 		for( ct in cur ) {
 			var tinf;
 			try

--- a/std/neko/vm/Module.hx
+++ b/std/neko/vm/Module.hx
@@ -180,8 +180,8 @@ class Module {
 			return i.readInt32();
 		}
 		var nglobals = readInt();
-		var nfields = readInt();
-		var codesize = readInt();
+		/*var nfields =*/ readInt();
+		/*var codesize =*/ readInt();
 		var a = new Array();
 		for( k in 0...nglobals ) {
 			switch(i.readByte()) {


### PR DESCRIPTION
When running the "Haxe: Run Global Diagnostics Check" command in vshaxe, several "unused variable" warnings currently point into standard library files, which is obviously not ideal.