### PR TITLE
[benchs] Output benchmarks' data

### DIFF
--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -101,10 +101,14 @@ class RunCi {
 				failMsg('test ${test} failed');
 			}
 
-			// --- BENCHMARKS
-			// this runs after each test target is successful and so properly set up, so that we don't have to re-setup them
+			/**
+				BENCHMARKS
 
-			if (success && RUN_BENCHMARKS) {
+				these run after each target's tests (so all dependencies are already set up)
+				and only for the targets that can write to the console
+			*/
+			var isBenchable = [Macro, Neko, Lua, Php, Php7, Cpp, Java, Cs, Python, Hl, /*Node*/Js].indexOf(test) >= 0;
+			if (success && RUN_BENCHMARKS && isBenchable) {
 
 				switch (ci) {
 					case TravisCI:
@@ -125,27 +129,21 @@ class RunCi {
 						case Neko:
 							runci.targets.Neko.runBench(args);
 						case Php:
-						//	runci.targets.Php.runBench(args);
+							runci.targets.Php.runBench(args);
 						case Python:
-						//	runci.targets.Python.runBench(args);
+							runci.targets.Python.runBench(args);
 						case Lua:
-						//	runci.targets.Lua.runBench(args);
+							runci.targets.Lua.runBench(args);
 						case Cpp:
-						//	runci.targets.Cpp.runBench(args, true, true);
-						case Cppia:
-						//	runci.targets.Cpp.runBench(args, false, true);
+							runci.targets.Cpp.runBench(args);
 						case Js:
-						//	runci.targets.Js.runBench(args);
+							runci.targets.Js.runBench(args);
 						case Java:
-						//	runci.targets.Java.runBench(args);
+							runci.targets.Java.runBench(args);
 						case Cs:
-						//	runci.targets.Cs.runBench(args);
-						case Flash9:
-						//	runci.targets.Flash.runBench(args);
-						case As3:
-						//	runci.targets.As3.runBench(args);
+							runci.targets.Cs.runBench(args);
 						case Hl:
-						//	runci.targets.Hl.runBench(args);
+							runci.targets.Hl.runBench(args);
 						case t:
 							throw "unknown target: " + t;
 					}
@@ -166,7 +164,6 @@ class RunCi {
 					failMsg('bench ${test} failed');
 				}
 			}
-			// --- end BENCHMARKS
 		}
 
 		if (success) {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -100,73 +100,73 @@ class RunCi {
 			} else {
 				failMsg('test ${test} failed');
 			}
-		}
 
+			// --- BENCHMARKS
+			// this runs after each test target is successful and so properly set up, so that we don't have to re-setup them
 
