### PR TITLE
[js] HTML extern minor improvements: keywords and docs

### DIFF
--- a/std/js/html/DOMElement.hx
+++ b/std/js/html/DOMElement.hx
@@ -301,7 +301,7 @@ extern class DOMElement extends Node
 		Retrieves the value of the attribute with the specified name and namespace, from the current node and returns it as an `Object`.
 	**/
 	@:pure
-	function getAttributeNS( namespace_ : String, localName : String ) : String;
+	function getAttributeNS( namespace : String, localName : String ) : String;
 	
 	/**
 		Toggles a boolean attribute, removing it if it is present and adding it if it is not present, on the specified element.
@@ -319,7 +319,7 @@ extern class DOMElement extends Node
 		Sets the value of the attribute with the specified name and namespace, from the current node.
 		@throws DOMError
 	**/
-	function setAttributeNS( namespace_ : String, name : String, value : String ) : Void;
+	function setAttributeNS( namespace : String, name : String, value : String ) : Void;
 	
 	/**
 		Removes the named attribute from the current node.
@@ -331,7 +331,7 @@ extern class DOMElement extends Node
 		Removes the attribute with the specified name and namespace, from the current node.
 		@throws DOMError
 	**/
-	function removeAttributeNS( namespace_ : String, localName : String ) : Void;
+	function removeAttributeNS( namespace : String, localName : String ) : Void;
 	
 	/**
 		Returns a `Boolean` indicating if the element has the specified attribute or not.
@@ -343,7 +343,7 @@ extern class DOMElement extends Node
 		Returns a `Boolean` indicating if the element has the specified attribute, in the specified namespace, or not.
 	**/
 	@:pure
-	function hasAttributeNS( namespace_ : String, localName : String ) : Bool;
+	function hasAttributeNS( namespace : String, localName : String ) : Bool;
 	
 	/**
 		Returns a `Boolean` indicating if the element has one or more HTML attributes present.
@@ -379,7 +379,7 @@ extern class DOMElement extends Node
 		@throws DOMError
 	**/
 	@:pure
-	function getElementsByTagNameNS( namespace_ : String, localName : String ) : HTMLCollection;
+	function getElementsByTagNameNS( namespace : String, localName : String ) : HTMLCollection;
 	
 	/**
 		Returns a live `HTMLCollection` that contains all descendants of the current element that possess the list of classes given in the parameter.

--- a/std/js/html/DOMImplementation.hx
+++ b/std/js/html/DOMImplementation.hx
@@ -50,7 +50,7 @@ extern class DOMImplementation
 		Creates and returns an `XMLDocument`.
 		@throws DOMError
 	**/
-	function createDocument( namespace_ : String, qualifiedName : String, ?doctype : DocumentType ) : HTMLDocument;
+	function createDocument( namespace : String, qualifiedName : String, ?doctype : DocumentType ) : HTMLDocument;
 	
 	/**
 		Creates and returns an HTML `Document`.

--- a/std/js/html/Document.hx
+++ b/std/js/html/Document.hx
@@ -369,7 +369,7 @@ extern class Document extends Node
 		@throws DOMError
 	**/
 	@:pure
-	function getElementsByTagNameNS( namespace_ : String, localName : String ) : HTMLCollection;
+	function getElementsByTagNameNS( namespace : String, localName : String ) : HTMLCollection;
 	
 	/**
 		Returns a list of elements with the given class name.
@@ -390,8 +390,8 @@ extern class Document extends Node
 		Creates a new element with the given tag name and namespace URI.
 		@throws DOMError
 	**/
-	@:overload( function( namespace_ : String, qualifiedName : String, ?options : String) : Element {} )
-	function createElementNS( namespace_ : String, qualifiedName : String, ?options : ElementCreationOptions ) : Element;
+	@:overload( function( namespace : String, qualifiedName : String, ?options : String) : Element {} )
+	function createElementNS( namespace : String, qualifiedName : String, ?options : ElementCreationOptions ) : Element;
 	
 	/**
 		Creates a new document fragment.
@@ -470,7 +470,7 @@ extern class Document extends Node
 		Creates a new attribute node in a given namespace and returns it.
 		@throws DOMError
 	**/
