### PR TITLE
@:semantics

### DIFF
--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -1038,3 +1038,36 @@ module Expr = struct
 		loop' "" e;
 		Buffer.contents buf
 end
+
+let has_meta_option metas meta s =
+	let rec loop ml = match ml with
+		| (meta',el,_) :: ml when meta = meta' ->
+			if List.exists (fun (e,p) ->
+				match e with
+					| EConst(Ident s2) when s = s2 -> true
+					| _ -> false
+			) el then
+				true
+			else
+				loop ml
+		| _ :: ml ->
+			loop ml
+		| [] ->
+			false
+	in
+	loop metas
+
+let get_meta_options metas meta =
+	let rec loop ml = match ml with
+		| (meta',el,_) :: ml when meta = meta' ->
+			ExtList.List.filter_map (fun (e,p) ->
+				match e with
+					| EConst(Ident s2) -> Some s2
+					| _ -> None
+			) el
+		| _ :: ml ->
+			loop ml
+		| [] ->
+			[]
+	in
+	loop metas

--- a/src/core/meta.ml
+++ b/src/core/meta.ml
@@ -143,6 +143,7 @@ type strict_meta =
 	| RuntimeValue
 	| Scalar
 	| SelfCall
+	| Semantics
 	| Setter
 	| SkipCtor
 	| SkipReflection
@@ -341,6 +342,7 @@ let get_info = function
 	| RuntimeValue -> ":runtimeValue",("Marks an abstract as being a runtime value",[UsedOn TAbstract])
 	| Scalar -> ":scalar",("Used by hxcpp to mark a custom coreType abstract",[UsedOn TAbstract; Platform Cpp])
 	| SelfCall -> ":selfCall",("Translates method calls into calling object directly",[UsedOn TClassField; Platforms [Js;Lua]])
+	| Semantics -> ":semantics",("The native semantics of the type",[UsedOnEither [TClass;TTypedef;TAbstract];HasParam "value | reference | variable"])
 	| Setter -> ":setter",("Generates a native setter function on the given field",[HasParam "Class field name";UsedOn TClassField;Platform Flash])
 	| SkipCtor -> ":skipCtor",("Used internally to generate a constructor as if it were a native type (no __hx_ctor)",[Platforms [Java;Cs]; UsedInternally])
 	| SkipReflection -> ":skipReflection",("Used internally to annotate a field that shouldn't have its reflection data generated",[Platforms [Java;Cs]; UsedOn TClassField; UsedInternally])

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -2722,10 +2722,12 @@ module ExtType = struct
 	type semantics =
 		| VariableSemantics
 		| ReferenceSemantics
+		| ValueSemantics
 
 	let semantics_name = function
 		| VariableSemantics -> "variable"
 		| ReferenceSemantics -> "reference"
+		| ValueSemantics -> "value"
 
 	let has_semantics t sem =
 		let name = semantics_name sem in
@@ -2749,6 +2751,7 @@ module ExtType = struct
 
 	let has_variable_semantics t = has_semantics t VariableSemantics
 	let has_reference_semantics t = has_semantics t ReferenceSemantics
+	let has_value_semantics t = has_semantics t ValueSemantics
 end
 
 module StringError = struct

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -485,7 +485,7 @@ module ConstPropagation = DataFlow(struct
 				if not (type_change_ok ctx.com t e.etype) then raise Not_found;
 				mk (TTypeExpr mt) t e.epos
 		in
-		let is_special_var v = v.v_capture || is_asvar_type v.v_type in
+		let is_special_var v = v.v_capture || ExtType.has_variable_semantics v.v_type in
 		let rec commit e = match e.eexpr with
 			| TLocal v when not (is_special_var v) ->
 				begin try
@@ -638,7 +638,7 @@ module LocalDce = struct
 			Meta.has Meta.Used v.v_meta
 		in
 		let keep v =
-			is_used v || ((match v.v_kind with VUser _ | VInlined -> true | _ -> false) && not ctx.config.local_dce) || is_ref_type v.v_type || v.v_capture || Meta.has Meta.This v.v_meta
+			is_used v || ((match v.v_kind with VUser _ | VInlined -> true | _ -> false) && not ctx.config.local_dce) || ExtType.has_reference_semantics v.v_type || v.v_capture || Meta.has Meta.This v.v_meta
 		in
 		let rec use v =
 			if not (is_used v) then begin

--- a/src/optimization/analyzerConfig.ml
+++ b/src/optimization/analyzerConfig.ml
@@ -57,25 +57,7 @@ let all_flags =
 	) [] [flag_optimize;flag_const_propagation;flag_copy_propagation;flag_local_dce;flag_fusion;flag_ignore;flag_dot_debug;flag_user_var_fusion]
 
 let has_analyzer_option meta s =
-	try
-		let rec loop ml = match ml with
-			| (Meta.Analyzer,el,_) :: ml ->
-				if List.exists (fun (e,p) ->
-					match e with
-						| EConst(Ident s2) when s = s2 -> true
-						| _ -> false
-				) el then
-					true
-				else
-					loop ml
-			| _ :: ml ->
-				loop ml
-			| [] ->
-				false
-		in
-		loop meta
-	with Not_found ->
-		false
+	Ast.has_meta_option meta Meta.Analyzer s
 
 let is_ignored meta =
 	has_analyzer_option meta flag_ignore

--- a/src/optimization/analyzerTexprTransformer.ml
+++ b/src/optimization/analyzerTexprTransformer.ml
@@ -305,11 +305,11 @@ let rec func ctx bb tf t p =
 	and call bb e e1 el =
 		let bb = ref bb in
 		let check e t = match e.eexpr with
-			| TLocal v when is_ref_type t ->
+			| TLocal v when ExtType.has_reference_semantics t ->
 				v.v_capture <- true;
 				e
 			| _ ->
-				if is_asvar_type t then begin
+				if ExtType.has_variable_semantics t then begin
 					let v = alloc_var VGenerated "tmp" t e.epos in
 					let bb',e = bind_to_temp ~v:(Some v) !bb false e in
 					bb := bb';

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -415,7 +415,7 @@ class inline_state ctx ethis params cf f p = object(self)
 	method finalize config e tl tret p =
 		let has_params,map_type = match config with Some config -> config | None -> inline_default_config cf ethis.etype in
 		if self#had_side_effect then List.iter (fun (l,e) ->
-			if self#might_be_affected e then l.i_force_temp <- true;
+			if self#might_be_affected e && not (ExtType.has_value_semantics e.etype) then l.i_force_temp <- true;
 		) _inlined_vars;
 		let vars,subst = self#get_substitutions p in
 		let rec inline_params in_call in_assignment e =

--- a/std/cpp/ConstPointer.hx
+++ b/std/cpp/ConstPointer.hx
@@ -21,7 +21,7 @@
  */
  package cpp;
 
-@:coreType @:include("cpp/Pointer.h") @:native("cpp.Pointer") @:analyzer(as_var)
+@:coreType @:include("cpp/Pointer.h") @:native("cpp.Pointer") @:semantics(variable)
 extern class ConstPointer<T>
 {
    // ptr actually returns the pointer - not strictly a 'T' - for pointers to smart pointers

--- a/std/cpp/Pointer.hx
+++ b/std/cpp/Pointer.hx
@@ -24,7 +24,7 @@
 import haxe.extern.AsVar;
 
 @:coreType
-@:analyzer(as_var)
+@:semantics(variable)
 extern class Pointer<T> extends ConstPointer<T> implements ArrayAccess<T>
 {
    public var ref(get,set):Reference<T>;

--- a/std/cpp/Reference.hx
+++ b/std/cpp/Reference.hx
@@ -23,6 +23,7 @@ package cpp;
 
 // Allows haxe to type result correctly, and hxcpp can recognise this and prevent
 //  unwanted casting
+@:semantics(reference)
 typedef Reference<T> = T;
 
 

--- a/std/cs/Out.hx
+++ b/std/cs/Out.hx
@@ -29,4 +29,5 @@ package cs;
 **/
 @:analyzer(no_simplification)
 @:analyzer(no_local_dce)
+@:semantics(reference)
 typedef Out<T> = T;

--- a/std/cs/Ref.hx
+++ b/std/cs/Ref.hx
@@ -28,4 +28,5 @@ package cs;
 	Note: Using this type should be considered a bad practice unless overriding a native function is needed.
 **/
 @:analyzer(no_simplification)
+@:semantics(reference)
 typedef Ref<T> = T;

--- a/std/haxe/extern/AsVar.hx
+++ b/std/haxe/extern/AsVar.hx
@@ -27,5 +27,5 @@ package haxe.extern;
 	argument expressions are bound to a local variable.
 **/
 @:forward
-@:analyzer(as_var)
+@:semantics(variable)
 abstract AsVar<T>(T) from T to T {}

--- a/std/hl/Ref.hx
+++ b/std/hl/Ref.hx
@@ -21,6 +21,7 @@
  */
 package hl;
 
+@:semantics(reference)
 @:coreType abstract Ref<T> {
 
 	@:from extern public static inline function make<T>( v : T ) {

--- a/std/php/NativeArray.hx
+++ b/std/php/NativeArray.hx
@@ -26,7 +26,7 @@ using php.Global;
 /**
 	Native PHP array.
 **/
-@:coreType @:runtimeValue abstract NativeArray {
+@:coreType @:runtimeValue @:semantics(value) abstract NativeArray {
 	public inline function new()
 		this = Syntax.arrayDecl();
 

--- a/std/php/NativeAssocArray.hx
+++ b/std/php/NativeAssocArray.hx
@@ -22,6 +22,7 @@
 package php;
 
 @:forward
+@:semantics(value)
 abstract NativeAssocArray<T>(NativeArray) from NativeArray to NativeArray {
 	public inline function new()
 		this = Syntax.arrayDecl();

--- a/std/php/NativeIndexedArray.hx
+++ b/std/php/NativeIndexedArray.hx
@@ -22,6 +22,7 @@
 package php;
 
 @:forward
+@:semantics(value)
 abstract NativeIndexedArray<T>(NativeArray) from NativeArray to NativeArray {
 	public inline function new()
 		this = Syntax.arrayDecl();

--- a/std/php/Ref.hx
+++ b/std/php/Ref.hx
@@ -4,4 +4,5 @@ package php;
 	Special type which allows passing function arguments by reference.
 	This type should be used for externs only.
 **/
+@:semantics(reference)
 typedef Ref<T> = T;


### PR DESCRIPTION
This is my attempt at cleaning up the way we deal with native semantics for types:

* `@:semantics(variable)`: Replaces `@:analyzer(as_var)`
* `@:semantics(reference)`: Used on the previously hardcoded reference types for C#, HL and PHP
* `@:semantics(value)`: Indicates that the type has value semantics and should not be assigned to temp vars because that would create a copy. Currently only used on PHP's `NativeIndexedArray` to deal with the problems in #4872.

