### PR TITLE
HTML Extern Improvements

### DIFF
--- a/std/js/html/BodyElement.hx
+++ b/std/js/html/BodyElement.hx
@@ -66,7 +66,7 @@ extern class BodyElement extends Element
 	var background : String;
 	var onafterprint : haxe.Constraints.Function;
 	var onbeforeprint : haxe.Constraints.Function;
-	var onbeforeunload : Event -> String;
+	var onbeforeunload : Event -> Null<String>;
 	var onhashchange : haxe.Constraints.Function;
 	var onlanguagechange : haxe.Constraints.Function;
 	var onmessage : haxe.Constraints.Function;

--- a/std/js/html/Document.hx
+++ b/std/js/html/Document.hx
@@ -543,11 +543,11 @@ extern class Document extends Node
 	/** @throws DOMError */
 	@:overload( function( expression : String, ?resolver : haxe.Constraints.Function) : XPathExpression {} )
 	@:overload( function( expression : String, ?resolver : XPathNSResolver) : XPathExpression {} )
-	function createExpression( expression : String, ?resolver : String -> String ) : XPathExpression;
+	function createExpression( expression : String, ?resolver : String -> Null<String> ) : XPathExpression;
 	@:pure
 	function createNSResolver( nodeResolver : Node ) : Node;
 	/** @throws DOMError */
 	@:overload( function( expression : String, contextNode : Node, ?resolver : haxe.Constraints.Function, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
 	@:overload( function( expression : String, contextNode : Node, ?resolver : XPathNSResolver, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
-	function evaluate( expression : String, contextNode : Node, ?resolver : String -> String, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
+	function evaluate( expression : String, contextNode : Node, ?resolver : String -> Null<String>, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
 }

--- a/std/js/html/FrameSetElement.hx
+++ b/std/js/html/FrameSetElement.hx
@@ -46,7 +46,7 @@ extern class FrameSetElement extends Element
 	var rows : String;
 	var onafterprint : haxe.Constraints.Function;
 	var onbeforeprint : haxe.Constraints.Function;
-	var onbeforeunload : Event -> String;
+	var onbeforeunload : Event -> Null<String>;
 	var onhashchange : haxe.Constraints.Function;
 	var onlanguagechange : haxe.Constraints.Function;
 	var onmessage : haxe.Constraints.Function;

--- a/std/js/html/Navigator.hx
+++ b/std/js/html/Navigator.hx
@@ -77,6 +77,11 @@ extern class Navigator
 		Returns the build identifier of the browser (e.g., "2006090803").
 	**/
 	var buildID(default,null) : String;
+	
+	/**
+		Returns a `ServiceWorkerContainer` object, which provides access to registration, removal, upgrade, and communication with the `ServiceWorker` objects for the associated document.
+	**/
+	var serviceWorker(default,null) : ServiceWorkerContainer;
 	var hardwareConcurrency(default,null) : Int;
 	
 	/**

--- a/std/js/html/RegistrationOptions.hx
+++ b/std/js/html/RegistrationOptions.hx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)2005-2018 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// This file is generated from mozilla\ServiceWorkerContainer.webidl. Do not edit!
+
+package js.html;
+
+typedef RegistrationOptions =
+{
+	@:optional var scope : String;
+	@:optional var updateViaCache : ServiceWorkerUpdateViaCache;
+}

--- a/std/js/html/ServiceWorkerContainer.hx
+++ b/std/js/html/ServiceWorkerContainer.hx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)2005-2018 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// This file is generated from mozilla\ServiceWorkerContainer.webidl. Do not edit!
+
+package js.html;
+
+/**
+	The `ServiceWorkerContainer` interface of the ServiceWorker API provides an object representing the service worker as an overall unit in the network ecosystem, including facilities to register, unregister and update service workers, and access the state of service workers and their registrations.
+
+	Documentation [ServiceWorkerContainer](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
+
+	@see <https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer>
+**/
+@:native("ServiceWorkerContainer")
+extern class ServiceWorkerContainer extends EventTarget
+{
+	
+	/**
+		Returns a `ServiceWorker` object if its state is `activated` (the same object returned by `ServiceWorkerRegistration.active`). This property returns `null` during a force-refresh request (Shift + refresh) or if there is no active worker.
+	**/
+	var controller(default,null) : ServiceWorker;
+	
+	/**
+		Provides a way of delaying code execution until a service worker is active. It returns a `Promise` that will never reject, and which waits indefinitely until the `ServiceWorkerRegistration` associated with the current page has an `ServiceWorkerRegistration.active` worker. Once that condition is met, it resolves with the `ServiceWorkerRegistration`.
+	**/
+	var ready(default,null) : Promise<ServiceWorkerRegistration>;
+	
+	/**
+		Fired whenever a `controllerchange` event occurs — when the document's associated `ServiceWorkerRegistration` acquires a new `ServiceWorkerRegistration.active` worker.
+	**/
+	var oncontrollerchange : haxe.Constraints.Function;
+	
+	/**
+		Fired whenever an `error` event occurs in the associated service workers.
+	**/
+	var onerror : haxe.Constraints.Function;
+	
+	/**
+		Fired whenever a `message` event occurs — when incoming messages are received to the `ServiceWorkerContainer` object (e.g. via a `MessagePort.postMessage()` call.)
+	**/
+	var onmessage : haxe.Constraints.Function;
+	
+	function register( scriptURL : String, ?options : RegistrationOptions ) : Promise<ServiceWorkerRegistration>;
+	
+	/**
+		Gets a `ServiceWorkerRegistration` object whose scope matches the provided document URL.  If the method can't return a `ServiceWorkerRegistration`, it returns a `Promise`. 
+	**/
+	function getRegistration( ?documentURL : String = "" ) : Promise<Dynamic>;
+	
+	/**
+		Returns all `ServiceWorkerRegistration` objects associated with a `ServiceWorkerContainer` in an array.  If the method can't return `ServiceWorkerRegistration` objects, it returns a `Promise`. 
+	**/
+	function getRegistrations() : Promise<Array<ServiceWorkerRegistration>>;
+}

--- a/std/js/html/Window.hx
+++ b/std/js/html/Window.hx
@@ -344,7 +344,7 @@ extern class Window extends EventTarget
 	var ontouchcancel : haxe.Constraints.Function;
 	var onafterprint : haxe.Constraints.Function;
 	var onbeforeprint : haxe.Constraints.Function;
-	var onbeforeunload : Event -> String;
+	var onbeforeunload : Event -> Null<String>;
 	var onhashchange : haxe.Constraints.Function;
 	var onlanguagechange : haxe.Constraints.Function;
 	var onmessage : haxe.Constraints.Function;

--- a/std/js/html/XPathEvaluator.hx
+++ b/std/js/html/XPathEvaluator.hx
@@ -32,11 +32,11 @@ extern class XPathEvaluator
 	/** @throws DOMError */
 	@:overload( function( expression : String, ?resolver : haxe.Constraints.Function) : XPathExpression {} )
 	@:overload( function( expression : String, ?resolver : XPathNSResolver) : XPathExpression {} )
-	function createExpression( expression : String, ?resolver : String -> String ) : XPathExpression;
+	function createExpression( expression : String, ?resolver : String -> Null<String> ) : XPathExpression;
 	@:pure
 	function createNSResolver( nodeResolver : Node ) : Node;
 	/** @throws DOMError */
 	@:overload( function( expression : String, contextNode : Node, ?resolver : haxe.Constraints.Function, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
 	@:overload( function( expression : String, contextNode : Node, ?resolver : XPathNSResolver, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
-	function evaluate( expression : String, contextNode : Node, ?resolver : String -> String, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
+	function evaluate( expression : String, contextNode : Node, ?resolver : String -> Null<String>, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
 }


### PR DESCRIPTION
Tweaks to close old html extern issues, closes #5638 and closes #5675

- Enabled navigator.serviceWorker
- Emit Null<T> for return type method signatures when return is optional

Opening for visibility – will merge tomorrow