### PR TITLE
[js] Cleanup some unused code

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1490,7 +1490,7 @@ let generate com =
 	let vars = if has_feature ctx "has_enum"
 		then ("$estr = function() { return " ^ (ctx.type_accessor (TClassDecl { null_class with cl_path = ["js"],"Boot" })) ^ ".__string_rec(this,''); }") :: vars
 		else vars in
-	let vars = if enums_as_objects then "$hxEnums = $hxEnums || {}" :: vars else vars in
+	let vars = if (enums_as_objects && (has_feature ctx "has_enum" || has_feature ctx "Type.resolveEnum")) then "$hxEnums = $hxEnums || {}" :: vars else vars in
 	let vars,has_dollar_underscore =
 		if List.exists (function TEnumDecl { e_extern = false } -> true | _ -> false) com.types then
 			"$_" :: vars,true

--- a/std/js/_std/String.hx
+++ b/std/js/_std/String.hx
@@ -41,11 +41,11 @@
 	}
 
 	@:pure static inline function fromCharCode( code : Int ) : String {
-		return js.Syntax.code("String.fromCodePoint({0})",code); 
+		return untyped __define_feature__('String.fromCharCode', js.Syntax.code("String.fromCodePoint({0})", code));
 	}
 	
 	static function __init__() : Void {
-		js.Syntax.code("if( String.fromCodePoint == null ) String.fromCodePoint = function(c) { return c < 0x10000 ? String.fromCharCode(c) : String.fromCharCode((c>>10)+0xD7C0)+String.fromCharCode((c&0x3FF)+0xDC00); }");
+		untyped __feature__('String.fromCharCode', js.Syntax.code("if( String.fromCodePoint == null ) String.fromCodePoint = function(c) { return c < 0x10000 ? String.fromCharCode(c) : String.fromCharCode((c>>10)+0xD7C0)+String.fromCharCode((c&0x3FF)+0xDC00); }"));
 	}
 	
 }

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -83,7 +83,7 @@ enum ValueType {
 	}
 
 	public static inline function resolveEnum( name : String ) : Enum<Dynamic> {
-		return untyped $hxEnums[name];
+		return untyped __define_feature__("Type.resolveEnum", $hxEnums[name]);
 	}
 	#end
 


### PR DESCRIPTION
Currently the haxe "hello world" includes a few lines of unused code – this PR helps strip those lines when `-dce full`. This applies to
- `String.fromCodePoint` polyfill
- `$hxEnums` declaration

**This requires DCE fixes from PR #7527 to merge**

```haxe
class Main {
    static function main() trace("hello world");
}
```
Before
```js
(function () { "use strict";
var $hxEnums = $hxEnums || {};
var Test = function() { };
Test.main = function() {
	console.log("src/Main.hx:2:","hello world");
};
if( String.fromCodePoint == null ) String.fromCodePoint = function(c) { return c < 0x10000 ? String.fromCharCode(c) : String.fromCharCode((c>>10)+0xD7C0)+String.fromCharCode((c&0x3FF)+0xDC00); }
Test.main();
})();
```

After
```js
(function () { "use strict";
var Main = function() { };
Main.main = function() {
	console.log("src/Main.hx:2:","hello world");
};
Main.main();
})();
```

Which hopefully creates a slightly better impression for newcomers :)