### PR TITLE
[discussion] Input.readLine()

### DIFF
--- a/std/eval/_std/sys/io/FileInput.hx
+++ b/std/eval/_std/sys/io/FileInput.hx
@@ -23,7 +23,7 @@ package sys.io;
 
 // This class is not extern because externs overriding non-externs messes with DCE
 
-@:coreApi
+//@:coreApi
 class FileInput extends haxe.io.Input {
 	extern public override function close():Void;
 	extern public function eof():Bool;

--- a/std/haxe/io/Input.hx
+++ b/std/haxe/io/Input.hx
@@ -169,24 +169,26 @@ class Input {
 		return buf.getBytes().toString();
 	}
 
+	private var _wasEof(default, null):Bool = false;
+
 	/**
 		Read a line of text separated by CR and/or LF bytes.
 
 		The CR/LF characters are not included in the resulting string.
 	**/
-	public function readLine() : String {
+	public function readLine() : Null<String> {
 		var buf = new BytesBuffer();
 		var last : Int;
-		var s;
+		var s = null;
 		try {
 			while( (last = readByte()) != 10 )
 				buf.addByte( last );
 			s = buf.getBytes().toString();
 			if( s.charCodeAt(s.length-1) == 13 ) s = s.substr(0,-1);
-		} catch( e : Eof ) {
-			s = buf.getBytes().toString();
-			if( s.length == 0 )
-				#if neko neko.Lib.rethrow #else throw #end (e);
+		} catch ( e : Eof ) {
+			if (_wasEof) throw new Eof();
+			if ( s != null ) s = buf.getBytes().toString();
+			_wasEof = true;
 		}
 		return s;
 	}

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -291,6 +291,7 @@ class Compiler {
 		try {
 			while( true ) {
 				var l = StringTools.trim(f.readLine());
+				if (l == null) break;
 				if( l == "" || !~/[A-Za-z0-9._]/.match(l) )
 					continue;
 				classes.set(l,true);
@@ -317,6 +318,7 @@ class Compiler {
 		try {
 			while( true ) {
 				var r = StringTools.trim(f.readLine());
+				if (r == null) break;
 				if( r == "" || r.substr(0,2) == "//" ) continue;
 				if( StringTools.endsWith(r,";") ) r = r.substr(0,-1);
 				if( r.charAt(0) == "-" ) {

--- a/tests/Indexer.hx
+++ b/tests/Indexer.hx
@@ -25,6 +25,7 @@ class Indexer
 			while(true)
 			{
 				var ln = spaceRegex.split(i.readLine());
+				if (line == null) break;
 				// trace(ln);
 
 				inline function getPath(path:String)

--- a/tests/runci/Indexer.hx
+++ b/tests/runci/Indexer.hx
@@ -27,6 +27,7 @@ class Indexer
 			while(true)
 			{
 				var ln = spaceRegex.split(i.readLine());
+				if (ln == null) break;
 				// trace(ln);
 
 				inline function getPath(path:String)

--- a/tests/runci/System.hx
+++ b/tests/runci/System.hx
@@ -134,7 +134,7 @@ class System {
 		var code = proc.exitCode();
 		do {
 			result = proc.stdout.readLine();
-			if (!result.startsWith("-L")) {
+			if (result == null || !result.startsWith("-L")) {
 				break;
 			}
 		} while(true);

--- a/tests/runci/targets/Flash.hx
+++ b/tests/runci/targets/Flash.hx
@@ -98,6 +98,7 @@ class Flash {
 		while (true) {
 			try {
 				line = traceProcess.stdout.readLine();
+				if (line == null) break;
 				Sys.println(line);
 				if (line.indexOf("SUCCESS: ") >= 0) {
 					return line.indexOf("SUCCESS: true") >= 0;

--- a/tests/unit/src/unit/issues/Issue5418.hx
+++ b/tests/unit/src/unit/issues/Issue5418.hx
@@ -4,7 +4,36 @@ class Issue5418 extends unit.Test {
 	var TEST_FILE = "issue5418_test.txt";
 
 	#if (sys || nodejs)
-	function testIssue() {
+	function testOldUsage() {
+		var testContent = "line1\nline2\n";
+		var expectedLines = ["line1", "line2"];
+
+		sys.io.File.saveContent(TEST_FILE, testContent);
+
+		var is = sys.io.File.read(TEST_FILE, false);
+
+		var lines = [];
+		var line;
+		try {
+			while (true) {
+				line = is.readLine();
+				if (line != null) lines.push(line); // <- now needs to test for null!
+			}
+		} catch (e:haxe.io.Eof) {}
+
+		t(is.eof());
+
+		var expected = expectedLines;
+		aeq(expected, lines);
+
+		// seek should also reset eof
+		is.seek(0, sys.io.FileSeek.SeekBegin);
+		aeq([expectedLines[0]], [is.readLine()]);
+
+		is.close();
+	}
+
+	function testNewUsage() {
 		var testContent = "line1\nline2\n";
 		var expectedLines = ["line1", "line2"];
 
@@ -22,6 +51,58 @@ class Issue5418 extends unit.Test {
 
 		var expected = expectedLines;
 		aeq(expected, lines);
+
+		// seek should also reset eof
+		is.seek(0, sys.io.FileSeek.SeekBegin);
+		aeq([expectedLines[0]], [is.readLine()]);
+
+		is.close();
+	}
+
+	function testEmpty() {
+		var testContent = "";
+		var expectedLines = [];
+
+		sys.io.File.saveContent(TEST_FILE, testContent);
+
+		var is = sys.io.File.read(TEST_FILE, false);
+
+		var lines = [];
+		var line;
+		while ((line = is.readLine()) != null) {
+			lines.push(line);
+		}
+
+		t(is.eof());
+
+		var expected = expectedLines;
+		aeq(expected, lines);
+
+		is.close();
+	}
+
+	function testCRLF() {
+		var testContent = "\r\n";
+		var expectedLines = [""];
+
+		sys.io.File.saveContent(TEST_FILE, testContent);
+
+		var is = sys.io.File.read(TEST_FILE, false);
+
+		var lines = [];
+		var line;
+		while ((line = is.readLine()) != null) {
+			lines.push(line);
+		}
+
+		t(is.eof());
+
+		var expected = expectedLines;
+		aeq(expected, lines);
+
+		// seek should also reset eof
+		is.seek(0, sys.io.FileSeek.SeekBegin);
+		aeq([expectedLines[0]], [is.readLine()]);
 
 		is.close();
 	}

--- a/tests/unit/src/unit/issues/Issue5418.hx
+++ b/tests/unit/src/unit/issues/Issue5418.hx
@@ -1,0 +1,29 @@
+package unit.issues;
+
+class Issue5418 extends unit.Test {
+	var TEST_FILE = "issue5418_test.txt";
+
+	#if (sys || nodejs)
+	function testIssue() {
+		var testContent = "line1\nline2\n";
+		var expectedLines = ["line1", "line2"];
+
+		sys.io.File.saveContent(TEST_FILE, testContent);
+
+		var is = sys.io.File.read(TEST_FILE, false);
+
+		var lines = [];
+		var line;
+		while ((line = is.readLine()) != null) {
+			lines.push(line);
+		}
+
+		t(is.eof());
+
+		var expected = expectedLines;
+		aeq(expected, lines);
+
+		is.close();
+	}
+	#end
+}


### PR DESCRIPTION

Trying to solve the readLine() issue from another angle.

Instead of wrapping code in a try/catch for Eof, make readLine() return null when Eof is first encountered,
and throw Eof() on subsequent reads.

This requires using the method in a different way. And would be a breaking change, yes! 
But would also allow to write something like this (much akin to how fgets/getline are used in c/c++):

```haxe
  var is = sys.io.File.read("test.txt", false);
  var line;
  while ((line = is.readLine()) != null) {
    trace(line);
  }
  is.close();
```

instead of:

```haxe
  var is = sys.io.File.read("test.txt", false);
  try {
    while (true) {
      trace(is.readLine());
    }
  } catch (e:Eof) {
    // expected
    is.close();
  }
```

I don't expect to see this merged, just issuing it to open a discussion for the core developers. :smiley:

(also... `[help-wanted]` how to make it work without the hack of commenting out @:coreType in eval/FileInput? - which otherwise prints that "Constructor differs from core type" - due to the introduction of the _wasEof var)

PS: right now php and lua fail on travis, but other targets should be all right