-		// --- BENCHMARKS
-		// this runs after each test target is properly set up, so that we don't have to re-setup them
+			if (success && RUN_BENCHMARKS) {
 
-		if (success && RUN_BENCHMARKS) {
-
-			switch (ci) {
-				case TravisCI:
-					Sys.println('travis_fold:start:bench-${test}');
-				case _:
-					//pass
-			}
-
-			infoMsg('bench $test');
-			var benchSuccess = true;
-			try {
-				changeDirectory(benchsDir);
-
-
-				switch (test) {
-					case Macro:
-						runci.targets.Macro.runBench(args);
-					case Neko:
-						runci.targets.Neko.runBench(args);
-					case Php:
-					//	runci.targets.Php.runBench(args);
-					case Python:
-					//	runci.targets.Python.runBench(args);
-					case Lua:
-					//	runci.targets.Lua.runBench(args);
-					case Cpp:
-					//	runci.targets.Cpp.runBench(args, true, true);
-					case Cppia:
-					//	runci.targets.Cpp.runBench(args, false, true);
-					case Js:
-					//	runci.targets.Js.runBench(args);
-					case Java:
-					//	runci.targets.Java.runBench(args);
-					case Cs:
-					//	runci.targets.Cs.runBench(args);
-					case Flash9:
-					//	runci.targets.Flash.runBench(args);
-					case As3:
-					//	runci.targets.As3.runBench(args);
-					case Hl:
-					//	runci.targets.Hl.runBench(args);
-					case t:
-						throw "unknown target: " + t;
+				switch (ci) {
+					case TravisCI:
+						Sys.println('travis_fold:start:bench-${test}');
+					case _:
+						//pass
 				}
-			} catch(f:Failure) {
-				benchSuccess = false;
-			}
 
-			switch (ci) {
-				case TravisCI:
-					Sys.println('travis_fold:end:bench-${test}');
-				case _:
-					//pass
-			}
+				infoMsg('bench $test');
+				var benchSuccess = true;
+				try {
+					changeDirectory(benchsDir);
 
-			if (benchSuccess) {
-				successMsg('bench ${test} succeeded');
-			} else {
-				failMsg('bench ${test} failed');
+
+					switch (test) {
+						case Macro:
+							runci.targets.Macro.runBench(args);
+						case Neko:
+							runci.targets.Neko.runBench(args);
+						case Php:
+						//	runci.targets.Php.runBench(args);
+						case Python:
+						//	runci.targets.Python.runBench(args);
+						case Lua:
+						//	runci.targets.Lua.runBench(args);
+						case Cpp:
+						//	runci.targets.Cpp.runBench(args, true, true);
+						case Cppia:
+						//	runci.targets.Cpp.runBench(args, false, true);
+						case Js:
+						//	runci.targets.Js.runBench(args);
+						case Java:
+						//	runci.targets.Java.runBench(args);
+						case Cs:
+						//	runci.targets.Cs.runBench(args);
+						case Flash9:
+						//	runci.targets.Flash.runBench(args);
+						case As3:
+						//	runci.targets.As3.runBench(args);
+						case Hl:
+						//	runci.targets.Hl.runBench(args);
+						case t:
+							throw "unknown target: " + t;
+					}
+				} catch(f:Failure) {
+					benchSuccess = false;
+				}
+
+				switch (ci) {
+					case TravisCI:
+						Sys.println('travis_fold:end:bench-${test}');
+					case _:
+						//pass
+				}
+
+				if (benchSuccess) {
+					successMsg('bench ${test} succeeded');
+				} else {
+					failMsg('bench ${test} failed');
+				}
 			}
+			// --- end BENCHMARKS
 		}
 
 		if (success) {

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -20,6 +20,7 @@ using StringTools;
 class RunCi {
 	static function main():Void {
 		Sys.putEnv("OCAMLRUNPARAM", "b");
+		var RUN_BENCHMARKS = true;
 
 		var args = Sys.args();
 		var tests:Array<TestTarget> = switch (args.length==1 ? args[0] : Sys.getEnv("TEST")) {
@@ -98,6 +99,73 @@ class RunCi {
 				successMsg('test ${test} succeeded');
 			} else {
 				failMsg('test ${test} failed');
+			}
+		}
+
+
+		// --- BENCHMARKS
+		// this runs after each test target is properly set up, so that we don't have to re-setup them
+
+		if (success && RUN_BENCHMARKS) {
+
+			switch (ci) {
+				case TravisCI:
+					Sys.println('travis_fold:start:bench-${test}');
+				case _:
+					//pass
+			}
+
+			infoMsg('bench $test');
+			var benchSuccess = true;
+			try {
+				changeDirectory(benchsDir);
+
+
+				switch (test) {
+					case Macro:
+						runci.targets.Macro.runBench(args);
+					case Neko:
+						runci.targets.Neko.runBench(args);
+					case Php:
+					//	runci.targets.Php.runBench(args);
+					case Python:
+					//	runci.targets.Python.runBench(args);
+					case Lua:
+					//	runci.targets.Lua.runBench(args);
+					case Cpp:
+					//	runci.targets.Cpp.runBench(args, true, true);
+					case Cppia:
+					//	runci.targets.Cpp.runBench(args, false, true);
+					case Js:
+					//	runci.targets.Js.runBench(args);
+					case Java:
+					//	runci.targets.Java.runBench(args);
+					case Cs:
+					//	runci.targets.Cs.runBench(args);
+					case Flash9:
+					//	runci.targets.Flash.runBench(args);
+					case As3:
+					//	runci.targets.As3.runBench(args);
+					case Hl:
+					//	runci.targets.Hl.runBench(args);
+					case t:
+						throw "unknown target: " + t;
+				}
+			} catch(f:Failure) {
+				benchSuccess = false;
+			}
+
+			switch (ci) {
+				case TravisCI:
+					Sys.println('travis_fold:end:bench-${test}');
+				case _:
+					//pass
+			}
+
+			if (benchSuccess) {
+				successMsg('bench ${test} succeeded');
+			} else {
+				failMsg('bench ${test} failed');
 			}
 		}
 

--- a/tests/benchs/src/cases/CharacterAccess.hx
+++ b/tests/benchs/src/cases/CharacterAccess.hx
@@ -74,6 +74,7 @@ class CharacterAccess extends TestCase {
 		return suite.run();
 	}
 
+	#if !cpp
 	function measureL1000000() {
 		var s = "".lpad("a", 1000000);
 		var suite = new Suite("length 1000000");
@@ -103,4 +104,5 @@ class CharacterAccess extends TestCase {
 		}, var index = 0);
 		return suite.run();
 	}
+	#end
 }

--- a/tests/runci/Config.hx
+++ b/tests/runci/Config.hx
@@ -18,6 +18,7 @@ class Config {
 	static public final displayDir = cwd + "display/";
 	static public final serverDir = cwd + "server/";
 	static public final sourcemapsDir = cwd + "sourcemaps/";
+	static public final benchsDir = cwd + "benchs/";
 
 	static public final ci:Null<Ci> =
 		if (Sys.getEnv("TRAVIS") == "true")

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -79,4 +79,9 @@ class Cpp {
 		// 	runCpp("bin/TestObjc-debug");
 		// }
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-cpp", "bin/benchs.cpp"]);
+		runCpp("bin/benchs.cpp/Main", []);
+	}
 }

--- a/tests/runci/targets/Cs.hx
+++ b/tests/runci/targets/Cs.hx
@@ -80,4 +80,9 @@ class Cs {
 			runCs("bin/main/bin/Main.exe");
 		}
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-cs", "bin/benchs.cs"]);
+		runCs("bin/benchs.cs/bin/Main.exe", []);
+	}
 }

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -44,7 +44,7 @@ class Hl {
         runCommand("cmake", [
             "--build", hlBuild
         ]);
-        
+
         addToPATH(Path.join([hlBuild, "bin"]));
         runCommand("hl", ["--version"]);
     }
@@ -55,5 +55,10 @@ class Hl {
         runCommand("hl", ["bin/unit.hl"]);
 
         // TODO sys test
+    }
+
+    static public function runBench(args:Array<String>, benchCase:String = "") {
+        runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-hl", "bin/benchs.hl"]);
+        runCommand("hl", ["bin/benchs.hl"]);
     }
 }

