### PR TITLE
[js] Add ArrayBuffer.slice polyfill for IE 10 support

### DIFF
--- a/std/js/html/ArrayBuffer.hx
+++ b/std/js/html/ArrayBuffer.hx
@@ -34,3 +34,22 @@ extern class ArrayBuffer
 	function new( length : Int ) : Void;
 	function slice( begin : Int, ?end : Int ) : ArrayBuffer;
 }
+
+#if (js_es <= 5)
+@:ifFeature('js.html.ArrayBuffer.slice')
+private class ArrayBufferCompat {
+
+	static function sliceImpl(begin, ?end) {	
+		var u = new js.html.Uint8Array(js.Lib.nativeThis, begin, end == null ? null : (end - begin));
+		var resultArray = new js.html.Uint8Array(u.byteLength);	
+		resultArray.set(u);	
+		return resultArray.buffer;
+	}
+
+	static inline function __init__(): Void untyped {
+		// IE10 ArrayBuffer.slice polyfill
+		if( __js__("ArrayBuffer").prototype.slice == null ) __js__("ArrayBuffer").prototype.slice = sliceImpl;
+	}
+
+}
+#end

--- a/std/js/html/ArrayBuffer.hx
+++ b/std/js/html/ArrayBuffer.hx
@@ -46,7 +46,7 @@ private class ArrayBufferCompat {
 		return resultArray.buffer;
 	}
 
-	static inline function __init__(): Void untyped {
+	static function __init__(): Void untyped {
 		// IE10 ArrayBuffer.slice polyfill
 		if( __js__("ArrayBuffer").prototype.slice == null ) __js__("ArrayBuffer").prototype.slice = sliceImpl;
 	}


### PR DESCRIPTION
- Fixes failing CI test for  IE 10 on Windows 7

- TypedArray polyfills were removed in #7406, IE 10 supports TypedArrays but it's missing the `slice` method on `ArrayBuffer`. `ArrayBuffer.slice` is used by `haxe.io.Bytes` so I think it's worth polyfilling in haxe

- Polyfill is only emitted if targeting es5 or below and the `ArrayBuffer.slice` method is used