### PR TITLE
[benchs] add custom iterator bench

### DIFF
--- a/tests/benchs/src/cases/CustomIterator.hx
+++ b/tests/benchs/src/cases/CustomIterator.hx
@@ -1,0 +1,105 @@
+package cases;
+
+import hxbenchmark.Suite;
+
+class CustomIterator<T> extends TestCase {
+
+	var MAX_TIME_PER_CASE:Float = .5;
+	var N = 1000;
+
+	function measureInt() {
+		var data = [for (i in 0...N) i];
+		var custom = new Custom(data);
+
+		var suite = new Suite('Custom(Array<Int>[$N])', MAX_TIME_PER_CASE);
+		suite.add("array", for (v in data) {});
+		suite.add("inlineIterator()", for (v in custom.inlineIterator()) {});
+		suite.add("iterator()", for (v in custom.iterator()) {});
+		suite.add("iteratorT()", for (v in custom.iteratorT()) {});
+		suite.add("iter(func)", custom.iter(function(v) {}));
+		return suite.run();
+	}
+
+	function measureString() {
+		var data = [for (i in 0...N) "" + i];
+		var custom = new Custom(data);
+
+		var suite = new Suite('Custom(Array<String>[$N])', MAX_TIME_PER_CASE);
+		suite.add("array", for (v in data) {});
+		suite.add("inlineIterator()", for (v in custom.inlineIterator()) {});
+		suite.add("iterator()", for (v in custom.iterator()) {});
+		suite.add("iteratorT()", for (v in custom.iteratorT()) {});
+		suite.add("iter(func)", custom.iter(function(v) {}));
+		return suite.run();
+	}
+
+	function measureDummy() {
+		var data = [for (i in 0...N) new Dummy()];
+		var custom = new Custom(data);
+
+		var suite = new Suite('Custom(Array<Dummy>[$N])', MAX_TIME_PER_CASE);
+		suite.add("array", for (v in data) {});
+		suite.add("inlineIterator()", for (v in custom.inlineIterator()) {});
+		suite.add("iterator()", for (v in custom.iterator()) {});
+		suite.add("iteratorT()", for (v in custom.iteratorT()) {});
+		suite.add("iter(func)", custom.iter(function(v) {}));
+		return suite.run();
+	}
+}
+
+class Custom<T> {
+	public var data:Array<T>;
+
+	public function new(data:Array<T>) {
+		this.data = data;
+	}
+
+	inline public function inlineIterator():Iterator<T> {
+		return data.iterator();
+	}
+
+	public function iterator():Iterator<T> {
+		return data.iterator();
+	}
+
+	public function iteratorT():Iterator<T> {
+		return new IteratorT(this);
+	}
+
+	public function iter(func:T->Void) {
+		var len = data.length;
+		var idx = 0;
+		while (idx < len) {
+			func(data[idx]);
+			idx++;
+		}
+	}
+}
+
+class IteratorT<T> {
+	var data:Array<T>;
+	var len:Int;
+	var idx:Int;
+
+	public function new(custom:Custom<T>) {
+		this.data = custom.data;
+		this.len = data.length;
+		this.idx = 0;
+	}
+
+	inline public function hasNext():Bool {
+		return idx < len;
+	}
+
+	inline public function next():T {
+		return data[idx++];
+	}
+}
+
+class Dummy {
+	var x:Int;
+	var s:String;
+	var o:{};
+
+	public function new() {}
+}

--- a/tests/benchs/src/cases/CustomIterator.hx
+++ b/tests/benchs/src/cases/CustomIterator.hx
@@ -12,7 +12,6 @@ class CustomIterator<T> extends TestCase {
 		var custom = new Custom(data);
 
 		var suite = new Suite('Custom(Array<Int>[$N])', MAX_TIME_PER_CASE);
-		suite.add("array", for (v in data) {});
 		suite.add("inlineIterator()", for (v in custom.inlineIterator()) {});
 		suite.add("iterator()", for (v in custom.iterator()) {});
 		suite.add("iteratorT()", for (v in custom.iteratorT()) {});
@@ -25,7 +24,6 @@ class CustomIterator<T> extends TestCase {
 		var custom = new Custom(data);
 
 		var suite = new Suite('Custom(Array<String>[$N])', MAX_TIME_PER_CASE);
-		suite.add("array", for (v in data) {});
 		suite.add("inlineIterator()", for (v in custom.inlineIterator()) {});
 		suite.add("iterator()", for (v in custom.iterator()) {});
 		suite.add("iteratorT()", for (v in custom.iteratorT()) {});
@@ -38,7 +36,6 @@ class CustomIterator<T> extends TestCase {
 		var custom = new Custom(data);
 
 		var suite = new Suite('Custom(Array<Dummy>[$N])', MAX_TIME_PER_CASE);
-		suite.add("array", for (v in data) {});
 		suite.add("inlineIterator()", for (v in custom.inlineIterator()) {});
 		suite.add("iterator()", for (v in custom.iterator()) {});
 		suite.add("iteratorT()", for (v in custom.iteratorT()) {});


### PR DESCRIPTION
Testing performance of different ways of using/implementing iterators with custom classes.

Not intended to be merged, just to open a discussion, and see if things can be improved. :smiley:

Some stats for some targets maybe outliers: they can "over-optimize" empty loops by replacing them with no-ops (i think the cpp array test falls in this field (and probably others)).

Here's a sample of what cs reports:

**`Suite: Custom(Array<Int>[1000])`:**

| test             | ops     | percent |
|------------------|---------|---------|
|             array| 544,544 | 100.00% |
|        iter(func)|  15,436 |   2.83% |
|  inlineIterator()|   7,165 |   1.31% |
|        iterator()|   7,048 |   1.29% |
|       iteratorT()|   5,695 |   1.04% |

**`Suite: Custom(Array<String>[1000])`:**

| test             | ops     | percent |
|------------------|---------|---------|
|             array| 438,438 | 100.00% |
|        iter(func)|  28,548 |   6.51% |
|  inlineIterator()|   8,137 |   1.85% |
|       iteratorT()|   6,870 |   1.56% |
|        iterator()|   6,835 |   1.55% |

**`Suite: Custom(Array<Dummy>[1000])`:**

| test             | ops     | percent |
|------------------|---------|---------|
|             array| 451,451 | 100.00% |
|        iter(func)|  41,707 |   9.23% |
|  inlineIterator()|   7,556 |   1.67% |
|        iterator()|   7,108 |   1.57% |
|       iteratorT()|   6,917 |   1.53% |

(I'm planning to automate the gathering of stats and plot them onto a chart that includes all targets, so that it would be easier to compare performances and have a better understanding of what's happening)