### PR TITLE
fix _floatToI32/_doubleToI64 in FP emulation

### DIFF
--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -57,13 +57,17 @@ class FPHelper {
 
 	static inline function _floatToI32(f: Float): Int {
 		if ( f == 0 )
+		#if js
 			return 1 / f > 0 ? 0 : 0x80000000;
+		#else
+			return 0;
+		#end
 		if (Math.isNaN(f))
 			return 0x7FC00000;
 		var af = f < 0 ? -f : f;
 		var exp = Math.floor(Math.log(af) / LN2);
 		if (exp > 127) {
-			return f < 0 ? 0xFF800000 :0x7F800000;
+			return f < 0 ? 0xFF800000 : 0x7F800000;
 		} else {
 			if (exp <= -127) {
 				exp = -127;
@@ -85,7 +89,11 @@ class FPHelper {
 		var i64 = i64tmp;
 		if (v == 0) {
 			i64.set_low(0);
+			#if js
 			i64.set_high(1 / v > 0 ? 0 : 0x80000000);
+			#else
+			i64.set_high(0);
+			#end
 		} else if (!Math.isFinite(v)) {
 			i64.set_low(0);
 			i64.set_high(Math.isNaN(v) ? 0x7FF80000 : (v > 0 ? 0x7FF00000 : 0xFFF00000));

--- a/std/haxe/io/FPHelper.hx
+++ b/std/haxe/io/FPHelper.hx
@@ -56,15 +56,15 @@ class FPHelper {
 	}
 
 	static inline function _floatToI32(f: Float): Int {
-		if ( f == 0 )
+		if ( f == 0.)
 		#if js
-			return 1 / f > 0 ? 0 : 0x80000000;
+			return 1 / f > 0. ? 0 : 0x80000000;
 		#else
 			return 0;
 		#end
 		if (Math.isNaN(f))
 			return 0x7FC00000;
-		var af = f < 0 ? -f : f;
+		var af = f < 0. ? -f : f;
 		var exp = Math.floor(Math.log(af) / LN2);
 		if (exp > 127) {
 			return f < 0 ? 0xFF800000 : 0x7F800000;
@@ -80,25 +80,25 @@ class FPHelper {
 				}
 				af = (af - 1.0) * 0x800000;
 			}
-			return (f < 0 ? 0x80000000 : 0) | ((exp + 127) << 23) | Math.round(af);
+			return (f < 0. ? 0x80000000 : 0) | ((exp + 127) << 23) | Math.round(af);
 		}
 	}
 
 	@:access(haxe.Int64)
 	static inline function _doubleToI64(v: Float): Int64 {
 		var i64 = i64tmp;
-		if (v == 0) {
+		if (v == 0.) {
 			i64.set_low(0);
 			#if js
-			i64.set_high(1 / v > 0 ? 0 : 0x80000000);
+			i64.set_high(1 / v > 0. ? 0 : 0x80000000);
 			#else
 			i64.set_high(0);
 			#end
 		} else if (!Math.isFinite(v)) {
 			i64.set_low(0);
-			i64.set_high(Math.isNaN(v) ? 0x7FF80000 : (v > 0 ? 0x7FF00000 : 0xFFF00000));
+			i64.set_high(Math.isNaN(v) ? 0x7FF80000 : (v > 0. ? 0x7FF00000 : 0xFFF00000));
 		} else {
-			var av = v < 0 ? -v : v;
+			var av = v < 0. ? -v : v;
 			var exp = Math.floor(Math.log(av) / LN2);
 			if (exp > 1023) {
 				i64.set_low(0xFFFFFFFF);
@@ -123,7 +123,7 @@ class FPHelper {
 				var sig_l = Std.int(sig);
 				var sig_h = Std.int(sig / 4294967296.0);
 				i64.set_low(sig_l);
-				i64.set_high((v < 0 ? 0x80000000 : 0) | ((exp + 1023) << 20) | sig_h);
+				i64.set_high((v < 0. ? 0x80000000 : 0) | ((exp + 1023) << 20) | sig_h);
 			}
 		}
 		return i64;

--- a/tests/unit/src/unit/issues/Issue7497.hx
+++ b/tests/unit/src/unit/issues/Issue7497.hx
@@ -8,30 +8,30 @@ class Issue7497 extends unit.Test {
 	static function pot(n) return Math.pow(2, n);
 	static function hexI32(b: Int) return StringTools.hex(b, 8);
 
-	static function i2f(i) return @:privateAccess FPHelper._i32ToFloat(i);
-	static function f2i(f) return @:privateAccess FPHelper._floatToI32(f);
+	static function emuI32ToFloat(i) return @:privateAccess FPHelper._i32ToFloat(i);
+	static function emuFloatToI32(f) return @:privateAccess FPHelper._floatToI32(f);
 
-	static function d2ii(d) return @:privateAccess FPHelper._doubleToI64(d);
-	static function ii2d(lo, hi) return @:privateAccess FPHelper._i64ToDouble(lo, hi);
+	static function emuDoubleToI64(d) return @:privateAccess FPHelper._doubleToI64(d);
+	static function emuI64ToDouble(lo, hi) return @:privateAccess FPHelper._i64ToDouble(lo, hi);
 
 	function rtsingle(i:Int, n:Float, name:String) {
-		var ai = f2i(n);
-		var af = i2f(ai);
+		var ai = emuFloatToI32(n);
+		var af = emuI32ToFloat(ai);
 		var bi = FPHelper.floatToI32(af);
 		var ci = FPHelper.floatToI32(n);
 		if (!(isNaN(n) && isNaN(af)))
-			eq(n, af);
+			feq(n, af);
 		eq(ai, bi);
 		eq(ai, ci);
 	}
 
 	function rtdouble(i:Int, n:Float, name:String){
-		var ai = d2ii(n);
-		var ad = ii2d(ai.low, ai.high);
+		var ai = emuDoubleToI64(n);
+		var ad = emuI64ToDouble(ai.low, ai.high);
 		var bi = FPHelper.doubleToI64(ad);
 		var ci = FPHelper.doubleToI64(n);
 		if (!(isNaN(n) && isNaN(ad)))
-			eq(n, ad);
+			feq(n, ad);
 		eq(ai, bi);
 		eq(ai, ci);
 	}

--- a/tests/unit/src/unit/issues/Issue7497.hx
+++ b/tests/unit/src/unit/issues/Issue7497.hx
@@ -1,0 +1,82 @@
+package unit.issues;
+
+import haxe.io.FPHelper;
+import Math.isNaN;
+
+class Issue7497 extends unit.Test {
+#if js
+	static function pot(n) return Math.pow(2, n);
+	static function hexI32(b: Int) return StringTools.hex(b, 8);
+
+	static function i2f(i) return @:privateAccess FPHelper._i32ToFloat(i);
+	static function f2i(f) return @:privateAccess FPHelper._floatToI32(f);
+
+	static function d2ii(d) return @:privateAccess FPHelper._doubleToI64(d);
+	static function ii2d(lo, hi) return @:privateAccess FPHelper._i64ToDouble(lo, hi);
+
+	function rtsingle(i:Int, n:Float, name:String) {
+		var ai = f2i(n);
+		var af = i2f(ai);
+		var bi = FPHelper.floatToI32(af);
+		var ci = FPHelper.floatToI32(n);
+		if (!(isNaN(n) && isNaN(af)))
+			eq(n, af);
+		eq(ai, bi);
+		eq(ai, ci);
+	}
+
+	function rtdouble(i:Int, n:Float, name:String){
+		var ai = d2ii(n);
+		var ad = ii2d(ai.low, ai.high);
+		var bi = FPHelper.doubleToI64(ad);
+		var ci = FPHelper.doubleToI64(n);
+		if (!(isNaN(n) && isNaN(ad)))
+			eq(n, ad);
+		eq(ai, bi);
+		eq(ai, ci);
+	}
+
+	function test() {
+		var NA = -9999;
+		// float32 to int32
+		rtsingle(NA, 0, "s 0");
+		rtsingle(NA, -0.0, "s -0");
+		rtsingle(NA, pot(-149), "s min");
+		rtsingle(NA, -pot(-149), "s -min");
+		rtsingle(NA, pot(127) * (2 - pot(-23)), "s max");
+		rtsingle(NA, -pot(127) * (2 - pot(-23)), "s -max");
+		rtsingle(NA, Math.NEGATIVE_INFINITY, "-infinity");
+		rtsingle(NA, Math.POSITIVE_INFINITY, "infinity");
+		rtsingle(NA, Math.NaN, "nan");
+		for(i in -149...128){ // min denormalized float to max normalized pot float
+			var n = pot(i);
+			var uulp = if(i < -126) pot(-149) else pot(i - 23);
+			var dulp = if(i <= -126) pot(-149) else pot(i - 24);
+			rtsingle(i, n, "s pot");
+			rtsingle(i, n + uulp, "s pot+");
+			rtsingle(i, n - dulp, "s pot-");
+			rtsingle(i, n - 2 * dulp, "s pot--");
+		}
+
+		// float64 to int64
+		rtdouble(NA, 0, "s 0");
+		rtdouble(NA, -0.0, "s -0");
+		rtdouble(NA, pot(-1075), "d min");
+		rtdouble(NA, -pot(-1075), "d -min");
+		rtdouble(NA, pot(1023) * (2 - pot( -52)), "d max");
+		rtdouble(NA, -pot(1023) * (2 - pot( -52)), "d -max");
+		rtdouble(NA, Math.POSITIVE_INFINITY, "d Inf");
+		rtdouble(NA, Math.NEGATIVE_INFINITY, "d -Inf");
+		rtdouble(NA, Math.NaN, "d NaN");
+		for(i in -1075...1024){ // min denormalized double to max normalized pot double
+			var n = pot(i);
+			var uulp = if(i < -1022) pot(-1075) else pot(i - 52);
+			var dulp = if(i <= -1022) pot(-1075) else pot(i - 53);
+			rtdouble(i, n, "d pot");
+			rtdouble(i, n + 2 * uulp, "d pot+");
+			rtdouble(i, n - dulp, "d pot-");
+			rtdouble(i, n - 2 * dulp, "d pot--");
+		}
+	}
+#end
+}


### PR DESCRIPTION
close #7497

here is the test:
```haxe
package;

import haxe.io.FPHelper;
import Math.isNaN;

class Main {

    static function pot(n) return Math.pow(2, n);
    static function hexI32(b: Int) return StringTools.hex(b, 8);

    static function i2f(i) return @:privateAccess FPHelper._i32ToFloat(i);
    static function f2i(f) return @:privateAccess FPHelper._floatToI32(f);

    static function d2ii(d) return @:privateAccess FPHelper._doubleToI64(d);
    static function ii2d(lo, hi) return @:privateAccess FPHelper._i64ToDouble(lo, hi);

    static function rtsingle(i:Int, n:Float, name:String) {
        var ai = f2i(n);
        var af = i2f(ai);
        var bi = FPHelper.floatToI32(af);
        var ci = FPHelper.floatToI32(n);
        if((n != af && !(isNaN(n) && isNaN(af))) || ai != bi || ai != ci)
            throw('"$name" i:$i, n:$n, af:$af');
    }

    static function rtdouble(i:Int, n:Float, name:String){
        var ai = d2ii(n);
        var ad = ii2d(ai.low, ai.high);
        var bi = FPHelper.doubleToI64(ad);
        var ci = FPHelper.doubleToI64(n);
        if((n != ad && !(isNaN(n) && isNaN(ad))) || ai != bi || ai != ci)
            throw('"$name" i:$i, n:$n, ad:$ad');
    }

    static function main() {
        var NA = -9999;
        // float32 to int32
        rtsingle(NA, 0, "s 0");
        rtsingle(NA, -0.0, "s -0");
        rtsingle(NA, pot(-149), "s min");
        rtsingle(NA, -pot(-149), "s -min");
        rtsingle(NA, pot(127) * (2 - pot(-23)), "s max");
        rtsingle(NA, -pot(127) * (2 - pot(-23)), "s -max");
        rtsingle(NA, Math.NEGATIVE_INFINITY, "-infinity");
        rtsingle(NA, Math.POSITIVE_INFINITY, "infinity");
        rtsingle(NA, Math.NaN, "nan");
        for(i in -149...128){ // min denormalized float to max normalized pot float
            var n = pot(i);
            var uulp = if(i < -126) pot(-149) else pot(i - 23);
            var dulp = if(i <= -126) pot(-149) else pot(i - 24);
            rtsingle(i, n, "s pot");
            rtsingle(i, n + uulp, "s pot+");
            rtsingle(i, n - dulp, "s pot-");
            rtsingle(i, n - 2 * dulp, "s pot--");
        }

        // float64 to int64
        rtdouble(NA, 0, "s 0");
        rtdouble(NA, -0.0, "s -0");
        rtdouble(NA, pot(-1075), "d min");
        rtdouble(NA, -pot(-1075), "d -min");
        rtdouble(NA, pot(1023) * (2 - pot( -52)), "d max");
        rtdouble(NA, -pot(1023) * (2 - pot( -52)), "d -max");
        rtdouble(NA, Math.POSITIVE_INFINITY, "d Inf");
        rtdouble(NA, Math.NEGATIVE_INFINITY, "d -Inf");
        rtdouble(NA, Math.NaN, "d NaN");
        for(i in -1075...1024){ // min denormalized double to max normalized pot double
            var n = pot(i);
            var uulp = if(i < -1022) pot(-1075) else pot(i - 52);
            var dulp = if(i <= -1022) pot(-1075) else pot(i - 53);
            rtdouble(i, n, "d pot");
            rtdouble(i, n + 2 * uulp, "d pot+");
            rtdouble(i, n - dulp, "d pot-");
            rtdouble(i, n - 2 * dulp, "d pot--");
        }
    }
}
```