### PR TITLE
Support `final x` at expression-level

### DIFF
--- a/src/context/display/display.ml
+++ b/src/context/display/display.ml
@@ -55,7 +55,7 @@ module ExprPreprocessing = struct
 			match fst e with
 			| EVars vl when is_annotated (pos e) && is_completion ->
 				let rec loop2 acc mark vl = match vl with
-					| ((s,pn),tho,eo) as v :: vl ->
+					| ((s,pn),final,tho,eo) as v :: vl ->
 						if mark then
 							loop2 (v :: acc) mark vl
 						else if is_annotated pn then
@@ -79,7 +79,7 @@ module ExprPreprocessing = struct
 								in
 								let p = {p0 with pmax = (pos e).pmin} in
 								let e = if is_annotated p then annotate_marked e else e in
-								loop2 (((s,pn),tho,(Some e)) :: acc) mark vl
+								loop2 (((s,pn),final,tho,(Some e)) :: acc) mark vl
 						end
 					| [] ->
 						List.rev acc,mark

--- a/src/context/display/documentSymbols.ml
+++ b/src/context/display/documentSymbols.ml
@@ -12,7 +12,7 @@ let collect_module_symbols with_locals (pack,decls) =
 		let add name kind location = add name kind location parent in
 		begin match e with
 		| EVars vl ->
