### PR TITLE
[js] html externs: remove `?` from args with default value

### DIFF
--- a/std/js/html/CSSGroupingRule.hx
+++ b/std/js/html/CSSGroupingRule.hx
@@ -37,7 +37,7 @@ extern class CSSGroupingRule extends CSSRule
 	var cssRules(default,null) : CSSRuleList;
 	
 	/** @throws DOMError */
-	function insertRule( rule : String, ?index : Int = 0 ) : Int;
+	function insertRule( rule : String, index : Int = 0 ) : Int;
 	/** @throws DOMError */
 	function deleteRule( index : Int ) : Void;
 }

--- a/std/js/html/CSSStyleDeclaration.hx
+++ b/std/js/html/CSSStyleDeclaration.hx
@@ -958,7 +958,7 @@ extern class CSSStyleDeclaration implements ArrayAccess<String>
 	function getPropertyValue( property : String ) : String;
 	function getPropertyPriority( property : String ) : String;
 	/** @throws DOMError */
-	function setProperty( property : String, value : String, ?priority : String = "" ) : Void;
+	function setProperty( property : String, value : String, priority : String = "" ) : Void;
 	/** @throws DOMError */
 	function removeProperty( property : String ) : String;
 }

--- a/std/js/html/CSSStyleSheet.hx
+++ b/std/js/html/CSSStyleSheet.hx
@@ -56,7 +56,7 @@ extern class CSSStyleSheet extends StyleSheet
 		Inserts a new rule at the specified position in the style sheet, given the textual representation of the rule.
 		@throws DOMError
 	**/
-	function insertRule( rule : String, ?index : Int = 0 ) : Int;
+	function insertRule( rule : String, index : Int = 0 ) : Int;
 	
 	/**
 		Deletes a rule at the specified position from the style sheet.

--- a/std/js/html/CanvasElement.hx
+++ b/std/js/html/CanvasElement.hx
@@ -56,13 +56,13 @@ extern class CanvasElement extends Element
 		Returns a data-URL containing a representation of the image in the format specified by the `type` parameter (defaults to `png`). The returned image is in a resolution of 96dpi.
 		@throws DOMError
 	**/
-	function toDataURL( ?type : String = "", ?encoderOptions : Dynamic ) : String;
+	function toDataURL( type : String = "", ?encoderOptions : Dynamic ) : String;
 	
 	/**
 		Creates a `Blob` object representing the image contained in the canvas; this file may be cached on the disk or stored in memory at the discretion of the user agent.
 		@throws DOMError
 	**/
-	function toBlob( callback : Blob -> Void, ?type : String = "", ?encoderOptions : Dynamic ) : Void;
+	function toBlob( callback : Blob -> Void, type : String = "", ?encoderOptions : Dynamic ) : Void;
 	
 	/**
 		Returns a `CanvasCaptureMediaStream` that is a real-time video capture of the surface of the canvas.

--- a/std/js/html/CanvasRenderingContext2D.hx
+++ b/std/js/html/CanvasRenderingContext2D.hx
@@ -71,14 +71,14 @@ extern class CanvasRenderingContext2D
 	@:overload( function( image : ImageElement, dx : Float, dy : Float, dw : Float, dh : Float ) : Void {} )
 	function drawImage( image : ImageElement, sx : Float, sy : Float, sw : Float, sh : Float, dx : Float, dy : Float, dw : Float, dh : Float ) : Void;
 	function beginPath() : Void;
-	@:overload( function( ?winding : CanvasWindingRule = NONZERO ) : Void {} )
-	function fill( path : Path2D, ?winding : CanvasWindingRule = NONZERO ) : Void;
+	@:overload( function( winding : CanvasWindingRule = NONZERO ) : Void {} )
+	function fill( path : Path2D, winding : CanvasWindingRule = NONZERO ) : Void;
 	@:overload( function() : Void {} )
 	function stroke( path : Path2D ) : Void;
-	@:overload( function( ?winding : CanvasWindingRule = NONZERO ) : Void {} )
-	function clip( path : Path2D, ?winding : CanvasWindingRule = NONZERO ) : Void;
-	@:overload( function( x : Float, y : Float, ?winding : CanvasWindingRule = NONZERO ) : Bool {} )
-	function isPointInPath( path : Path2D, x : Float, y : Float, ?winding : CanvasWindingRule = NONZERO ) : Bool;
+	@:overload( function( winding : CanvasWindingRule = NONZERO ) : Void {} )
+	function clip( path : Path2D, winding : CanvasWindingRule = NONZERO ) : Void;
+	@:overload( function( x : Float, y : Float, winding : CanvasWindingRule = NONZERO ) : Bool {} )
+	function isPointInPath( path : Path2D, x : Float, y : Float, winding : CanvasWindingRule = NONZERO ) : Bool;
 	@:overload( function( x : Float, y : Float ) : Bool {} )
 	function isPointInStroke( path : Path2D, x : Float, y : Float ) : Bool;
 	function createLinearGradient( x0 : Float, y0 : Float, x1 : Float, y1 : Float ) : CanvasGradient;
@@ -114,9 +114,9 @@ extern class CanvasRenderingContext2D
 	function arcTo( x1 : Float, y1 : Float, x2 : Float, y2 : Float, radius : Float ) : Void;
 	function rect( x : Float, y : Float, w : Float, h : Float ) : Void;
 	/** @throws DOMError */
-	function arc( x : Float, y : Float, radius : Float, startAngle : Float, endAngle : Float, ?anticlockwise : Bool = false ) : Void;
+	function arc( x : Float, y : Float, radius : Float, startAngle : Float, endAngle : Float, anticlockwise : Bool = false ) : Void;
 	/** @throws DOMError */
-	function ellipse( x : Float, y : Float, radiusX : Float, radiusY : Float, rotation : Float, startAngle : Float, endAngle : Float, ?anticlockwise : Bool = false ) : Void;
+	function ellipse( x : Float, y : Float, radiusX : Float, radiusY : Float, rotation : Float, startAngle : Float, endAngle : Float, anticlockwise : Bool = false ) : Void;
 	function clearRect( x : Float, y : Float, w : Float, h : Float ) : Void;
 	function fillRect( x : Float, y : Float, w : Float, h : Float ) : Void;
 	function strokeRect( x : Float, y : Float, w : Float, h : Float ) : Void;

--- a/std/js/html/CanvasRenderingContext2D.hx
+++ b/std/js/html/CanvasRenderingContext2D.hx
@@ -71,14 +71,14 @@ extern class CanvasRenderingContext2D
 	@:overload( function( image : ImageElement, dx : Float, dy : Float, dw : Float, dh : Float ) : Void {} )
 	function drawImage( image : ImageElement, sx : Float, sy : Float, sw : Float, sh : Float, dx : Float, dy : Float, dw : Float, dh : Float ) : Void;
 	function beginPath() : Void;
-	@:overload( function( ?winding : CanvasWindingRule = "nonzero" ) : Void {} )
-	function fill( path : Path2D, ?winding : CanvasWindingRule = "nonzero" ) : Void;
+	@:overload( function( ?winding : CanvasWindingRule = NONZERO ) : Void {} )
+	function fill( path : Path2D, ?winding : CanvasWindingRule = NONZERO ) : Void;
 	@:overload( function() : Void {} )
 	function stroke( path : Path2D ) : Void;
-	@:overload( function( ?winding : CanvasWindingRule = "nonzero" ) : Void {} )
-	function clip( path : Path2D, ?winding : CanvasWindingRule = "nonzero" ) : Void;
-	@:overload( function( x : Float, y : Float, ?winding : CanvasWindingRule = "nonzero" ) : Bool {} )
-	function isPointInPath( path : Path2D, x : Float, y : Float, ?winding : CanvasWindingRule = "nonzero" ) : Bool;
+	@:overload( function( ?winding : CanvasWindingRule = NONZERO ) : Void {} )
+	function clip( path : Path2D, ?winding : CanvasWindingRule = NONZERO ) : Void;
+	@:overload( function( x : Float, y : Float, ?winding : CanvasWindingRule = NONZERO ) : Bool {} )
+	function isPointInPath( path : Path2D, x : Float, y : Float, ?winding : CanvasWindingRule = NONZERO ) : Bool;
 	@:overload( function( x : Float, y : Float ) : Bool {} )
 	function isPointInStroke( path : Path2D, x : Float, y : Float ) : Bool;
 	function createLinearGradient( x0 : Float, y0 : Float, x1 : Float, y1 : Float ) : CanvasGradient;

--- a/std/js/html/Client.hx
+++ b/std/js/html/Client.hx
@@ -56,5 +56,5 @@ extern class Client
 		Sends a message to the client.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, ?transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, transfer : Array<Dynamic> = [] ) : Void;
 }

--- a/std/js/html/Comment.hx
+++ b/std/js/html/Comment.hx
@@ -35,5 +35,5 @@ package js.html;
 extern class Comment extends CharacterData
 {
 	/** @throws DOMError */
-	function new( ?data : String = "" ) : Void;
+	function new( data : String = "" ) : Void;
 }

--- a/std/js/html/CompositionEvent.hx
+++ b/std/js/html/CompositionEvent.hx
@@ -51,5 +51,5 @@ extern class CompositionEvent extends UIEvent
 	/**
 		Initializes the attributes of a `CompositionEvent` object.
 	**/
-	function initCompositionEvent( typeArg : String, ?canBubbleArg : Bool = false, ?cancelableArg : Bool = false, ?viewArg : Window, ?dataArg : String, ?localeArg : String = "" ) : Void;
+	function initCompositionEvent( typeArg : String, canBubbleArg : Bool = false, cancelableArg : Bool = false, ?viewArg : Window, ?dataArg : String, localeArg : String = "" ) : Void;
 }

--- a/std/js/html/Console.hx
+++ b/std/js/html/Console.hx
@@ -38,7 +38,7 @@ extern class Console
 	/**
 		Log a message and stack trace to console if the first argument is `false`.
 	**/
-	static function assert( ?condition : Bool = false, data : haxe.extern.Rest<Dynamic> ) : Void;
+	static function assert( condition : Bool = false, data : haxe.extern.Rest<Dynamic> ) : Void;
 	
 	/**
 		Clear the console.
@@ -48,12 +48,12 @@ extern class Console
 	/**
 		Log the number of times this line has been called with the given label.
 	**/
-	static function count( ?label : String = "default" ) : Void;
+	static function count( label : String = "default" ) : Void;
 	
 	/**
 		Resets the value of the counter with the given label.
 	**/
-	static function countReset( ?label : String = "default" ) : Void;
+	static function countReset( label : String = "default" ) : Void;
 	
 	/**
 		Outputs a message to the console with the log level `"debug"`.
@@ -122,17 +122,17 @@ extern class Console
 	/**
 		Starts a timer with a name specified as an input parameter. Up to 10,000 simultaneous timers can run on a given page.
 	**/
-	static function time( ?label : String = "default" ) : Void;
+	static function time( label : String = "default" ) : Void;
 	
 	/**
 		Logs the value of the specified timer to the console.
 	**/
-	static function timeLog( ?label : String = "default", data : haxe.extern.Rest<Dynamic> ) : Void;
+	static function timeLog( label : String = "default", data : haxe.extern.Rest<Dynamic> ) : Void;
 	
 	/**
 		Stops the specified timer and logs the elapsed time in seconds since it started.
 	**/
-	static function timeEnd( ?label : String = "default" ) : Void;
+	static function timeEnd( label : String = "default" ) : Void;
 	
 	/**
 		An alias for `error()`.

--- a/std/js/html/ConsoleInstance.hx
+++ b/std/js/html/ConsoleInstance.hx
@@ -37,7 +37,7 @@ extern interface ConsoleInstance
 	/**
 		Log a message and stack trace to console if the first argument is `false`.
 	**/
