### PR TITLE
removed --dead-code-elimination from args

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -451,14 +451,14 @@ and usage_string arg_spec usage =
 	let cat_order = ["Target";"Compilation";"Optimization";"Debug";"Batch";"Services";"Compilation Server";"Target-specific";"Miscellaneous"] in
 	let cats = List.filter (fun x -> List.mem x (List.map (fun (cat, _, _, _, _, _) -> cat) args)) cat_order in
 	let max_length = List.fold_left max 0 (List.map String.length (List.map (fun (_, ok, _, _, hint, _) -> make_label ok hint) args)) in
-	usage ^ (String.concat "\n" (List.flatten (List.map (fun cat -> [cat] @ (List.map (fun (cat, ok, dep, spec, hint, doc) ->
+	usage ^ (String.concat "\n" (List.flatten (List.map (fun cat -> ["\n"^cat^":"] @ (List.map (fun (cat, ok, dep, spec, hint, doc) ->
 		let label = make_label ok hint in
 		Printf.sprintf "  %s%s  %s" label (String.make (max_length - (String.length label)) ' ') doc
 	) (List.filter (fun (cat', _, _, _, _, _) -> (if List.mem cat' cat_order then cat' else "Miscellaneous") = cat) args))) cats)))
 
 and init ctx =
 	let usage = Printf.sprintf
-		"Haxe Compiler %s - (C)2005-2018 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files...]\n\n"
+		"Haxe Compiler %s - (C)2005-2018 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files...]\n"
 		s_version (if Sys.os_type = "Win32" then ".exe" else "")
 	in
 	let com = ctx.com in
@@ -564,7 +564,7 @@ try
 		("Compilation",["-L";"--library"],["-lib"],Arg.String (fun l ->
 			cp_libs := l :: !cp_libs;
 			Common.raw_define com l;
-		),"<library[:version]>","use a haxelib library");
+		),"<name[:ver]>","use a haxelib library");
 		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
 			begin match var with
 				| "no_copt" | "no-copt" -> com.foptimize <- false;
@@ -605,7 +605,7 @@ try
 		),"[args...]","args that will be passed to the macro interpreter");
 	] in
 	let adv_args_spec = [
-		("Optimization",["--dce";"--dead-code-elimination"],["-dce"],Arg.String (fun mode ->
+		("Optimization",["--dce"],["-dce"],Arg.String (fun mode ->
 			(match mode with
 			| "std" | "full" | "no" -> ()
 			| _ -> raise (Arg.Bad "Invalid DCE mode, expected std | full | no"));


### PR DESCRIPTION
Make the help information more friendly when typing `haxe --help`

origin:
```bash
Haxe Compiler 4.0.0-preview.4+c1e9da2ca - (C)2005-2018 Haxe Foundation
Usage: haxe.exe <target> [options] [hxml files...]

Target
  --js <file>                                   compile code to JavaScript file
  --lua <file>                                  compile code to Lua file
  --swf <file>                                  compile code to Flash SWF file
  --as3 <directory>                             generate AS3 code into target di
rectory
  --neko <file>                                 compile code to Neko Binary
  --php <directory>                             generate PHP code into target di
rectory
  --cpp <directory>                             generate C++ code into target di
rectory
  --cppia <file>                                generate Cppia code into target
file
  --cs <directory>                              generate C# code into target dir
ectory
  --java <directory>                            generate Java code into target d
irectory
  --python <file>                               generate Python code as target f
ile
  --hl <file>                                   compile HL code as target file
  --interp                                      interpret the program using inte
rnal macro system
```

new:
```bash
Haxe Compiler 4.0.0-preview.4+c1e9da2ca - (C)2005-2018 Haxe Foundation
Usage: haxe.exe <target> [options] [hxml files...]

Target:
  --js <file>                   compile code to JavaScript file
  --lua <file>                  compile code to Lua file
  --swf <file>                  compile code to Flash SWF file
  --as3 <directory>             generate AS3 code into target directory
  --neko <file>                 compile code to Neko Binary
  --php <directory>             generate PHP code into target directory
  --cpp <directory>             generate C++ code into target directory
  --cppia <file>                generate Cppia code into target file
  --cs <directory>              generate C# code into target directory
  --java <directory>            generate Java code into target directory
  --python <file>               generate Python code as target file
  --hl <file>                   compile HL code as target file
  --interp                      interpret the program using internal macro syste
m

Compilation:
  -p, --class-path <path>       add a directory to find source files
  -m, --main <class>            select startup class
  -L, --library <name[:ver]>    use a haxelib library
  -D, --define <var[=value]>    define a conditional compilation flag
  -r, --resource <file>[@name]  add a named resource file
```