-	function createAttributeNS( namespace_ : String, name : String ) : Attr;
+	function createAttributeNS( namespace : String, name : String ) : Attr;
 	@:pure
 	function getElementsByName( elementName : String ) : NodeList;
 	

--- a/std/js/html/ElementCreationOptions.hx
+++ b/std/js/html/ElementCreationOptions.hx
@@ -26,6 +26,5 @@ package js.html;
 
 typedef ElementCreationOptions =
 {
-	@:native("is")
-	@:optional var is_ : String;
+	@:optional var is : String;
 }

--- a/std/js/html/EndingTypes.hx
+++ b/std/js/html/EndingTypes.hx
@@ -27,5 +27,5 @@ package js.html;
 enum abstract EndingTypes(String)
 {
 	var TRANSPARENT = "transparent";
-	var NATIVE_ = "native";
+	var NATIVE = "native";
 }

--- a/std/js/html/FontFaceSet.hx
+++ b/std/js/html/FontFaceSet.hx
@@ -60,8 +60,7 @@ extern class FontFaceSet extends EventTarget
 	/** @throws DOMError */
 	function add( font : FontFace ) : Void;
 	function has( font : FontFace ) : Bool;
-	@:native("delete")
-	function delete_( font : FontFace ) : Bool;
+	function delete( font : FontFace ) : Bool;
 	function clear() : Void;
 	function entries() : FontFaceSetIterator;
 	function values() : FontFaceSetIterator;

--- a/std/js/html/FormData.hx
+++ b/std/js/html/FormData.hx
@@ -47,8 +47,7 @@ extern class FormData
 	/**
 		Deletes a key/value pair from a `FormData` object.
 	**/
-	@:native("delete")
-	function delete_( name : String ) : Void;
+	function delete( name : String ) : Void;
 	
 	/**
 		Returns the first value associated with a given key from within a `FormData` object.

--- a/std/js/html/FormData.hx
+++ b/std/js/html/FormData.hx
@@ -43,6 +43,10 @@ extern class FormData
 	**/
 	@:overload( function( name : String, value : Blob, ?filename : String ) : Void {} )
 	function append( name : String, value : String ) : Void;
+	
+	/**
+		Deletes a key/value pair from a `FormData` object.
+	**/
 	@:native("delete")
 	function delete_( name : String ) : Void;
 	

--- a/std/js/html/Headers.hx
+++ b/std/js/html/Headers.hx
@@ -44,7 +44,11 @@ extern class Headers
 		@throws DOMError
 	**/
 	function append( name : String, value : String ) : Void;
-	/** @throws DOMError */
+	
+	/**
+		Deletes a header from a `Headers` object.
+		@throws DOMError
+	**/
 	@:native("delete")
 	function delete_( name : String ) : Void;
 	

--- a/std/js/html/Headers.hx
+++ b/std/js/html/Headers.hx
@@ -49,8 +49,7 @@ extern class Headers
 		Deletes a header from a `Headers` object.
 		@throws DOMError
 	**/
-	@:native("delete")
-	function delete_( name : String ) : Void;
+	function delete( name : String ) : Void;
 	
 	/**
 		Returns a `ByteString` sequence of all the values of a header within a `Headers` object with a given name.

--- a/std/js/html/LinkElement.hx
+++ b/std/js/html/LinkElement.hx
@@ -106,8 +106,7 @@ extern class LinkElement extends Element
 	/**
 		Is a `DOMString` representing the type of content being loaded by the HTML link.
 	**/
-	@:native("as")
-	var as_ : String;
+	var as : String;
 	var sheet(default,null) : StyleSheet;
 	
 }

--- a/std/js/html/LinkElement.hx
+++ b/std/js/html/LinkElement.hx
@@ -102,6 +102,10 @@ extern class LinkElement extends Element
 	**/
 	var target : String;
 	var integrity : String;
+	
+	/**
+		Is a `DOMString` representing the type of content being loaded by the HTML link.
+	**/
 	@:native("as")
 	var as_ : String;
 	var sheet(default,null) : StyleSheet;

