### PR TITLE
Uniform Unicode

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -82,7 +82,7 @@ let error ctx msg p =
 
 let reserved_flags = [
 	"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
-	"as3";"swc";"macro";"sys";"static"
+	"as3";"swc";"macro";"sys";"static";"utf16"
 	]
 
 let delete_file f = try Sys.remove f with _ -> ()

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -484,7 +484,7 @@ let init_platform com pf =
 	com.config <- get_config com;
 	if com.config.pf_static then define com Define.Static;
 	if com.config.pf_sys then define com Define.Sys else com.package_rules <- PMap.add "sys" Forbidden com.package_rules;
-	if com.config.pf_utf16 then define com Define.Utf16;
+	if com.config.pf_uses_utf16 then define com Define.Utf16;
 	raw_define com name
 
 let add_feature com f =

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -96,6 +96,8 @@ type platform_config = {
 	pf_reserved_type_paths : path list;
 	(** supports function == function **)
 	pf_supports_function_equality : bool;
+	(** uses utf16 encoding with ucs2 api **)
+	pf_uses_utf16 : bool;
 }
 
 type compiler_callback = {
@@ -238,6 +240,7 @@ let default_config =
 		pf_can_skip_non_nullable_argument = true;
 		pf_reserved_type_paths = [];
 		pf_supports_function_equality = true;
+		pf_uses_utf16 = true;
 	}
 
 let get_config com =
@@ -258,6 +261,7 @@ let get_config com =
 			default_config with
 			pf_static = false;
 			pf_capture_policy = CPLoopVars;
