### PR TITLE
[display] revert f1248f5e (positions in generic toplevel) for now

### DIFF
--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -321,7 +321,7 @@ and display_expr ctx e_ast e dk with_type p =
 				let item = completion_item_of_expr ctx e2 in
 				raise_fields fields (CRField(item,e2.epos)) (Some {e.epos with pmin = e.epos.pmax - String.length s;})
 			| _ ->
-				raise_toplevel ctx dk with_type (Some p) p
+				raise_toplevel ctx dk with_type None p
 		end
 	| DMDefault | DMNone | DMModuleSymbols _ | DMDiagnostics _ | DMStatistics ->
 		let fields = DisplayFields.collect ctx e_ast e dk with_type p in


### PR DESCRIPTION
Currently seems to cause more issues than it solves.

I've already worked around the multi-line ranges that are sometimes reported in the language server (https://github.com/vshaxe/haxe-languageserver/commit/4a136ab0909c6876d97cfe2af6cca02ddefdbcf3), but this also seems to cause problems in other cases, e.g. here:

![](https://i.imgur.com/BQcbkwP.png)

With this change, completion shows again:

![](https://i.imgur.com/aPrGQwp.png)

Must be the replaceRange not containing the cursor position or something like that..