### PR TITLE
A faster / more stable JavaScript Std.parseInt

### DIFF
--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -43,10 +43,7 @@ import js.Boot;
 
 	@:pure
 	public static function parseInt( x : String ) : Null<Int> {
-		var v = untyped __js__("parseInt")(x, 10);
-		// parse again if hexadecimal
-		if( v == 0 && (x.charCodeAt(1) == 'x'.code || x.charCodeAt(1) == 'X'.code) )
-			v = untyped __js__("parseInt")(x);
+		var v = untyped __js__('parseInt({0}, {0} && {0}[0]=="0" && ({0}[1]=="x" || {0}[1]=="X") ? 16 : 10)', x);
 		if( untyped __js__("isNaN")(v) )
 			return null;
 		return cast v;


### PR DESCRIPTION
A possibly improved version of the JS `Std.parseInt` that:

1) Avoids calling `parseInt` twice by determining up-front whether the String has a leading `"0x"` or `"0X"`.
2) Uses string array access (an [es5 standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access)) instead of `.charCodeAt`, which throws less often.

Here's the primary logic, as rendered JavaScript:

```javascript
var v = parseInt(x, x && x[0]=="0" && (x[1]=="x" || x[1]=="X") ? 16 : 10);
```

It also happens to:
- be 2X faster at parsing hex values, ~24% faster at non-hex values, [tested in Chrome 69 / Win 10](https://jsperf.com/newparseint/1).
- fix the exception thrown when number 0 is passed in accidentally.

The only question is -- is it worth the change? Maybe. Hopefully the unit tests show it to be 100% compatible with the existing implementation, but [this test shows](https://try.haxe.org/#2c911) it's very promising.

Opinions? Is array access on string legit? Worth the change? @back2dos @elsassph @kevinresol @ncannasse 