--- a/tests/runci/targets/Java.hx
+++ b/tests/runci/targets/Java.hx
@@ -39,4 +39,9 @@ class Java {
 			}
 		}
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-java", "bin/benchs.java"]);
+		runCommand("java", ["-jar", "bin/benchs.java/Main.jar"]);
+	}
 }

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -93,4 +93,9 @@ class Js {
 		// runCommand("haxe", ["build.hxml"]);
 		// runCommand("node", ["test.js"]);
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-js", "bin/benchs.js"]);
+		runCommand("node", ["bin/benchs.js"]);
+	}
 }

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -95,7 +95,7 @@ class Js {
 	}
 
 	static public function runBench(args:Array<String>, benchCase:String = "") {
-		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-js", "bin/benchs.js"]);
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-js", "bin/benchs.js", "-lib", "hxnodejs"]);
 		runCommand("node", ["bin/benchs.js"]);
 	}
 }

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -68,4 +68,9 @@ class Lua {
 			runCommand("haxe", ["compile.hxml"]);
 		}
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-lua", "bin/benchs.lua"]);
+		runCommand("lua", ["bin/benchs.lua"]);
+	}
 }

--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -26,4 +26,8 @@ class Macro {
 		runCommand("haxe", ["compile-macro.hxml"]);
 		runCommand("haxe", ["compile-each.hxml", "--run", "Main"]);
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "--run", "Main"]);
+	}
 }

--- a/tests/runci/targets/Neko.hx
+++ b/tests/runci/targets/Neko.hx
@@ -14,4 +14,9 @@ class Neko {
 		runCommand("haxe", ["compile-neko.hxml"]);
 		runCommand("neko", ["bin/neko/sys.n"]);
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-neko", "bin/benchs.n"]);
+		runCommand("neko", ["bin/benchs.n"]);
+	}
 }

--- a/tests/runci/targets/Php.hx
+++ b/tests/runci/targets/Php.hx
@@ -38,4 +38,9 @@ class Php {
 		runCommand("haxe", ["compile-php.hxml"]);
 		runCommand("php", ["bin/php/Main/index.php"]);
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-php", "bin/benchs.php"]);
+		runCommand("php", ["bin/benchs.php/index.php"]);
+	}
 }

--- a/tests/runci/targets/Python.hx
+++ b/tests/runci/targets/Python.hx
@@ -75,4 +75,12 @@ class Python {
 			runCommand(py, ["test.py"]);
 		}
 	}
+
+	static public function runBench(args:Array<String>, benchCase:String = "") {
+		var pys = getPythonDependencies();
+		runCommand("haxe", ["build.hxml", "-D", "test=" + benchCase, "-python", "bin/benchs.py"]);
+		for (py in pys) {
+			runCommand(py, ["bin/benchs.py"]);
+		}
+	}
 }


### PR DESCRIPTION
Run benchmarks and print data to console after travis-ci tests.
Benchmarks for each target is in a `bench-<testTarget>` fold.

Then the data can be parsed and processed externally like I tried to do here (https://azrafe7.github.io/haxe-bencharts/ - still working on it) after seeing the work of @kevinresol (thanks!).

PS: there's an issue with the CharacterAccess.L1000000 case for cpp (it doesn't terminate or takes too long), so I disabled it.