### PR TITLE
[js] html externs, replace default value strings with enum values

### DIFF
--- a/std/js/html/CanvasRenderingContext2D.hx
+++ b/std/js/html/CanvasRenderingContext2D.hx
@@ -71,14 +71,14 @@ extern class CanvasRenderingContext2D
 	@:overload( function( image : ImageElement, dx : Float, dy : Float, dw : Float, dh : Float ) : Void {} )
 	function drawImage( image : ImageElement, sx : Float, sy : Float, sw : Float, sh : Float, dx : Float, dy : Float, dw : Float, dh : Float ) : Void;
 	function beginPath() : Void;
-	@:overload( function( ?winding : CanvasWindingRule = "nonzero" ) : Void {} )
-	function fill( path : Path2D, ?winding : CanvasWindingRule = "nonzero" ) : Void;
+	@:overload( function( ?winding : CanvasWindingRule = NONZERO ) : Void {} )
+	function fill( path : Path2D, ?winding : CanvasWindingRule = NONZERO ) : Void;
 	@:overload( function() : Void {} )
 	function stroke( path : Path2D ) : Void;
-	@:overload( function( ?winding : CanvasWindingRule = "nonzero" ) : Void {} )
-	function clip( path : Path2D, ?winding : CanvasWindingRule = "nonzero" ) : Void;
-	@:overload( function( x : Float, y : Float, ?winding : CanvasWindingRule = "nonzero" ) : Bool {} )
-	function isPointInPath( path : Path2D, x : Float, y : Float, ?winding : CanvasWindingRule = "nonzero" ) : Bool;
+	@:overload( function( ?winding : CanvasWindingRule = NONZERO ) : Void {} )
+	function clip( path : Path2D, ?winding : CanvasWindingRule = NONZERO ) : Void;
+	@:overload( function( x : Float, y : Float, ?winding : CanvasWindingRule = NONZERO ) : Bool {} )
+	function isPointInPath( path : Path2D, x : Float, y : Float, ?winding : CanvasWindingRule = NONZERO ) : Bool;
 	@:overload( function( x : Float, y : Float ) : Bool {} )
 	function isPointInStroke( path : Path2D, x : Float, y : Float ) : Bool;
 	function createLinearGradient( x0 : Float, y0 : Float, x1 : Float, y1 : Float ) : CanvasGradient;

--- a/std/js/html/InputElement.hx
+++ b/std/js/html/InputElement.hx
@@ -121,7 +121,7 @@ extern class InputElement extends Element
 	function select() : Void;
 	/** @throws DOMError */
 	@:overload( function( replacement : String ) : Void {} )
-	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = "preserve" ) : Void;
+	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = PRESERVE ) : Void;
 	/** @throws DOMError */
 	function setSelectionRange( start : Int, end : Int, ?direction : String ) : Void;
 }

--- a/std/js/html/TextAreaElement.hx
+++ b/std/js/html/TextAreaElement.hx
@@ -65,7 +65,7 @@ extern class TextAreaElement extends Element
 	function select() : Void;
 	/** @throws DOMError */
 	@:overload( function( replacement : String ) : Void {} )
-	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = "preserve" ) : Void;
+	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = PRESERVE ) : Void;
 	/** @throws DOMError */
 	function setSelectionRange( start : Int, end : Int, ?direction : String ) : Void;
 }

--- a/std/js/html/eme/MediaKeys.hx
+++ b/std/js/html/eme/MediaKeys.hx
@@ -41,7 +41,7 @@ extern class MediaKeys
 		Returns a new `MediaKeySession` object, which represents a context for message exchange with a content decryption module (CDM).
 		@throws DOMError
 	**/
-	function createSession( ?sessionType : MediaKeySessionType = "temporary" ) : MediaKeySession;
+	function createSession( ?sessionType : MediaKeySessionType = TEMPORARY ) : MediaKeySession;
 	
 	/**
 		Returns a `Promise` to a server certificate to be used to encrypt messages to the license server.

--- a/std/js/html/idb/Database.hx
+++ b/std/js/html/idb/Database.hx
@@ -89,8 +89,8 @@ extern class Database extends js.html.EventTarget
 		Immediately returns a transaction object (`IDBTransaction`) containing the `IDBTransaction.objectStore` method, which you can use to access your object store. Runs in a separate thread.
 		@throws DOMError
 	**/
-	@:overload( function( storeNames : Array<String>, ?mode : TransactionMode = "readonly") : Transaction {} )
-	function transaction( storeNames : String, ?mode : TransactionMode = "readonly" ) : Transaction;
+	@:overload( function( storeNames : Array<String>, ?mode : TransactionMode = READONLY) : Transaction {} )
+	function transaction( storeNames : String, ?mode : TransactionMode = READONLY ) : Transaction;
 	
 	/**
 		Returns immediately and closes the connection to a database in a separate thread.

--- a/std/js/html/idb/Index.hx
+++ b/std/js/html/idb/Index.hx
@@ -65,13 +65,13 @@ extern class Index
 		Returns an `IDBRequest` object, and, in a separate thread, creates a cursor over the specified key range.
 		@throws DOMError
 	**/
-	function openCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, creates a cursor over the specified key range, as arranged by this index.
 		@throws DOMError
 	**/
-	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, finds either the value in the referenced object store that corresponds to the given key or the first corresponding value, if `key` is an `IDBKeyRange`.

--- a/std/js/html/idb/MutableFile.hx
+++ b/std/js/html/idb/MutableFile.hx
@@ -41,7 +41,7 @@ extern class MutableFile extends js.html.EventTarget
 	var onerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function open( ?mode : js.html.FileMode = "readonly" ) : FileHandle;
+	function open( ?mode : js.html.FileMode = READONLY ) : FileHandle;
 	/** @throws DOMError */
 	function getFile() : js.html.DOMRequest;
 }

--- a/std/js/html/idb/ObjectStore.hx
+++ b/std/js/html/idb/ObjectStore.hx
@@ -101,7 +101,7 @@ extern class ObjectStore
 		Returns an `IDBRequest` object, and, in a separate thread, returns a new `IDBCursorWithValue` object. Used for iterating through an object store by primary key with a cursor.
 		@throws DOMError
 	**/
-	function openCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Creates a new index during a version upgrade, returning a new `IDBIndex` object in the connected database.
@@ -144,5 +144,5 @@ extern class ObjectStore
 		Returns an `IDBRequest` object, and, in a separate thread, returns a new `IDBCursor`. Used for iterating through an object store with a key.
 		@throws DOMError
 	**/
-	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 }


### PR DESCRIPTION
Inline strings as default values for enums have been replaced by their enum value counterpart

Task of #7752

https://github.com/HaxeFoundation/html-externs/commit/10dfda529dbe619b40e5b64e8de3cf491370f1aa