### PR TITLE
[display] "display/findReferences" -> "display/references"

### DIFF
--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -228,7 +228,7 @@ let handler =
 			hctx.display#set_display_file false true false;
 			hctx.display#enable_display DMDefinition;
 		);
-		"display/findReferences", (fun hctx ->
+		"display/references", (fun hctx ->
 			Common.define hctx.com Define.NoCOpt;
 			hctx.display#set_display_file false true false;
 			hctx.display#enable_display (DMUsage false);


### PR DESCRIPTION
This makes things more consistent, right now this is the only `"display/"` method that uses a verb (and it's also inconsistent with the LSP).