### PR TITLE
bugfix for [#2689], design implementation for [#7183]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ tmp.tmp
 dev-display.hxml
 
 .DS_Store
+.history
 tests/sourcemaps/bin
 /*_plugin.ml
 tests/benchs/export/


### PR DESCRIPTION
Hello,

I believe I fixed issue #2689. Now, when compiled in java, the following generates a special "another overloaded field..." error. The error specifies that the signatures are different in Haxe, but not in the implementation. Not sure if it works for all cases, but I also tested wrapping the lambda parameters in Null<T> and a generic class Box<T>:
```
class Overload {
    @:overload static function apply(f: (Int, Int) -> Int): Int {
        return f(3, 4);
    }

    @:overload static function apply(f: (String, String) -> String): String {
        return f("hello ", "world");
    }

    static public function main(): Void {
        trace(apply((x, y) -> x * y));
        trace(apply((x: String, y: String) -> x + y));
    }
}
```

I also implemented something for #7183: a field annotation `@:structInitOptional`, which allows you to omit the annotated field when initializing a class from a structure. This was mainly just an experiment for me to get familiar with editing the compiler.