### PR TITLE
[std] fix formatting of the Fast.nodes code example

### DIFF
--- a/std/haxe/xml/Fast.hx
+++ b/std/haxe/xml/Fast.hx
@@ -132,15 +132,17 @@ abstract Fast(Xml) {
 	/**
 		Access to the List of elements with the given name.
 		```haxe
-		var fast = new haxe.xml.Fast(Xml.parse("<users>
+		var fast = new haxe.xml.Fast(Xml.parse("
+			<users>
 				<user name='John'/>
 				<user name='Andy'/>
 				<user name='Dan'/>
-		</users>"));
+			</users>"
+		));
 
 		var users = fast.node.users;
-		for(user in users.nodes.user) {
-				trace(user.att.name);
+		for (user in users.nodes.user) {
+			trace(user.att.name);
 		}
 		```
 	**/


### PR DESCRIPTION
I noticed that the formatting here looked a bit off. Before:

![](https://i.imgur.com/OorV13d.png)

After:

![](https://i.imgur.com/N1VmP8R.png)