### PR TITLE
Changed shell from bash to sh for process spawn.

### DIFF
--- a/std/lua/_std/sys/io/Process.hx
+++ b/std/lua/_std/sys/io/Process.hx
@@ -44,7 +44,7 @@ class Process {
 	public var  stdin(default,null) : haxe.io.Output;
 
 	static var argQuote = Sys.systemName() == "Windows" ? function(x) return StringTools.quoteWinArg(x,true) : StringTools.quoteUnixArg;
-	static var _shell = Sys.systemName() == "Windows" ? 'cmd.exe' : '/bin/bash';
+	static var _shell = Sys.systemName() == "Windows" ? 'cmd.exe' : '/bin/sh';
 
 	/**
 	  Sets the args for the shell, which will include the cmd to be executed


### PR DESCRIPTION
This is because on an embedded system without bash (a likely case when targeting lua), sys.io.Process() will seg fault.