-	function assert( ?condition : Bool = false, data : haxe.extern.Rest<Dynamic> ) : Void;
+	function assert( condition : Bool = false, data : haxe.extern.Rest<Dynamic> ) : Void;
 	
 	/**
 		Clear the console.
@@ -47,12 +47,12 @@ extern interface ConsoleInstance
 	/**
 		Log the number of times this line has been called with the given label.
 	**/
-	function count( ?label : String = "default" ) : Void;
+	function count( label : String = "default" ) : Void;
 	
 	/**
 		Resets the value of the counter with the given label.
 	**/
-	function countReset( ?label : String = "default" ) : Void;
+	function countReset( label : String = "default" ) : Void;
 	
 	/**
 		Outputs a message to the console with the log level `"debug"`.
@@ -121,17 +121,17 @@ extern interface ConsoleInstance
 	/**
 		Starts a timer with a name specified as an input parameter. Up to 10,000 simultaneous timers can run on a given page.
 	**/
-	function time( ?label : String = "default" ) : Void;
+	function time( label : String = "default" ) : Void;
 	
 	/**
 		Logs the value of the specified timer to the console.
 	**/
-	function timeLog( ?label : String = "default", data : haxe.extern.Rest<Dynamic> ) : Void;
+	function timeLog( label : String = "default", data : haxe.extern.Rest<Dynamic> ) : Void;
 	
 	/**
 		Stops the specified timer and logs the elapsed time in seconds since it started.
 	**/
-	function timeEnd( ?label : String = "default" ) : Void;
+	function timeEnd( label : String = "default" ) : Void;
 	
 	/**
 		An alias for `error()`.

--- a/std/js/html/CustomEvent.hx
+++ b/std/js/html/CustomEvent.hx
@@ -48,5 +48,5 @@ extern class CustomEvent extends Event
 		 Initializes a `CustomEvent` object. If the event has already being dispatched, this method does nothing.
 		 
 	**/
-	function initCustomEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?detail : Dynamic ) : Void;
+	function initCustomEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?detail : Dynamic ) : Void;
 }

--- a/std/js/html/DOMElement.hx
+++ b/std/js/html/DOMElement.hx
@@ -416,7 +416,7 @@ extern class DOMElement extends Node
 	/**
 		Sets up mouse event capture, redirecting all mouse events to this element.
 	**/
-	function setCapture( ?retargetToElement : Bool = false ) : Void;
+	function setCapture( retargetToElement : Bool = false ) : Void;
 	function releaseCapture() : Void;
 	
 	/**

--- a/std/js/html/DOMError.hx
+++ b/std/js/html/DOMError.hx
@@ -46,5 +46,5 @@ extern class DOMError
 	var message(default,null) : String;
 	
 	/** @throws DOMError */
-	function new( name : String, ?message : String = "" ) : Void;
+	function new( name : String, message : String = "" ) : Void;
 }

--- a/std/js/html/DOMException.hx
+++ b/std/js/html/DOMException.hx
@@ -83,5 +83,5 @@ extern class DOMException
 	var stack(default,null) : String;
 	
 	/** @throws DOMError */
-	function new( ?message : String = "", ?name : String ) : Void;
+	function new( message : String = "", ?name : String ) : Void;
 }

--- a/std/js/html/DOMMatrix.hx
+++ b/std/js/html/DOMMatrix.hx
@@ -47,27 +47,27 @@ extern class DOMMatrix extends DOMMatrixReadOnly
 	/**
 		Returns itself, a `DOMMatrix`, with its new content being the result of the matrix being translated by the given vector.
 	**/
-	function translateSelf( tx : Float, ty : Float, ?tz : Float = 0.0 ) : DOMMatrix;
+	function translateSelf( tx : Float, ty : Float, tz : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns itself, a `DOMMatrix`, with its new content being the result of the matrix x and y dimensions being scaled by the given factor, centered on the origin given.
 	**/
-	function scaleSelf( scale : Float, ?originX : Float = 0.0, ?originY : Float = 0.0 ) : DOMMatrix;
+	function scaleSelf( scale : Float, originX : Float = 0.0, originY : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns itself, a `DOMMatrix`, with its new content being the result of the matrix x, y and z dimension being scaled by the given factor, centered on the origin given.
 	**/
-	function scale3dSelf( scale : Float, ?originX : Float = 0.0, ?originY : Float = 0.0, ?originZ : Float = 0.0 ) : DOMMatrix;
+	function scale3dSelf( scale : Float, originX : Float = 0.0, originY : Float = 0.0, originZ : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns itself, a `DOMMatrix`, with its new content being the result of the matrix x, y and z dimension being scaled by the given factor for each dimension, centered on the origin given.
 	**/
-	function scaleNonUniformSelf( scaleX : Float, ?scaleY : Float = 1.0, ?scaleZ : Float = 1.0, ?originX : Float = 0.0, ?originY : Float = 0.0, ?originZ : Float = 0.0 ) : DOMMatrix;
+	function scaleNonUniformSelf( scaleX : Float, scaleY : Float = 1.0, scaleZ : Float = 1.0, originX : Float = 0.0, originY : Float = 0.0, originZ : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns itself, a `DOMMatrix`, with its new content being the result of the original matrix being rotated by the given angle, with the rotation centered on the origin given.
 	**/
-	function rotateSelf( angle : Float, ?originX : Float = 0.0, ?originY : Float = 0.0 ) : DOMMatrix;
+	function rotateSelf( angle : Float, originX : Float = 0.0, originY : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns itself, a `DOMMatrix`, with its new content being the result of the original matrix being rotated by the angle between the given vector and (1,0), centered on the origin given.

--- a/std/js/html/DOMMatrixReadOnly.hx
+++ b/std/js/html/DOMMatrixReadOnly.hx
@@ -117,27 +117,27 @@ extern class DOMMatrixReadOnly
 	/**
 		Returns a `DOMMatrix` containing a new matrix being the result of the matrix being translated by the given vector. The original matrix is not modified.
 	**/
-	function translate( tx : Float, ty : Float, ?tz : Float = 0.0 ) : DOMMatrix;
+	function translate( tx : Float, ty : Float, tz : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns a `DOMMatrix` containing a new matrix being the result of the matrix x and y dimensions being scaled by the given factor, centered on the origin given. The original matrix is not modified.
 	**/
-	function scale( scale : Float, ?originX : Float = 0.0, ?originY : Float = 0.0 ) : DOMMatrix;
+	function scale( scale : Float, originX : Float = 0.0, originY : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns a `DOMMatrix` containing a new matrix being the result of the matrix x, y and z dimension being scaled by the given factor, centered on the origin given. The original matrix is not modified.
 	**/
-	function scale3d( scale : Float, ?originX : Float = 0.0, ?originY : Float = 0.0, ?originZ : Float = 0.0 ) : DOMMatrix;
+	function scale3d( scale : Float, originX : Float = 0.0, originY : Float = 0.0, originZ : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns a `DOMMatrix` containing a new matrix being the result of the matrix x, y and z dimension being scaled by the given factor for each dimension, centered on the origin given. The original matrix is not modified.
 	**/
-	function scaleNonUniform( scaleX : Float, ?scaleY : Float = 1.0, ?scaleZ : Float = 1.0, ?originX : Float = 0.0, ?originY : Float = 0.0, ?originZ : Float = 0.0 ) : DOMMatrix;
+	function scaleNonUniform( scaleX : Float, scaleY : Float = 1.0, scaleZ : Float = 1.0, originX : Float = 0.0, originY : Float = 0.0, originZ : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns a `DOMMatrix` containing a new matrix being the result of the original matrix being rotated by the given angle, with the rotation centered on the origin given. The original matrix is not modified.
 	**/
-	function rotate( angle : Float, ?originX : Float = 0.0, ?originY : Float = 0.0 ) : DOMMatrix;
+	function rotate( angle : Float, originX : Float = 0.0, originY : Float = 0.0 ) : DOMMatrix;
 	
 	/**
 		Returns a `DOMMatrix` containing a new matrix being the result of the original matrix being rotated by the angle between the given vector and (1,0), centered on the origin given. The original matrix is not modified.

--- a/std/js/html/DOMPoint.hx
+++ b/std/js/html/DOMPoint.hx
@@ -36,5 +36,5 @@ extern class DOMPoint extends DOMPointReadOnly
 {
 	static function fromPoint( ?other : DOMPointInit ) : DOMPoint;
 	/** @throws DOMError */
-	function new( ?x : Float = 0.0, ?y : Float = 0.0, ?z : Float = 0.0, ?w : Float = 1.0 ) : Void;
+	function new( x : Float = 0.0, y : Float = 0.0, z : Float = 0.0, w : Float = 1.0 ) : Void;
 }

--- a/std/js/html/DOMPointReadOnly.hx
+++ b/std/js/html/DOMPointReadOnly.hx
@@ -57,7 +57,7 @@ extern class DOMPointReadOnly
 	var w(default,null) : Float;
 	
 	/** @throws DOMError */
-	function new( ?x : Float = 0.0, ?y : Float = 0.0, ?z : Float = 0.0, ?w : Float = 1.0 ) : Void;
+	function new( x : Float = 0.0, y : Float = 0.0, z : Float = 0.0, w : Float = 1.0 ) : Void;
 	
 	/**
 		Returns a JSON representation of the `DOMPointReadOnly` object.

--- a/std/js/html/DOMRect.hx
+++ b/std/js/html/DOMRect.hx
@@ -35,5 +35,5 @@ package js.html;
 extern class DOMRect extends DOMRectReadOnly
 {
 	/** @throws DOMError */
-	function new( ?x : Float = 0.0, ?y : Float = 0.0, ?width : Float = 0.0, ?height : Float = 0.0 ) : Void;
+	function new( x : Float = 0.0, y : Float = 0.0, width : Float = 0.0, height : Float = 0.0 ) : Void;
 }

--- a/std/js/html/DOMRectReadOnly.hx
+++ b/std/js/html/DOMRectReadOnly.hx
@@ -76,6 +76,6 @@ extern class DOMRectReadOnly
 	var left(default,null) : Float;
 	
 	/** @throws DOMError */
-	function new( ?x : Float = 0.0, ?y : Float = 0.0, ?width : Float = 0.0, ?height : Float = 0.0 ) : Void;
+	function new( x : Float = 0.0, y : Float = 0.0, width : Float = 0.0, height : Float = 0.0 ) : Void;
 	function toJSON() : Dynamic;
 }

--- a/std/js/html/DedicatedWorkerGlobalScope.hx
+++ b/std/js/html/DedicatedWorkerGlobalScope.hx
@@ -55,7 +55,7 @@ extern class DedicatedWorkerGlobalScope extends WorkerGlobalScope
 		Sends a message — which can consist of `any` JavaScript object — to the parent document that first spawned the worker.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, ?transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, transfer : Array<Dynamic> = [] ) : Void;
 	
 	/**
 		Discards any tasks queued in the `WorkerGlobalScope`'s event loop, effectively closing this particular scope.

--- a/std/js/html/DeviceMotionEvent.hx
+++ b/std/js/html/DeviceMotionEvent.hx
@@ -57,5 +57,5 @@ extern class DeviceMotionEvent extends Event
 	
 	/** @throws DOMError */
 	function new( type : String, ?eventInitDict : DeviceMotionEventInit ) : Void;
-	function initDeviceMotionEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?acceleration : DeviceAccelerationInit, ?accelerationIncludingGravity : DeviceAccelerationInit, ?rotationRate : DeviceRotationRateInit, ?interval : Float ) : Void;
+	function initDeviceMotionEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?acceleration : DeviceAccelerationInit, ?accelerationIncludingGravity : DeviceAccelerationInit, ?rotationRate : DeviceRotationRateInit, ?interval : Float ) : Void;
 }

--- a/std/js/html/DeviceOrientationEvent.hx
+++ b/std/js/html/DeviceOrientationEvent.hx
@@ -57,5 +57,5 @@ extern class DeviceOrientationEvent extends Event
 	
 	/** @throws DOMError */
 	function new( type : String, ?eventInitDict : DeviceOrientationEventInit ) : Void;
-	function initDeviceOrientationEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?alpha : Float, ?beta : Float, ?gamma : Float, ?absolute : Bool = false ) : Void;
+	function initDeviceOrientationEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?alpha : Float, ?beta : Float, ?gamma : Float, absolute : Bool = false ) : Void;
 }

