### PR TITLE
Also use private instead of protected with final keyword

### DIFF
--- a/src/codegen/gencommon/overloadingConstructor.ml
+++ b/src/codegen/gencommon/overloadingConstructor.ml
@@ -146,10 +146,7 @@ let create_static_ctor com ~empty_ctor_expr cl ctor follow_type =
 		) cur_tf_args in
 
 		let static_ctor = mk_class_field static_ctor_name fn_type false ctor.cf_pos (Method MethNormal) ctor_types in
-		let static_ctor_meta = match Meta.has Meta.Final cl.cl_meta with
-			| true -> Meta.Private
-			| false -> Meta.Protected
-		in
+		let static_ctor_meta = if cl.cl_final then Meta.Private else Meta.Protected in
 		static_ctor.cf_meta <- (static_ctor_meta,[],ctor.cf_pos) :: static_ctor.cf_meta;
 
 		(* change ctor contents to reference the 'me' var instead of 'this' *)


### PR DESCRIPTION
Following #7830, this adds support for `final class` too (was using haxe 4 rc1 std so I tested with `@:final` only).