--- a/std/js/html/Node.hx
+++ b/std/js/html/Node.hx
@@ -259,7 +259,7 @@ extern class Node extends EventTarget
 		Returns a `DOMString` containing the prefix for a given namespace URI, if present, and `null` if not. When multiple prefixes are possible, the result is implementation-dependent.
 	**/
 	@:pure
-	function lookupPrefix( namespace_ : String ) : String;
+	function lookupPrefix( namespace : String ) : String;
 	
 	/**
 		Accepts a prefix and returns the namespace URI associated with it on the given node if found (and `null` if not). Supplying `null` for the prefix will return the default namespace.
@@ -271,5 +271,5 @@ extern class Node extends EventTarget
 		Accepts a namespace URI as an argument and returns a `Boolean` with a value of `true` if the namespace is the default namespace on the given node or `false` if not.
 	**/
 	@:pure
-	function isDefaultNamespace( namespace_ : String ) : Bool;
+	function isDefaultNamespace( namespace : String ) : Bool;
 }

--- a/std/js/html/NotificationPermission.hx
+++ b/std/js/html/NotificationPermission.hx
@@ -26,7 +26,7 @@ package js.html;
 
 enum abstract NotificationPermission(String)
 {
-	var DEFAULT_ = "default";
+	var DEFAULT = "default";
 	var DENIED = "denied";
 	var GRANTED = "granted";
 }

--- a/std/js/html/RequestCache.hx
+++ b/std/js/html/RequestCache.hx
@@ -26,7 +26,7 @@ package js.html;
 
 enum abstract RequestCache(String)
 {
-	var DEFAULT_ = "default";
+	var DEFAULT = "default";
 	var NO_STORE = "no-store";
 	var RELOAD = "reload";
 	var NO_CACHE = "no-cache";

--- a/std/js/html/ResponseType.hx
+++ b/std/js/html/ResponseType.hx
@@ -28,7 +28,7 @@ enum abstract ResponseType(String)
 {
 	var BASIC = "basic";
 	var CORS = "cors";
-	var DEFAULT_ = "default";
+	var DEFAULT = "default";
 	var ERROR = "error";
 	var OPAQUE = "opaque";
 	var OPAQUEREDIRECT = "opaqueredirect";

--- a/std/js/html/ShadowRoot.hx
+++ b/std/js/html/ShadowRoot.hx
@@ -55,7 +55,7 @@ extern class ShadowRoot extends DocumentFragment
 	
 	function getElementById( elementId : String ) : Element;
 	function getElementsByTagName( localName : String ) : HTMLCollection;
-	function getElementsByTagNameNS( namespace_ : String, localName : String ) : HTMLCollection;
+	function getElementsByTagNameNS( namespace : String, localName : String ) : HTMLCollection;
 	function getElementsByClassName( classNames : String ) : HTMLCollection;
 	function elementFromPoint( x : Float, y : Float ) : Element;
 	function elementsFromPoint( x : Float, y : Float ) : Array<Element>;

--- a/std/js/html/SpeechSynthesisVoice.hx
+++ b/std/js/html/SpeechSynthesisVoice.hx
@@ -54,6 +54,10 @@ extern class SpeechSynthesisVoice
 		A `Boolean` indicating whether the voice is supplied by a local speech synthesizer service (`true`), or a remote speech synthesizer service (`false`.)
 	**/
 	var localService(default,null) : Bool;
+	
+	/**
+		A `Boolean` indicating whether the voice is the default voice for the current app language (`true`), or not (`false`.)
+	**/
 	@:native("default")
 	var default_(default,null) : Bool;
 	

--- a/std/js/html/StorageType.hx
+++ b/std/js/html/StorageType.hx
@@ -28,5 +28,5 @@ enum abstract StorageType(String)
 {
 	var PERSISTENT = "persistent";
 	var TEMPORARY = "temporary";
-	var DEFAULT_ = "default";
+	var DEFAULT = "default";
 }

--- a/std/js/html/TrackElement.hx
+++ b/std/js/html/TrackElement.hx
@@ -59,6 +59,10 @@ extern class TrackElement extends Element
 		Is a `DOMString` that reflects the `label` HTML attribute, indicating a user-readable title for the track.
 	**/
 	var label : String;
+	
+	/**
+		Is a `Boolean` reflects the `default` HTML attribute, indicating that the track is to be enabled if the user's preferences do not indicate that another track would be more appropriate.
+	**/
 	@:native("default")
 	var default_ : Bool;
 	

--- a/std/js/html/URLSearchParams.hx
+++ b/std/js/html/URLSearchParams.hx
@@ -43,6 +43,10 @@ extern class URLSearchParams
 		Appends a specified key/value pair as a new search parameter.
 	**/
 	function append( name : String, value : String ) : Void;
+	
+	/**
+		Deletes the given search parameter, and its associated value, from the list of all search parameters.
+	**/
 	@:native("delete")
 	function delete_( name : String ) : Void;
 	

--- a/std/js/html/URLSearchParams.hx
+++ b/std/js/html/URLSearchParams.hx
@@ -47,8 +47,7 @@ extern class URLSearchParams
 	/**
 		Deletes the given search parameter, and its associated value, from the list of all search parameters.
 	**/
-	@:native("delete")
-	function delete_( name : String ) : Void;
+	function delete( name : String ) : Void;
 	
 	/**
 		Returns the first value associated to the given search parameter.

--- a/std/js/html/idb/Cursor.hx
+++ b/std/js/html/idb/Cursor.hx
@@ -67,7 +67,11 @@ extern class Cursor
 		@throws DOMError
 	**/
 	function advance( count : Int ) : Void;
-	/** @throws DOMError */
+	
+	/**
+		Advances the cursor to the next position along its direction, to the item whose key matches the optional `key` parameter.
+		@throws DOMError
+	**/
 	@:native("continue")
 	function continue_( ?key : Dynamic ) : Void;
 	
@@ -76,7 +80,11 @@ extern class Cursor
 		@throws DOMError
 	**/
 	function continuePrimaryKey( key : Dynamic, primaryKey : Dynamic ) : Void;
-	/** @throws DOMError */
+	
+	/**
+		Returns an `IDBRequest` object, and, in a separate thread, deletes the record at the cursor's position, without changing the cursor's position. This can be used to delete specific records.
+		@throws DOMError
+	**/
 	@:native("delete")
 	function delete_() : Request;
 }

--- a/std/js/html/idb/Cursor.hx
+++ b/std/js/html/idb/Cursor.hx
@@ -85,6 +85,5 @@ extern class Cursor
 		Returns an `IDBRequest` object, and, in a separate thread, deletes the record at the cursor's position, without changing the cursor's position. This can be used to delete specific records.
 		@throws DOMError
 	**/
-	@:native("delete")
-	function delete_() : Request;
+	function delete() : Request;
 }