-			List.iter (fun ((s,p),_,eo) ->
+			List.iter (fun ((s,p),_,_,eo) ->
 				add s Variable p;
 				expr_opt parent eo
 			) vl

--- a/src/context/display/findReferences.ml
+++ b/src/context/display/findReferences.ml
@@ -52,7 +52,7 @@ let find_possible_references kind name (pack,decls) =
 			expr e1;
 			check KAnyField s;
 		| EVars vl ->
-			List.iter (fun (_,tho,eo) ->
+			List.iter (fun (_,_,tho,eo) ->
 				Option.may type_hint tho;
 				expr_opt eo
 			) vl;

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -193,7 +193,7 @@ and expr_def =
 	| ECall of expr * expr list
 	| ENew of placed_type_path * expr list
 	| EUnop of unop * unop_flag * expr
-	| EVars of (placed_name * type_hint option * expr option) list
+	| EVars of (placed_name * bool * type_hint option * expr option) list
 	| EFunction of placed_name option * func
 	| EBlock of expr list
 	| EFor of expr * expr
@@ -624,10 +624,10 @@ let map_expr loop (e,p) =
 		ENew (t,el)
 	| EUnop (op,f,e) -> EUnop (op,f,loop e)
 	| EVars vl ->
-		EVars (List.map (fun (n,t,eo) ->
+		EVars (List.map (fun (n,b,t,eo) ->
 			let t = opt type_hint t in
 			let eo = opt loop eo in
-			n,t,eo
+			n,b,t,eo
 		) vl)
 	| EFunction (n,f) -> EFunction (n,func f)
 	| EBlock el -> EBlock (List.map loop el)
@@ -708,7 +708,7 @@ let iter_expr loop (e,p) =
 	| EFunction(_,f) ->
 		List.iter (fun (_,_,_,_,eo) -> opt eo) f.f_args;
 		opt f.f_expr
-	| EVars vl -> List.iter (fun (_,_,eo) -> opt eo) vl
+	| EVars vl -> List.iter (fun (_,_,_,eo) -> opt eo) vl
 
 let s_object_key_name name =  function
 	| DoubleQuotes -> "\"" ^ s_escape name ^ "\""
@@ -821,7 +821,7 @@ let s_expr e =
 		if List.length tl > 0 then "<" ^ String.concat ", " (List.map (s_type_param tabs) tl) ^ ">" else ""
 	and s_func_arg tabs ((n,_),o,_,t,e) =
 		if o then "?" else "" ^ n ^ s_opt_type_hint tabs t ":" ^ s_opt_expr tabs e " = "
-	and s_var tabs ((n,_),t,e) =
+	and s_var tabs ((n,_),_,t,e) =
 		n ^ (s_opt_type_hint tabs t ":") ^ s_opt_expr tabs e " = "
 	and s_case tabs (el,e1,e2,_) =
 		"case " ^ s_expr_list tabs el ", " ^
@@ -959,7 +959,7 @@ module Expr = struct
 				loop e1
 			| EVars vl ->
 				add "EVars";
-				List.iter (fun ((n,p),_,eo) -> match eo with
+				List.iter (fun ((n,p),_,_,eo) -> match eo with
 					| None -> ()
 					| Some e ->
 						add n;

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -277,6 +277,8 @@ and generate_tvar ctx v =
 		| TVOPatternVariable -> 3
 		| TVOCatchVariable -> 4
 		| TVOLocalFunction -> 5
+		| TVOLocalFinal -> 6
+		| TVOPatternFinal -> 7
 	in
 	let fields = match v.v_kind with
 			| VUser origin -> ("origin",jint (origin_to_int origin)) :: fields

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -2646,7 +2646,7 @@ module TExprToExpr = struct
 			let arg (v,c) = (v.v_name,v.v_pos), false, v.v_meta, mk_type_hint v.v_type null_pos, (match c with None -> None | Some c -> Some (EConst (tconst_to_const c),e.epos)) in
 			EFunction (None,{ f_params = []; f_args = List.map arg f.tf_args; f_type = mk_type_hint f.tf_type null_pos; f_expr = Some (convert_expr f.tf_expr) })
 		| TVar (v,eo) ->
-			EVars ([(v.v_name,v.v_pos), mk_type_hint v.v_type v.v_pos, eopt eo])
+			EVars ([(v.v_name,v.v_pos), false, mk_type_hint v.v_type v.v_pos, eopt eo])
 		| TBlock el -> EBlock (List.map convert_expr el)
 		| TFor (v,it,e) ->
 			let ein = (EBinop (OpIn,(EConst (Ident v.v_name),it.epos),convert_expr it),it.epos) in

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -92,6 +92,8 @@ and tvar_origin =
 	| TVOPatternVariable
 	| TVOCatchVariable
 	| TVOLocalFunction
+	| TVOLocalFinal
+	| TVOPatternFinal
 
 and tvar_kind =
 	| VUser of tvar_origin
@@ -2646,7 +2648,7 @@ module TExprToExpr = struct
 			let arg (v,c) = (v.v_name,v.v_pos), false, v.v_meta, mk_type_hint v.v_type null_pos, (match c with None -> None | Some c -> Some (EConst (tconst_to_const c),e.epos)) in
 			EFunction (None,{ f_params = []; f_args = List.map arg f.tf_args; f_type = mk_type_hint f.tf_type null_pos; f_expr = Some (convert_expr f.tf_expr) })
 		| TVar (v,eo) ->
-			EVars ([(v.v_name,v.v_pos), false, mk_type_hint v.v_type v.v_pos, eopt eo])
+			EVars ([(v.v_name,v.v_pos), (match v.v_kind with VUser TVOLocalFinal -> true | _ -> false), mk_type_hint v.v_type v.v_pos, eopt eo])
 		| TBlock el -> EBlock (List.map convert_expr el)
 		| TFor (v,it,e) ->
 			let ein = (EBinop (OpIn,(EConst (Ident v.v_name),it.epos),convert_expr it),it.epos) in

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -277,7 +277,7 @@ let rec expr_to_value ctx env e =
 			let v1 = loop e1 in
 			throw v1 (pos e)
 		| EVars vl ->
-			List.iter (fun ((n,_),_,eo) ->
+			List.iter (fun ((n,_),_,_,eo) ->
 				match eo with
 				| Some e ->
 					env.env_extra_locals <- IntMap.add (hash_s n) (loop e) env.env_extra_locals

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -628,10 +628,10 @@ let optimize_completion_expr e args =
 				());
 			map e
 		| EVars vl ->
-			let vl = List.map (fun ((v,pv),t,e) ->
+			let vl = List.map (fun ((v,pv),final,t,e) ->
 				let e = (match e with None -> None | Some e -> Some (loop e)) in
 				decl v (Option.map fst t) e;
-				((v,pv),t,e)
+				((v,pv),final,t,e)
 			) vl in
 			(EVars vl,p)
 		| EBlock el ->
@@ -660,7 +660,7 @@ let optimize_completion_expr e args =
 			let old = save() in
 			let etmp = (EConst (Ident "$tmp"),p) in
 			decl n None (Some (EBlock [
-				(EVars [("$tmp",null_pos),None,None],p);
+				(EVars [("$tmp",null_pos),false,None,None],p);
 				(EFor ((EBinop (OpIn,id,it),p),(EBinop (OpAssign,etmp,(EConst (Ident n),p)),p)),p);
 				etmp
 			],p));
@@ -755,7 +755,7 @@ let optimize_completion_expr e args =
 							with Not_found ->
 								let e = subst_locals lc e in
 								let name = "$tmp_" ^ string_of_int id in
-								tmp_locals := ((name,null_pos),None,Some e) :: !tmp_locals;
+								tmp_locals := ((name,null_pos),false,None,Some e) :: !tmp_locals;
 								tmp_hlocals := PMap.add id name !tmp_hlocals;
 								name
 							) in

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -910,7 +910,9 @@ and block_with_pos acc p s =
 	block_with_pos' acc parse_block_elt p s
 
 and parse_block_elt = parser
-	| [< '(Kwd Var,p1); vl = parse_var_decls p1; p2 = semicolon >] ->
+	| [< '(Kwd Var,p1); vl = parse_var_decls false p1; p2 = semicolon >] ->
+		(EVars vl,punion p1 p2)
+	| [< '(Kwd Final,p1); vl = parse_var_decls true p1; p2 = semicolon >] ->
 		(EVars vl,punion p1 p2)
 	| [< '(Kwd Inline,p1); '(Kwd Function,_); e = parse_function p1 true; _ = semicolon >] -> e
 	| [< e = expr; _ = semicolon >] -> e
@@ -974,38 +976,38 @@ and parse_array_decl p1 s =
 	in
 	EArrayDecl (List.rev el),punion p1 p2
 
-and parse_var_decl_head = parser
-	| [< name, p = dollar_ident; t = popt parse_type_hint >] -> (name,false,t,p)
+and parse_var_decl_head final = parser
+	| [< name, p = dollar_ident; t = popt parse_type_hint >] -> (name,final,t,p)
 
 and parse_var_assignment = parser
 	| [< '(Binop OpAssign,p1); s >] ->
 		Some (expr_or_fail (fun () -> error (Custom "expression expected after =") p1) s)
 	| [< >] -> None
 
-and parse_var_assignment_resume vl name pn t s =
+and parse_var_assignment_resume final vl name pn t s =
 	try
 		let eo = parse_var_assignment s in
-		((name,pn),false,t,eo)
+		((name,pn),final,t,eo)
 	with Display e ->
-		let v = ((name,pn),false,t,Some e) in
+		let v = ((name,pn),final,t,Some e) in
 		let e = (EVars(List.rev (v :: vl)),punion pn (pos e)) in
 		display e
 
-and parse_var_decls_next vl = parser
-	| [< '(Comma,p1); name,final,t,pn = parse_var_decl_head; s >] ->
-		let v_decl = parse_var_assignment_resume vl name pn t s in
-		parse_var_decls_next (v_decl :: vl) s
+and parse_var_decls_next final vl = parser
+	| [< '(Comma,p1); name,final,t,pn = parse_var_decl_head final; s >] ->
+		let v_decl = parse_var_assignment_resume final vl name pn t s in
+		parse_var_decls_next final (v_decl :: vl) s
 	| [< >] ->
 		vl
 
-and parse_var_decls p1 = parser
-	| [< name,final,t,pn = parse_var_decl_head; s >] ->
-		let v_decl = parse_var_assignment_resume [] name pn t s in
-		List.rev (parse_var_decls_next [v_decl] s)
+and parse_var_decls final p1 = parser
+	| [< name,final,t,pn = parse_var_decl_head final; s >] ->
+		let v_decl = parse_var_assignment_resume final [] name pn t s in
+		List.rev (parse_var_decls_next final [v_decl] s)
 	| [< s >] -> error (Custom "Missing variable identifier") p1
 
-and parse_var_decl = parser
-	| [< name,final,t,pn = parse_var_decl_head; v_decl = parse_var_assignment_resume [] name pn t >] -> v_decl
+and parse_var_decl final = parser
+	| [< name,final,t,pn = parse_var_decl_head final; v_decl = parse_var_assignment_resume final [] name pn t >] -> v_decl
 
 and inline_function = parser
 	| [< '(Kwd Inline,_); '(Kwd Function,p1) >] -> true, p1
@@ -1016,7 +1018,9 @@ and parse_macro_expr p = parser
 		let _, to_type, _  = reify !in_macro in
 		let t = to_type t p in
 		(ECheckType (t,(CTPath { tpackage = ["haxe";"macro"]; tname = "Expr"; tsub = Some "ComplexType"; tparams = [] },null_pos)),p)
-	| [< '(Kwd Var,p1); vl = psep Comma parse_var_decl >] ->
+	| [< '(Kwd Var,p1); vl = psep Comma (parse_var_decl false) >] ->
+		reify_expr (EVars vl,p1) !in_macro
+	| [< '(Kwd Final,p1); vl = psep Comma (parse_var_decl true) >] ->
 		reify_expr (EVars vl,p1) !in_macro
 	| [< d = parse_class None [] [] false >] ->
 		let _,_,to_type = reify !in_macro in
@@ -1105,7 +1109,8 @@ and expr = parser
 		| [< e = parse_macro_expr p >] -> e
 		| [< >] -> serror()
 		end
-	| [< '(Kwd Var,p1); v = parse_var_decl >] -> (EVars [v],p1)
+	| [< '(Kwd Var,p1); v = parse_var_decl false >] -> (EVars [v],p1)
+	| [< '(Kwd Final,p1); v = parse_var_decl true >] -> (EVars [v],p1)
 	| [< '(Const c,p); s >] -> expr_next (EConst c,p) s
 	| [< '(Kwd This,p); s >] -> expr_next (EConst (Ident "this"),p) s
 	| [< '(Kwd True,p); s >] -> expr_next (EConst (Ident "true"),p) s
@@ -1271,6 +1276,7 @@ and parse_guard = parser
 
 and expr_or_var = parser
 	| [< '(Kwd Var,p1); name,p2 = dollar_ident; >] -> EVars [(name,p2),false,None,None],punion p1 p2
+	| [< '(Kwd Final,p1); name,p2 = dollar_ident; >] -> EVars [(name,p2),true,None,None],punion p1 p2
 	| [< e = secure_expr >] -> e
 
 and parse_switch_cases eswitch cases = parser

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -271,10 +271,11 @@ let reify in_macro =
 			) [] p in
 			expr "EUnop" [op;to_bool (flag = Postfix) p;loop e]
 		| EVars vl ->
-			expr "EVars" [to_array (fun ((n,pn),th,e) p ->
+			expr "EVars" [to_array (fun ((n,pn),final,th,e) p ->
 				let fields = [
 					(* "name", to_obj ["name",to_string n pn;"pos",to_pos pn] p; *)
 					"name", to_string n pn;
+					"isFinal",to_bool final p;
 					"type", to_opt to_type_hint th p;
 					"expr", to_opt to_expr e p;
 				] in

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -273,11 +273,10 @@ let reify in_macro =
 		| EVars vl ->
 			expr "EVars" [to_array (fun ((n,pn),final,th,e) p ->
 				let fields = [
-					(* "name", to_obj ["name",to_string n pn;"pos",to_pos pn] p; *)
 					"name", to_string n pn;
-					"isFinal",to_bool final p;
 					"type", to_opt to_type_hint th p;
 					"expr", to_opt to_expr e p;
+					"isFinal",to_bool final p;
 				] in
 				to_obj fields p
 			) vl p]

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -673,7 +673,7 @@ let type_macro ctx mode cpath f (el:Ast.expr list) p =
 			with Error (Custom _,_) ->
 				(* if it's not a constant, let's make something that is typed as haxe.macro.Expr - for nice error reporting *)
 				(EBlock [
-					(EVars [("__tmp",null_pos),Some (CTPath ctexpr,p),Some (EConst (Ident "null"),p)],p);
+					(EVars [("__tmp",null_pos),false,Some (CTPath ctexpr,p),Some (EConst (Ident "null"),p)],p);
 					(EConst (Ident "__tmp"),p);
 				],p)
 			) in
@@ -725,7 +725,7 @@ let type_macro ctx mode cpath f (el:Ast.expr list) p =
 						else
 							List.map Interp.decode_field (Interp.decode_array v)
 					in
-					(EVars [("fields",null_pos),Some (CTAnonymous fields,p),None],p)
+					(EVars [("fields",null_pos),false,Some (CTAnonymous fields,p),None],p)
 				| MMacroType ->
 					let t = if v = Interp.vnull then
 						mk_mono()

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -174,7 +174,7 @@ module Pattern = struct
 		let verror name p =
 			error (Printf.sprintf "Variable %s must appear exactly once in each sub-pattern" name) p
 		in
-		let add_local name p =
+		let add_local final name p =
 			let is_wildcard_local = name = "_" in
 			if not is_wildcard_local && PMap.mem name pctx.current_locals then error (Printf.sprintf "Variable %s is bound multiple times" name) p;
 			match pctx.or_locals with
@@ -184,7 +184,7 @@ module Pattern = struct
 				pctx.current_locals <- PMap.add name (v,p) pctx.current_locals;
 				v
 			| _ ->
-				let v = alloc_var (VUser TVOPatternVariable) name t p in
+				let v = alloc_var (VUser (if final then TVOPatternFinal else TVOPatternVariable)) name t p in
 				pctx.current_locals <- PMap.add name (v,p) pctx.current_locals;
 				ctx.locals <- PMap.add name v ctx.locals;
 				v
@@ -278,7 +278,7 @@ module Pattern = struct
 								pctx.ctx.com.warning (Printf.sprintf "`case %s` has been deprecated, use `case var %s` instead" s s) p *)
 						| l -> pctx.ctx.com.warning ("Potential typo detected (expected similar values are " ^ (String.concat ", " l) ^ "). Consider using `var " ^ s ^ "` instead") p
 					end;
-					let v = add_local s p in
+					let v = add_local false s p in
 					PatVariable v
 				end
 			| exc ->
@@ -308,8 +308,8 @@ module Pattern = struct
 						if i = "_" then PatAny
 						else handle_ident i (pos e)
 				end
-			| EVars([(s,p),_,None,None]) ->
-				let v = add_local s p in
+			| EVars([(s,p),final,None,None]) ->
+				let v = add_local final s p in
 				PatVariable v
 			| ECall(e1,el) ->
 				let e1 = type_expr ctx e1 (WithType t) in
@@ -442,7 +442,7 @@ module Pattern = struct
 			| EBinop(OpAssign,e1,e2) ->
 				let rec loop dko e = match e with
 					| (EConst (Ident s),p) ->
-						let v = add_local s p in
+						let v = add_local false s p in
 						begin match dko with
 						| None -> ()
 						| Some dk -> ignore(TyperDisplay.display_expr ctx e (mk (TLocal v) v.v_type p) dk (WithType t) p);
@@ -457,7 +457,7 @@ module Pattern = struct
 			| EBinop(OpArrow,e1,e2) ->
 				let restore = save_locals ctx in
 				ctx.locals <- pctx.ctx_locals;
-				let v = add_local "_" null_pos in
+				let v = add_local false "_" null_pos in
 				let e1 = type_expr ctx e1 Value in
 				v.v_name <- "tmp";
 				restore();

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -308,7 +308,7 @@ module Pattern = struct
 						if i = "_" then PatAny
 						else handle_ident i (pos e)
 				end
-			| EVars([(s,p),None,None]) ->
+			| EVars([(s,p),_,None,None]) ->
 				let v = add_local s p in
 				PatVariable v
 			| ECall(e1,el) ->

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -208,7 +208,7 @@ let transform_abstract_field com this_t a_t a f =
 	| FProp _ when not stat ->
 		error "Member property accessors must be get/set or never" p;
 	| FFun fu when fst f.cff_name = "new" && not stat ->
-		let init p = (EVars [("this",null_pos),Some this_t,None],p) in
+		let init p = (EVars [("this",null_pos),false,Some this_t,None],p) in
 		let cast e = (ECast(e,None)),pos e in
 		let ret p = (EReturn (Some (cast (EConst (Ident "this"),p))),p) in
 		let meta = (Meta.Impl,[],null_pos) :: (Meta.NoCompletion,[],null_pos) :: f.cff_meta in
@@ -341,7 +341,7 @@ let build_enum_abstract ctx c a fields p =
 		| _ ->
 			()
 	) fields;
-	EVars [("",null_pos),Some (CTAnonymous fields,p),None],p
+	EVars [("",null_pos),false,Some (CTAnonymous fields,p),None],p
 
 let apply_macro ctx mode path el p =
 	let cpath, meth = (match List.rev (ExtString.String.nsplit path ".") with
@@ -540,7 +540,7 @@ let build_fields (ctx,cctx) c fields =
 	c.cl_build <- (fun() -> BuildMacro pending);
 	build_module_def ctx (TClassDecl c) c.cl_meta get_fields cctx.context_init (fun (e,p) ->
 		match e with
-		| EVars [_,Some (CTAnonymous f,p),None] ->
+		| EVars [_,_,Some (CTAnonymous f,p),None] ->
 			let f = List.map (fun f ->
 				let f = match cctx.abstract with
 					| Some a ->

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -608,7 +608,7 @@ let init_module_type ctx context_init do_init (decl,p) =
 		let init () = List.iter (fun f -> f()) !context_init in
 		TypeloadFields.build_module_def ctx (TEnumDecl e) e.e_meta get_constructs init (fun (e,p) ->
 			match e with
-			| EVars [_,Some (CTAnonymous fields,p),None] ->
+			| EVars [_,_,Some (CTAnonymous fields,p),None] ->
 				constructs := List.map (fun f ->
 					let args, params, t = (match f.cff_kind with
 					| FVar (t,None) -> [], [], t

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1470,7 +1470,7 @@ and type_array_access ctx e1 e2 p mode =
 		AKExpr (mk (TArray (e1,e2)) pt p)
 
 and type_vars ctx vl p =
-	let vl = List.map (fun ((v,pv),t,e) ->
+	let vl = List.map (fun ((v,pv),final,t,e) ->
 		try
 			let t = Typeload.load_type_hint ctx p t in
 			let e = (match e with

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -35,6 +35,8 @@ open Calls
 
 let check_assign ctx e =
 	match e.eexpr with
+	| TLocal {v_kind = VUser (TVOLocalFinal | TVOPatternFinal)} ->
+		error "Cannot assign to final" e.epos
 	| TLocal {v_extra = None} | TArray _ | TField _ | TIdent _ ->
 		()
 	| TConst TThis | TTypeExpr _ when ctx.untyped ->
@@ -1481,7 +1483,7 @@ and type_vars ctx vl p =
 					Some e
 			) in
 			if starts_with v '$' then display_error ctx "Variables names starting with a dollar are not allowed" p;
-			let v = add_local_with_origin ctx TVOLocalVariable v t pv in
+			let v = add_local_with_origin ctx (if final then TVOLocalFinal else TVOLocalVariable) v t pv in
 			if ctx.in_display && DisplayPosition.encloses_display_position pv then
 				DisplayEmitter.display_variable ctx v pv;
 			v,e

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -313,6 +313,11 @@ typedef Var = {
 		The expression of the variable, if available.
 	**/
 	var expr : Null<Expr>;
+
+	/**
+		Whether or not the variable can be assigned to.
+	**/
+	var ?isFinal : Bool;
 }
 
 /**

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -172,8 +172,11 @@ class ExprTools {
 			case EUnop(op, postFix, e): EUnop(op, postFix, f(e));
 			case EVars(vars):
 				var ret = [];
-				for (v in vars)
-					ret.push( { name: v.name, type:v.type, expr: opt(v.expr, f), isFinal: v.isFinal } );
+				for (v in vars) {
+					var v2:Var = { name: v.name, type:v.type, expr: opt(v.expr, f) };
+					if (v.isFinal != null) v2.isFinal = v.isFinal;
+					ret.push(v2);
+				}
 				EVars(ret);
 			case EBlock(el): EBlock(ExprArrayTools.map(el, f));
 			case EFor(it, expr): EFor(f(it), f(expr));

--- a/std/haxe/macro/ExprTools.hx
+++ b/std/haxe/macro/ExprTools.hx
@@ -173,7 +173,7 @@ class ExprTools {
 			case EVars(vars):
 				var ret = [];
 				for (v in vars)
-					ret.push( { name: v.name, type:v.type, expr: opt(v.expr, f) } );
+					ret.push( { name: v.name, type:v.type, expr: opt(v.expr, f), isFinal: v.isFinal } );
 				EVars(ret);
 			case EBlock(el): EBlock(ExprArrayTools.map(el, f));
 			case EFor(it, expr): EFor(f(it), f(expr));

--- a/tests/unit/src/unitstd/haxe/macro/ExprTools.unit.hx
+++ b/tests/unit/src/unitstd/haxe/macro/ExprTools.unit.hx
@@ -106,7 +106,7 @@ var map = haxe.macro.ExprTools.map;
 function check(e, ?pos) {
 	var e2 = map(e, wrap);
 	var e3 = map(e, unwrap);
-	eq(Std.string(e.expr), Std.string(e3.expr), pos);
+	eq(haxe.macro.ExprTools.toString(e), haxe.macro.ExprTools.toString(e3), pos);
 }
 map(econst, wrap).expr == econst.expr;
 map(econtinue, wrap).expr == econtinue.expr;


### PR DESCRIPTION
This allows `final x` instead of `var x` at expression-level. It works just like `var x` except that you cannot assign to it.

At macro-level, a `isFinal` field has been added to the `Var` structure. At typing-level, we use the variable origin to keep track of this. I'll probably review that again because it's tied to `VUser`, which doesn't make much sense. Still, I would like to merge this first.

Closes #6584