### PR TITLE
[js] html externs: enable requestFullscreen() flag

### DIFF
--- a/std/js/html/DOMElement.hx
+++ b/std/js/html/DOMElement.hx
@@ -501,6 +501,12 @@ extern class DOMElement extends Node
 	function attachShadow( shadowRootInitDict : ShadowRootInit ) : ShadowRoot;
 	
 	/**
+		Asynchronously asks the browser to make the element full-screen.
+		@throws DOMError
+	**/
+	function requestFullscreen() : Void;
+	
+	/**
 		Allows to asynchronously ask for the pointer to be locked on the given element.
 	**/
 	function requestPointerLock() : Void;

--- a/std/js/html/Document.hx
+++ b/std/js/html/Document.hx
@@ -187,6 +187,22 @@ extern class Document extends Node
 	var applets(default,null) : HTMLCollection;
 	
 	/**
+		`true` when the document is in `Using_full-screen_mode`.
+	**/
+	var fullscreen(default,null) : Bool;
+	var fullscreenEnabled(default,null) : Bool;
+	
+	/**
+		Is an `EventHandler` representing the code to be called when the `fullscreenchange` event is raised.
+	**/
+	var onfullscreenchange : haxe.Constraints.Function;
+	
+	/**
+		Is an `EventHandler` representing the code to be called when the `fullscreenerror` event is raised.
+	**/
+	var onfullscreenerror : haxe.Constraints.Function;
+	
+	/**
 		Represents the event handling code for the `pointerlockchange` event.
 	**/
 	var onpointerlockchange : haxe.Constraints.Function;
@@ -484,6 +500,7 @@ extern class Document extends Node
 		Releases the current mouse capture if it's on an element in this document.
 	**/
 	function releaseCapture() : Void;
+	function exitFullscreen() : Void;
 	
 	/**
 		Release the pointer lock.


### PR DESCRIPTION
Flag `nsDocument::IsUnprefixedFullscreenEnabled` was enabled in the externs generator (previously didn't exist)

Closes #7784 

https://github.com/HaxeFoundation/html-externs/commit/969ffb804b723664af3630ad977eb021ad7db1cd