### PR TITLE
Fix for "0" / 0 behavior of JS Std.parseInt

### DIFF
--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -45,7 +45,7 @@ import js.Boot;
 	public static function parseInt( x : String ) : Null<Int> {
 		var v = untyped __js__("parseInt")(x, 10);
 		// parse again if hexadecimal
-		if( v == 0 && (x.charCodeAt(1) == 'x'.code || x.charCodeAt(1) == 'X'.code) )
+		if( v == 0 && untyped __js__('typeof {0}=="string"',x) && (x.charCodeAt(1) == 'x'.code || x.charCodeAt(1) == 'X'.code) )
 			v = untyped __js__("parseInt")(x);
 		if( untyped __js__("isNaN")(v) )
 			return null;


### PR DESCRIPTION
The default behavior of the Haxe JS parseInt uses the JavaScript native `parseInt` -- that's really nice, it deals with some irritations of JavaScript. So it handles both `number` and `string`, which is handy because JavaScript believes these are equal:

```
123=="123"  // true
0=="0"  // true
```

This general problem with JavaScript means that JS libraries are often careless about adhering to the typiness of numbers. So passing in either a `0` or a `"0"` is likely, from any given data source, like server-provided JSON data.

The native `parseInt` does handle this, so it works for every number passed in... except for `0`. Because Haxe's desire to handle the `0x` prefix means that if native `parseInt` returns `0`, it assumes that `x` is definitely a String, accessing the `charCodeAt` function, throwing: `Uncaught TypeError: s.charCodeAt is not a function`

I'm suggesting we should be more careful with that assumption, since JS is stupid about strings and numbers, we need to ensure that `x` indeed is a string.

Suggested testcase:

```haxe
package cases;

class Issue7458 extends unit.Test {
	function test() {
#if js
    // JavaScript parseInt needs to handle string or number. 0 used to throw.
    eq( Std.parseInt(untyped 1), Std.parseInt(untyped "1") );
    eq( Std.parseInt(untyped 0), Std.parseInt(untyped "0") );
#end
	}
}

```

**The long story:**

My coworker just asked me why he had to put this check in --

```haxe
  function foo(num:String) {
    if (num!="0" && Std.parseInt(num)==1) { ... }
```

_'The code throws without this check. Why does Haxe's Std.parseInt throw when "0" is passed in?'_, he asked. I had to explain that it's not really "0", and JavaScript is dumb. I would like to not have to explain this.