### PR TITLE
[js] Remove -D old_browser (only affects Json)

### DIFF
--- a/std/js/_std/haxe/Json.hx
+++ b/std/js/_std/haxe/Json.hx
@@ -22,7 +22,7 @@
 package haxe;
 
 @:coreApi
-#if (!haxeJSON && !old_browser)
+#if !haxeJSON
 @:native("JSON") extern
 #end
 class Json {
@@ -36,13 +36,6 @@ class Json {
 	#if haxeJSON inline #end
 	public static function stringify( value : Dynamic, ?replacer:(key:Dynamic, value:Dynamic) -> Dynamic, ?space:String ) : String #if !haxeJSON ; #else {
 		return haxe.format.JsonPrinter.print(value, replacer, space);
-	}
-	#end
-
-	#if (!haxeJSON && old_browser)
-	static function __init__():Void untyped {
-		if( __js__('typeof(JSON)') != 'undefined' )
-			Json = __js__('JSON');
 	}
 	#end
 


### PR DESCRIPTION
From js polyfills consistency discussion #7091 

The `old_browser` flag adds a check for `JSON` support and switched to haxe-json when not supported

[Very few](https://caniuse.com/#search=JSON) browsers lack JSON support these days and if you explicitly target you can always pass `-D haxeJSON` to only use haxe's implementation or use one of the available polyfills