### PR TITLE
Add haxe.Log.debug

### DIFF
--- a/std/haxe/Log.hx
+++ b/std/haxe/Log.hx
@@ -70,5 +70,10 @@ class Log {
 		throw "Not implemented"
 		#end
 	}
+	
+	public static inline function debug<T>(v:T, ?pos:haxe.PosInfos):T {
+		haxe.Log.trace(v, pos);
+		return v;
+	}
 
 }


### PR DESCRIPTION
... which prints the value and returns it. Useful for a quick debugging, eliminating the need to add a separate `trace` statement which might in turn requires one to wrap the code in a block (if it is not one already)

I think it should reduce to the original expression with `--no-traces`, so that there is no overhead.