### PR TITLE
Adds onBytes function to enable bytes requests

### DIFF
--- a/std/haxe/http/HttpBase.hx
+++ b/std/haxe/http/HttpBase.hx
@@ -157,7 +157,15 @@ class HttpBase {
 	**/
 	public dynamic function onData(data:String) {
 	}
+	/**
+		This method is called upon a successful request, with `bytes` containing
+		the result Bytes.
 
+		The intended usage is to bind it to a custom function:
+		`httpInstance.onBytes = function(bytes) { // handle result }`
+	**/
+	public dynamic function onBytes(bytes:haxe.io.Bytes) {
+	}
 	/**
 		This method is called upon a request error, with `msg` containing the
 		error description.

--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -59,11 +59,12 @@ class Http extends haxe.http.HttpBase {
 		}
 		customRequest(post,output);
 		if(!err){
-			onBytes(output.getBytes());
+			var bytes:haxe.io.Bytes = output.getBytes();
+			onBytes(bytes);
 		#if neko
-			onData(responseData = neko.Lib.stringReference(output.getBytes()));
+			onData(responseData = neko.Lib.stringReference(bytes));
 		#else
-			onData(responseData = output.getBytes().toString());
+			onData(responseData = bytes.toString());
 		#end
 		}
 	}

--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -58,12 +58,14 @@ class Http extends haxe.http.HttpBase {
 			onError(e);
 		}
 		customRequest(post,output);
-		if(!err)
+		if(!err){
+			onBytes(output.getBytes());
 		#if neko
 			onData(responseData = neko.Lib.stringReference(output.getBytes()));
 		#else
 			onData(responseData = output.getBytes().toString());
 		#end
+		}
 	}
 
 	@:noCompletion


### PR DESCRIPTION
This will enable the ability to get bytes data for images, zip files, etc. Tested on Hashlink but should work on neko also. Initial pull request was [here](https://github.com/HaxeFoundation/haxe/pull/7891). Proposed changes by @haxiomic are made in this repo.