--- a/std/js/html/Directory.hx
+++ b/std/js/html/Directory.hx
@@ -35,5 +35,5 @@ extern class Directory
 	/** @throws DOMError */
 	function getFilesAndDirectories() : Promise<Array<haxe.extern.EitherType<File,Directory>>>;
 	/** @throws DOMError */
-	function getFiles( ?recursiveFlag : Bool = false ) : Promise<Array<File>>;
+	function getFiles( recursiveFlag : Bool = false ) : Promise<Array<File>>;
 }

--- a/std/js/html/Document.hx
+++ b/std/js/html/Document.hx
@@ -418,7 +418,7 @@ extern class Document extends Node
 		Returns a clone of a node from an external document.
 		@throws DOMError
 	**/
-	function importNode( node : Node, ?deep : Bool = false ) : Node;
+	function importNode( node : Node, deep : Bool = false ) : Node;
 	
 	/**
 		Adopt node from an external document.
@@ -442,17 +442,17 @@ extern class Document extends Node
 		Creates a `NodeIterator` object.
 		@throws DOMError
 	**/
-	@:overload( function( root : Node, ?whatToShow : Int = cast 4294967295, ?filter : haxe.Constraints.Function) : NodeIterator {} )
-	@:overload( function( root : Node, ?whatToShow : Int = cast 4294967295, ?filter : NodeFilter) : NodeIterator {} )
-	function createNodeIterator( root : Node, ?whatToShow : Int = cast 4294967295, ?filter : Node -> Int ) : NodeIterator;
+	@:overload( function( root : Node, whatToShow : Int = cast 4294967295, ?filter : haxe.Constraints.Function) : NodeIterator {} )
+	@:overload( function( root : Node, whatToShow : Int = cast 4294967295, ?filter : NodeFilter) : NodeIterator {} )
+	function createNodeIterator( root : Node, whatToShow : Int = cast 4294967295, ?filter : Node -> Int ) : NodeIterator;
 	
 	/**
 		Creates a `TreeWalker` object.
 		@throws DOMError
 	**/
-	@:overload( function( root : Node, ?whatToShow : Int = cast 4294967295, ?filter : haxe.Constraints.Function) : TreeWalker {} )
-	@:overload( function( root : Node, ?whatToShow : Int = cast 4294967295, ?filter : NodeFilter) : TreeWalker {} )
-	function createTreeWalker( root : Node, ?whatToShow : Int = cast 4294967295, ?filter : Node -> Int ) : TreeWalker;
+	@:overload( function( root : Node, whatToShow : Int = cast 4294967295, ?filter : haxe.Constraints.Function) : TreeWalker {} )
+	@:overload( function( root : Node, whatToShow : Int = cast 4294967295, ?filter : NodeFilter) : TreeWalker {} )
+	function createTreeWalker( root : Node, whatToShow : Int = cast 4294967295, ?filter : Node -> Int ) : TreeWalker;
 	
 	/**
 		Creates a new CDATA node and returns it.
@@ -510,7 +510,7 @@ extern class Document extends Node
 	/**
 		Creates a `Touch` object.
 	**/
-	function createTouch( ?view : Window, ?target : EventTarget, ?identifier : Int = 0, ?pageX : Int = 0, ?pageY : Int = 0, ?screenX : Int = 0, ?screenY : Int = 0, ?clientX : Int = 0, ?clientY : Int = 0, ?radiusX : Int = 0, ?radiusY : Int = 0, ?rotationAngle : Float = 0.0, ?force : Float = 0.0 ) : Touch;
+	function createTouch( ?view : Window, ?target : EventTarget, identifier : Int = 0, pageX : Int = 0, pageY : Int = 0, screenX : Int = 0, screenY : Int = 0, clientX : Int = 0, clientY : Int = 0, radiusX : Int = 0, radiusY : Int = 0, rotationAngle : Float = 0.0, force : Float = 0.0 ) : Touch;
 	
 	/**
 		Creates a `TouchList` object.
@@ -547,7 +547,7 @@ extern class Document extends Node
 	@:pure
 	function createNSResolver( nodeResolver : Node ) : Node;
 	/** @throws DOMError */
-	@:overload( function( expression : String, contextNode : Node, ?resolver : haxe.Constraints.Function, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
-	@:overload( function( expression : String, contextNode : Node, ?resolver : XPathNSResolver, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
-	function evaluate( expression : String, contextNode : Node, ?resolver : String -> Null<String>, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
+	@:overload( function( expression : String, contextNode : Node, ?resolver : haxe.Constraints.Function, type : Int = 0, ?result : Dynamic) : XPathResult {} )
+	@:overload( function( expression : String, contextNode : Node, ?resolver : XPathNSResolver, type : Int = 0, ?result : Dynamic) : XPathResult {} )
+	function evaluate( expression : String, contextNode : Node, ?resolver : String -> Null<String>, type : Int = 0, ?result : Dynamic ) : XPathResult;
 }

--- a/std/js/html/DragEvent.hx
+++ b/std/js/html/DragEvent.hx
@@ -42,5 +42,5 @@ extern class DragEvent extends MouseEvent
 	
 	/** @throws DOMError */
 	function new( type : String, ?eventInitDict : DragEventInit ) : Void;
-	function initDragEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?aView : Window, ?aDetail : Int = 0, ?aScreenX : Int = 0, ?aScreenY : Int = 0, ?aClientX : Int = 0, ?aClientY : Int = 0, ?aCtrlKey : Bool = false, ?aAltKey : Bool = false, ?aShiftKey : Bool = false, ?aMetaKey : Bool = false, ?aButton : Int = 0, ?aRelatedTarget : EventTarget, ?aDataTransfer : DataTransfer ) : Void;
+	function initDragEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?aView : Window, aDetail : Int = 0, aScreenX : Int = 0, aScreenY : Int = 0, aClientX : Int = 0, aClientY : Int = 0, aCtrlKey : Bool = false, aAltKey : Bool = false, aShiftKey : Bool = false, aMetaKey : Bool = false, aButton : Int = 0, ?aRelatedTarget : EventTarget, ?aDataTransfer : DataTransfer ) : Void;
 }

--- a/std/js/html/Event.hx
+++ b/std/js/html/Event.hx
@@ -140,5 +140,5 @@ extern class Event
 	/**
 		Initializes the value of an Event created. If the event has already being dispatched, this method does nothing.
 	**/
-	function initEvent( type : String, ?bubbles : Bool = false, ?cancelable : Bool = false ) : Void;
+	function initEvent( type : String, bubbles : Bool = false, cancelable : Bool = false ) : Void;
 }

--- a/std/js/html/FontFaceSet.hx
+++ b/std/js/html/FontFaceSet.hx
@@ -66,7 +66,7 @@ extern class FontFaceSet extends EventTarget
 	function values() : FontFaceSetIterator;
 	/** @throws DOMError */
 	function forEach( cb : FontFace -> FontFace -> FontFaceSet -> Void, ?thisArg : Dynamic ) : Void;
-	function load( font : String, ?text : String = " " ) : Promise<Array<FontFace>>;
+	function load( font : String, text : String = " " ) : Promise<Array<FontFace>>;
 	/** @throws DOMError */
-	function check( font : String, ?text : String = " " ) : Bool;
+	function check( font : String, text : String = " " ) : Bool;
 }

--- a/std/js/html/HTMLDocument.hx
+++ b/std/js/html/HTMLDocument.hx
@@ -45,8 +45,8 @@ extern class HTMLDocument extends Document
 	var all(default,null) : HTMLAllCollection;
 	
 	/** @throws DOMError */
-	@:overload( function( ?type : String, ?replace : String = "" ) : HTMLDocument {} )
-	function open( url : String, name : String, features : String, ?replace : Bool = false ) : Window;
+	@:overload( function( ?type : String, replace : String = "" ) : HTMLDocument {} )
+	function open( url : String, name : String, features : String, replace : Bool = false ) : Window;
 	/** @throws DOMError */
 	function close() : Void;
 	/** @throws DOMError */
@@ -54,7 +54,7 @@ extern class HTMLDocument extends Document
 	/** @throws DOMError */
 	function writeln( text : haxe.extern.Rest<String> ) : Void;
 	/** @throws DOMError */
-	function execCommand( commandId : String, ?showUI : Bool = false, ?value : String = "" ) : Bool;
+	function execCommand( commandId : String, showUI : Bool = false, value : String = "" ) : Bool;
 	/** @throws DOMError */
 	function queryCommandEnabled( commandId : String ) : Bool;
 	/** @throws DOMError */

--- a/std/js/html/HashChangeEvent.hx
+++ b/std/js/html/HashChangeEvent.hx
@@ -47,5 +47,5 @@ extern class HashChangeEvent extends Event
 	
 	/** @throws DOMError */
 	function new( type : String, ?eventInitDict : HashChangeEventInit ) : Void;
-	function initHashChangeEvent( typeArg : String, ?canBubbleArg : Bool = false, ?cancelableArg : Bool = false, ?oldURLArg : String = "", ?newURLArg : String = "" ) : Void;
+	function initHashChangeEvent( typeArg : String, canBubbleArg : Bool = false, cancelableArg : Bool = false, oldURLArg : String = "", newURLArg : String = "" ) : Void;
 }

--- a/std/js/html/History.hx
+++ b/std/js/html/History.hx
@@ -55,7 +55,7 @@ extern class History
 		Loads a page from the session history, identified by its relative location to the current page, for example -1 for the previous page or 1  for the next page. If you specify an out-of-bounds value (for instance, specifying -1 when there are no previously-visited pages in the session history), this method silently has no effect. Calling `go()` without parameters or a value of 0 reloads the current page. Internet Explorer lets you also specify a string to go to a specific page in the history list.
 		@throws DOMError
 	**/
-	function go( ?delta : Int = 0 ) : Void;
+	function go( delta : Int = 0 ) : Void;
 	
 	/**
 		Goes to the previous page in session history, the same action as when the user clicks the browser's Back button. Equivalent to `history.go(-1)`.

--- a/std/js/html/InputElement.hx
+++ b/std/js/html/InputElement.hx
@@ -121,7 +121,7 @@ extern class InputElement extends Element
 	function select() : Void;
 	/** @throws DOMError */
 	@:overload( function( replacement : String ) : Void {} )
-	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = "preserve" ) : Void;
+	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = PRESERVE ) : Void;
 	/** @throws DOMError */
 	function setSelectionRange( start : Int, end : Int, ?direction : String ) : Void;
 }

--- a/std/js/html/InputElement.hx
+++ b/std/js/html/InputElement.hx
@@ -101,7 +101,7 @@ extern class InputElement extends Element
 		 
 		@throws DOMError
 	**/
-	function stepUp( ?n : Int = 1 ) : Void;
+	function stepUp( n : Int = 1 ) : Void;
 	
 	/**
 		Decrements the `value` by (`step` * n), where n defaults to 1 if not specified. Throws an INVALID_STATE_ERR exception:
@@ -114,14 +114,14 @@ extern class InputElement extends Element
 		 
 		@throws DOMError
 	**/
