### PR TITLE
generate_pos_as_range always returns full jobject for replaceRange

### DIFF
--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -90,8 +90,7 @@ let pos_to_range p =
 	]
 
 let generate_pos_as_range p =
-	if p.pmin = -1 then jnull
-	else jobject (pos_to_range p)
+	jobject (pos_to_range p)
 
 let generate_pos_as_location p =
 	if p.pmin = -1 then


### PR DESCRIPTION
Here's a dead simple attempt to address: https://github.com/HaxeFoundation/haxe/issues/7296

I can see that it generates the replaceRange alright for partial completions, but not yet for top level.  Still, I want to see if this simple change works on its own or if I'm missing something.