### PR TITLE
[display] add expected types to CRPattern

### DIFF
--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -125,16 +125,18 @@ let completion_item_of_expr ctx e =
 	in
 	loop e
 
-let raise_toplevel ctx dk with_type po p =
+let get_expected_type ctx with_type =
 	let t = match with_type with
 		| WithType t -> Some t
 		| _ -> None
 	in
-	let ct = match t with
+	match t with
 		| None -> None
 		| Some t -> Some (completion_type_of_type ctx t,completion_type_of_type ctx (follow t))
-	in
-	raise_fields (DisplayToplevel.collect ctx (match dk with DKPattern _ -> TKPattern p | _ -> TKExpr p) with_type) (CRToplevel ct) po
+
+let raise_toplevel ctx dk with_type po p =
+	let expected_type = get_expected_type ctx with_type in
+	raise_fields (DisplayToplevel.collect ctx (match dk with DKPattern _ -> TKPattern p | _ -> TKExpr p) with_type) (CRToplevel expected_type) po
 
 let rec handle_signature_display ctx e_ast with_type =
 	ctx.in_display <- true;
@@ -479,6 +481,6 @@ let handle_edisplay ctx e dk with_type =
 		begin try
 			handle_display ctx e dk with_type
 		with DisplayException(DisplayFields(l,CRToplevel _,p)) ->
-			raise_fields l (CRPattern outermost) p
+			raise_fields l (CRPattern ((get_expected_type ctx with_type),outermost)) p
 		end
 	| _ -> handle_display ctx e dk with_type


### PR DESCRIPTION
I noticed that #7323 effectively removed some info from nested patterns. We can use the expected type info to offer generating [structure patterns](https://haxe.org/manual/lf-pattern-matching-structure.html) there.