### PR TITLE
Java fix for Type.createInstance issue with anonymous structures.

### DIFF
--- a/std/java/_std/Type.hx
+++ b/std/java/_std/Type.hx
@@ -145,7 +145,10 @@ enum ValueType {
 			for (arg in args) {
 				argNum++;
 				var expectedType = argNum < ptypes.length ? ptypes[argNum] : ptypes[ptypes.length - 1]; // varags
-				if (arg == null || expectedType.isAssignableFrom(java.Lib.toNativeType(Type.getClass(arg)))) {
+				var isDynamic = Std.is(arg, DynamicObject) && expectedType.isAssignableFrom(java.Lib.getNativeType(arg));
+				var argType = Type.getClass(arg);
+
+				if (arg == null || isDynamic || (argType != null && expectedType.isAssignableFrom(java.Lib.toNativeType(argType)))) {
 					callArguments[argNum] = arg;
 				} else if (Std.is(arg, java.lang.Number)) {
 					var name = expectedType.getName();

--- a/tests/unit/src/unit/issues/Issue7233.hx
+++ b/tests/unit/src/unit/issues/Issue7233.hx
@@ -1,0 +1,18 @@
+package unit.issues;
+
+class Issue7233 extends unit.Test {
+	function test() {
+		var data = {name: "Test"};
+		var obj = Type.createInstance(TestClass, [data]);
+
+		eq("Test", obj.name);
+	}
+}
+
+private class TestClass {
+    var name : String;
+
+    public function new(data) {
+        this.name = data.name;
+    }
+}

--- a/tests/unit/src/unit/issues/Issue7233.hx
+++ b/tests/unit/src/unit/issues/Issue7233.hx
@@ -10,7 +10,7 @@ class Issue7233 extends unit.Test {
 }
 
 private class TestClass {
-    var name : String;
+    public var name : String;
 
     public function new(data) {
         this.name = data.name;


### PR DESCRIPTION
This is an attempt to fix `Type.createInstance` for Java. It crashes when using an anonymous structure as argument, as in:

```haxe
class Main {
    static function main() {
        var data = {name: "Test"};
        var main = Type.createInstance(Main, [data]);
        trace(main.name);
    }

    var name : String;

    public function new(data) {
        this.name = data.name;
    }
}
```

A minimal code example project is available at https://github.com/ciscoheat/haxetests/tree/javatypefix