### PR TITLE
Allow arbitrary expressions in place of property identifiers

### DIFF
--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -323,7 +323,7 @@ let convert_ilfield ctx p field =
 	let kind = match readonly with
 		| true ->
 			cff_meta := (Meta.ReadOnly, [], cff_pos) :: !cff_meta;
-			FProp (("default",null_pos), ("never",null_pos), Some (convert_signature ctx p field.fsig.snorm,null_pos), None)
+			FProp ((EConst (Ident "default"),null_pos), (EConst (Ident "never"),null_pos), Some (convert_signature ctx p field.fsig.snorm,null_pos), None)
 		| false ->
 			FVar (Some (convert_signature ctx p field.fsig.snorm,null_pos), None)
 	in
@@ -561,7 +561,7 @@ let convert_ilprop ctx p prop is_explicit_impl =
 	in
 
 	let kind =
-		FProp ((get,null_pos), (set,null_pos), Some(convert_signature ctx p ilsig,null_pos), None)
+		FProp ((EConst (Ident get),null_pos), (EConst (Ident set),null_pos), Some(convert_signature ctx p ilsig,null_pos), None)
 	in
 	{
 		cff_name = prop.pname,null_pos;

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -294,7 +294,7 @@ let convert_java_enum ctx p pe =
 
 		let kind = match field.jf_kind with
 			| JKField when !readonly ->
-				FProp (("default",null_pos), ("null",null_pos), Some (convert_signature ctx p field.jf_signature,null_pos), None)
+				FProp ((EConst (Ident "default"),null_pos), (EConst (Ident "null"),null_pos), Some (convert_signature ctx p field.jf_signature,null_pos), None)
 			| JKField ->
 				FVar (Some (convert_signature ctx p field.jf_signature,null_pos), None)
 			| JKMethod ->

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -191,7 +191,7 @@ let build_class com c file =
 		match f.hlf_kind with
 		| HFVar v ->
 			if v.hlv_const then
-				cf.cff_kind <- FProp (("default",null_pos),("never",null_pos),Some (make_type v.hlv_type,null_pos),None)
+				cf.cff_kind <- FProp ((EConst (Ident "default"),null_pos),(EConst (Ident "never"),null_pos),Some (make_type v.hlv_type,null_pos),None)
 			else
 				cf.cff_kind <- FVar (Some (make_dyn_type v.hlv_type,null_pos),None);
 			cf :: acc
@@ -296,7 +296,7 @@ let build_class com c file =
 			cff_doc = None;
 			cff_access = flags;
 			cff_meta = [];
-			cff_kind = if get && set then FVar (Some (make_dyn_type t,null_pos), None) else FProp (((if get then "default" else "never"),null_pos),((if set then "default" else "never"),null_pos),Some (make_dyn_type t,null_pos),None);
+			cff_kind = if get && set then FVar (Some (make_dyn_type t,null_pos), None) else FProp (((EConst (Ident (if get then "default" else "never"))),null_pos),(EConst (Ident (if set then "default" else "never")),null_pos),Some (make_dyn_type t,null_pos),None);
 		}
 	in
 	let fields = Hashtbl.fold (fun (name,stat) t acc ->
@@ -319,7 +319,7 @@ let build_class com c file =
 			| f :: l ->
 				match f.cff_kind with
 				| FVar (Some (CTPath { tpackage = []; tname = ("String" | "Int" | "UInt") as tname },null_pos),None)
-				| FProp (("default",_),("never",_),Some (CTPath { tpackage = []; tname = ("String" | "Int" | "UInt") as tname },null_pos),None) when List.mem_assoc AStatic f.cff_access ->
+				| FProp ((EConst (Ident "default"),_),(EConst (Ident "never"),_),Some (CTPath { tpackage = []; tname = ("String" | "Int" | "UInt") as tname },null_pos),None) when List.mem_assoc AStatic f.cff_access ->
 					if !real_type = "" then real_type := tname else if !real_type <> tname then raise Exit;
 					{
 						ec_name = f.cff_name;

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -242,7 +242,7 @@ and placed_access = access * pos
 and class_field_kind =
 	| FVar of type_hint option * expr option
 	| FFun of func
-	| FProp of placed_name * placed_name * type_hint option * expr option
+	| FProp of expr * expr * type_hint option * expr option
 
 and class_field = {
 	cff_name : placed_name;
@@ -790,7 +790,7 @@ let s_expr e =
 		if List.length f.cff_access > 0 then String.concat " " (List.map s_placed_access f.cff_access) else "" ^
 		match f.cff_kind with
 		| FVar (t,e) -> "var " ^ (fst f.cff_name) ^ s_opt_type_hint tabs t " : " ^ s_opt_expr tabs e " = "
-		| FProp ((get,_),(set,_),t,e) -> "var " ^ (fst f.cff_name) ^ "(" ^ get ^ "," ^ set ^ ")" ^ s_opt_type_hint tabs t " : " ^ s_opt_expr tabs e " = "
+		| FProp (eget,eset,t,e) -> "var " ^ (fst f.cff_name) ^ "(" ^ s_expr_inner tabs eget ^ "," ^ s_expr_inner tabs eset ^ ")" ^ s_opt_type_hint tabs t " : " ^ s_opt_expr tabs e " = "
 		| FFun func -> "function " ^ (fst f.cff_name) ^ s_func tabs func
 	and s_metadata tabs (s,e,_) =
 		"@" ^ Meta.to_string s ^ if List.length e > 0 then "(" ^ s_expr_list tabs e ", " ^ ")" else ""

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -412,7 +412,7 @@ and encode_field (f:class_field) =
 	let tag, pl = match f.cff_kind with
 		| FVar (t,e) -> 0, [null encode_ctype t; null encode_expr e]
 		| FFun f -> 1, [encode_fun f]
-		| FProp (get,set, t, e) -> 2, [encode_placed_name get; encode_placed_name set; null encode_ctype t; null encode_expr e]
+		| FProp (eget,eset, t, e) -> 2, [encode_expr eget; encode_expr eset; null encode_ctype t; null encode_expr e]
 	in
 	encode_obj OField [
 		"name",encode_placed_name f.cff_name;
@@ -724,8 +724,8 @@ and decode_field v =
 			FVar (opt decode_ctype t, opt decode_expr e)
 		| 1, [f] ->
 			FFun (decode_fun f)
-		| 2, [get;set; t; e] ->
-			FProp (decode_placed_name vnull get, decode_placed_name vnull set, opt decode_ctype t, opt decode_expr e)
+		| 2, [eget;eset; t; e] ->
+			FProp (decode_expr eget, decode_expr eset, opt decode_ctype t, opt decode_expr e)
 		| _ ->
 			raise Invalid_expr
 	in

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -186,7 +186,7 @@ let reify in_macro =
 			let n, vl = (match k with
 				| FVar (ct,e) -> "FVar", [to_opt to_type_hint ct p;to_opt to_expr e p]
 				| FFun f -> "FFun", [to_fun f p]
-				| FProp (get,set,t,e) -> "FProp", [to_placed_name get; to_placed_name set; to_opt to_type_hint t p; to_opt to_expr e p]
+				| FProp (eget,eset,t,e) -> "FProp", [to_expr eget p; to_expr eset p; to_opt to_type_hint t p; to_opt to_expr e p]
 			) in
 			mk_enum "FieldType" n vl p
 		in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -450,8 +450,12 @@ and load_complex_type ctx allow_display p (t,pn) =
 					t
 				| FProp (i1,i2,t,e) ->
 					no_expr e;
-					let access (m,_) get =
-						match m with
+					let access (m,pm) get =
+						let ident = match m with
+							| EConst(Ident s) -> s
+							| _ -> error "Identifier expected" pm
+						in
+						match ident with
 						| "null" -> AccNo
 						| "never" -> AccNever
 						| "default" -> AccNormal

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -850,7 +850,7 @@ enum FieldType {
 	/**
 		Represents a property with getter and setter field type.
 	**/
-	FProp( get : String, set : String, ?t : Null<ComplexType>, ?e : Null<Expr> );
+	FProp( get : Expr, set : Expr, ?t : Null<ComplexType>, ?e : Null<Expr> );
 }
 
 /**

--- a/std/haxe/macro/TypeTools.hx
+++ b/std/haxe/macro/TypeTools.hx
@@ -63,8 +63,8 @@ class TypeTools {
 			kind: switch([ cf.kind, cf.type ]) {
 				case [ FVar(read, write), ret ]:
 					FProp(
-						varAccessToString(read, "get"),
-						varAccessToString(write, "set"),
+						macro $i{varAccessToString(read, "get")},
+						macro $i{varAccessToString(write, "set")},
 						toComplexType(ret),
 						null);
 				case [ FMethod(_), TFun(args, ret) ]:


### PR DESCRIPTION
This change allows parsing any expression where we currently only allow property identifiers. If any non-identifier is used, it fails while loading the type.

This breaks macros that inspect `FProp`, which is unfortunate, but I believe we should break this properly instead of trying to maintain backwards compatibility through some hacks.

Obviously, I have a follow-up planned once this is merged.