### PR TITLE
[std] use the new function type syntax for replacer in Json

### DIFF
--- a/std/flash/_std/haxe/Json.hx
+++ b/std/flash/_std/haxe/Json.hx
@@ -33,7 +33,7 @@ class Json {
 	}
 
 	#if (haxeJSON || !flash11) inline #end
-	public static function stringify( value : Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space:String ) : String {
+	public static function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String ) : String {
 		return haxe.format.JsonPrinter.print(value, replacer, space);
 	}
 }

--- a/std/haxe/Json.hx
+++ b/std/haxe/Json.hx
@@ -56,7 +56,7 @@ class Json {
 
 		@see https://haxe.org/manual/std-Json-encoding.html
 	**/
-	public static inline function stringify( value : Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space : String ) : String {
+	public static inline function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space : String ) : String {
 		return haxe.format.JsonPrinter.print(value, replacer, space);
 	}
 

--- a/std/haxe/format/JsonPrinter.hx
+++ b/std/haxe/format/JsonPrinter.hx
@@ -41,19 +41,19 @@ class JsonPrinter {
 		If `space` is given and is not null, the result will be pretty-printed.
 		Successive levels will be indented by this string.
 	**/
-	static public function print(o:Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space:String) : String {
+	static public function print(o:Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String) : String {
 		var printer = new JsonPrinter(replacer, space);
 		printer.write("", o);
 		return printer.buf.toString();
 	}
 
 	var buf : #if flash flash.utils.ByteArray #else StringBuf #end;
-	var replacer : Dynamic -> Dynamic -> Dynamic;
+	var replacer:(key:Dynamic, value:Dynamic) -> Dynamic;
 	var indent:String;
 	var pretty:Bool;
 	var nind:Int;
 
-	function new(replacer:Dynamic -> Dynamic -> Dynamic, space:String) {
+	function new(replacer:(key:Dynamic, value:Dynamic) -> Dynamic, space:String) {
 		this.replacer = replacer;
 		this.indent = space;
 		this.pretty = space != null;

--- a/std/js/_std/haxe/Json.hx
+++ b/std/js/_std/haxe/Json.hx
@@ -33,7 +33,7 @@ class Json {
 	}
 
 	#if haxeJSON inline #end
-	public static function stringify( value : Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space:String ) : String {
+	public static function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String ) : String {
 		return haxe.format.JsonPrinter.print(value, replacer, space);
 	}
 

--- a/std/lua/_std/haxe/Json.hx
+++ b/std/lua/_std/haxe/Json.hx
@@ -28,7 +28,7 @@ class Json {
 		return haxe.format.JsonParser.parse(text);
 	}
 
-	public static function stringify( value : Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space:String ) : String {
+	public static function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String ) : String {
 		return haxe.format.JsonPrinter.print(value, replacer, space);
 	}
 

--- a/std/php/_std/haxe/Json.hx
+++ b/std/php/_std/haxe/Json.hx
@@ -35,7 +35,7 @@ class Json {
 		#end
 	}
 
-	public static inline function stringify( value : Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space:String ) : String {
+	public static inline function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String ) : String {
 		#if haxeJSON
 			return JsonPrinter.print(value, replacer, space);
 		#else
@@ -74,7 +74,7 @@ class Json {
 		return value;
 	}
 
-	static function phpJsonEncode(value:Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space:String):String {
+	static function phpJsonEncode(value:Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String):String {
 		if(null != replacer || null != space) {
 			return JsonPrinter.print(value, replacer, space);
 		}

--- a/std/python/_std/haxe/Json.hx
+++ b/std/python/_std/haxe/Json.hx
@@ -29,7 +29,7 @@ class Json {
 		return python.lib.Json.loads(text, { object_hook : python.Lib.dictToAnon });
 	}
 
-	public static inline function stringify( value : Dynamic, ?replacer:Dynamic -> Dynamic -> Dynamic, ?space : String ) : String {
+	public static inline function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space : String ) : String {
 		return haxe.format.JsonPrinter.print(value, replacer, space);
 	}
 }


### PR DESCRIPTION
This seems like a great use for the new syntax: `Dynamic -> Dynamic -> Dynamic` isn't very helpful at all when reading the code, so you probably have to look up the meaning of the parameters in the doc comment, but `(key:Dynamic, value:Dynamic) -> Dynamic` gives you a pretty good idea of what's going on right away. :)