### PR TITLE
[cli] Do not parse hxml with double-hyphened --cmd

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -406,7 +406,7 @@ let rec process_params create pl =
 			ctx.flush()
 		| arg :: l ->
 			match List.rev (ExtString.String.nsplit arg ".") with
-			| "hxml" :: _ when (match acc with "-cmd" :: _ -> false | _ -> true) ->
+			| "hxml" :: _ when (match acc with "-cmd" :: _ | "--cmd" :: _ -> false | _ -> true) ->
 				let acc, l =
 					(try
 						let parsed = parse_hxml arg in


### PR DESCRIPTION
Treated `--cmd` just as `-cmd`.

Expected output:

```
$ ./haxe -cmd "echo build.hxml"
build.hxml

$ ./haxe --cmd "echo build.hxml"
build.hxml

$ 
```

This should fix manipulating HXML files with `--cmd` within HXML files.