### PR TITLE
[js] html externs: add more missing fullscreen fields

### DIFF
--- a/std/js/html/Document.hx
+++ b/std/js/html/Document.hx
@@ -275,6 +275,11 @@ extern class Document extends Node
 	var activeElement(default,null) : Element;
 	var styleSheets(default,null) : StyleSheetList;
 	var pointerLockElement(default,null) : Element;
+	
+	/**
+		The element that's currently in full screen mode for this document.
+	**/
+	var fullscreenElement(default,null) : Element;
 	var fonts(default,null) : FontFaceSet;
 	var onabort : haxe.Constraints.Function;
 	var onblur : haxe.Constraints.Function;

--- a/std/js/html/ShadowRoot.hx
+++ b/std/js/html/ShadowRoot.hx
@@ -52,6 +52,7 @@ extern class ShadowRoot extends DocumentFragment
 	var activeElement(default,null) : Element;
 	var styleSheets(default,null) : StyleSheetList;
 	var pointerLockElement(default,null) : Element;
+	var fullscreenElement(default,null) : Element;
 	
 	function getElementById( elementId : String ) : Element;
 	function getElementsByTagName( localName : String ) : HTMLCollection;


### PR DESCRIPTION
Adds a few additional `requestFullscreen()` related fields that were behind a separate flag `nsIDocument::IsUnprefixedFullscreenEnabled`.

(These are all well supported fields)

Part of #7784 

https://github.com/HaxeFoundation/html-externs/commit/088485aabacdd30a55ce89a27216f098056b1774