### PR TITLE
Fix Http request without content-length

### DIFF
--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -365,6 +365,7 @@ class Http extends haxe.http.HttpBase {
 			try {
 				while(true) {
 					var len = sock.input.readBytes(buf,0,bufsize);
+					if (len == 0) break;
 					api.writeBytes(buf,0,len);
 				}
 			} catch(e:haxe.io.Eof) {


### PR DESCRIPTION
When server responds without `content-length` and `noShutdown` is true, Http may end up in infinite loop due to socket always reading 0 bytes and never resulting in `Eof` error throw. 
Example: Google do not send `content-length` when exporting spreadsheet table by url, resulting in `Http` ending up in infinite loop because `readBytes` always read 0 bytes from socket. 