### PR TITLE
[lua] throw eof properly in FileInput

### DIFF
--- a/std/lua/_std/sys/io/FileInput.hx
+++ b/std/lua/_std/sys/io/FileInput.hx
@@ -67,6 +67,11 @@ class FileInput extends haxe.io.Input {
 		}
 		return NativeStringTools.byte(byte);
 	}
+			
+	override function readBytes( s : Bytes, pos : Int, len : Int ) : Int {
+		if(eof()) throw new haxe.io.Eof();
+		return super.readBytes(s, pos, len);
+	}
 
 	override inline public function close() : Void {
 		f.close();


### PR DESCRIPTION
I always find it difficult to run the haxe unit tests locally. So I decided to let the CI do it.

(can't close the issue #7544 just yet, there is still `ProcessInput`)