-	function stepDown( ?n : Int = 1 ) : Void;
+	function stepDown( n : Int = 1 ) : Void;
 	function checkValidity() : Bool;
 	function reportValidity() : Bool;
 	function setCustomValidity( error : String ) : Void;
 	function select() : Void;
 	/** @throws DOMError */
 	@:overload( function( replacement : String ) : Void {} )
-	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = PRESERVE ) : Void;
+	function setRangeText( replacement : String, start : Int, end : Int, selectionMode : SelectionMode = PRESERVE ) : Void;
 	/** @throws DOMError */
 	function setSelectionRange( start : Int, end : Int, ?direction : String ) : Void;
 }

--- a/std/js/html/KeyEvent.hx
+++ b/std/js/html/KeyEvent.hx
@@ -214,5 +214,5 @@ extern class KeyEvent
 	static inline var DOM_VK_PA1 : Int = 253;
 	static inline var DOM_VK_WIN_OEM_CLEAR : Int = 254;
 	
-	function initKeyEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?view : Window, ?ctrlKey : Bool = false, ?altKey : Bool = false, ?shiftKey : Bool = false, ?metaKey : Bool = false, ?keyCode : Int = 0, ?charCode : Int = 0 ) : Void;
+	function initKeyEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?view : Window, ctrlKey : Bool = false, altKey : Bool = false, shiftKey : Bool = false, metaKey : Bool = false, keyCode : Int = 0, charCode : Int = 0 ) : Void;
 }

--- a/std/js/html/KeyboardEvent.hx
+++ b/std/js/html/KeyboardEvent.hx
@@ -297,10 +297,10 @@ extern class KeyboardEvent extends UIEvent
 		Initializes a `KeyboardEvent` object. This is now deprecated. You should instead use the `KeyboardEvent.KeyboardEvent` constructor.
 		@throws DOMError
 	**/
-	function initKeyboardEvent( typeArg : String, ?bubblesArg : Bool = false, ?cancelableArg : Bool = false, ?viewArg : Window, ?keyArg : String = "", ?locationArg : Int = 0, ?ctrlKey : Bool = false, ?altKey : Bool = false, ?shiftKey : Bool = false, ?metaKey : Bool = false ) : Void;
+	function initKeyboardEvent( typeArg : String, bubblesArg : Bool = false, cancelableArg : Bool = false, ?viewArg : Window, keyArg : String = "", locationArg : Int = 0, ctrlKey : Bool = false, altKey : Bool = false, shiftKey : Bool = false, metaKey : Bool = false ) : Void;
 	
 	/**
 		Initializes a `KeyboardEvent` object. This was implemented only by Firefox, and is no longer supported even there; instead, you should use the `KeyboardEvent.KeyboardEvent` constructor.
 	**/
-	function initKeyEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?view : Window, ?ctrlKey : Bool = false, ?altKey : Bool = false, ?shiftKey : Bool = false, ?metaKey : Bool = false, ?keyCode : Int = 0, ?charCode : Int = 0 ) : Void;
+	function initKeyEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?view : Window, ctrlKey : Bool = false, altKey : Bool = false, shiftKey : Bool = false, metaKey : Bool = false, keyCode : Int = 0, charCode : Int = 0 ) : Void;
 }

--- a/std/js/html/Location.hx
+++ b/std/js/html/Location.hx
@@ -97,5 +97,5 @@ extern class Location
 		Reloads the resource from the current URL. Its optional unique parameter is a `Boolean`, which, when it is `true`, causes the page to always be reloaded from the server. If it is `false` or not specified, the browser may reload the page from its cache.
 		@throws DOMError
 	**/
-	function reload( ?forceget : Bool = false ) : Void;
+	function reload( forceget : Bool = false ) : Void;
 }

--- a/std/js/html/MediaElement.hx
+++ b/std/js/html/MediaElement.hx
@@ -233,7 +233,7 @@ extern class MediaElement extends Element
 	/**
 		Adds a text track (such as a track for subtitles) to a media element.
 	**/
-	function addTextTrack( kind : TextTrackKind, ?label : String = "", ?language : String = "" ) : TextTrack;
+	function addTextTrack( kind : TextTrackKind, label : String = "", language : String = "" ) : TextTrack;
 	
 	/**
 		Returns `Promise`. Sets the `MediaKeys` keys to use when decrypting media during playback.

--- a/std/js/html/MediaRecorder.hx
+++ b/std/js/html/MediaRecorder.hx
@@ -58,7 +58,7 @@ extern class MediaRecorder extends EventTarget
 	
 	/** @throws DOMError */
 	@:overload( function( stream : MediaStream, ?options : MediaRecorderOptions ) : Void {} )
-	function new( node : js.html.audio.AudioNode, ?output : Int = 0, ?options : MediaRecorderOptions ) : Void;
+	function new( node : js.html.audio.AudioNode, output : Int = 0, ?options : MediaRecorderOptions ) : Void;
 	
 	/**
 		Begins recording media; this method can optionally be passed a `timeslice` argument with a value in milliseconds. If this is specified, the media will be captured in separate chunks of that duration, rather than the default behavior of recording the media in a single large chunk.

--- a/std/js/html/MessageEvent.hx
+++ b/std/js/html/MessageEvent.hx
@@ -66,7 +66,7 @@ extern class MessageEvent extends Event
 	/**
 		Initializes a message event. Do not use this anymore — use the `MessageEvent.MessageEvent` constructor instead.
 	**/
-	@:overload( function( type : String, ?bubbles : Bool = false, ?cancelable : Bool = false, ?data : Dynamic, ?origin : String = "", ?lastEventId : String = "", ?source : MessagePort, ?ports : Array<MessagePort> = []) : Void {} )
-	@:overload( function( type : String, ?bubbles : Bool = false, ?cancelable : Bool = false, ?data : Dynamic, ?origin : String = "", ?lastEventId : String = "", ?source : ServiceWorker, ?ports : Array<MessagePort> = []) : Void {} )
-	function initMessageEvent( type : String, ?bubbles : Bool = false, ?cancelable : Bool = false, ?data : Dynamic, ?origin : String = "", ?lastEventId : String = "", ?source : Window, ?ports : Array<MessagePort> = [] ) : Void;
+	@:overload( function( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : MessagePort, ports : Array<MessagePort> = []) : Void {} )
+	@:overload( function( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : ServiceWorker, ports : Array<MessagePort> = []) : Void {} )
+	function initMessageEvent( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : Window, ports : Array<MessagePort> = [] ) : Void;
 }

--- a/std/js/html/MessagePort.hx
+++ b/std/js/html/MessagePort.hx
@@ -38,7 +38,7 @@ extern class MessagePort extends EventTarget
 	var onmessageerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function postMessage( message : Dynamic, ?transferable : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, transferable : Array<Dynamic> = [] ) : Void;
 	function start() : Void;
 	function close() : Void;
 }

--- a/std/js/html/MouseEvent.hx
+++ b/std/js/html/MouseEvent.hx
@@ -135,11 +135,11 @@ extern class MouseEvent extends UIEvent
 	/**
 		Initializes the value of a `MouseEvent` created. If the event has already being dispatched, this method does nothing.
 	**/
-	function initMouseEvent( typeArg : String, ?canBubbleArg : Bool = false, ?cancelableArg : Bool = false, ?viewArg : Window, ?detailArg : Int = 0, ?screenXArg : Int = 0, ?screenYArg : Int = 0, ?clientXArg : Int = 0, ?clientYArg : Int = 0, ?ctrlKeyArg : Bool = false, ?altKeyArg : Bool = false, ?shiftKeyArg : Bool = false, ?metaKeyArg : Bool = false, ?buttonArg : Int = 0, ?relatedTargetArg : EventTarget ) : Void;
+	function initMouseEvent( typeArg : String, canBubbleArg : Bool = false, cancelableArg : Bool = false, ?viewArg : Window, detailArg : Int = 0, screenXArg : Int = 0, screenYArg : Int = 0, clientXArg : Int = 0, clientYArg : Int = 0, ctrlKeyArg : Bool = false, altKeyArg : Bool = false, shiftKeyArg : Bool = false, metaKeyArg : Bool = false, buttonArg : Int = 0, ?relatedTargetArg : EventTarget ) : Void;
 	
 	/**
 		Returns the current state of the specified modifier key. See the `KeyboardEvent.getModifierState`() for details.
 	**/
 	function getModifierState( keyArg : String ) : Bool;
-	function initNSMouseEvent( typeArg : String, ?canBubbleArg : Bool = false, ?cancelableArg : Bool = false, ?viewArg : Window, ?detailArg : Int = 0, ?screenXArg : Int = 0, ?screenYArg : Int = 0, ?clientXArg : Int = 0, ?clientYArg : Int = 0, ?ctrlKeyArg : Bool = false, ?altKeyArg : Bool = false, ?shiftKeyArg : Bool = false, ?metaKeyArg : Bool = false, ?buttonArg : Int = 0, ?relatedTargetArg : EventTarget, ?pressure : Float = 0.0, ?inputSourceArg : Int = 0 ) : Void;
+	function initNSMouseEvent( typeArg : String, canBubbleArg : Bool = false, cancelableArg : Bool = false, ?viewArg : Window, detailArg : Int = 0, screenXArg : Int = 0, screenYArg : Int = 0, clientXArg : Int = 0, clientYArg : Int = 0, ctrlKeyArg : Bool = false, altKeyArg : Bool = false, shiftKeyArg : Bool = false, metaKeyArg : Bool = false, buttonArg : Int = 0, ?relatedTargetArg : EventTarget, pressure : Float = 0.0, inputSourceArg : Int = 0 ) : Void;
 }

--- a/std/js/html/MouseScrollEvent.hx
+++ b/std/js/html/MouseScrollEvent.hx
@@ -39,5 +39,5 @@ extern class MouseScrollEvent extends MouseEvent
 	
 	var axis(default,null) : Int;
 	
-	function initMouseScrollEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?view : Window, ?detail : Int = 0, ?screenX : Int = 0, ?screenY : Int = 0, ?clientX : Int = 0, ?clientY : Int = 0, ?ctrlKey : Bool = false, ?altKey : Bool = false, ?shiftKey : Bool = false, ?metaKey : Bool = false, ?button : Int = 0, ?relatedTarget : EventTarget, ?axis : Int = 0 ) : Void;
+	function initMouseScrollEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?view : Window, detail : Int = 0, screenX : Int = 0, screenY : Int = 0, clientX : Int = 0, clientY : Int = 0, ctrlKey : Bool = false, altKey : Bool = false, shiftKey : Bool = false, metaKey : Bool = false, button : Int = 0, ?relatedTarget : EventTarget, axis : Int = 0 ) : Void;
 }

--- a/std/js/html/MutationEvent.hx
+++ b/std/js/html/MutationEvent.hx
@@ -45,5 +45,5 @@ extern class MutationEvent extends Event
 	var attrChange(default,null) : Int;
 	
 	/** @throws DOMError */
-	function initMutationEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?relatedNode : Node, ?prevValue : String = "", ?newValue : String = "", ?attrName : String = "", ?attrChange : Int = 0 ) : Void;
+	function initMutationEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?relatedNode : Node, prevValue : String = "", newValue : String = "", attrName : String = "", attrChange : Int = 0 ) : Void;
 }

--- a/std/js/html/Node.hx
+++ b/std/js/html/Node.hx
@@ -229,7 +229,7 @@ extern class Node extends EventTarget
 		Clone a `Node`, and optionally, all of its contents. By default, it clones the content of the node.
 		@throws DOMError
 	**/
-	function cloneNode( ?deep : Bool = false ) : Node;
+	function cloneNode( deep : Bool = false ) : Node;
 	
 	/**
 		Returns a `Boolean` value indicating whether or not the two nodes are the same (that is, they reference the same object).

--- a/std/js/html/Option.hx
+++ b/std/js/html/Option.hx
@@ -28,5 +28,5 @@ package js.html;
 extern class Option extends OptionElement
 {
 	/** @throws DOMError */
