### PR TITLE
[std] Fix TimeZone deprecation for cs target

### DIFF
--- a/std/cs/_std/Date.hx
+++ b/std/cs/_std/Date.hx
@@ -46,7 +46,11 @@ import haxe.Int64;
 
 	public inline function getTime() : Float
 	{
+		#if (net_ver < 35)
 		return cast(cs.system.TimeZone.CurrentTimeZone.ToUniversalTime(date).Ticks - epochTicks, Float) / cast(TimeSpan.TicksPerMillisecond, Float);
+		#else
+		return cast(cs.system.TimeZoneInfo.ConvertTimeToUtc(date).Ticks - epochTicks, Float) / cast(TimeSpan.TicksPerMillisecond, Float);
+		#end
 	}
 
 	public inline function getHours() : Int
@@ -106,7 +110,14 @@ import haxe.Int64;
 
 	static public inline function fromTime( t : Float ) : Date
 	{
+		#if (net_ver < 35)
 		return new Date(cs.system.TimeZone.CurrentTimeZone.ToLocalTime(new DateTime(cast(t * cast(TimeSpan.TicksPerMillisecond, Float), Int64) + epochTicks)));
+		#else
+		return new Date(cs.system.TimeZoneInfo.ConvertTimeFromUtc(
+			new DateTime(cast(t * cast(TimeSpan.TicksPerMillisecond, Float), Int64) + epochTicks),
+			cs.system.TimeZoneInfo.Local
+		));
+		#end
 	}
 
 	static public function fromString( s : String ) : Date


### PR DESCRIPTION
I am getting these warnings when compiling for C# (admittedly, with a recent .net version):
> warning CS0618: 'TimeZone' is obsolete: 'System.TimeZone has been deprecated.  Please investigate the use of System.TimeZoneInfo instead.'

I updated `std/cs/_std/Date.hx` to use `TimeZoneInfo`, which according to [its MSDN page](https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo?view=netframework-4.7.2) applies to:
> .NET Core
> 3.0 Preview 2, 2.2, 2.1, 2.0, 1.1, 1.0
> .NET Framework
> 4.8, 4.7.2, 4.7.1, 4.7, 4.6.2, 4.6.1, 4.6, 4.5.2, 4.5.1, 4.5, 4.0, 3.5
> .NET Standard
> 2.0, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0

I'm not sure since when `TimeZone` has been deprecated, nor if/how we show handle projects using .NET Framework < 3.5.