### PR TITLE
Fixing Issue 6937. Warning problem with leading optional argument

### DIFF
--- a/src/core/abstract.ml
+++ b/src/core/abstract.ml
@@ -94,3 +94,10 @@ let rec follow_with_abstracts t = match follow t with
 		follow_with_abstracts (get_underlying_type a tl)
 	| t ->
 		t
+
+let rec follow_with_abstracts_from t =	
+	match follow t with
+	| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) ->
+		build_abstract a;
+		List.rev_append a.a_from (List.map fst a.a_from_field)
+	| t -> []


### PR DESCRIPTION
Hi, it is my first pull request in this project.

I had trouble with the CI (that why I have removed my last pull request), Travis doesn't go well, but I think it is not caused by my modification.

It correspond to the issue #6937.

I had a look at the code, and I think the problem is that once a warning has been thrown to the server, it can not be removed easily in the typing process.

The problem can be seen in this code example:

```ocaml
class Main {
	static function main() {
		var o = new Observable([123]);
		o.select(function (v) {
			$type(v);
			return true;
		});
	}
}

class Observable<T> {
	public function new(value:T) {}
	public function select(?options:Int, cb:T->Bool) {}
}
```
Here we have a first try of unification of type of the anonymous function with the first parameter (optional) options. Obviously it fails, and it carries on with the unification of type with the second parameter which is a function and succeed. It corresponds to this particular portion of code of the function unify_call_args' in the file calls.ml (line 172) :

```ocaml
	| e :: el,(name,opt,t) :: args ->
		begin try
			let e = type_against name t e in
			(e,opt) :: loop el args
		with
			WithTypeError (ul,p)->
				if opt then
					let e_def = skip name ul t p in
					(e_def,true) :: loop (e :: el) args
				else
					arg_error ul name false p
		end
```
The first time, it fails and it raises the exception WithTypeError. At this point, the body of the anonymous function has already been visited and the warning message has already been sent to the server. The second unification succeed and throw another warning to the server.

We need to get rid of the first warning message when it fails. The problem is that we do not have the access to the context of the server during the typing process. The warnings are stored in this context.

So we need to keep only one of the two warnings messages at the server level.

The modification made is in the file main.ml. We have modified the function `message` which deals to send the messages to the server. We have assumed that there can be only one warning message per exact position (except for the message located at `null_pos`). So if a warning message is thrown at the same exact position than a previous warning message, the previous warning message is removed from the messages list.

Is that a good assumption ?

Here we consider the position of the warning message as an ID. We insure that there will not be two message with the same position in the server message list. But maybe the positions are not proper ID for warning message and we should consider to give ID to the functions which throw warnings. But it is a heavier solution and maybe not necessary.