### PR TITLE
Add @:using

### DIFF
--- a/src/context/display/displayFields.ml
+++ b/src/context/display/displayFields.ml
@@ -95,6 +95,12 @@ let collect_static_extensions ctx items e p =
 	| _ ->
 		let items = loop items ctx.m.module_using in
 		let items = loop items ctx.g.global_using in
+		let items = try
+			let mt = module_type_of_type e.etype in
+			loop items (t_infos mt).mt_using
+		with Exit ->
+			items
+		in
 		items
 
 let collect ctx e_ast e dk with_type p =

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -855,6 +855,12 @@ let rec string_list_of_expr_path_raise (e,p) =
 	| EField (e,f) -> f :: string_list_of_expr_path_raise e
 	| _ -> raise Exit
 
+let rec string_pos_list_of_expr_path_raise (e,p) =
+	match e with
+	| EConst (Ident i) -> [i,p]
+	| EField (e,f) -> (f,p) :: string_pos_list_of_expr_path_raise e (* wrong p? *)
+	| _ -> raise Exit
+
 let expr_of_type_path (sl,s) p =
 	match sl with
 	| [] -> (EConst(Ident s),p)

--- a/src/core/meta.ml
+++ b/src/core/meta.ml
@@ -167,6 +167,7 @@ type strict_meta =
 	| UnifyMinDynamic
 	| Unreflective
 	| Unsafe
+	| Using
 	| Used
 	| Value
 	| Void
@@ -366,6 +367,7 @@ let get_info = function
 	| Unreflective -> ":unreflective",("",[Platform Cpp])
 	| Unsafe -> ":unsafe",("Declares a class, or a method with the C#'s 'unsafe' flag",[Platform Cs; UsedOnEither [TClass;TClassField]])
 	| Used -> ":used",("Internally used by DCE to mark a class or field as used",[UsedInternally])