--- a/std/js/html/idb/ObjectStore.hx
+++ b/std/js/html/idb/ObjectStore.hx
@@ -77,8 +77,7 @@ extern class ObjectStore
 		returns an `IDBRequest` object, and, in a separate thread, deletes the store object selected by the specified key. This is for deleting individual records out of an object store.
 		@throws DOMError
 	**/
-	@:native("delete")
-	function delete_( key : Dynamic ) : Request;
+	function delete( key : Dynamic ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, returns the store object store selected by the specified key. This is for retrieving specific records from an object store.

--- a/std/js/html/idb/ObjectStore.hx
+++ b/std/js/html/idb/ObjectStore.hx
@@ -72,7 +72,11 @@ extern class ObjectStore
 		@throws DOMError
 	**/
 	function add( value : Dynamic, ?key : Dynamic ) : Request;
-	/** @throws DOMError */
+	
+	/**
+		returns an `IDBRequest` object, and, in a separate thread, deletes the store object selected by the specified key. This is for deleting individual records out of an object store.
+		@throws DOMError
+	**/
 	@:native("delete")
 	function delete_( key : Dynamic ) : Request;
 	

--- a/std/js/html/rtc/IceConnectionState.hx
+++ b/std/js/html/rtc/IceConnectionState.hx
@@ -26,7 +26,7 @@ package js.html.rtc;
 
 enum abstract IceConnectionState(String)
 {
-	var NEW_ = "new";
+	var NEW = "new";
 	var CHECKING = "checking";
 	var CONNECTED = "connected";
 	var COMPLETED = "completed";

--- a/std/js/html/rtc/IceGatheringState.hx
+++ b/std/js/html/rtc/IceGatheringState.hx
@@ -26,7 +26,7 @@ package js.html.rtc;
 
 enum abstract IceGatheringState(String)
 {
-	var NEW_ = "new";
+	var NEW = "new";
 	var GATHERING = "gathering";
 	var COMPLETE = "complete";
 }

--- a/std/js/html/svg/FECompositeElement.hx
+++ b/std/js/html/svg/FECompositeElement.hx
@@ -41,14 +41,15 @@ extern class FECompositeElement extends Element
 	static inline var SVG_FECOMPOSITE_OPERATOR_ATOP : Int = 4;
 	static inline var SVG_FECOMPOSITE_OPERATOR_XOR : Int = 5;
 	static inline var SVG_FECOMPOSITE_OPERATOR_ARITHMETIC : Int = 6;
-
-
+	
+	
 	/**
 		An `SVGAnimatedString` corresponding to the `in` attribute of the given element.
 	**/
 	var in1(default,null) : AnimatedString;
 	var in2(default,null) : AnimatedString;
-	@:native("operator") var operator_(default,null) : AnimatedEnumeration;
+	@:native("operator")
+	var operator_(default,null) : AnimatedEnumeration;
 	var k1(default,null) : AnimatedNumber;
 	var k2(default,null) : AnimatedNumber;
 	var k3(default,null) : AnimatedNumber;
@@ -58,5 +59,5 @@ extern class FECompositeElement extends Element
 	var width(default,null) : AnimatedLength;
 	var height(default,null) : AnimatedLength;
 	var result(default,null) : AnimatedString;
-
+	
 }

--- a/std/js/html/svg/FEMorphologyElement.hx
+++ b/std/js/html/svg/FEMorphologyElement.hx
@@ -37,23 +37,24 @@ extern class FEMorphologyElement extends Element
 	static inline var SVG_MORPHOLOGY_OPERATOR_UNKNOWN : Int = 0;
 	static inline var SVG_MORPHOLOGY_OPERATOR_ERODE : Int = 1;
 	static inline var SVG_MORPHOLOGY_OPERATOR_DILATE : Int = 2;
-
-
+	
+	
 	/**
 		An `SVGAnimatedString` corresponding to the `in` attribute of the given element.
 	**/
 	var in1(default,null) : AnimatedString;
-
+	
 	/**
 		An `SVGAnimatedEnumeration` corresponding to the `operator` attribute of the given element. It takes one of the `SVG_MORPHOLOGY_OPERATOR_*` constants defined on this interface.
 	**/
-	@:native("operator") var operator_(default,null) : AnimatedEnumeration;
-
+	@:native("operator")
+	var operator_(default,null) : AnimatedEnumeration;
+	
 	/**
 		An `SVGAnimatedNumber` corresponding to the X component of the `radius` attribute of the given element.
 	**/
 	var radiusX(default,null) : AnimatedNumber;
-
+	
 	/**
 		An `SVGAnimatedNumber` corresponding to the Y component of the `radius` attribute of the given element.
 	**/
@@ -63,5 +64,5 @@ extern class FEMorphologyElement extends Element
 	var width(default,null) : AnimatedLength;
 	var height(default,null) : AnimatedLength;
 	var result(default,null) : AnimatedString;
-
+	
 }

--- a/std/js/html/webgl/PowerPreference.hx
+++ b/std/js/html/webgl/PowerPreference.hx
@@ -26,7 +26,7 @@ package js.html.webgl;
 
 enum abstract PowerPreference(String)
 {
-	var DEFAULT_ = "default";
+	var DEFAULT = "default";
 	var LOW_POWER = "low-power";
 	var HIGH_PERFORMANCE = "high-performance";
 }


### PR DESCRIPTION
Minor improvements:

- Remove trailing underscore from non-keywords such as `DEFAULT_` or `delete_`
- Add documentation that was missing because of trailing underscore

### Impact
Minimal to no impact on existing code - I've found no references to any of these fields in any of the popular libraries