### PR TITLE
Use private instead of protected for static ctor in final classes

### DIFF
--- a/src/codegen/gencommon/overloadingConstructor.ml
+++ b/src/codegen/gencommon/overloadingConstructor.ml
@@ -146,7 +146,11 @@ let create_static_ctor com ~empty_ctor_expr cl ctor follow_type =
 		) cur_tf_args in
 
 		let static_ctor = mk_class_field static_ctor_name fn_type false ctor.cf_pos (Method MethNormal) ctor_types in
-		static_ctor.cf_meta <- (Meta.Protected,[],ctor.cf_pos) :: static_ctor.cf_meta;
+		let static_ctor_meta = match Meta.has Meta.Final cl.cl_meta with
+			| true -> Meta.Private
+			| false -> Meta.Protected
+		in
+		static_ctor.cf_meta <- (static_ctor_meta,[],ctor.cf_pos) :: static_ctor.cf_meta;
 
 		(* change ctor contents to reference the 'me' var instead of 'this' *)
 		let actual_super_call = ref None in


### PR DESCRIPTION
_Disclaimer: it's my first time using ocaml, so there might well be mistakes_

Previous behavior was to always use `protected` for static counterparts of 'ctor' when overloading constructors.

At least with cs target, this causes issues with final classes, leading to "new protected member declared in sealed class" warnings. By using `private` instead of `protected` in final classes, the warnings disappear.