### PR TITLE
[js] html externs: remove invalid default values

### DIFF
--- a/std/js/html/Client.hx
+++ b/std/js/html/Client.hx
@@ -55,5 +55,5 @@ extern class Client {
 		Sends a message to the client.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, ?transfer : Array<Dynamic> ) : Void;
 }

--- a/std/js/html/DedicatedWorkerGlobalScope.hx
+++ b/std/js/html/DedicatedWorkerGlobalScope.hx
@@ -54,7 +54,7 @@ extern class DedicatedWorkerGlobalScope extends WorkerGlobalScope {
 		Sends a message — which can consist of `any` JavaScript object — to the parent document that first spawned the worker.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, ?transfer : Array<Dynamic> ) : Void;
 	
 	/**
 		Discards any tasks queued in the `WorkerGlobalScope`'s event loop, effectively closing this particular scope.

--- a/std/js/html/MessageEvent.hx
+++ b/std/js/html/MessageEvent.hx
@@ -65,7 +65,7 @@ extern class MessageEvent extends Event {
 	/**
 		Initializes a message event. Do not use this anymore — use the `MessageEvent.MessageEvent` constructor instead.
 	**/
-	@:overload( function( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : MessagePort, ports : Array<MessagePort> = []) : Void {} )
-	@:overload( function( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : ServiceWorker, ports : Array<MessagePort> = []) : Void {} )
-	function initMessageEvent( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : Window, ports : Array<MessagePort> = [] ) : Void;
+	@:overload( function( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : MessagePort, ?ports : Array<MessagePort>) : Void {} )
+	@:overload( function( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : ServiceWorker, ?ports : Array<MessagePort>) : Void {} )
+	function initMessageEvent( type : String, bubbles : Bool = false, cancelable : Bool = false, ?data : Dynamic, origin : String = "", lastEventId : String = "", ?source : Window, ?ports : Array<MessagePort> ) : Void;
 }

--- a/std/js/html/MessagePort.hx
+++ b/std/js/html/MessagePort.hx
@@ -37,7 +37,7 @@ extern class MessagePort extends EventTarget {
 	var onmessageerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function postMessage( message : Dynamic, transferable : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, ?transferable : Array<Dynamic> ) : Void;
 	function start() : Void;
 	function close() : Void;
 }

--- a/std/js/html/ServiceWorker.hx
+++ b/std/js/html/ServiceWorker.hx
@@ -51,5 +51,5 @@ extern class ServiceWorker extends EventTarget {
 	var onerror : haxe.Constraints.Function;
 	
 	/** @throws DOMError */
-	function postMessage( message : Dynamic, transferable : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, ?transferable : Array<Dynamic> ) : Void;
 }

--- a/std/js/html/URLSearchParams.hx
+++ b/std/js/html/URLSearchParams.hx
@@ -34,9 +34,9 @@ package js.html;
 @:native("URLSearchParams")
 extern class URLSearchParams {
 	/** @throws DOMError */
-	@:overload( function( init : haxe.DynamicAccess<String> = "") : URLSearchParams {} )
+	@:overload( function( ?init : haxe.DynamicAccess<String>) : URLSearchParams {} )
 	@:overload( function( init : String = "") : URLSearchParams {} )
-	function new( init : Array<Array<String>> = "" ) : Void;
+	function new( ?init : Array<Array<String>> ) : Void;
 	
 	/**
 		Appends a specified key/value pair as a new search parameter.

--- a/std/js/html/Window.hx
+++ b/std/js/html/Window.hx
@@ -435,7 +435,7 @@ extern class Window extends EventTarget {
 		Provides a secure means for one window to send a string of data to another window, which need not be within the same domain as the first.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, targetOrigin : String, transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, targetOrigin : String, ?transfer : Array<Dynamic> ) : Void;
 	
 	/**
 		Registers the window to capture all events of the specified type.

--- a/std/js/html/Worker.hx
+++ b/std/js/html/Worker.hx
@@ -57,5 +57,5 @@ extern class Worker extends EventTarget {
 		Sends a message — which can consist of `any` JavaScript object — to the worker's inner scope.
 		@throws DOMError
 	**/
-	function postMessage( message : Dynamic, transfer : Array<Dynamic> = [] ) : Void;
+	function postMessage( message : Dynamic, ?transfer : Array<Dynamic> ) : Void;
 }


### PR DESCRIPTION
The externs contained some default values that were invalid, but passed the type-checker because haxe wasn't validating extern default value types

This has been fixed by @Simn in #7752 

This PR removes invalid default values from the externs

https://github.com/HaxeFoundation/html-externs/commit/c719dc5e5b6979c2a4ab1d7d2ad933c04916d11c