### PR TITLE
[js] use ES6 Map for haxe.ds.*Map when -D js-es >= 6

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -156,6 +156,33 @@ class Boot {
 		}
 	}
 
+	#if (js_es >= 6)
+	static function __copyMap<K,V>(src:js.Map<K,V>, dst:js.Map<K,V>):js.Map<K,V> {
+		var iter = src.entries(), step = iter.next();
+		while (!step.done) {
+			dst.set(step.value.key, step.value.value);
+			step = iter.next();
+		}
+		return dst;
+	}
+
+	static function __mapToString<K,V>(m:js.Map<K,V>):String {
+		var s = new StringBuf();
+		s.add("{");
+		var iter = m.entries(), step = iter.next();
+		while (!step.done) {
+			s.add(step.value.key);
+			s.add(" => ");
+			s.add(Std.string(step.value.value));
+			step = iter.next();
+			if (!step.done)
+				s.add(", ");
+		}
+		s.add("}");
+		return s.toString();
+	}
+	#end
+
 	private static function __interfLoop(cc : Dynamic,cl : Dynamic) {
 		if( cc == null )
 			return false;

--- a/std/js/JsIterator.hx
+++ b/std/js/JsIterator.hx
@@ -10,3 +10,23 @@ typedef JsIteratorStep<T> = {
 	done:Bool,
 	?value:T
 }
+
+class JsIteratorAdapter<T> {
+	var i:JsIterator<T>;
+	var s:JsIteratorStep<T>;
+
+	public inline function new(i) {
+		this.i = i;
+	}
+
+	public inline function hasNext() {
+		if (s == null) s = i.next();
+		return !s.done;
+	}
+
+	public inline function next() {
+		var v = s.value;
+		s = i.next();
+		return v;
+	}
+}

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -22,7 +22,18 @@
 package haxe.ds;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int,T> {
-
+#if (js_es >= 6)
+	var m:js.Map<Int,T>;
+	@:pure public inline function new() this.m = new js.Map();
+	@:pure public inline function get(key:Int):Null<T> return m.get(key);
+	public inline function set(key:Int, value:T):Void m.set(key, value);
+	@:pure public inline function exists(key:Int):Bool return m.has(key);
+	public inline function remove(key:Int):Bool return m.delete(key);
+	@:pure public inline function keys():Iterator<Int> return new js.JsIterator.JsIteratorAdapter(m.keys());
+	@:pure public inline function iterator():Iterator<T> return new js.JsIterator.JsIteratorAdapter(m.values());
+	@:pure public inline function copy():IntMap<T> return { var copy = new IntMap(); @:privateAccess js.Boot.__copyMap(this.m, copy.m); copy; };
+	@:pure public inline function toString():String return @:privateAccess js.Boot.__mapToString(m);
+#else
 	private var h : Dynamic;
 
 	public inline function new() : Void {
@@ -82,5 +93,5 @@ package haxe.ds;
 		s.add("}");
 		return s.toString();
 	}
-
+#end
 }

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -24,7 +24,18 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap<K:{ }, V> implements haxe.Constraints.IMap<K,V> {
-
+#if (js_es >= 6)
+	var m:js.Map<K,V>;
+	@:pure public inline function new() this.m = new js.Map();
+	@:pure public inline function get(key:K):Null<V> return m.get(key);
+	public inline function set(key:K, value:V):Void m.set(key, value);
+	@:pure public inline function exists(key:K):Bool return m.has(key);
+	public inline function remove(key:K):Bool return m.delete(key);
+	@:pure public inline function keys():Iterator<K> return new js.JsIterator.JsIteratorAdapter(m.keys());
+	@:pure public inline function iterator():Iterator<V> return new js.JsIterator.JsIteratorAdapter(m.values());
+	@:pure public inline function copy():ObjectMap<K,V> return { var copy = new ObjectMap(); @:privateAccess js.Boot.__copyMap(this.m, copy.m); copy; };
+	@:pure public inline function toString():String return @:privateAccess js.Boot.__mapToString(m);
+#else
 	static var count:Int;
 
 	// initialize count through __init__ magic, because these are generated
@@ -108,4 +119,5 @@ class ObjectMap<K:{ }, V> implements haxe.Constraints.IMap<K,V> {
 		s.add("}");
 		return s.toString();
 	}
+#end
 }

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -21,6 +21,7 @@
  */
 package haxe.ds;
 
+#if (js_es < 6)
 private class StringMapIterator<T> {
 	var map : StringMap<T>;
 	var keys : Array<String>;
@@ -39,9 +40,21 @@ private class StringMapIterator<T> {
 		return map.get(keys[index++]);
 	}
 }
+#end
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String,T> {
-
+#if (js_es >= 6)
+	var m:js.Map<String,T>;
+	@:pure public inline function new() this.m = new js.Map();
+	@:pure public inline function get(key:String):Null<T> return m.get(key);
+	public inline function set(key:String, value:T):Void m.set(key, value);
+	@:pure public inline function exists(key:String):Bool return m.has(key);
+	public inline function remove(key:String):Bool return m.delete(key);
+	@:pure public inline function keys():Iterator<String> return new js.JsIterator.JsIteratorAdapter(m.keys());
+	@:pure public inline function iterator():Iterator<T> return new js.JsIterator.JsIteratorAdapter(m.values());
+	@:pure public inline function copy():StringMap<T> return { var copy = new StringMap(); @:privateAccess js.Boot.__copyMap(this.m, copy.m); copy; };
+	@:pure public inline function toString():String return @:privateAccess js.Boot.__mapToString(m);
+#else
 	private var h : Dynamic;
 	private var rh : Dynamic;
 
@@ -150,5 +163,5 @@ private class StringMapIterator<T> {
 	static function __init__() : Void {
 		untyped __js__("var __map_reserved = {};");
 	}
-
+#end
 }

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -28,12 +28,12 @@ class Js {
 		getJSDependencies();
 
 		var jsOutputs = [
-			for (es3 in       [[], ["-D", "js-es=3"]])
+			for (es in        [[], ["-D", "js-es=3"], ["-D", "js-es=6"]])
 			for (unflatten in [[], ["-D", "js-unflatten"]])
 			for (classic in   [[], ["-D", "js-classic"]])
 			for (enums_as_objects in [[], ["-D", "js-enums-as-arrays"]])
 			{
-				var extras = args.concat(es3).concat(unflatten).concat(classic).concat(enums_as_objects);
+				var extras = args.concat(es).concat(unflatten).concat(classic).concat(enums_as_objects);
 
 				runCommand("haxe", ["compile-js.hxml"].concat(extras));
 

--- a/tests/unit/src/unitstd/Map.unit.hx
+++ b/tests/unit/src/unitstd/Map.unit.hx
@@ -221,7 +221,7 @@ map["bar"] = map["foo"] = 9;
 map["bar"] == 9;
 map["foo"] == 9;
 
-#if !(java || cs)
+#if !(java || cs || js_es >= 6)
 ['' => ''].keys().next() == '';
 ['' => ''].iterator().next() == '';
 [2 => 3].keys().next() == 2;


### PR DESCRIPTION
Some notes:
 * I tried to use a common base class for them, but `@:coreApi` checks don't seem to look for parent-class methods, so I ended up copy-pasting the implementation, moving larger methods into `js.Boot`.
 * Ideally we would inherit from native `Map` instead of wrapping it, but it's not really possible until we implement #6546.
 * I added `JsIteratorAdapter` that adaps ES6 iteration protocol to haxe, but it only works if you call `hasNext` before `next`, which is required by the spec according to @ncannasse. However we have [some unit tests that tell otherwise](https://github.com/HaxeFoundation/haxe/blob/c27156a9508f86e6c47460d73c50292db6cc9d9e/tests/unit/src/unitstd/Map.unit.hx#L225-L230) (added in https://github.com/HaxeFoundation/haxe/commit/789c02208892a208e1232acb280f791da440a01a and related to the discussion in https://github.com/HaxeFoundation/haxe/issues/3908). So I added another guard to the `#if` for now. I guess we should remove the test and update the documentation for `Iterator<T>` to make things clear.
 * I didn't use `new js.Map(this.m)` for the `copy` method as [it's not supported by IE](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#Browser_compatibility).
 * I looked into also implementing `haxe.ds.WeakMap` using the native ES6 WeakMap, but unfortunately [its API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) is insufficient:
   > Because of references being weak, WeakMap keys are not enumerable (i.e. there is no method giving you a list of the keys). If they were, the list would depend on the state of garbage collection, introducing non-determinism. If you want to have a list of keys, you should use a Map.
  
   This raises questions if `haxe.ds.WeakMap` should have `iterator` and `copy` methods.