-	function new( ?text : String = "", ?value : String, ?defaultSelected : Bool = false, ?selected : Bool = false ) : Void;
+	function new( text : String = "", ?value : String, defaultSelected : Bool = false, selected : Bool = false ) : Void;
 }

--- a/std/js/html/Path2D.hx
+++ b/std/js/html/Path2D.hx
@@ -52,7 +52,7 @@ extern class Path2D
 	function arcTo( x1 : Float, y1 : Float, x2 : Float, y2 : Float, radius : Float ) : Void;
 	function rect( x : Float, y : Float, w : Float, h : Float ) : Void;
 	/** @throws DOMError */
-	function arc( x : Float, y : Float, radius : Float, startAngle : Float, endAngle : Float, ?anticlockwise : Bool = false ) : Void;
+	function arc( x : Float, y : Float, radius : Float, startAngle : Float, endAngle : Float, anticlockwise : Bool = false ) : Void;
 	/** @throws DOMError */
-	function ellipse( x : Float, y : Float, radiusX : Float, radiusY : Float, rotation : Float, startAngle : Float, endAngle : Float, ?anticlockwise : Bool = false ) : Void;
+	function ellipse( x : Float, y : Float, radiusX : Float, radiusY : Float, rotation : Float, startAngle : Float, endAngle : Float, anticlockwise : Bool = false ) : Void;
 }

--- a/std/js/html/PluginArray.hx
+++ b/std/js/html/PluginArray.hx
@@ -42,5 +42,5 @@ extern class PluginArray implements ArrayAccess<Plugin>
 	
 	function item( index : Int ) : Plugin;
 	function namedItem( name : String ) : Plugin;
-	function refresh( ?reloadDocuments : Bool = false ) : Void;
+	function refresh( reloadDocuments : Bool = false ) : Void;
 }

--- a/std/js/html/Range.hx
+++ b/std/js/html/Range.hx
@@ -112,7 +112,7 @@ extern class Range
 	/**
 		Collapses the `Range` to one of its boundary points.
 	**/
-	function collapse( ?toStart : Bool = false ) : Void;
+	function collapse( toStart : Bool = false ) : Void;
 	
 	/**
 		Sets the `Range` to contain the `Node` and its contents.

--- a/std/js/html/Response.hx
+++ b/std/js/html/Response.hx
@@ -44,7 +44,7 @@ extern class Response
 		Creates a new response with a different URL.
 		@throws DOMError
 	**/
-	static function redirect( url : String, ?status : Int = 302 ) : Response;
+	static function redirect( url : String, status : Int = 302 ) : Response;
 	
 	/**
 		Contains the type of the response (e.g., `basic`, `cors`).

--- a/std/js/html/ScrollAreaEvent.hx
+++ b/std/js/html/ScrollAreaEvent.hx
@@ -32,5 +32,5 @@ extern class ScrollAreaEvent extends UIEvent
 	var width(default,null) : Float;
 	var height(default,null) : Float;
 	
-	function initScrollAreaEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?view : Window, ?detail : Int = 0, ?x : Float = 0.0, ?y : Float = 0.0, ?width : Float = 0.0, ?height : Float = 0.0 ) : Void;
+	function initScrollAreaEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?view : Window, detail : Int = 0, x : Float = 0.0, y : Float = 0.0, width : Float = 0.0, height : Float = 0.0 ) : Void;
 }

--- a/std/js/html/Selection.hx
+++ b/std/js/html/Selection.hx
@@ -102,9 +102,9 @@ extern class Selection
 		Collapses the current selection to a single point.
 		@throws DOMError
 	**/
-	function collapse( node : Node, ?offset : Int = 0 ) : Void;
+	function collapse( node : Node, offset : Int = 0 ) : Void;
 	/** @throws DOMError */
-	function setPosition( node : Node, ?offset : Int = 0 ) : Void;
+	function setPosition( node : Node, offset : Int = 0 ) : Void;
 	
 	/**
 		Collapses the selection to the start of the first range in the selection.
@@ -122,7 +122,7 @@ extern class Selection
 		Moves the focus of the selection to a specified point.
 		@throws DOMError
 	**/
-	function extend( node : Node, ?offset : Int = 0 ) : Void;
+	function extend( node : Node, offset : Int = 0 ) : Void;
 	
 	/**
 		Sets the selection to be a range including all or parts of two specified DOM nodes, and any content located between them.
@@ -146,7 +146,7 @@ extern class Selection
 		Indicates if a certain node is part of the selection.
 		@throws DOMError
 	**/
-	function containsNode( node : Node, ?allowPartialContainment : Bool = false ) : Bool;
+	function containsNode( node : Node, allowPartialContainment : Bool = false ) : Bool;
 	
 	/**
 		Changes the current selection.

--- a/std/js/html/ServiceWorker.hx
+++ b/std/js/html/ServiceWorker.hx
@@ -52,5 +52,5 @@ extern class ServiceWorker extends EventTarget
 	var onerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function postMessage( message : Dynamic, ?transferable : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, transferable : Array<Dynamic> = [] ) : Void;
 }

--- a/std/js/html/ServiceWorkerContainer.hx
+++ b/std/js/html/ServiceWorkerContainer.hx
@@ -65,7 +65,7 @@ extern class ServiceWorkerContainer extends EventTarget
 	/**
 		Gets a `ServiceWorkerRegistration` object whose scope matches the provided document URL.  If the method can't return a `ServiceWorkerRegistration`, it returns a `Promise`. 
 	**/
-	function getRegistration( ?documentURL : String = "" ) : Promise<Dynamic>;
+	function getRegistration( documentURL : String = "" ) : Promise<Dynamic>;
 	
 	/**
 		Returns all `ServiceWorkerRegistration` objects associated with a `ServiceWorkerContainer` in an array.  If the method can't return `ServiceWorkerRegistration` objects, it returns a `Promise`. 

--- a/std/js/html/StorageEvent.hx
+++ b/std/js/html/StorageEvent.hx
@@ -42,5 +42,5 @@ extern class StorageEvent extends Event
 	
 	/** @throws DOMError */
 	function new( type : String, ?eventInitDict : StorageEventInit ) : Void;
-	function initStorageEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?key : String, ?oldValue : String, ?newValue : String, ?url : String, ?storageArea : Storage ) : Void;
+	function initStorageEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?key : String, ?oldValue : String, ?newValue : String, ?url : String, ?storageArea : Storage ) : Void;
 }

--- a/std/js/html/TableElement.hx
+++ b/std/js/html/TableElement.hx
@@ -141,7 +141,7 @@ extern class TableElement extends Element
 		Returns an `HTMLTableRowElement` representing a new row of the table. It inserts it in the rows collection immediately before the `tr` element at the given `index` position. If necessary a `tbody` is created. If the `index` is `-1`, the new row is appended to the collection. If the `index` is smaller than `-1` or greater than the number of rows in the collection, a `DOMException` with the value `IndexSizeError` is raised.
 		@throws DOMError
 	**/
-	function insertRow( ?index : Int = -1 ) : Element;
+	function insertRow( index : Int = -1 ) : Element;
 	
 	/**
 		Removes the row corresponding to the `index` given in parameter. If the `index` value is `-1` the last row is removed; if it smaller than `-1` or greater than the amount of rows in the collection, a `DOMException` with the value `IndexSizeError` is raised.

--- a/std/js/html/TableRowElement.hx
+++ b/std/js/html/TableRowElement.hx
@@ -80,7 +80,7 @@ extern class TableRowElement extends Element
 		Inserts a new cell just before the given position in the row. If the given position is not given or is `-1`, it appends the cell to the row. If the given position is greater (or equal as it starts at zero) than the amount of cells in the row, or is smaller than `-1`, it raises a `DOMException` with the `IndexSizeError` value. Returns a reference to a HTMLTableCellElement [en-US].
 		@throws DOMError
 	**/
-	function insertCell( ?index : Int = -1 ) : Element;
+	function insertCell( index : Int = -1 ) : Element;
 	
 	/**
 		Removes the cell at the given position in the row. If the given position is greater (or equal as it starts at zero) than the amount of cells in the row, or is smaller than `0`, it raises a `DOMException` with the `IndexSizeError` value.

--- a/std/js/html/TableSectionElement.hx
+++ b/std/js/html/TableSectionElement.hx
@@ -65,7 +65,7 @@ extern class TableSectionElement extends Element
 		Inserts a new row just before the given position in the section. If the given position is not given or is `-1`, it appends the row to the end of section. If the given position is greater (or equal as it starts at zero) than the amount of rows in the section, or is smaller than `-1`, it raises a `DOMException` with the `IndexSizeError` value.
 		@throws DOMError
 	**/
-	function insertRow( ?index : Int = -1 ) : Element;
+	function insertRow( index : Int = -1 ) : Element;
 	
 	/**
 		Removes the cell at the given position in the section. If the given position is greater (or equal as it starts at zero) than the amount of rows in the section, or is smaller than `0`, it raises a `DOMException` with the `IndexSizeError` value.

--- a/std/js/html/Text.hx
+++ b/std/js/html/Text.hx
@@ -41,7 +41,7 @@ extern class Text extends CharacterData
 	var wholeText(default,null) : String;
 	
 	/** @throws DOMError */
-	function new( ?data : String = "" ) : Void;
+	function new( data : String = "" ) : Void;
 	/** @throws DOMError */
 	function splitText( offset : Int ) : Text;
 	/** @throws DOMError */

--- a/std/js/html/TextAreaElement.hx
+++ b/std/js/html/TextAreaElement.hx
@@ -65,7 +65,7 @@ extern class TextAreaElement extends Element
 	function select() : Void;
 	/** @throws DOMError */
 	@:overload( function( replacement : String ) : Void {} )
-	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = "preserve" ) : Void;
+	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = PRESERVE ) : Void;
 	/** @throws DOMError */
 	function setSelectionRange( start : Int, end : Int, ?direction : String ) : Void;
 }

--- a/std/js/html/TextAreaElement.hx
+++ b/std/js/html/TextAreaElement.hx
@@ -65,7 +65,7 @@ extern class TextAreaElement extends Element
 	function select() : Void;
 	/** @throws DOMError */
 	@:overload( function( replacement : String ) : Void {} )
-	function setRangeText( replacement : String, start : Int, end : Int, ?selectionMode : SelectionMode = PRESERVE ) : Void;
+	function setRangeText( replacement : String, start : Int, end : Int, selectionMode : SelectionMode = PRESERVE ) : Void;
 	/** @throws DOMError */
 	function setSelectionRange( start : Int, end : Int, ?direction : String ) : Void;
 }

--- a/std/js/html/TextDecoder.hx
+++ b/std/js/html/TextDecoder.hx
@@ -51,7 +51,7 @@ extern class TextDecoder
 	var ignoreBOM(default,null) : Bool;
 	
 	/** @throws DOMError */
-	function new( ?label : String = "utf-8", ?options : TextDecoderOptions ) : Void;
+	function new( label : String = "utf-8", ?options : TextDecoderOptions ) : Void;
 	
 	/**
 		Returns a `DOMString` containing the text decoded with the method of the specific `TextDecoder` object.

--- a/std/js/html/TextEncoder.hx
+++ b/std/js/html/TextEncoder.hx
@@ -46,5 +46,5 @@ extern class TextEncoder
 	/**
 		Returns a `Uint8Array` containing utf-8 encoded text.
 	**/
-	function encode( ?input : String = "" ) : Uint8Array;
+	function encode( input : String = "" ) : Uint8Array;
 }

