### PR TITLE
Fix bad unification with static fields

### DIFF
--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -1873,7 +1873,9 @@ let rec type_eq param a b =
 					let f2 = PMap.find n a2.a_fields in
 					if f1.cf_kind <> f2.cf_kind && (param = EqStrict || param = EqCoreType || not (unify_kind f1.cf_kind f2.cf_kind)) then error [invalid_kind n f1.cf_kind f2.cf_kind];
 					let a = f1.cf_type and b = f2.cf_type in
-					(try type_eq param a b with Unify_error l -> error (invalid_field n :: l))
+					(try type_eq param a b with Unify_error l -> error (invalid_field n :: l));
+					if f1.cf_public != f2.cf_public then error [cannot_unify a b];
+					if f1.cf_final != f2.cf_final then error [cannot_unify a b];
 				with
 					Not_found ->
 						if is_closed a2 then error [has_no_field b n];

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -1862,6 +1862,12 @@ let rec type_eq param a b =
 		List.iter2 (type_eq param) tl1 tl2
 	| TAnon a1, TAnon a2 ->
 		(try
+			(match !(a2.a_status) with
+			| Statics c -> (match !(a1.a_status) with Statics c2 when c == c2 -> () | _ -> error [])
+			| EnumStatics e -> (match !(a1.a_status) with EnumStatics e2 when e == e2 -> () | _ -> error [])
+			| AbstractStatics a -> (match !(a1.a_status) with AbstractStatics a2 when a == a2 -> () | _ -> error [])
+			| _ -> ()
+			);
 			PMap.iter (fun n f1 ->
 				try
 					let f2 = PMap.find n a2.a_fields in

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -1874,8 +1874,7 @@ let rec type_eq param a b =
 					if f1.cf_kind <> f2.cf_kind && (param = EqStrict || param = EqCoreType || not (unify_kind f1.cf_kind f2.cf_kind)) then error [invalid_kind n f1.cf_kind f2.cf_kind];
 					let a = f1.cf_type and b = f2.cf_type in
 					(try type_eq param a b with Unify_error l -> error (invalid_field n :: l));
-					if f1.cf_public != f2.cf_public then error [cannot_unify a b];
-					if f1.cf_final != f2.cf_final then error [cannot_unify a b];
+					if f1.cf_public != f2.cf_public then error [invalid_visibility n];
 				with
 					Not_found ->
 						if is_closed a2 then error [has_no_field b n];

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -1118,7 +1118,6 @@ module Cleanup = struct
 			| TField({eexpr = TTypeExpr _},_) ->
 				e
 			| TTypeExpr (TClassDecl c) ->
-				List.iter (fun cf -> if not (Meta.has Meta.MaybeUsed cf.cf_meta) then cf.cf_meta <- (Meta.MaybeUsed,[],cf.cf_pos) :: cf.cf_meta;) c.cl_ordered_statics;
 				e
 			| TMeta((Meta.Ast,_,_),e1) when (match e1.eexpr with TSwitch _ -> false | _ -> true) ->
 				loop e1

--- a/tests/misc/projects/Issue7526/Main.hx
+++ b/tests/misc/projects/Issue7526/Main.hx
@@ -1,0 +1,20 @@
+class C {
+
+    static private var member: Int = 42;
+
+}
+
+abstract A(Any) {
+
+	static private var member: Int = 42;
+
+}
+
+class Main {
+
+    static function main() {
+        (C: { member: Int }).member;
+        (A: { member: Int }).member;
+    }
+
+}

--- a/tests/misc/projects/Issue7526/compile-fail.hxml
+++ b/tests/misc/projects/Issue7526/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/Issue7526/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7526/compile-fail.hxml.stderr
@@ -1,0 +1,6 @@
+Main.hx:16: characters 9-29 : Class<C> should be { member : Int }
+Main.hx:16: characters 9-29 : { Statics C } should be { member : Int }
+Main.hx:16: characters 9-29 : The field member is not public
+Main.hx:17: characters 9-29 : Class<_Main.A_Impl_> should be { member : Int }
+Main.hx:17: characters 9-29 : { Statics _Main.A_Impl_ } should be { member : Int }
+Main.hx:17: characters 9-29 : The field member is not public


### PR DESCRIPTION
Fixes #7526 

This PR adds a check for matching `TAnon.a_status` in `type_eq` similar to in `unify_anon`. It also removes a previous fix for #4910 that's no longer required.

Removing the now redundant fix for #4910 helps fix some DCE issues (see #7528)