### PR TITLE
Enable server tests again and start on DCE tests

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -105,6 +105,7 @@ class compiler_callbacks = object(self)
 	val mutable after_typing = [];
 	val mutable before_save = [];
 	val mutable after_save = [];
+	val mutable after_filters = [];
 	val mutable after_generation = [];
 	val mutable null_safety_report = [];
 
@@ -120,6 +121,9 @@ class compiler_callbacks = object(self)
 	method add_after_save (f : unit -> unit) : unit =
 		after_save <- f :: after_save
 
+	method add_after_filters (f : unit -> unit) : unit =
+		after_filters <- f :: after_filters
+
 	method add_after_generation (f : unit -> unit) : unit =
 		after_generation <- f :: after_generation
 
@@ -130,6 +134,7 @@ class compiler_callbacks = object(self)
 	method get_after_typing = after_typing
 	method get_before_save = before_save
 	method get_after_save = after_save
+	method get_after_filters = after_filters
 	method get_after_generation = after_generation
 	method get_null_safety_report = null_safety_report
 end

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -233,6 +233,14 @@ let handler =
 			) ();
 			hctx.send_result (jarray !l)
 		);
+		(* TODO: wait till gama complains about the naming, then change it to something else *)
+		"typer/compiledTypes", (fun hctx ->
+			hctx.com.callbacks#add_after_filters (fun () ->
+				let ctx = create_context GMFull in
+				let l = List.map (generate_module_type ctx) hctx.com.types in
+				hctx.send_result (jarray l)
+			);
+		);
 	] in
 	List.iter (fun (s,f) -> Hashtbl.add h s f) l;
 	h

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -904,4 +904,5 @@ let run com tctx main =
 	in
 	let t = filter_timer detail_times ["type 3"] in
 	List.iter (fun t -> List.iter (fun f -> f tctx t) type_filters) com.types;
