### PR TITLE
[eval] rework object prototype handling

### DIFF
--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -170,11 +170,9 @@ let rec kind_name ctx kind =
 let call_function f vl = f vl
 
 let object_fields o =
-	let fields = IntMap.fold (fun key vvalue acc -> (key,vvalue) :: acc) o.oextra [] in
 	IntMap.fold (fun key index acc ->
-		if IntMap.mem key o.oremoved then acc
-		else (key,(o.ofields.(index))) :: acc
-	) o.oproto.pinstance_names fields
+		(key,(o.ofields.(index))) :: acc
+	) o.oproto.pinstance_names []
 
 let instance_fields i =
 	IntMap.fold (fun name key acc ->

--- a/src/macro/eval/evalEmitter.ml
+++ b/src/macro/eval/evalEmitter.ml
@@ -84,8 +84,6 @@ let emit_object_declaration proto fa env =
 	vobject {
 		ofields = a;
 		oproto = proto;
-		oextra = IntMap.empty;
-		oremoved = IntMap.empty;
 	}
 
 let emit_array_declaration execs env =
@@ -406,7 +404,6 @@ let emit_anon_field_write exec1 proto i name exec2 env =
 		| VObject o ->
 			if proto == o.oproto then begin
 				o.ofields.(i) <- v2;
-				o.oremoved <- IntMap.remove name o.oremoved;
 			end else set_object_field o name v2
 		| _ ->
 			set_field v1 name v2;

--- a/src/macro/eval/evalEncode.ml
+++ b/src/macro/eval/evalEncode.ml
@@ -119,8 +119,6 @@ let encode_obj _ l =
 	vobject {
 		ofields = Array.of_list (List.map snd sorted);
 		oproto = proto;
-		oextra = IntMap.empty;
-		oremoved = IntMap.empty;
 	}
 
 let encode_obj_s k l =

--- a/src/macro/eval/evalField.ml
+++ b/src/macro/eval/evalField.ml
@@ -38,8 +38,7 @@ let instance_field vi name =
 	vi.ifields.(get_instance_field_index_raise vi.iproto name)
 
 let object_field_raise o name =
-	try o.ofields.(get_instance_field_index_raise o.oproto name)
-	with Not_found -> IntMap.find name o.oextra
+	o.ofields.(get_instance_field_index_raise o.oproto name)
 
 let object_field o name =
 	try object_field_raise o name with Not_found -> vnull

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -121,8 +121,6 @@ let create com api is_macro =
 		toplevel = 	vobject {
 			ofields = [||];
 			oproto = fake_proto key_eval_toplevel;
-			oextra = IntMap.empty;
-			oremoved = IntMap.empty;
 		};
 		eval = eval;
 		exception_stack = [];

--- a/src/macro/eval/evalValue.ml
+++ b/src/macro/eval/evalValue.ml
@@ -108,13 +108,9 @@ and vfunc = value list -> value
 
 and vobject = {
 	(* The fields of the object known when it is created. *)
-	ofields : value array;
+	mutable ofields : value array;
 	(* The prototype of the object. *)
-	oproto : vprototype;
-	(* Extra fields that were added after the object was created. *)
-	mutable oextra : value IntMap.t;
-	(* Map of fields (in ofields) that were deleted via Reflect.deleteField *)
-	mutable oremoved : bool IntMap.t;
+	mutable oproto : vprototype;
 }
 
 and vprototype = {


### PR DESCRIPTION
https://github.com/HaxeFoundation/hashlink/issues/178 made me check structure field handling on eval and realize that it was doing some nonsense that involved map lookups. I've changed it so that we now modify object prototypes when fields are added and removed.

Before:

```
source/Main.hx:72: JSON:
o.i: 9.4
o.f: 9.6
o.ai[0]: 12.6
o.af[0]: 11.7
o.oi: 9
o.of: 9.1
o.str.length: 10.5
o.sub.i: 13.2
o.sub.f: 13.4
o.sub.ai[0]: 15.4
o.sub.af[0]: 15.9
o.sub.oi: 13.3
o.sub.of: 13.1
o.sub.str.length: 14.2
```

After:

```
source/Main.hx:72: JSON:
o.i: 5.2
o.f: 5.3
o.ai[0]: 6.2
o.af[0]: 6.1
o.oi: 5.2
o.of: 5.1
o.str.length: 5.4
o.sub.i: 5.7
o.sub.f: 5.6
o.sub.ai[0]: 6.6
o.sub.af[0]: 6.5
o.sub.oi: 5.7
o.sub.of: 5.7
o.sub.str.length: 6.1
```