### PR TITLE
label:platform-python  getChar uses Msvcrt.getch instead of Msvcrt.getwch

### DIFF
--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -141,7 +141,8 @@ class Sys {
 				}
 
 			case "Windows":
-				python.lib.Msvcrt.getch().decode("utf-8").charCodeAt(0);
+				//python.lib.Msvcrt.getch().decode("utf-8").charCodeAt(0);
+				python.lib.Msvcrt.getwch().charCodeAt(0);
 			case var x :
 				throw "platform " + x + " not supported";
 		}

--- a/std/python/lib/Msvcrt.hx
+++ b/std/python/lib/Msvcrt.hx
@@ -25,5 +25,5 @@ package python.lib;
 extern class Msvcrt {
 
 	public static function getch ():python.Bytes;
-
+	public static function getwch ():String;
 }


### PR DESCRIPTION
on windows 10 console cannot be input äöü on utf-8 (cp65001)
