### PR TITLE
[cs] String compare fix

### DIFF
--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -3075,7 +3075,7 @@ let generate con =
 						{ e with eexpr = TBinop(op, e1, mk_cast t2 e2) }
 					| _ ->
 							let handler = if is_string e1.etype then begin
-									{ e1 with eexpr = TCall(mk_static_field_access_infer string_cl "Compare" e1.epos [], [ e1; e2 ]); etype = gen.gcon.basic.tint }
+									{ e1 with eexpr = TCall(mk_static_field_access_infer string_cl "CompareOrdinal" e1.epos [], [ e1; e2 ]); etype = gen.gcon.basic.tint }
 								end else begin
 									let static = mk_static_field_access_infer (runtime_cl) "compare" e1.epos [] in
 									{ eexpr = TCall(static, [e1; e2]); etype = gen.gcon.basic.tint; epos=e1.epos }

--- a/std/cs/_std/String.hx
+++ b/std/cs/_std/String.hx
@@ -26,6 +26,8 @@ import cs.StdTypes;
 	@:overload private static function Compare(s1:String, s2:String):Int;
 	@:overload private static function Compare(s1:String, s2:String, kind:cs.system.StringComparison):Int;
 
+	private static function CompareOrdinal(s1:String, s2:String):Int;
+
 	var length(default,null) : Int;
 
 	function new(string:String) : Void;

--- a/tests/unit/src/unit/issues/Issue6717.hx
+++ b/tests/unit/src/unit/issues/Issue6717.hx
@@ -1,0 +1,23 @@
+package unit.issues;
+
+class Issue6717 extends unit.Test {
+	function test() {
+		var space = " ";  // ASCII 0x20
+		var hyphen = "-"; // ASCII 0x2D
+
+		t(space.charAt(0) < hyphen.charAt(0));
+
+		// example strings from https://docs.microsoft.com/en-us/dotnet/api/system.globalization.compareoptions
+		var unsorted = ["cant", "bill's", "coop", "cannot", "billet", "can't", "con", "bills", "co-op"];
+		var expected = ["bill's", "billet", "bills", "can't", "cannot", "cant", "co-op", "con", "coop"];
+
+		var actual = unsorted.copy();
+		actual.sort(strcmp);
+
+		aeq(expected, actual);
+	}
+
+	static function strcmp(a:String, b:String):Int {
+		return a < b ? -1 : a > b ? 1 : 0;
+	}
+}


### PR DESCRIPTION
The purpose of this PR is to try fixing #6717 (which only relates to CS).

It invokes `string.CompareOrdinal()` instead of `string.Compare()`, so that the comparison is culture-invariant and case-sensitive (see https://docs.microsoft.com/en-us/dotnet/api/system.globalization.compareoptions).

I'm having some problems testing this thoroughly. Locally C# and most targets are OK, but remotely Travis seems to hang testing flash.

PS: probably this will also help with #5336.

Let me know if this needs any changes.