### PR TITLE
Support urls without a / separating the path and query parts

### DIFF
--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -103,8 +103,12 @@ class Http extends haxe.http.HttpBase {
 		var host = url_regexp.matched(2);
 		var portString = url_regexp.matched(3);
 		var request = url_regexp.matched(4);
-		if(request == "")
-			request = "/";
+		// ensure path begins with a forward slash
+		// this is required by original URL specifications and many servers have issues if it's not supplied
+		// see https://stackoverflow.com/questions/1617058/ok-to-skip-slash-before-query-string
+		if (request.charAt(0) != "/") {
+			request = "/" + request;
+		}
 		var port = if (portString == null || portString == "") secure ? 443:80 else Std.parseInt(portString.substr(1, portString.length - 1));
 
 		var multipart = (file != null);


### PR DESCRIPTION
@pcdv noticed a try.haxe.org example that didn't work on all targets (#7563)

The example was [Load Json using Http](https://try.haxe.org/#5CC2c)

It turns out to be because HTTP requests in the JS target work with URLs that don't have a slash after their host, such as http://example.com?a=1 but this fails on other targets.

This is a valid URL as of [RFC 3986](https://tools.ietf.org/html/rfc3986) (2005) ([more discussion](https://stackoverflow.com/a/42193734)). I found cURL [prepends a forward slash](https://github.com/curl/curl/blob/master/src/tool_operate.c#L794) to the path if one is missing so that's the approach I've taken in this change

After this PR URLs such as `http://example.com?a=1` will work on all targets

closes #7563 