--- a/std/js/html/TimeEvent.hx
+++ b/std/js/html/TimeEvent.hx
@@ -37,5 +37,5 @@ extern class TimeEvent extends Event
 	var detail(default,null) : Int;
 	var view(default,null) : Window;
 	
-	function initTimeEvent( aType : String, ?aView : Window, ?aDetail : Int = 0 ) : Void;
+	function initTimeEvent( aType : String, ?aView : Window, aDetail : Int = 0 ) : Void;
 }

--- a/std/js/html/TouchEvent.hx
+++ b/std/js/html/TouchEvent.hx
@@ -72,5 +72,5 @@ extern class TouchEvent extends UIEvent
 	
 	/** @throws DOMError */
 	function new( type : String, ?eventInitDict : TouchEventInit ) : Void;
-	function initTouchEvent( type : String, ?canBubble : Bool = false, ?cancelable : Bool = false, ?view : Window, ?detail : Int = 0, ?ctrlKey : Bool = false, ?altKey : Bool = false, ?shiftKey : Bool = false, ?metaKey : Bool = false, ?touches : TouchList, ?targetTouches : TouchList, ?changedTouches : TouchList ) : Void;
+	function initTouchEvent( type : String, canBubble : Bool = false, cancelable : Bool = false, ?view : Window, detail : Int = 0, ctrlKey : Bool = false, altKey : Bool = false, shiftKey : Bool = false, metaKey : Bool = false, ?touches : TouchList, ?targetTouches : TouchList, ?changedTouches : TouchList ) : Void;
 }

--- a/std/js/html/UIEvent.hx
+++ b/std/js/html/UIEvent.hx
@@ -81,5 +81,5 @@ extern class UIEvent extends Event
 	/**
 		Initializes a `UIEvent` object. If the event has already being dispatched, this method does nothing.
 	**/
-	function initUIEvent( aType : String, ?aCanBubble : Bool = false, ?aCancelable : Bool = false, ?aView : Window, ?aDetail : Int = 0 ) : Void;
+	function initUIEvent( aType : String, aCanBubble : Bool = false, aCancelable : Bool = false, ?aView : Window, aDetail : Int = 0 ) : Void;
 }

