### PR TITLE
[display] fix class path exploration removing remapped files

### DIFF
--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -38,7 +38,7 @@ let explore_class_paths com timer class_paths recusive f_pack f_module =
 					| _ when Sys.is_directory (dir ^ file) && file.[0] >= 'a' && file.[0] <= 'z' ->
 						begin try
 							begin match PMap.find file com.package_rules with
-								| Forbidden -> ()
+								| Forbidden | Remap _ -> ()
 								| _ -> raise Not_found
 							end
 						with Not_found ->


### PR DESCRIPTION
The issue in the example was:

- explore_class_paths loop comes across flash.display.Bitmap (from std) and calls the callback
- the callback calls TypeloadParse.parse_module' on the file, but the package of the returned module is remapped to openfl.display due to --remap
- this then triggers the CompilationServer.remove_file call, removing the file from the cache

closes #7283