### PR TITLE
[std] document onGenerate/onAfterGenerate behavior with --no-output

### DIFF
--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -312,6 +312,8 @@ class Context {
 		If `persistent` is set to `false`, changes to types made by the callback only
 		affect the current compilation. If no compilation server is used, this flag has
 		no effect.
+
+		*Note*: the callback is still invoked when generation is disabled with  `--no-output`.
 	**/
 	public static function onGenerate( callback : Array<Type> -> Void, persistent:Bool = true ) {
 		load("on_generate",2)(callback, persistent);
@@ -323,6 +325,8 @@ class Context {
 
 		Compilation has completed at this point and cannot be influenced
 		anymore. However, contextual information is still available.
+
+		*Note*: the callback is still invoked when generation is disabled with  `--no-output`.
 	**/
 	@:require(haxe_ver >= 3.1)
 	public static function onAfterGenerate( callback : Void -> Void ) {


### PR DESCRIPTION
One could reasonably expect that disabling generation also means that the callbacks don't run, so it seems helpful to document that.