### PR TITLE
Reference haxe.Timer.stamp from Date.getTime docs

### DIFF
--- a/std/Date.hx
+++ b/std/Date.hx
@@ -53,6 +53,9 @@ extern class Date
 	/**
 		Returns the timestamp (in milliseconds) of the date. It might
 		only have a per-second precision depending on the platforms.
+
+		For measuring time differences with millisecond accuracy on
+		all platforms, see `haxe.Timer.stamp`.
 	**/
 	function getTime() : Float;
 


### PR DESCRIPTION
This documentation has always bugged me (I swear I have another PR somewhere...):

"might only have a per-second precision"

1) It's in the cross-platform API, I cringe at this ambiguity
2) People familiar with JavaScript expect `Date.getTime` to be the canonical way to measure events with millisecond accuracy.

I might suggest that we deprecate / rename this function `toTimestamp():Float` just to break the JS confusion...

But minimally, I suggest we cross-reference `haxe.Timer.stamp` which is what many people are looking for when they look up `Date.getTime`. And it makes the "might" ambiguity a little better to know that Haxe does provide a more reliable API.