+	| Using -> ":using",("Automatically uses the argument types as static extensions for the annotated type",[UsedOnEither [TClass;TEnum;TAbstract]])
 	| Value -> ":value",("Used to store default values for fields and function arguments",[UsedOn TClassField])
 	| Void -> ":void",("Use Cpp native 'void' return type",[Platform Cpp])
 	| Last -> assert false

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -215,6 +215,7 @@ and tinfos = {
 	mt_doc : Ast.documentation;
 	mutable mt_meta : metadata;
 	mt_params : type_params;
+	mt_using : (tclass * pos) list;
 }
 
 and tclass = {
@@ -226,6 +227,7 @@ and tclass = {
 	mutable cl_doc : Ast.documentation;
 	mutable cl_meta : metadata;
 	mutable cl_params : type_params;
+	mutable cl_using : (tclass * pos) list;
 	(* do not insert any fields above *)
 	mutable cl_kind : tclass_kind;
 	mutable cl_extern : bool;
@@ -272,6 +274,7 @@ and tenum = {
 	e_doc : Ast.documentation;
 	mutable e_meta : metadata;
 	mutable e_params : type_params;
+	mutable e_using : (tclass * pos) list;
 	(* do not insert any fields above *)
 	e_type : tdef;
 	mutable e_extern : bool;
@@ -288,6 +291,7 @@ and tdef = {
 	t_doc : Ast.documentation;
 	mutable t_meta : metadata;
 	mutable t_params : type_params;
+	mutable t_using : (tclass * pos) list;
 	(* do not insert any fields above *)
 	mutable t_type : t;
 }
@@ -301,6 +305,7 @@ and tabstract = {
 	a_doc : Ast.documentation;
 	mutable a_meta : metadata;
 	mutable a_params : type_params;
+	mutable a_using : (tclass * pos) list;
 	(* do not insert any fields above *)
 	mutable a_ops : (Ast.binop * tclass_field) list;
 	mutable a_unops : (Ast.unop * unop_flag * tclass_field) list;
@@ -442,6 +447,7 @@ let mk_class m path pos name_pos =
 		cl_final = false;
 		cl_interface = false;
 		cl_params = [];
+		cl_using = [];
 		cl_super = None;
 		cl_implements = [];
 		cl_fields = PMap.empty;
@@ -521,6 +527,7 @@ let null_abstract = {
 	a_doc = None;
 	a_meta = [];
 	a_params = [];
+	a_using = [];
 	a_ops = [];
 	a_unops = [];
 	a_impl = None;
@@ -2789,6 +2796,7 @@ let class_module_type c = {
 	};
 	t_private = true;
 	t_params = [];
+	t_using = [];
 	t_meta = no_meta;
 }
 
@@ -2801,6 +2809,7 @@ let enum_module_type m path p  = {
 	t_type = mk_mono();
 	t_private = true;
 	t_params = [];
+	t_using = [];
 	t_meta = [];
 }
 
@@ -2816,6 +2825,7 @@ let abstract_module_type a tl = {
 	};
 	t_private = true;
 	t_params = [];
+	t_using = [];
 	t_meta = no_meta;
 }
 

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -215,7 +215,7 @@ and tinfos = {
 	mt_doc : Ast.documentation;
 	mutable mt_meta : metadata;
 	mt_params : type_params;
-	mt_using : (tclass * pos) list;
+	mutable mt_using : (tclass * pos) list;
 }
 
 and tclass = {

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -890,3 +890,38 @@ let handle_path_display ctx path p =
 			) m.m_types;
 		| (IDK,_),_ ->
 			()
+
+let handle_using ctx path p =
+	let t = match List.rev path with
+		| (s1,_) :: (s2,_) :: sl ->
+			if is_lower_ident s2 then { tpackage = (List.rev (s2 :: List.map fst sl)); tname = s1; tsub = None; tparams = [] }
+			else { tpackage = List.rev (List.map fst sl); tname = s2; tsub = Some s1; tparams = [] }
+		| (s1,_) :: sl ->
+			{ tpackage = List.rev (List.map fst sl); tname = s1; tsub = None; tparams = [] }
+		| [] ->
+			DisplayException.raise_fields (DisplayToplevel.collect ctx TKType NoValue) CRUsing None;
+	in
+	let types = (match t.tsub with
+		| None ->
+			let md = ctx.g.do_load_module ctx (t.tpackage,t.tname) p in
+			let types = List.filter (fun t -> not (t_infos t).mt_private) md.m_types in
+			types
+		| Some _ ->
+			let t = load_type_def ctx p t in
+			[t]
+	) in
+	(* delay the using since we need to resolve typedefs *)
+	let filter_classes types =
+		let rec loop acc types = match types with
+			| td :: l ->
+				(match resolve_typedef td with
+				| TClassDecl c | TAbstractDecl({a_impl = Some c}) ->
+					loop ((c,p) :: acc) l
+				| td ->
+					loop acc l)
+			| [] ->
+				acc
+		in
+		loop [] types
+	in
+	types,filter_classes

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -380,6 +380,17 @@ let build_module_def ctx mt meta fvars context_init fbuild =
 						()
 				end
 			)
+		| Meta.Using,el,p -> (fun () ->
+			List.iter (fun e ->
+				try
+					let path = List.rev (string_pos_list_of_expr_path_raise e) in
+					let types,filter_classes = handle_using ctx path (pos e) in
+					let ti = t_infos mt in
+					ti.mt_using <- (filter_classes types) @ ti.mt_using;
+				with Exit ->
+					error "dot path expected" (pos e)
+			) el;
+		) :: f_build,f_enum
 		| _ ->
 			f_build,f_enum
 	in

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -235,6 +235,7 @@ let module_pass_1 ctx m tdecls loadp =
 				e_doc = d.d_doc;
 				e_meta = d.d_meta;
 				e_params = [];
+				e_using = [];
 				e_private = priv;
 				e_extern = List.mem EExtern d.d_flags;
 				e_constrs = PMap.empty;
@@ -257,6 +258,7 @@ let module_pass_1 ctx m tdecls loadp =
 				t_doc = d.d_doc;
 				t_private = priv;
 				t_params = [];
+				t_using = [];
 				t_type = mk_mono();
 				t_meta = d.d_meta;
 			} in
@@ -281,6 +283,7 @@ let module_pass_1 ctx m tdecls loadp =
 				a_name_pos = pos d.d_name;
 				a_doc = d.d_doc;
 				a_params = [];
+				a_using = [];
 				a_meta = d.d_meta;
 				a_from = [];
 				a_to = [];
@@ -400,6 +403,7 @@ let init_module_type ctx context_init do_init (decl,p) =
 					t_doc = None;
 					t_meta = [];
 					t_params = (t_infos t).mt_params;
+					t_using = [];
 					t_type = f (List.map snd (t_infos t).mt_params);
 				} in
 				if ctx.is_display_file && DisplayPosition.encloses_display_position p then


### PR DESCRIPTION
As discussed, this allows type-level static extensions through the `@:using(Path1, Path2)` metadata. It works exactly like module-level static extensions and is checked right after that, but before global static extensions.

I was considering suggesting a specific syntax for this, e.g. `class Main using MainUsing { }`, but I'm not sure if that's necessary.

There are no extensive tests yet; this is my usage example:

```haxe
// MainMacroUsing.hx
import haxe.macro.Expr;

class MainMacroUsing {
	macro static public function getVersion(e:ExprOf<Main>) {
		trace("Getting version...");
		return macro 9001;
	}
}
```

```haxe
// Main.hx
@:using(Main.MainUsing, MainMacroUsing)
class Main {
	static public function main() {
		var m = new Main();
		m.useMain("yay");
		trace(m.getVersion());
	}

	function new() { }
}

class MainUsing {
	static public function useMain(m:Main, arg:String) {
		trace('Main $m is being used with argument $arg');
	}
}
```

Output:

```
source/MainMacroUsing.hx:5: Getting version...
source/Main.hx:14: Main Main is being used with argument yay
source/Main.hx:6: 9001
```

And  here's the obligatory example with enums so everybody goes "Aaaah so that's why this is useful":

```haxe
// MyOption.hx
@:using(MyOption.MyOptionTools)
enum MyOption<T> {
	None;
	Some(v:T);
}

class MyOptionTools {
	static public inline function get<T>(o:MyOption<T>) {
		return switch (o) {
			case None: throw false;
			case Some(v): v;
		}
	}
}
```

```haxe
// Main.hx
import MyOption;

class Main {
	static public function main() {
		var myOption = Some(12);
		trace(myOption.get());
	}
}
```

Generated JS:

```js
Main.main = function() {
	console.log("source/Main.hx:6:",12);
};
```

I even remembered to show these fields in completion.