-	t()
+	t();
+	List.iter (fun f -> f()) (List.rev com.callbacks#get_after_filters)

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -90,6 +90,7 @@ class Js {
 		runCommand("haxe", ["run.hxml"]);
 		haxelibInstall("utest");
 
+		runci.targets.Java.getJavaDependencies(); // this is awkward
 		changeDirectory(serverDir);
 		runCommand("haxe", ["build.hxml"]);
 		runCommand("node", ["test.js"]);

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -89,8 +89,9 @@ class Js {
 		changeDirectory(optDir);
 		runCommand("haxe", ["run.hxml"]);
 		haxelibInstall("utest");
-		// changeDirectory(serverDir);
-		// runCommand("haxe", ["build.hxml"]);
-		// runCommand("node", ["test.js"]);
+
+		changeDirectory(serverDir);
+		runCommand("haxe", ["build.hxml"]);
+		runCommand("node", ["test.js"]);
 	}
 }

--- a/tests/server/src/AsyncMacro.hx
+++ b/tests/server/src/AsyncMacro.hx
@@ -7,7 +7,7 @@ class AsyncMacro {
 			case EBlock(el): el;
 			case _: Context.error("Block expression expected", e.pos);
 		}
-		el.unshift(macro var _done = utest.Assert.createAsync(1000));
+		el.unshift(macro var _done = utest.Assert.createAsync(5000));
 		el.push(macro _done());
 		function loop(el:Array<Expr>) {
 			var e0 = el.shift();

--- a/tests/server/src/AsyncMacro.hx
+++ b/tests/server/src/AsyncMacro.hx
@@ -14,10 +14,10 @@ class AsyncMacro {
 			return if (el.length == 0) {
 				e0;
 			} else switch (e0) {
-				case macro haxe($a{args}):
+				case macro runHaxe($a{args}):
 					var e = loop(el);
 					args.push(macro () -> $e);
-					macro haxe($a{args});
+					macro runHaxe($a{args});
 				case _:
 					macro { $e0; ${loop(el)}};
 			}

--- a/tests/server/src/HaxeServer.hx
+++ b/tests/server/src/HaxeServer.hx
@@ -62,14 +62,14 @@ private class DisplayRequest {
         return Buffer.concat(chunks, length + 4);
     }
 
-    public function processResult(data:String) {
+    public function processResult(context:Context, data:String) {
         var buf = new StringBuf();
         var hasError = false;
         for (line in data.split("\n")) {
             switch (line.fastCodeAt(0)) {
                 case 0x01: // print
                     var line = line.substring(1).replace("\x01", "\n");
-                    trace("Haxe print:\n" + line);
+					context.sendLogMessage("Haxe print: " + line + "\n");
                 case 0x02: // error
                     hasError = true;
                 default:
@@ -229,7 +229,7 @@ class HaxeServer {
             if (currentRequest != null) {
                 var request = currentRequest;
                 currentRequest = null;
-                request.processResult(msg);
+                request.processResult(context, msg);
                 checkQueue();
             }
         }

--- a/tests/server/src/HaxeServerTestCase.hx
+++ b/tests/server/src/HaxeServerTestCase.hx
@@ -123,6 +123,8 @@ class HaxeServerTestCase {
 				case _: false;
 			}
 		}
-		Assert.isTrue(check(type), null, p);
+		if (type != null) {
+			Assert.isTrue(check(type), null, p);
+		}
 	}
 }

--- a/tests/server/src/HaxeServerTestCase.hx
+++ b/tests/server/src/HaxeServerTestCase.hx
@@ -1,5 +1,6 @@
 import HaxeServer;
 import utest.Assert;
+using StringTools;
 
 class TestContext {
 	public var messages:Array<String> = []; // encapsulation is overrated
@@ -13,7 +14,10 @@ class TestContext {
 	public function sendErrorMessage(msg:String) { }
 
 	public function sendLogMessage(msg:String) {
-		messages.push(msg);
+		var split = msg.split("\n");
+		for (message in split) {
+			messages.push(message.trim());
+		}
 	}
 }
 
@@ -42,7 +46,7 @@ class HaxeServerTestCase {
 		server.stop();
 	}
 
-	function haxe(args:Array<String>, done:Void -> Void) {
+	function runHaxe(args:Array<String>, done:Void -> Void) {
 		context.messages = [];
 		server.process(args, null, function(_) {
 			done();
@@ -58,7 +62,7 @@ class HaxeServerTestCase {
 
 	function hasMessage<T>(msg:String) {
 		for (message in context.messages) {
-			if (message.indexOf(msg) != -1) {
+			if (message.endsWith(msg)) {
 				return true;
 			}
 		}
@@ -66,7 +70,7 @@ class HaxeServerTestCase {
 	}
 
 	function assertHasPrint(line:String, ?p:haxe.PosInfos) {
-		Assert.isTrue(hasMessage("" + line), null, p);
+		Assert.isTrue(hasMessage("Haxe print: " + line), null, p);
 	}
 
 	function assertReuse(module:String, ?p:haxe.PosInfos) {

--- a/tests/server/src/Main.hx
+++ b/tests/server/src/Main.hx
@@ -71,6 +71,17 @@ class Macro extends HaxeServerTestCase {
 	}
 }
 
+class DceEmpty extends HaxeServerTestCase {
+	public function test() {
+		async({
+			vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
+			var args = ["-main", "Empty", "--no-output", "-java", "java"];
+			runHaxe(args);
+			runHaxe(args, true);
+			assertHasField("", "Type", "enumIndex", true);
+		});
+	}
+}
 
 class Main {
 	static public function main() {
@@ -80,6 +91,7 @@ class Main {
 		runner.addCase(new Modification());
 		runner.addCase(new Dependency());
 		runner.addCase(new Macro());
+		runner.addCase(new DceEmpty());
 		utest.ui.Report.create(runner);
 		runner.run();
 	}

--- a/tests/server/src/Main.hx
+++ b/tests/server/src/Main.hx
@@ -6,10 +6,10 @@ class NoModification extends HaxeServerTestCase {
 		async({
 			vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
 			var args = ["-main", "HelloWorld.hx", "--no-output", "-js", "no.js"];
-			haxe(args);
-			haxe(args);
+			runHaxe(args);
+			runHaxe(args);
 			assertReuse("HelloWorld");
-			haxe(args);
+			runHaxe(args);
 			assertReuse("HelloWorld");
 		});
 	}
@@ -20,9 +20,9 @@ class Modification extends HaxeServerTestCase {
 		async({
 			vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
 			var args = ["-main", "HelloWorld.hx", "--no-output", "-js", "no.js"];
-			haxe(args);
+			runHaxe(args);
 			vfs.touchFile("HelloWorld.hx");
-			haxe(args);
+			runHaxe(args);
 			assertSkipping("HelloWorld");
 			assertNotCacheModified("HelloWorld");
 		});
@@ -35,12 +35,12 @@ class Dependency extends HaxeServerTestCase {
 			vfs.putContent("WithDependency.hx", getTemplate("WithDependency.hx"));
 			vfs.putContent("Dependency.hx", getTemplate("Dependency.hx"));
 			var args = ["-main", "WithDependency.hx", "--no-output", "-js", "no.js"];
-			haxe(args);
+			runHaxe(args);
 			vfs.touchFile("Dependency.hx");
-			haxe(args);
+			runHaxe(args);
 			assertSkipping("WithDependency", "Dependency");
 			assertNotCacheModified("Dependency");
-			haxe(args);
+			runHaxe(args);
 			assertReuse("Dependency");
 			assertReuse("WithDependency");
 		});
@@ -53,19 +53,19 @@ class Macro extends HaxeServerTestCase {
 			vfs.putContent("MacroMain.hx", getTemplate("MacroMain.hx"));
 			vfs.putContent("Macro.hx", getTemplate("Macro.hx"));
 			var args = ["-main", "MacroMain.hx", "--no-output", "-js", "no.js"];
-			haxe(args);
+			runHaxe(args);
 			assertHasPrint("1");
 			vfs.touchFile("MacroMain.hx");
-			haxe(args);
+			runHaxe(args);
 			assertHasPrint("1");
 			vfs.touchFile("Macro.hx");
-			haxe(args);
+			runHaxe(args);
 			assertHasPrint("1");
 			vfs.putContent("Macro.hx", getTemplate("Macro.hx").replace("1", "2"));
-			haxe(args);
+			runHaxe(args);
 			assertHasPrint("2");
 			vfs.touchFile("MacroMain.hx");
-			haxe(args);
+			runHaxe(args);
 			assertHasPrint("2");
 		});
 	}

--- a/tests/server/test/templates/Empty.hx
+++ b/tests/server/test/templates/Empty.hx
@@ -1,0 +1,5 @@
+class Empty {
+	public static function main() {
+
+	}
+}


### PR DESCRIPTION
This adds a `"typer/compiledTypes"` method to the JSON protocol which makes the compiler output `com.types` as `Array<JsonModuleType>` in the state just before generation. This allows us to write accurate DCE- and compilation-server tests easily:

```haxe
class DceEmpty extends HaxeServerTestCase {
	public function test() {
		async({
			vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
			var args = ["-main", "Empty", "--no-output", "-java", "java"];
			runHaxe(args);
			runHaxe(args, true);
			assertHasField("", "Type", "enumIndex", true);
		});
	}
}
```