### PR TITLE
Ignore UTF-8 and -16 BOMs in JSON. Fixes #7629

### DIFF
--- a/std/haxe/format/JsonParser.hx
+++ b/std/haxe/format/JsonParser.hx
@@ -50,7 +50,11 @@ class JsonParser {
 
 	function new( str : String ) {
 		this.str = str;
-		this.pos = 0;
+
+		// Skip various Byte-Order Marks if present in the given JSON.
+		this.pos = if (this.str.charCodeAt(0) == 239) 3 // UTF8
+		else if (this.str.charCodeAt(0) == 65279) 1 // UTF16
+		else 0;
 	}
 
 	function doParse() : Dynamic {

--- a/tests/unit/src/unit/TestJson.hx
+++ b/tests/unit/src/unit/TestJson.hx
@@ -108,4 +108,18 @@ class TestJson extends Test {
 		eq( parsed.x, -4500 );
 		eq( parsed.y, 1.456 );
 	}
+
+	function test7629() {
+		// Test multiple byte order marks
+		var boms = [ [65279], [239, 187, 191] ];
+
+		for (bom in boms) {
+			var bomString = [for (byte in bom) String.fromCharCode(byte)].join("");
+			var strJson = bomString + haxe.Json.stringify( { x : -4500, y : 1.456, a : ["hello", "wor'\"\n\t\rd"] } );
+
+			var parsed : Dynamic = haxe.Json.parse( strJson );
+			eq( parsed.x, -4500 );
+			eq( parsed.y, 1.456 );
+		}
+	}
 }

--- a/tests/unit/src/unit/TestJson.hx
+++ b/tests/unit/src/unit/TestJson.hx
@@ -110,16 +110,13 @@ class TestJson extends Test {
 	}
 
 	function test7629() {
-		// Test multiple byte order marks
-		var boms = [ [65279], [239, 187, 191] ];
+		// Test UTF-8 byte order mark
 
-		for (bom in boms) {
-			var bomString = [for (byte in bom) String.fromCharCode(byte)].join("");
-			var strJson = bomString + haxe.Json.stringify( { x : -4500, y : 1.456, a : ["hello", "wor'\"\n\t\rd"] } );
+		var bomString = [for (byte in [239, 187, 191]) String.fromCharCode(byte)].join("");
+		var strJson = bomString + haxe.Json.stringify( { x : -4500, y : 1.456, a : ["hello", "wor'\"\n\t\rd"] } );
 
-			var parsed : Dynamic = haxe.Json.parse( strJson );
-			eq( parsed.x, -4500 );
-			eq( parsed.y, 1.456 );
-		}
+		var parsed : Dynamic = haxe.Json.parse( strJson );
+		eq( parsed.x, -4500 );
+		eq( parsed.y, 1.456 );
 	}
 }


### PR DESCRIPTION
As I said in #7629 I had some confusion about which BOMs are important enough to skip. [There are a lot of them.](https://en.wikipedia.org/wiki/Byte_order_mark#Byte_order_marks_by_encoding) For now it's just UTF-8 and UTF-16, which fixes the use-case I had originally.