### PR TITLE
[python] Allow main() as entry point when imported

### DIFF
--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -2463,13 +2463,11 @@ module Generator = struct
 			| Some e ->
 				newline ctx;
 				newline ctx;
-				spr ctx "if __name__ == '__main__':";
-				newline ctx;
 				match e.eexpr with
 				| TBlock el ->
-					List.iter (fun e -> gen_expr ctx e "" "    "; newline ctx) el;
+					List.iter (fun e -> gen_expr ctx e "" ""; newline ctx) el
 				| _ ->
-					gen_expr ctx e "" "    "; newline ctx
+					gen_expr ctx e "" ""; newline ctx
 
 	(* Entry point *)
 

--- a/std/python/Lib.hx
+++ b/std/python/Lib.hx
@@ -33,6 +33,10 @@ typedef PySys = python.lib.Sys;
 	and vice-versa.
 **/
 class Lib {
+
+	static public var __name__(get, never):String;
+	static inline function get___name__():String return python.Syntax.code('__name__');
+
 	/**
 		Print the specified value on the default output.
 	**/


### PR DESCRIPTION
See #7495 for more details

Currently there's no entry point to execute code when your haxe python script is imported. This PR removes the `if __name__ == '__main__':` check (rolling back #6865) so that `main()` is always executed, and it adds `__name__` to `python.Lib` so the check can be implemented by users.

This makes the python target match the import behavior of other targets like js

The reason `if __name__ == '__main__':` exists is so you can create a python script that behaves differently when used as a CLI or library. However, I don't think users expect this to be the default behavior and if this behavior is required then you can do

```haxe
static function main() {
    if (python.Lib.__name__ == '__main__') {
        trace('You are executing this script directly');
    }  else {
        trace('You are loading this script via python import');
    }
}
```

(closes #7495)