### PR TITLE
[php] fix Socket.setTimeout

### DIFF
--- a/std/php/Const.hx
+++ b/std/php/Const.hx
@@ -168,6 +168,9 @@ extern class Const {
 	static var AF_INET6 : Int;
 	static var AF_UNIX : Int;
 	static var SOL_TCP : Int;
+	static var SOL_SOCKET : Int;
+	static var SO_RCVTIMEO : Int;
+	static var SO_SNDTIMEO : Int;
 	static var TCP_NODELAY : Int;
 	static var PHP_BINARY_READ : Int;
 	/**

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -1132,7 +1132,7 @@ extern class Global {
 	/**
 		@see http://php.net/manual/en/function.socket-set-option.php
 	**/
-	static function socket_set_option( stream:Resource, level:Int, option:Int, val:Bool ) : Bool;
+	static function socket_set_option( stream:Resource, level:Int, option:Int, val:Any ) : Bool;
 
 	/**
 		@see http://php.net/manual/en/function.socket-select.php

--- a/std/php/_std/sys/net/Socket.hx
+++ b/std/php/_std/sys/net/Socket.hx
@@ -123,8 +123,11 @@ class Socket {
 	public function setTimeout( timeout : Float ) : Void {
 		var s = Std.int(timeout);
 		var ms = Std.int((timeout - s) * 1000000);
-		var r = stream_set_timeout(__s, s, ms);
-		checkError(r, 0, 'Unable to set timeout');
+		var timeOut:NativeStructArray<{sec:Int, usec:Int}> = {sec: s, usec: ms};
+		var r = socket_set_option(__s, SOL_SOCKET, SO_RCVTIMEO, timeOut);
+		checkError(r, 0, 'Unable to set receive timeout');
+		r = socket_set_option(__s, SOL_SOCKET, SO_SNDTIMEO, timeOut);
+		checkError(r, 0, 'Unable to set send timeout');
 	}
 
 	public function setBlocking( b : Bool ) : Void {

--- a/std/php/net/Socket.hx
+++ b/std/php/net/Socket.hx
@@ -124,13 +124,21 @@ class Socket extends sys.net.Socket {
 		checkError(r, 0, 'Unable to retrieve the host name');
 		return hpOfString(r);
 	}
+
+	override public function setTimeout( timeout : Float ) : Void {
+		var s = Std.int(timeout);
+		var ms = Std.int((timeout - s) * 1000000);
+		var r = stream_set_timeout(__s, s, ms);
+		checkError(r, 0, 'Unable to set timeout');
+	}
+
 	private static function getType(isUdp : Bool) : Int {
 		return isUdp ? SOCK_DGRAM : SOCK_STREAM;
 	}
 
 	private static function getProtocol(protocol : String) : Int {
 		return getprotobyname(protocol);
- 	}
+	}
 
 	public static function select(read : Array<Socket>, write : Array<Socket>, others : Array<Socket>, ?timeout : Float) : { read: Array<Socket>,write: Array<Socket>,others: Array<Socket> }
 	{

--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -97,8 +97,13 @@ class Http extends haxe.http.HttpBase {
 				#else
 				throw "Https is only supported with -lib hxssl";
 				#end
-			} else
+			} else {
+				#if php
+				sock = new php.net.Socket();
+				#else
 				sock = new Socket();
+				#end
+			}
 		}
 		var host = url_regexp.matched(2);
 		var portString = url_regexp.matched(3);


### PR DESCRIPTION
`stream_set_timeout` doesn't work on a non-stream socket, so sending a Http request in PHP would produce a `stream_set_timeout(): supplied resource is not a valid stream resource` error.

I am not sure if `socket_set_option` works correctly for `_std/sys/net/Socket.hx`, since it does not timeout after 10s (my TCP/IP knowledge is a bit rusty and those options might not do what I think...).

`stream_set_timeout` in `net/Socket.hx` correctly times out after 10s, that's why I added it to `Http.hx`.