--- a/std/js/html/URLSearchParams.hx
+++ b/std/js/html/URLSearchParams.hx
@@ -35,9 +35,9 @@ package js.html;
 extern class URLSearchParams
 {
 	/** @throws DOMError */
-	@:overload( function( ?init : haxe.DynamicAccess<String> = "") : URLSearchParams {} )
-	@:overload( function( ?init : String = "") : URLSearchParams {} )
-	function new( ?init : Array<Array<String>> = "" ) : Void;
+	@:overload( function( init : haxe.DynamicAccess<String> = "") : URLSearchParams {} )
+	@:overload( function( init : String = "") : URLSearchParams {} )
+	function new( init : Array<Array<String>> = "" ) : Void;
 	
 	/**
 		Appends a specified key/value pair as a new search parameter.

--- a/std/js/html/Window.hx
+++ b/std/js/html/Window.hx
@@ -403,7 +403,7 @@ extern class Window extends EventTarget
 		Opens a new window.
 		@throws DOMError
 	**/
-	function open( ?url : String = "", ?target : String = "", ?features : String = "" ) : Window;
+	function open( url : String = "", target : String = "", features : String = "" ) : Window;
 	
 	/**
 		Displays an alert dialog.
@@ -416,13 +416,13 @@ extern class Window extends EventTarget
 		Displays a dialog with a message that the user needs to respond to.
 		@throws DOMError
 	**/
-	function confirm( ?message : String = "" ) : Bool;
+	function confirm( message : String = "" ) : Bool;
 	
 	/**
 		Returns the text entered by the user in a prompt dialog.
 		@throws DOMError
 	**/
-	function prompt( ?message : String = "", ?default_ : String = "" ) : String;
+	function prompt( message : String = "", default_ : String = "" ) : String;
 	
 	/**
 		Opens the Print Dialog to print the current document.
@@ -434,7 +434,7 @@ extern class Window extends EventTarget
 		Provides a secure means for one window to send a string of data to another window, which need not be within the same domain as the first.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, targetOrigin : String, ?transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, targetOrigin : String, transfer : Array<Dynamic> = [] ) : Void;
 	
 	/**
 		Registers the window to capture all events of the specified type.
@@ -456,7 +456,7 @@ extern class Window extends EventTarget
 		Gets computed style for the specified element. Computed style indicates the computed values of all CSS properties of the element.
 		@throws DOMError
 	**/
-	function getComputedStyle( elt : Element, ?pseudoElt : String = "" ) : CSSStyleDeclaration;
+	function getComputedStyle( elt : Element, pseudoElt : String = "" ) : CSSStyleDeclaration;
 	
 	/**
 		Returns a `MediaQueryList` object representing the specified media query string.
@@ -522,7 +522,7 @@ extern class Window extends EventTarget
 		Gets default computed style for the specified element, ignoring author stylesheets.
 		@throws DOMError
 	**/
-	function getDefaultComputedStyle( elt : Element, ?pseudoElt : String = "" ) : CSSStyleDeclaration;
+	function getDefaultComputedStyle( elt : Element, pseudoElt : String = "" ) : CSSStyleDeclaration;
 	
 	/**
 		Scrolls the document by the given number of lines.
@@ -543,13 +543,13 @@ extern class Window extends EventTarget
 	/**
 		Updates the state of commands of the current chrome window (UI).
 	**/
-	function updateCommands( action : String, ?sel : Selection, ?reason : Int = 0 ) : Void;
+	function updateCommands( action : String, ?sel : Selection, reason : Int = 0 ) : Void;
 	
 	/**
 		Searches for a given string in a window.
 		@throws DOMError
 	**/
-	function find( ?str : String = "", ?caseSensitive : Bool = false, ?backwards : Bool = false, ?wrapAround : Bool = false, ?wholeWord : Bool = false, ?searchInFrames : Bool = false, ?showDialog : Bool = false ) : Bool;
+	function find( str : String = "", caseSensitive : Bool = false, backwards : Bool = false, wrapAround : Bool = false, wholeWord : Bool = false, searchInFrames : Bool = false, showDialog : Bool = false ) : Bool;
 	
 	/**
 		Writes a message to the console.
@@ -565,13 +565,13 @@ extern class Window extends EventTarget
 	/** @throws DOMError */
 	function atob( atob : String ) : String;
 	/** @throws DOMError */
-	@:overload( function( handler : haxe.Constraints.Function, ?timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
-	function setTimeout( handler : String, ?timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
-	function clearTimeout( ?handle : Int = 0 ) : Void;
+	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
+	function setTimeout( handler : String, timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
+	function clearTimeout( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
-	@:overload( function( handler : haxe.Constraints.Function, ?timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
-	function setInterval( handler : String, ?timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
-	function clearInterval( ?handle : Int = 0 ) : Void;
+	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
+	function setInterval( handler : String, timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
+	function clearInterval( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
 	@:overload( function( aImage : VideoElement) : Promise<ImageBitmap> {} )
 	@:overload( function( aImage : CanvasElement) : Promise<ImageBitmap> {} )

--- a/std/js/html/Worker.hx
+++ b/std/js/html/Worker.hx
@@ -58,5 +58,5 @@ extern class Worker extends EventTarget
 		Sends a message — which can consist of `any` JavaScript object — to the worker's inner scope.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, ?transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, transfer : Array<Dynamic> = [] ) : Void;
 }

--- a/std/js/html/WorkerGlobalScope.hx
+++ b/std/js/html/WorkerGlobalScope.hx
@@ -86,13 +86,13 @@ extern class WorkerGlobalScope extends EventTarget
 	/** @throws DOMError */
 	function atob( atob : String ) : String;
 	/** @throws DOMError */
-	@:overload( function( handler : haxe.Constraints.Function, ?timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
-	function setTimeout( handler : String, ?timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
-	function clearTimeout( ?handle : Int = 0 ) : Void;
+	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
+	function setTimeout( handler : String, timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
+	function clearTimeout( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
-	@:overload( function( handler : haxe.Constraints.Function, ?timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
-	function setInterval( handler : String, ?timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
-	function clearInterval( ?handle : Int = 0 ) : Void;
+	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
+	function setInterval( handler : String, timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
+	function clearInterval( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
 	@:overload( function( aImage : VideoElement) : Promise<ImageBitmap> {} )
 	@:overload( function( aImage : CanvasElement) : Promise<ImageBitmap> {} )

--- a/std/js/html/XPathEvaluator.hx
+++ b/std/js/html/XPathEvaluator.hx
@@ -36,7 +36,7 @@ extern class XPathEvaluator
 	@:pure
 	function createNSResolver( nodeResolver : Node ) : Node;
 	/** @throws DOMError */
-	@:overload( function( expression : String, contextNode : Node, ?resolver : haxe.Constraints.Function, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
-	@:overload( function( expression : String, contextNode : Node, ?resolver : XPathNSResolver, ?type : Int = 0, ?result : Dynamic) : XPathResult {} )
-	function evaluate( expression : String, contextNode : Node, ?resolver : String -> Null<String>, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
+	@:overload( function( expression : String, contextNode : Node, ?resolver : haxe.Constraints.Function, type : Int = 0, ?result : Dynamic) : XPathResult {} )
+	@:overload( function( expression : String, contextNode : Node, ?resolver : XPathNSResolver, type : Int = 0, ?result : Dynamic) : XPathResult {} )
+	function evaluate( expression : String, contextNode : Node, ?resolver : String -> Null<String>, type : Int = 0, ?result : Dynamic ) : XPathResult;
 }

--- a/std/js/html/XPathExpression.hx
+++ b/std/js/html/XPathExpression.hx
@@ -39,5 +39,5 @@ extern class XPathExpression
 		provide a context node/document, `XPathResult` constant, and `XPathResult` to store the query or null to return a new XPathResult.
 		@throws DOMError
 	**/
-	function evaluate( contextNode : Node, ?type : Int = 0, ?result : Dynamic ) : XPathResult;
+	function evaluate( contextNode : Node, type : Int = 0, ?result : Dynamic ) : XPathResult;
 }

--- a/std/js/html/audio/AudioBuffer.hx
+++ b/std/js/html/audio/AudioBuffer.hx
@@ -68,11 +68,11 @@ extern class AudioBuffer
 		Copies the samples from the specified channel of the `AudioBuffer` to the `destination` array.
 		@throws DOMError
 	**/
-	function copyFromChannel( destination : js.html.Float32Array, channelNumber : Int, ?startInChannel : Int = 0 ) : Void;
+	function copyFromChannel( destination : js.html.Float32Array, channelNumber : Int, startInChannel : Int = 0 ) : Void;
 	
 	/**
 		Copies the samples to the specified channel of the `AudioBuffer`, from the `source` array.
 		@throws DOMError
 	**/
-	function copyToChannel( source : js.html.Float32Array, channelNumber : Int, ?startInChannel : Int = 0 ) : Void;
+	function copyToChannel( source : js.html.Float32Array, channelNumber : Int, startInChannel : Int = 0 ) : Void;
 }

--- a/std/js/html/audio/AudioBufferSourceNode.hx
+++ b/std/js/html/audio/AudioBufferSourceNode.hx
@@ -72,5 +72,5 @@ extern class AudioBufferSourceNode extends AudioScheduledSourceNode
 		Used to schedule playback of the audio data contained in the buffer, or to begin playback immediately.
 		@throws DOMError
 	**/
-	function start( ?when : Float = 0.0, ?grainOffset : Float = 0.0, ?grainDuration : Float ) : Void;
+	function start( when : Float = 0.0, grainOffset : Float = 0.0, ?grainDuration : Float ) : Void;
 }

--- a/std/js/html/audio/AudioNode.hx
+++ b/std/js/html/audio/AudioNode.hx
@@ -72,8 +72,8 @@ extern class AudioNode extends js.html.EventTarget
 		Allows us to connect the output of this node to be input into another node, either as audio data or as the value of an `AudioParam`.
 		@throws DOMError
 	**/
-	@:overload( function( destination : AudioNode, ?output : Int = 0, ?input : Int = 0 ) : AudioNode {} )
-	function connect( destination : AudioParam, ?output : Int = 0 ) : Void;
+	@:overload( function( destination : AudioNode, output : Int = 0, input : Int = 0 ) : AudioNode {} )
+	function connect( destination : AudioParam, output : Int = 0 ) : Void;
 	
 	/**
 		Allows us to disconnect the current node from another one it is already connected to.

--- a/std/js/html/audio/AudioScheduledSourceNode.hx
+++ b/std/js/html/audio/AudioScheduledSourceNode.hx
@@ -41,7 +41,7 @@ extern class AudioScheduledSourceNode extends AudioNode
 	var onended : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function start( ?when : Float = 0.0 ) : Void;
+	function start( when : Float = 0.0 ) : Void;
 	/** @throws DOMError */
-	function stop( ?when : Float = 0.0 ) : Void;
+	function stop( when : Float = 0.0 ) : Void;
 }

--- a/std/js/html/audio/BaseAudioContext.hx
+++ b/std/js/html/audio/BaseAudioContext.hx
@@ -101,7 +101,7 @@ extern class BaseAudioContext extends js.html.EventTarget
 		Creates a `ScriptProcessorNode`, which can be used for direct audio processing via JavaScript.
 		@throws DOMError
 	**/
-	function createScriptProcessor( ?bufferSize : Int = 0, ?numberOfInputChannels : Int = 2, ?numberOfOutputChannels : Int = 2 ) : ScriptProcessorNode;
+	function createScriptProcessor( bufferSize : Int = 0, numberOfInputChannels : Int = 2, numberOfOutputChannels : Int = 2 ) : ScriptProcessorNode;
 	
 	/**
 		Creates an `AnalyserNode`, which can be used to expose audio time and frequency data and for example to create data visualisations.
@@ -119,7 +119,7 @@ extern class BaseAudioContext extends js.html.EventTarget
 		Creates a `DelayNode`, which is used to delay the incoming audio signal by a certain amount. This node is also useful to create feedback loops in a Web Audio API graph.
 		@throws DOMError
 	**/
-	function createDelay( ?maxDelayTime : Float = 1.0 ) : DelayNode;
+	function createDelay( maxDelayTime : Float = 1.0 ) : DelayNode;
 	
 	/**
 		Creates a `BiquadFilterNode`, which represents a second order filter configurable as several different common filter types: high-pass, low-pass, band-pass, etc
@@ -161,13 +161,13 @@ extern class BaseAudioContext extends js.html.EventTarget
 		Creates a `ChannelSplitterNode`, which is used to access the individual channels of an audio stream and process them separately.
 		@throws DOMError
 	**/
-	function createChannelSplitter( ?numberOfOutputs : Int = 6 ) : ChannelSplitterNode;
+	function createChannelSplitter( numberOfOutputs : Int = 6 ) : ChannelSplitterNode;
 	
 	/**
 		Creates a `ChannelMergerNode`, which is used to combine channels from multiple audio streams into a single audio stream.
 		@throws DOMError
 	**/
-	function createChannelMerger( ?numberOfInputs : Int = 6 ) : ChannelMergerNode;
+	function createChannelMerger( numberOfInputs : Int = 6 ) : ChannelMergerNode;
 	
 	/**
 		Creates a `DynamicsCompressorNode`, which can be used to apply acoustic compression to an audio signal.

--- a/std/js/html/eme/MediaKeys.hx
+++ b/std/js/html/eme/MediaKeys.hx
@@ -41,7 +41,7 @@ extern class MediaKeys
 		Returns a new `MediaKeySession` object, which represents a context for message exchange with a content decryption module (CDM).
 		@throws DOMError
 	**/
-	function createSession( ?sessionType : MediaKeySessionType = TEMPORARY ) : MediaKeySession;
+	function createSession( sessionType : MediaKeySessionType = TEMPORARY ) : MediaKeySession;
 	
 	/**
 		Returns a `Promise` to a server certificate to be used to encrypt messages to the license server.

--- a/std/js/html/eme/MediaKeys.hx
+++ b/std/js/html/eme/MediaKeys.hx
@@ -41,7 +41,7 @@ extern class MediaKeys
 		Returns a new `MediaKeySession` object, which represents a context for message exchange with a content decryption module (CDM).
 		@throws DOMError
 	**/
-	function createSession( ?sessionType : MediaKeySessionType = "temporary" ) : MediaKeySession;
+	function createSession( ?sessionType : MediaKeySessionType = TEMPORARY ) : MediaKeySession;
 	
 	/**
 		Returns a `Promise` to a server certificate to be used to encrypt messages to the license server.

--- a/std/js/html/idb/Database.hx
+++ b/std/js/html/idb/Database.hx
@@ -89,8 +89,8 @@ extern class Database extends js.html.EventTarget
 		Immediately returns a transaction object (`IDBTransaction`) containing the `IDBTransaction.objectStore` method, which you can use to access your object store. Runs in a separate thread.
 		@throws DOMError
 	**/
-	@:overload( function( storeNames : Array<String>, ?mode : TransactionMode = "readonly") : Transaction {} )
-	function transaction( storeNames : String, ?mode : TransactionMode = "readonly" ) : Transaction;
+	@:overload( function( storeNames : Array<String>, ?mode : TransactionMode = READONLY) : Transaction {} )
+	function transaction( storeNames : String, ?mode : TransactionMode = READONLY ) : Transaction;
 	
 	/**
 		Returns immediately and closes the connection to a database in a separate thread.

--- a/std/js/html/idb/Database.hx
+++ b/std/js/html/idb/Database.hx
@@ -89,8 +89,8 @@ extern class Database extends js.html.EventTarget
 		Immediately returns a transaction object (`IDBTransaction`) containing the `IDBTransaction.objectStore` method, which you can use to access your object store. Runs in a separate thread.
 		@throws DOMError
 	**/
-	@:overload( function( storeNames : Array<String>, ?mode : TransactionMode = READONLY) : Transaction {} )
-	function transaction( storeNames : String, ?mode : TransactionMode = READONLY ) : Transaction;
+	@:overload( function( storeNames : Array<String>, mode : TransactionMode = READONLY) : Transaction {} )
+	function transaction( storeNames : String, mode : TransactionMode = READONLY ) : Transaction;
 	
 	/**
 		Returns immediately and closes the connection to a database in a separate thread.

--- a/std/js/html/idb/Index.hx
+++ b/std/js/html/idb/Index.hx
@@ -65,13 +65,13 @@ extern class Index
 		Returns an `IDBRequest` object, and, in a separate thread, creates a cursor over the specified key range.
 		@throws DOMError
 	**/
-	function openCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
+	function openCursor( ?range : Dynamic, direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, creates a cursor over the specified key range, as arranged by this index.
 		@throws DOMError
 	**/
-	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
+	function openKeyCursor( ?range : Dynamic, direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, finds either the value in the referenced object store that corresponds to the given key or the first corresponding value, if `key` is an `IDBKeyRange`.

--- a/std/js/html/idb/Index.hx
+++ b/std/js/html/idb/Index.hx
@@ -65,13 +65,13 @@ extern class Index
 		Returns an `IDBRequest` object, and, in a separate thread, creates a cursor over the specified key range.
 		@throws DOMError
 	**/
-	function openCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, creates a cursor over the specified key range, as arranged by this index.
 		@throws DOMError
 	**/
-	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Returns an `IDBRequest` object, and, in a separate thread, finds either the value in the referenced object store that corresponds to the given key or the first corresponding value, if `key` is an `IDBKeyRange`.

--- a/std/js/html/idb/KeyRange.hx
+++ b/std/js/html/idb/KeyRange.hx
@@ -45,19 +45,19 @@ extern class KeyRange
 		Creates a new key range with only a lower bound.
 		@throws DOMError
 	**/
-	static function lowerBound( lower : Dynamic, ?open : Bool = false ) : KeyRange;
+	static function lowerBound( lower : Dynamic, open : Bool = false ) : KeyRange;
 	
 	/**
 		Creates a new upper-bound key range.
 		@throws DOMError
 	**/
-	static function upperBound( upper : Dynamic, ?open : Bool = false ) : KeyRange;
+	static function upperBound( upper : Dynamic, open : Bool = false ) : KeyRange;
 	
 	/**
 		Creates a new key range with upper and lower bounds.
 		@throws DOMError
 	**/
-	static function bound( lower : Dynamic, upper : Dynamic, ?lowerOpen : Bool = false, ?upperOpen : Bool = false ) : KeyRange;
+	static function bound( lower : Dynamic, upper : Dynamic, lowerOpen : Bool = false, upperOpen : Bool = false ) : KeyRange;
 	
 	/**
 		Lower bound of the key range.

--- a/std/js/html/idb/MutableFile.hx
+++ b/std/js/html/idb/MutableFile.hx
@@ -41,7 +41,7 @@ extern class MutableFile extends js.html.EventTarget
 	var onerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function open( ?mode : js.html.FileMode = "readonly" ) : FileHandle;
+	function open( ?mode : js.html.FileMode = READONLY ) : FileHandle;
 	/** @throws DOMError */
 	function getFile() : js.html.DOMRequest;
 }

--- a/std/js/html/idb/MutableFile.hx
+++ b/std/js/html/idb/MutableFile.hx
@@ -41,7 +41,7 @@ extern class MutableFile extends js.html.EventTarget
 	var onerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function open( ?mode : js.html.FileMode = READONLY ) : FileHandle;
+	function open( mode : js.html.FileMode = READONLY ) : FileHandle;
 	/** @throws DOMError */
 	function getFile() : js.html.DOMRequest;
 }

--- a/std/js/html/idb/ObjectStore.hx
+++ b/std/js/html/idb/ObjectStore.hx
@@ -101,7 +101,7 @@ extern class ObjectStore
 		Returns an `IDBRequest` object, and, in a separate thread, returns a new `IDBCursorWithValue` object. Used for iterating through an object store by primary key with a cursor.
 		@throws DOMError
 	**/
-	function openCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
+	function openCursor( ?range : Dynamic, direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Creates a new index during a version upgrade, returning a new `IDBIndex` object in the connected database.
@@ -144,5 +144,5 @@ extern class ObjectStore
 		Returns an `IDBRequest` object, and, in a separate thread, returns a new `IDBCursor`. Used for iterating through an object store with a key.
 		@throws DOMError
 	**/
-	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
+	function openKeyCursor( ?range : Dynamic, direction : CursorDirection = NEXT ) : Request;
 }

--- a/std/js/html/idb/ObjectStore.hx
+++ b/std/js/html/idb/ObjectStore.hx
@@ -101,7 +101,7 @@ extern class ObjectStore
 		Returns an `IDBRequest` object, and, in a separate thread, returns a new `IDBCursorWithValue` object. Used for iterating through an object store by primary key with a cursor.
 		@throws DOMError
 	**/
-	function openCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 	
 	/**
 		Creates a new index during a version upgrade, returning a new `IDBIndex` object in the connected database.
@@ -144,5 +144,5 @@ extern class ObjectStore
 		Returns an `IDBRequest` object, and, in a separate thread, returns a new `IDBCursor`. Used for iterating through an object store with a key.
 		@throws DOMError
 	**/
-	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = "next" ) : Request;
+	function openKeyCursor( ?range : Dynamic, ?direction : CursorDirection = NEXT ) : Request;
 }

--- a/std/js/html/rtc/DTMFSender.hx
+++ b/std/js/html/rtc/DTMFSender.hx
@@ -38,5 +38,5 @@ extern class DTMFSender extends js.html.EventTarget
 	**/
 	var toneBuffer(default,null) : String;
 	
-	function insertDTMF( tones : String, ?duration : Int = 100, ?interToneGap : Int = 70 ) : Void;
+	function insertDTMF( tones : String, duration : Int = 100, interToneGap : Int = 70 ) : Void;
 }

--- a/std/js/html/webgl/WebGL2RenderingContext.hx
+++ b/std/js/html/webgl/WebGL2RenderingContext.hx
@@ -601,14 +601,14 @@ extern class WebGL2RenderingContext extends RenderingContext
 	@:overload( function( target : Int, size : Int, usage : Int ) : Void {} )
 	@:overload( function( target : Int, srcData : js.html.ArrayBuffer, usage : Int ) : Void {} )
 	@:overload( function( target : Int, srcData : js.html.ArrayBufferView, usage : Int ) : Void {} )
-	function bufferData( target : Int, srcData : js.html.ArrayBufferView, usage : Int, srcOffset : Int, ?length : Int = 0 ) : Void;
+	function bufferData( target : Int, srcData : js.html.ArrayBufferView, usage : Int, srcOffset : Int, length : Int = 0 ) : Void;
 	
 	/**
 		Updates a subset of a buffer object's data store.
 	**/
 	@:overload( function( target : Int, offset : Int, srcData : js.html.ArrayBuffer ) : Void {} )
 	@:overload( function( target : Int, offset : Int, srcData : js.html.ArrayBufferView ) : Void {} )
-	function bufferSubData( target : Int, dstByteOffset : Int, srcData : js.html.ArrayBufferView, srcOffset : Int, ?length : Int = 0 ) : Void;
+	function bufferSubData( target : Int, dstByteOffset : Int, srcData : js.html.ArrayBufferView, srcOffset : Int, length : Int = 0 ) : Void;
 	
 	/**
 		Copies part of the data of a buffer to another buffer.
@@ -618,7 +618,7 @@ extern class WebGL2RenderingContext extends RenderingContext
 	/**
 		Reads data from a buffer and writes them to an `ArrayBuffer` or `SharedArrayBuffer`.
 	**/
-	function getBufferSubData( target : Int, srcByteOffset : Int, dstData : js.html.ArrayBufferView, ?dstOffset : Int = 0, ?length : Int = 0 ) : Void;
+	function getBufferSubData( target : Int, srcByteOffset : Int, dstData : js.html.ArrayBufferView, dstOffset : Int = 0, length : Int = 0 ) : Void;
 	
 	/**
 		Transfers a block of pixels from the read framebuffer to the draw framebuffer.
@@ -719,28 +719,28 @@ extern class WebGL2RenderingContext extends RenderingContext
 	@:overload( function( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, type : Int, source : js.html.VideoElement ) : Void {} )
 	@:overload( function( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, type : Int, source : js.html.ImageBitmap ) : Void {} )
 	@:overload( function( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, type : Int, source : js.html.ImageData ) : Void {} )
-	function texSubImage3D( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, type : Int, srcData : js.html.ArrayBufferView, ?srcOffset : Int = 0 ) : Void;
+	function texSubImage3D( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, type : Int, srcData : js.html.ArrayBufferView, srcOffset : Int = 0 ) : Void;
 	
 	/**
 		Copies pixels from the current `WebGLFramebuffer` into an existing 3D texture sub-image.
 	**/
 	function copyTexSubImage3D( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, x : Int, y : Int, width : Int, height : Int ) : Void;
 	@:overload( function( target : Int, level : Int, internalformat : Int, width : Int, height : Int, border : Int, imageSize : Int, offset : Int ) : Void {} )
-	function compressedTexImage2D( target : Int, level : Int, internalformat : Int, width : Int, height : Int, border : Int, srcData : js.html.ArrayBufferView, ?srcOffset : Int = 0, ?srcLengthOverride : Int = 0 ) : Void;
+	function compressedTexImage2D( target : Int, level : Int, internalformat : Int, width : Int, height : Int, border : Int, srcData : js.html.ArrayBufferView, srcOffset : Int = 0, srcLengthOverride : Int = 0 ) : Void;
 	
 	/**
 		Specifies a three-dimensional texture image in a compressed format.
 	**/
 	@:overload( function( target : Int, level : Int, internalformat : Int, width : Int, height : Int, depth : Int, border : Int, imageSize : Int, offset : Int ) : Void {} )
-	function compressedTexImage3D( target : Int, level : Int, internalformat : Int, width : Int, height : Int, depth : Int, border : Int, srcData : js.html.ArrayBufferView, ?srcOffset : Int = 0, ?srcLengthOverride : Int = 0 ) : Void;
+	function compressedTexImage3D( target : Int, level : Int, internalformat : Int, width : Int, height : Int, depth : Int, border : Int, srcData : js.html.ArrayBufferView, srcOffset : Int = 0, srcLengthOverride : Int = 0 ) : Void;
 	@:overload( function( target : Int, level : Int, xoffset : Int, yoffset : Int, width : Int, height : Int, format : Int, imageSize : Int, offset : Int ) : Void {} )
-	function compressedTexSubImage2D( target : Int, level : Int, xoffset : Int, yoffset : Int, width : Int, height : Int, format : Int, srcData : js.html.ArrayBufferView, ?srcOffset : Int = 0, ?srcLengthOverride : Int = 0 ) : Void;
+	function compressedTexSubImage2D( target : Int, level : Int, xoffset : Int, yoffset : Int, width : Int, height : Int, format : Int, srcData : js.html.ArrayBufferView, srcOffset : Int = 0, srcLengthOverride : Int = 0 ) : Void;
 	
 	/**
 		Specifies a three-dimensional sub-rectangle for a texture image in a compressed format.
 	**/
 	@:overload( function( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, imageSize : Int, offset : Int ) : Void {} )
-	function compressedTexSubImage3D( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, srcData : js.html.ArrayBufferView, ?srcOffset : Int = 0, ?srcLengthOverride : Int = 0 ) : Void;
+	function compressedTexSubImage3D( target : Int, level : Int, xoffset : Int, yoffset : Int, zoffset : Int, width : Int, height : Int, depth : Int, format : Int, srcData : js.html.ArrayBufferView, srcOffset : Int = 0, srcLengthOverride : Int = 0 ) : Void;
 	
 	/**
 		Returns the binding of color numbers to user-defined varying out variables.
@@ -750,48 +750,48 @@ extern class WebGL2RenderingContext extends RenderingContext
 	function uniform2ui( location : UniformLocation, v0 : Int, v1 : Int ) : Void;
 	function uniform3ui( location : UniformLocation, v0 : Int, v1 : Int, v2 : Int ) : Void;
 	function uniform4ui( location : UniformLocation, v0 : Int, v1 : Int, v2 : Int, v3 : Int ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform1fv( location : UniformLocation, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform2fv( location : UniformLocation, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform3fv( location : UniformLocation, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform4fv( location : UniformLocation, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform1iv( location : UniformLocation, data : js.html.Int32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform2iv( location : UniformLocation, data : js.html.Int32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform3iv( location : UniformLocation, data : js.html.Int32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform4iv( location : UniformLocation, data : js.html.Int32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform1uiv( location : UniformLocation, data : js.html.Uint32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform2uiv( location : UniformLocation, data : js.html.Uint32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform3uiv( location : UniformLocation, data : js.html.Uint32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, data : Array<Int>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniform4uiv( location : UniformLocation, data : js.html.Uint32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix2fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix3x2fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix4x2fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix2x3fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix3fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix4x3fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix2x4fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix3x4fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
-	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, ?srcOffset : Int = 0, ?srcLength : Int = 0) : Void {} )
-	function uniformMatrix4fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, ?srcOffset : Int = 0, ?srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform1fv( location : UniformLocation, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform2fv( location : UniformLocation, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform3fv( location : UniformLocation, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform4fv( location : UniformLocation, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform1iv( location : UniformLocation, data : js.html.Int32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform2iv( location : UniformLocation, data : js.html.Int32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform3iv( location : UniformLocation, data : js.html.Int32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform4iv( location : UniformLocation, data : js.html.Int32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform1uiv( location : UniformLocation, data : js.html.Uint32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform2uiv( location : UniformLocation, data : js.html.Uint32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform3uiv( location : UniformLocation, data : js.html.Uint32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, data : Array<Int>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniform4uiv( location : UniformLocation, data : js.html.Uint32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix2fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix3x2fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix4x2fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix2x3fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix3fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix4x3fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix2x4fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix3x4fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
+	@:overload( function( location : UniformLocation, transpose : Bool, data : Array<Float>, srcOffset : Int = 0, srcLength : Int = 0) : Void {} )
+	function uniformMatrix4fv( location : UniformLocation, transpose : Bool, data : js.html.Float32Array, srcOffset : Int = 0, srcLength : Int = 0 ) : Void;
 	function vertexAttribI4i( index : Int, x : Int, y : Int, z : Int, w : Int ) : Void;
 	@:overload( function( index : Int, values : Array<Int>) : Void {} )
 	function vertexAttribI4iv( index : Int, values : js.html.Int32Array ) : Void;
@@ -832,12 +832,12 @@ extern class WebGL2RenderingContext extends RenderingContext
 		Specifies a list of color buffers to be drawn into.
 	**/
 	function drawBuffers( buffers : Array<Int> ) : Void;
-	@:overload( function( buffer : Int, drawbuffer : Int, values : Array<Float>, ?srcOffset : Int = 0) : Void {} )
-	function clearBufferfv( buffer : Int, drawbuffer : Int, values : js.html.Float32Array, ?srcOffset : Int = 0 ) : Void;
-	@:overload( function( buffer : Int, drawbuffer : Int, values : Array<Int>, ?srcOffset : Int = 0) : Void {} )
-	function clearBufferiv( buffer : Int, drawbuffer : Int, values : js.html.Int32Array, ?srcOffset : Int = 0 ) : Void;
-	@:overload( function( buffer : Int, drawbuffer : Int, values : Array<Int>, ?srcOffset : Int = 0) : Void {} )
-	function clearBufferuiv( buffer : Int, drawbuffer : Int, values : js.html.Uint32Array, ?srcOffset : Int = 0 ) : Void;
+	@:overload( function( buffer : Int, drawbuffer : Int, values : Array<Float>, srcOffset : Int = 0) : Void {} )
+	function clearBufferfv( buffer : Int, drawbuffer : Int, values : js.html.Float32Array, srcOffset : Int = 0 ) : Void;
+	@:overload( function( buffer : Int, drawbuffer : Int, values : Array<Int>, srcOffset : Int = 0) : Void {} )
+	function clearBufferiv( buffer : Int, drawbuffer : Int, values : js.html.Int32Array, srcOffset : Int = 0 ) : Void;
+	@:overload( function( buffer : Int, drawbuffer : Int, values : Array<Int>, srcOffset : Int = 0) : Void {} )
+	function clearBufferuiv( buffer : Int, drawbuffer : Int, values : js.html.Uint32Array, srcOffset : Int = 0 ) : Void;
 	function clearBufferfi( buffer : Int, drawbuffer : Int, depth : Float, stencil : Int ) : Void;
 	
 	/**


### PR DESCRIPTION
I’m Removes `?` and implied nullablity from arguments that have a default value in the WebIDL

Issue raised by @Gama11 here: https://github.com/HaxeFoundation/haxe/pull/7775#issuecomment-462169335

Merge #7775 first

## Expected impact on existing code
None since you can still pass null for these arguments but when nullSaftey is turned on, you’ll get errors for non-nullable values.

https://github.com/HaxeFoundation/html-externs/commit/0c060440f48aab3f003d3bfe11e71efc294fe532