### PR TITLE
added @:structInitOptional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ tmp.tmp
 dev-display.hxml
 
 .DS_Store
+.history
 tests/sourcemaps/bin
 /*_plugin.ml
 tests/benchs/export/

--- a/src/core/meta.ml
+++ b/src/core/meta.ml
@@ -157,6 +157,7 @@ type strict_meta =
 	| Struct
 	| StructAccess
 	| StructInit
+	| StructInitOptional
 	| SuppressWarnings
 	| This
 	| Throws
@@ -358,6 +359,7 @@ let get_info = function
 	| Struct -> ":struct",("Marks a class definition as a struct",[Platform Cs; UsedOn TClass])
 	| StructAccess -> ":structAccess",("Marks an extern class as using struct access('.') not pointer('->')",[Platform Cpp; UsedOn TClass])
 	| StructInit -> ":structInit",("Allows one to initialize the class with a structure that matches constructor parameters",[UsedOn TClass])
+	| StructInitOptional -> ":structInitOptional",("When initializing the class with a structure, this field can be absent, in which case it'll be assigned the default value for its type",[UsedOn TClassField])
 	| SuppressWarnings -> ":suppressWarnings",("Adds a SuppressWarnings annotation for the generated Java class",[Platform Java; UsedOn TClass])
 	| TemplatedCall -> ":templatedCall",("Indicates that the first parameter of static call should be treated as a template argument",[Platform Cpp; UsedOn TClassField])
 	| Throws -> ":throws",("Adds a 'throws' declaration to the generated function",[HasParam "Type as String"; Platform Java; UsedOn TClassField])

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -161,7 +161,7 @@ let ensure_struct_init_constructor ctx c ast_fields p =
 		let args,el,tl = List.fold_left (fun (args,el,tl) cf -> match cf.cf_kind with
 			| Var _ ->
 				let has_default_expr = field_has_default_expr cf.cf_name in
-				let opt = has_default_expr || (Meta.has Meta.Optional cf.cf_meta) in
+				let opt = has_default_expr || (Meta.has Meta.Optional cf.cf_meta || Meta.has Meta.StructInitOptional cf.cf_meta) in
 				let t = if opt then ctx.t.tnull cf.cf_type else cf.cf_type in
 				let v = alloc_var VGenerated cf.cf_name t p in
 				let ef = mk (TField(ethis,FInstance(c,params,cf))) t p in


### PR DESCRIPTION
I implemented something for #7183: a field annotation `@:structInitOptional`, which allows you to omit the annotated field when initializing a class from a structure. This was mainly just an experiment for me to get familiar with editing the compiler.