+			pf_uses_utf16 = false;
 		}
 	| Neko ->
 		{
@@ -285,6 +289,7 @@ let get_config com =
 		{
 			default_config with
 			pf_static = false;
+			pf_uses_utf16 = false;
 		}
 	| Cpp ->
 		{
@@ -312,6 +317,7 @@ let get_config com =
 			default_config with
 			pf_static = false;
 			pf_capture_policy = CPLoopVars;
+			pf_uses_utf16 = false;
 		}
 	| Hl ->
 		{
@@ -478,6 +484,7 @@ let init_platform com pf =
 	com.config <- get_config com;
 	if com.config.pf_static then define com Define.Static;
 	if com.config.pf_sys then define com Define.Sys else com.package_rules <- PMap.add "sys" Forbidden com.package_rules;
+	if com.config.pf_utf16 then define com Define.Utf16;
 	raw_define com name
 
 let add_feature com f =

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -108,6 +108,7 @@ type strict_defined =
 	| Unsafe
 	| UseNekoc
 	| UseRttiDoc
+	| Utf16
 	| Vcproj
 	| WarnVarShadowing
 	| NoMacroCache
@@ -223,6 +224,7 @@ let infos = function
 	| Unsafe -> "unsafe",("Allow unsafe code when targeting C#",[Platform Cs])
 	| UseNekoc -> "use_nekoc",("Use nekoc compiler instead of internal one",[Platform Neko])
 	| UseRttiDoc -> "use_rtti_doc",("Allows access to documentation during compilation",[])
+	| Utf16 -> "utf16",("Defined for all platforms that have utf16 encoding with ucs2 api",[])
 	| Vcproj -> "vcproj",("GenCPP internal",[Platform Cpp])
 	| WarnVarShadowing -> "warn_var_shadowing",("Warn about shadowing variable declarations",[])
 	| Last -> assert false

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -466,8 +466,13 @@ module StdBytesBuffer = struct
 
 	let addString = vifun2 (fun vthis src encoding ->
 		let this = this vthis in
-		let src = decode_string src in
-		Buffer.add_string this src;
+		let src = decode_vstring src in
+		let s = if src.sascii || StdBytes.encode_native encoding then
+			Lazy.force src.sstring
+		else
+			utf16_to_utf8 (Lazy.force src.sstring)
+		in
+		Buffer.add_string this s;
 		vnull
 	)
 

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -108,8 +108,8 @@ bytes.getString(0,bytes.length,RawNative) == "éあ😂";
 
 haxe.crypto.Md5.encode("éあ😂") == "d30b209e81e40d03dd474b26b77a8a18";
 haxe.crypto.Sha1.encode("éあ😂") == "ec79856a75c98572210430aeb7fe6300b6c4e20c";
-haxe.crypto.Sha224.encode("éあ😂") == "d7967c5f27bd6868e276647583c55ab09d5f45b40610a3d9c6d91b90";
-haxe.crypto.Sha256.encode("éあ😂") == "d0230b8d8ac2d6d0dbcee11ad0e0eaa68a6565347261871dc241571cab591676";
+//haxe.crypto.Sha224.encode("éあ😂") == "d7967c5f27bd6868e276647583c55ab09d5f45b40610a3d9c6d91b90";
+//haxe.crypto.Sha256.encode("éあ😂") == "d0230b8d8ac2d6d0dbcee11ad0e0eaa68a6565347261871dc241571cab591676";
 haxe.crypto.BaseCode.encode("éあ😂","0123456789abcdef") == "c3a9e38182f09f9882";
 
 var buf = new haxe.io.BytesBuffer();

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -35,9 +35,13 @@ s.charCodeAt(0) == "😂".code;
 #else
 // UTF-16 surrogate pairs encoding
 s.length == 2;
-s.charCodeAt(0) == 55357;
-s.charCodeAt(1) == 56834;
+s.charCodeAt(0) == 0xD83D;
+s.charCodeAt(1) == 0xDE02;
 #end
+
+"\u00E9\u3042" == "éあ";
+// "\uD83D\uDE02" == "😂" // gives Invalid Unicode char, that's correct
+// maybe later we can add support for \U******** for out of BMP escape sequence
 
 var s = "é" + "あ";
 s == "éあ";

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -28,7 +28,7 @@ var s = String.fromCharCode(0x1f602);
 s == "😂";
 
 
-#if (php || lua || python)
+#if !utf16
 // native UTF-16 or 32
 s.length == 1;
 s.charCodeAt(0) == "😂".code;
@@ -53,7 +53,7 @@ a[1] == "あ";
 a.join('😂') == s;
 
 var a = s.split('');
-#if ( php || lua || python )
+#if !utf16
 // native UTF-16 or 32
 a.length == 3;
 a[0] == "é";
@@ -98,7 +98,7 @@ str.toHex() == "c3a9e38182f09f9882";
 
 var bytes = haxe.io.Bytes.ofString("éあ😂",RawNative);
 
-#if (cpp || php || lua || eval || python )
+#if !utf16
 bytes.toHex() == "c3a9e38182f09f9882"; // UTF-8 native
 #else
 bytes.toHex() == "e90042303dd802de"; // UTF-16 native
@@ -108,15 +108,8 @@ bytes.getString(0,bytes.length,RawNative) == "éあ😂";
 
 haxe.crypto.Md5.encode("éあ😂") == "d30b209e81e40d03dd474b26b77a8a18";
 haxe.crypto.Sha1.encode("éあ😂") == "ec79856a75c98572210430aeb7fe6300b6c4e20c";
-#if php //utf-8
 haxe.crypto.Sha224.encode("éあ😂") == "d7967c5f27bd6868e276647583c55ab09d5f45b40610a3d9c6d91b90";
 haxe.crypto.Sha256.encode("éあ😂") == "d0230b8d8ac2d6d0dbcee11ad0e0eaa68a6565347261871dc241571cab591676";
-#elseif (lua || python)
-null; // skip these until str2blk is updated
-#else //utf-16
-haxe.crypto.Sha224.encode("éあ😂") == "5132a98e08a503350384c765388a1a3b8b0b532f038eca94c881537e";
-haxe.crypto.Sha256.encode("éあ😂") == "e662834bdc1a099b9f7b8d97975a1b1d9b6730c991268bba0e7fe7427e68be74";
-#end
 haxe.crypto.BaseCode.encode("éあ😂","0123456789abcdef") == "c3a9e38182f09f9882";
 
 var buf = new haxe.io.BytesBuffer();

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -96,15 +96,15 @@ str.toHex() == "c3a9e38182f09f9882";
 ["é", "e"].join("é") == "éée";
 ["é", "e"].join("e") == "éee";
 
-var bytes = haxe.io.Bytes.ofString("éあ😂",RawNative);
+var rawBytes = haxe.io.Bytes.ofString("éあ😂",RawNative);
 
 #if !utf16
-bytes.toHex() == "c3a9e38182f09f9882"; // UTF-8 native
+rawBytes.toHex() == "c3a9e38182f09f9882"; // UTF-8 native
 #else
-bytes.toHex() == "e90042303dd802de"; // UTF-16 native
+rawBytes.toHex() == "e90042303dd802de"; // UTF-16 native
 #end
 
-bytes.getString(0,bytes.length,RawNative) == "éあ😂";
+rawBytes.getString(0,rawBytes.length,RawNative) == "éあ😂";
 
 haxe.crypto.Md5.encode("éあ😂") == "d30b209e81e40d03dd474b26b77a8a18";
 haxe.crypto.Sha1.encode("éあ😂") == "ec79856a75c98572210430aeb7fe6300b6c4e20c";
@@ -121,6 +121,7 @@ bytes.getString(2,3) == "あ";
 bytes.getString(5,4) == "😂";
 bytes.getString(2,7) == "あ😂";
 bytes.getString(9,bytes.length - 9,RawNative) == "éあ😂";
+bytes.sub(9,bytes.length - 9).compare(rawBytes) == 0;
 
 var o = new haxe.io.BytesOutput();
 o.writeString("éあ😂");


### PR DESCRIPTION
This PR adds pf_uses_utf16 (which defines "utf16" native flag)

The goal is to have only two behaviors that can be tested with `#if utf16`: either UTF16 encoding over UCS2 API (JS, HL, and many others) or "full unicode handling" (php, lua, python so far).

Ignore the failing tests for some crypto functions, they are not utf16 compatible for now due to `str2blks`, I'll update the PR later unless someone else wants to contribute the fix.