### PR TITLE
[std] fix markdown syntax in haxe.Log.trace() docs

### DIFF
--- a/std/haxe/Log.hx
+++ b/std/haxe/Log.hx
@@ -46,6 +46,7 @@ class Log {
 		information about the position where the `trace()` call was made.
 
 		This method can be rebound to a custom function:
+		
 			var oldTrace = haxe.Log.trace; // store old function
 			haxe.Log.trace = function(v, ?infos) {
 			  // handle trace


### PR DESCRIPTION
This empty line is necessary to fix markdown formatting in VSCode hover hints. It seems to work in the API docs, but I don't think this is valid markdown, GitHub's markdown renderer also needs the empty line.

Before:

![](https://i.imgur.com/TuM7Zj9.png)

After:

![](https://i.imgur.com/kGVy558.png)