### PR TITLE
[js] Fixed wrong `blobParts` type.

### DIFF
--- a/std/js/html/Blob.hx
+++ b/std/js/html/Blob.hx
@@ -46,7 +46,7 @@ extern class Blob
 	var type(default,null) : String;
 	
 	/** @throws DOMError */
-	function new( ?blobParts : Array<haxe.extern.EitherType<haxe.extern.EitherType<ArrayBufferView,ArrayBuffer>,haxe.extern.EitherType<Blob,String>>>, ?options : BlobPropertyBag ) : Void;
+	function new( ?blobParts : Array<haxe.extern.EitherType<ArrayBuffer,haxe.extern.EitherType<ArrayBufferView,haxe.extern.EitherType<Blob,String>>>>, ?options : BlobPropertyBag ) : Void;
 	
 	/**
 		Returns a new `Blob` object containing the data in the specified range of bytes of the source `Blob`.


### PR DESCRIPTION
```haxe
var buffers = [Int32Array.fromBytes(bytes).getData().buffer];
var url = URL.createObjectURL(new Blob(buffers));
```
Haxe 4.0.0-preview.5:
```
ContentLoader.hx:261: characters 38-45 : Array<js.html.ArrayBuffer> should be Null<Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>>
ContentLoader.hx:261: characters 38-45 : Array<js.html.ArrayBuffer> should be Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>
ContentLoader.hx:261: characters 38-45 : Type parameters are invariant
ContentLoader.hx:261: characters 38-45 : js.html.ArrayBuffer should be haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>
ContentLoader.hx:261: characters 38-45 : For optional function argument 'blobParts'
ContentLoader.hx:261: characters 38-45 : Array<js.html.ArrayBuffer> should be Null<Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>>
ContentLoader.hx:261: characters 38-45 : Array<js.html.ArrayBuffer> should be Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>
ContentLoader.hx:261: characters 38-45 : Type parameters are invariant
ContentLoader.hx:261: characters 38-45 : js.html.ArrayBuffer should be haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>
ContentLoader.hx:261: characters 38-45 : For optional function argument 'blobParts'
ContentLoader.hx:262: characters 38-45 : Array<js.html.ArrayBuffer> should be Null<Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>>
ContentLoader.hx:262: characters 38-45 : Array<js.html.ArrayBuffer> should be Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>
ContentLoader.hx:262: characters 38-45 : Type parameters are invariant
ContentLoader.hx:262: characters 38-45 : js.html.ArrayBuffer should be haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>
ContentLoader.hx:262: characters 38-45 : For optional function argument 'blobParts'
ContentLoader.hx:262: characters 38-45 : Array<js.html.ArrayBuffer> should be Null<Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>>
ContentLoader.hx:262: characters 38-45 : Array<js.html.ArrayBuffer> should be Array<haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>>
ContentLoader.hx:262: characters 38-45 : Type parameters are invariant
ContentLoader.hx:262: characters 38-45 : js.html.ArrayBuffer should be haxe.extern.EitherType<haxe.extern.EitherType<js.html.ArrayBufferView, js.html.ArrayBuffer>, haxe.extern.EitherType<js.html.Blob, String>>
ContentLoader.hx:262: characters 38-45 : For optional function argument 'blobParts'
```