### PR TITLE
[wip] Improve parser error handling

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -483,7 +483,6 @@ try
 	com.warning <- (fun msg p -> message ctx (CMWarning(msg,p)));
 	com.error <- error ctx;
 	if CompilationServer.runs() then com.run_command <- run_command ctx;
-	Parser.display_error := (fun e p -> com.error (Parser.error_msg e) p);
 	com.class_path <- get_std_class_paths ();
 	com.std_path <- List.filter (fun p -> ExtString.String.ends_with p "std/" || ExtString.String.ends_with p "std\\") com.class_path;
 	let define f = Arg.Unit (fun () -> Common.define com f) in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -109,7 +109,6 @@ let ssend sock str =
 let rec wait_loop process_params verbose accept =
 	if verbose then ServerMessage.enable_all ();
 	Sys.catch_break false; (* Sys can never catch a break *)
-	let has_parse_error = ref false in
 	let cs = CompilationServer.create () in
 	MacroContext.macro_enable_cache := true;
 	let current_stdin = ref None in
@@ -130,7 +129,6 @@ let rec wait_loop process_params verbose accept =
 					if cfile.c_time <> ftime then raise Not_found;
 					Parser.ParseSuccess(cfile.c_package,cfile.c_decls)
 				with Not_found ->
-					has_parse_error := false;
 					let parse_result = TypeloadParse.parse_file com2 file p in
 					let info,is_unusual = match parse_result with
 						| ParseError(_,_,_) -> "not cached, has parse error",true

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -416,7 +416,6 @@ let rec wait_loop process_params verbose accept =
 				ServerMessage.defines ctx.com "";
 				ServerMessage.signature ctx.com "" sign;
 				ServerMessage.display_position ctx.com "" (!DisplayPosition.display_position);
-				Parser.display_error := (fun e p -> has_parse_error := true; ctx.com.error (Parser.error_msg e) p);
 				(* Special case for diagnostics: It's not treated as a display mode, but we still want to invalidate the
 				   current file in order to run diagnostics on it again. *)
 				if ctx.com.display.dms_display || (match ctx.com.display.dms_kind with DMDiagnostics _ -> true | _ -> false) then begin

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -81,8 +81,8 @@ exception Parse_expr_error of string
 let parse_expr ctx s p =
 	let error s = raise (Parse_expr_error s) in
 	match ParserEntry.parse_expr_string (ctx.curapi.get_com()).Common.defines s p error true with
-	| ParseSuccess data | ParseDisplayFile(data,[]) -> data
-	| ParseError(_,(msg,_),_) | ParseDisplayFile(_,(msg,_) :: _) -> error (Parser.error_msg msg)
+	| ParseSuccess data | ParseDisplayFile(data,_) -> data
+	| ParseError(_,(msg,_),_) -> error (Parser.error_msg msg)
 
 (* Vars *)
 

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -80,7 +80,9 @@ exception Parse_expr_error of string
 
 let parse_expr ctx s p =
 	let error s = raise (Parse_expr_error s) in
-	ParserEntry.parse_expr_string (ctx.curapi.get_com()).Common.defines s p error true
+	match ParserEntry.parse_expr_string (ctx.curapi.get_com()).Common.defines s p error true with
+	| ParseSuccess data | ParseDisplayFile(data,[]) -> data
+	| ParseError(_,(msg,_),_) | ParseDisplayFile(_,(msg,_) :: _) -> error (Parser.error_msg msg)
 
 (* Vars *)
 

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -327,7 +327,9 @@ and parse_class_fields tdecl p1 s =
 	let l = parse_class_field_resume tdecl s in
 	let p2 = (match s with parser
 		| [< '(BrClose,p2) >] -> p2
-		| [< >] -> syntax_error (Expected ["}"]) s (pos (last_token s))
+		| [< >] ->
+			(* We don't want to register this as a syntax error because it's part of the logic in display mode *)
+			if !in_display then (pos (last_token s)) else error (Expected ["}"]) (next_pos s)
 	) in
 	l, p2
 

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -30,6 +30,7 @@ type error_msg =
 	| Unclosed_macro
 	| Unimplemented
 	| Missing_type
+	| Expected of string list
 	| Custom of string
 
 type decl_flag =
@@ -60,6 +61,7 @@ let error_msg = function
 	| Unclosed_macro -> "Unclosed macro"
 	| Unimplemented -> "Not implemented for current platform"
 	| Missing_type -> "Missing type declaration"
+	| Expected sl -> "Expected " ^ (String.concat " or " sl)
 	| Custom s -> s
 
 let syntax_completion kind p =
@@ -95,6 +97,22 @@ module TokenCache = struct
 		(fun () -> cache := old_cache)
 end
 
+let last_token s =
+	let n = Stream.count s in
+	TokenCache.get (if n = 0 then 0 else n - 1)
+
+let last_pos s = pos (last_token s)
+
+let next_token s = match Stream.peek s with
+	| Some (Eof,p) ->
+		(Eof,{p with pmax = max_int})
+	| Some tk -> tk
+	| None ->
+		let last_pos = pos (last_token s) in
+		(Eof,{last_pos with pmax = max_int})
+
+let next_pos s = pos (next_token s)
+
 (* Global state *)
 
 let in_display = ref false
@@ -119,12 +137,12 @@ let reset_state () =
 
 let in_display_file = ref false
 let last_doc : (string * int) option ref = ref None
+let syntax_errors = ref []
 
-let last_token s =
-	let n = Stream.count s in
-	TokenCache.get (if n = 0 then 0 else n - 1)
-
-let last_pos s = pos (last_token s)
+let syntax_error (error_msg : error_msg) s v =
+	if not !in_display_file then error error_msg (next_pos s);
+	syntax_errors := error_msg :: !syntax_errors;
+	v
 
 let get_doc s =
 	(* do the peek first to make sure we fetch the doc *)
@@ -231,16 +249,6 @@ let handle_xml_literal p1 =
 	let e = EConst (String xml),{p1 with pmax = i} in
 	let e = make_meta Meta.Markup [] e p1 in
 	e
-
-let next_token s = match Stream.peek s with
-	| Some (Eof,p) ->
-		(Eof,{p with pmax = max_int})
-	| Some tk -> tk
-	| None ->
-		let last_pos = pos (last_token s) in
-		(Eof,{last_pos with pmax = max_int})
-
-let next_pos s = pos (next_token s)
 
 let punion_next p1 s =
 	let _,p2 = next_token s in

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -70,7 +70,6 @@ let syntax_completion kind p =
 	raise (SyntaxCompletion(kind,p))
 
 let error m p = raise (Error (m,p))
-let display_error : (error_msg -> pos -> unit) ref = ref (fun _ _ -> assert false)
 
 let special_identifier_files : (string,string) Hashtbl.t = Hashtbl.create 0
 

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -31,6 +31,7 @@ type error_msg =
 	| Unimplemented
 	| Missing_type
 	| Expected of string list
+	| StreamError of string
 	| Custom of string
 
 type decl_flag =
@@ -62,6 +63,7 @@ let error_msg = function
 	| Unimplemented -> "Not implemented for current platform"
 	| Missing_type -> "Missing type declaration"
 	| Expected sl -> "Expected " ^ (String.concat " or " sl)
+	| StreamError s -> s
 	| Custom s -> s
 
 let syntax_completion kind p =
@@ -139,8 +141,8 @@ let in_display_file = ref false
 let last_doc : (string * int) option ref = ref None
 let syntax_errors = ref []
 
-let syntax_error (error_msg : error_msg) s v =
-	if not !in_display_file then error error_msg (next_pos s);
+let syntax_error (error_msg : error_msg) ?(pos=None) s v =
+	if not !in_display_file then error error_msg (match pos with Some p -> p | None -> next_pos s);
 	syntax_errors := error_msg :: !syntax_errors;
 	v
 

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -160,7 +160,7 @@ let parse ctx code file =
 		| Sharp "if" ->
 			skip_tokens_loop p test (skip_tokens p false)
 		| Eof ->
-			if !in_display then tk else error Unclosed_macro p
+			syntax_error Unclosed_macro ~pos:(Some p) sraw tk
 		| _ ->
 			skip_tokens p test
 
@@ -174,7 +174,7 @@ let parse ctx code file =
 	) in
 	try
 		let l = parse_file s in
-		(match !mstack with p :: _ when not !in_display -> error Unclosed_macro p | _ -> ());
+		(match !mstack with p :: _ -> syntax_error Unclosed_macro ~pos:(Some p) sraw () | _ -> ());
 		restore();
 		Lexer.restore old;
 		l

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -194,7 +194,6 @@ let parse_string com s p error inlined =
 	let old = Lexer.save() in
 	let old_file = (try Some (Hashtbl.find Lexer.all_files p.pfile) with Not_found -> None) in
 	let old_display = !display_position in
-	let old_de = !display_error in
 	let old_in_display_file = !in_display_file in
 	let restore() =
 		(match old_file with
@@ -204,11 +203,9 @@ let parse_string com s p error inlined =
 			display_position := old_display;
 			in_display_file := old_in_display_file;
 		end;
-		Lexer.restore old;
-		display_error := old_de
+		Lexer.restore old
 	in
 	Lexer.init p.pfile true;
-	display_error := (fun e p -> raise (Error (e,p)));
 	if not inlined then begin
 		display_position := null_pos;
 		in_display_file := false;

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -81,6 +81,7 @@ let parse ctx code file =
 	code_ref := code;
 	in_display := !display_position <> null_pos;
 	in_display_file := !in_display && Path.unique_full_path file = !display_position.pfile;
+	syntax_errors := [];
 	let restore =
 		(fun () ->
 			restore_cache ();

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -201,6 +201,8 @@ let parse_string com s p error inlined =
 	let old_file = (try Some (Hashtbl.find Lexer.all_files p.pfile) with Not_found -> None) in
 	let old_display = !display_position in
 	let old_in_display_file = !in_display_file in
+	let old_syntax_errors = !syntax_errors in
+	syntax_errors := [];
 	let restore() =
 		(match old_file with
 		| None -> ()
@@ -209,6 +211,7 @@ let parse_string com s p error inlined =
 			display_position := old_display;
 			in_display_file := old_in_display_file;
 		end;
+		syntax_errors := old_syntax_errors;
 		Lexer.restore old
 	in
 	Lexer.init p.pfile true;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -235,7 +235,8 @@ let make_macro_api ctx p =
 				let v = (match v with None -> None | Some s ->
 					match ParserEntry.parse_string ctx.com.defines ("typedef T = " ^ s) null_pos error false with
 					| ParseSuccess(_,[ETypedef { d_data = ct },_]) -> Some ct
-					| ParseError(_,_,_) -> None (* PARSERTODO *)
+					| ParseDisplayFile _ -> assert false (* cannot happen because null_pos is used *)
+					| ParseError(_,(msg,p),_) -> Parser.error msg p (* p is null_pos, but we don't have anything else here... *)
 					| _ -> assert false
 				) in
 				let tp = get_type_patch ctx t (Some (f,s)) in

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -128,7 +128,9 @@ let make_macro_api ctx p =
 		typing_timer ctx false (fun() ->
 			try
 				begin match ParserEntry.parse_expr_string ctx.com.defines s p error inl with
-					| ParseSuccess data | ParseDisplayFile(data,_) -> data (* PARSERTODO *)
+					| ParseSuccess data -> data
+					| ParseDisplayFile(data,_) when inl -> data (* ignore errors when inline-parsing in display file *)
+					| ParseDisplayFile _ -> assert false (* cannot happen because ParserEntry.parse_string sets `display_position := null_pos;` *)
 					| ParseError _ -> raise MacroApi.Invalid_expr
 				end
 			with Exit ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -140,7 +140,8 @@ let make_macro_api ctx p =
 		try
 			match ParserEntry.parse_string ctx.com.defines (s ^ " typedef T = T") null_pos error false with
 			| ParseSuccess(_,[ETypedef t,_]) -> t.d_meta
-			| ParseError(_,_,_) -> [] (* PARSERTODO *)
+			| ParseDisplayFile _ -> assert false (* cannot happen because null_pos is used *)
+			| ParseError(_,_,_) -> error "Malformed metadata string" p
 			| _ -> assert false
 		with _ ->
 			error "Malformed metadata string" p

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -899,7 +899,10 @@ let handle_import_hx ctx m decls p =
 			r
 		with Not_found ->
 			if Sys.file_exists path then begin
-				let _,r = TypeloadParse.parse_file ctx.com path p in
+				let _,r = match TypeloadParse.parse_file ctx.com path p with
+					| ParseSuccess data -> data
+					| ParseError(data,_,_) | ParseDisplayFile(data,_) -> data (* PARSERTODO *)
+				in
 				List.iter (fun (d,p) -> match d with EImport _ | EUsing _ -> () | _ -> error "Only import and using is allowed in import.hx files" p) r;
 				add_dependency m (make_import_module path r);
 				r

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -901,7 +901,8 @@ let handle_import_hx ctx m decls p =
 			if Sys.file_exists path then begin
 				let _,r = match TypeloadParse.parse_file ctx.com path p with
 					| ParseSuccess data -> data
-					| ParseError(data,_,_) | ParseDisplayFile(data,_) -> data (* PARSERTODO *)
+					| ParseDisplayFile(data,_) -> data
+					| ParseError(_,(msg,p),_) -> Parser.error msg p
 				in
 				List.iter (fun (d,p) -> match d with EImport _ | EUsing _ -> () | _ -> error "Only import and using is allowed in import.hx files" p) r;
 				add_dependency m (make_import_module path r);

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -148,7 +148,7 @@ let parse_module' com m p =
 	let file = resolve_module_file com m remap p in
 	let pack,decls = match (!parse_hook) com file p with
 		| ParseSuccess data | ParseDisplayFile(data,_) -> data
-		| ParseError(data,_,_) -> data (* PARSERTODO *)
+		| ParseError(_,(msg,p),_) -> Parser.error msg p
 	in
 	file,remap,pack,decls
 

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1540,8 +1540,13 @@ and format_string ctx s p =
 		if slen > 0 then begin
 			let e =
 				let ep = { p with pmin = !pmin + pos + 2; pmax = !pmin + send + 1 } in
-				try ParserEntry.parse_expr_string ctx.com.defines scode ep error true
-				with Exit -> error "Invalid interpolated expression" ep
+				try
+					begin match ParserEntry.parse_expr_string ctx.com.defines scode ep error true with
+						| ParseSuccess data | ParseDisplayFile(data,_) -> data
+						| ParseError _ -> raise Exit (* PARSERTODO: keep message? *)
+					end
+				with Exit ->
+					error "Invalid interpolated expression" ep
 			in
 			add_expr e slen
 		end;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1543,7 +1543,7 @@ and format_string ctx s p =
 				try
 					begin match ParserEntry.parse_expr_string ctx.com.defines scode ep error true with
 						| ParseSuccess data | ParseDisplayFile(data,_) -> data
-						| ParseError _ -> raise Exit (* PARSERTODO: keep message? *)
+						| ParseError(_,(msg,p),_) -> error (Parser.error_msg msg) p
 					end
 				with Exit ->
 					error "Invalid interpolated expression" ep

--- a/tests/display/src/DisplayTestContext.hx
+++ b/tests/display/src/DisplayTestContext.hx
@@ -14,6 +14,10 @@ class HaxeInvocationException {
 		this.arguments = arguments;
 		this.source = source;
 	}
+
+	public function toString() {
+		return 'HaxeInvocationException($message, $fieldName, $arguments, $source])';
+	}
 }
 
 class DisplayTestContext {

--- a/tests/misc/projects/Issue3699/compile-var-fail.hxml.stderr
+++ b/tests/misc/projects/Issue3699/compile-var-fail.hxml.stderr
@@ -1,2 +1,1 @@
-MainVar.hx:3: characters 11-12 : expression expected after =
-MainVar.hx:3: characters 13-14 : Unexpected ;
+MainVar.hx:3: characters 13-14 : Expected expression

--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -10,9 +10,8 @@ class Macro {
 	static public function run(args:Array<String>) {
 		runCommand("haxe", ["compile-macro.hxml"].concat(args));
 
-		// TODO: enable this again at some point
-		// changeDirectory(displayDir);
-		// runCommand("haxe", ["build.hxml"]);
+		changeDirectory(displayDir);
+		runCommand("haxe", ["build.hxml"]);
 
 		changeDirectory(sourcemapsDir);
 		runCommand("haxe", ["run.hxml"]);

--- a/tests/server/build.hxml
+++ b/tests/server/build.hxml
@@ -3,3 +3,4 @@
 -js test.js
 -lib hxnodejs
 -lib utest
+--cmd node test.js

--- a/tests/server/build.hxml
+++ b/tests/server/build.hxml
@@ -3,4 +3,3 @@
 -js test.js
 -lib hxnodejs
 -lib utest
---cmd node test.js

--- a/tests/server/src/HaxeServerTestCase.hx
+++ b/tests/server/src/HaxeServerTestCase.hx
@@ -9,6 +9,7 @@ using Lambda;
 
 class TestContext {
 	public var messages:Array<String> = []; // encapsulation is overrated
+	public var errorMessages = [];
 	public var displayServerConfig:DisplayServerConfigBase;
 
 	public function new(config:DisplayServerConfigBase) {
@@ -54,6 +55,7 @@ class HaxeServerTestCase implements ITest {
 
 	function runHaxe(args:Array<String>, storeTypes = false, done:Void->Void) {
 		context.messages = [];
+		context.errorMessages = [];
 		storedTypes = [];
 		if (storeTypes) {
 			args = args.concat(['--display', '{ "method": "typer/compiledTypes", "id": 1 }']);
@@ -64,7 +66,7 @@ class HaxeServerTestCase implements ITest {
 			}
 			done();
 		}, function(message) {
-			Assert.fail(message);
+			context.errorMessages.push(message);
 			done();
 		});
 	}
@@ -82,6 +84,15 @@ class HaxeServerTestCase implements ITest {
 		return false;
 	}
 
+	function hasErrorMessage<T>(msg:String) {
+		for (message in context.errorMessages) {
+			if (message.endsWith(msg)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	function getStoredType(typePackage:String, typeName:String) {
 		for (type in storedTypes) {
 			if (type.pack.join(".") == typePackage && type.name == typeName) {
@@ -89,6 +100,10 @@ class HaxeServerTestCase implements ITest {
 			}
 		}
 		return null;
+	}
+
+	function assertErrorMessage(message:String, ?p:haxe.PosInfos) {
+		Assert.isTrue(hasErrorMessage(message), p);
 	}
 
 	function assertHasPrint(line:String, ?p:haxe.PosInfos) {

--- a/tests/server/src/Main.hx
+++ b/tests/server/src/Main.hx
@@ -77,6 +77,17 @@ class ServerTests extends HaxeServerTestCase {
 		assertSkipping("BuiltClass", "BuildMacro");
 		assertSkipping("BuildMacro");
 	}
+
+	function testBrokenSyntaxDiagnostics() {
+		vfs.putContent("BrokenSyntax.hx", getTemplate("BrokenSyntax.hx"));
+		vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
+		var args = ["-main", "BrokenSyntax.hx", "--interp", "--no-output"];
+		runHaxe(args);
+		assertErrorMessage("Expected }");
+		runHaxe(args.concat(["--display", "Empty.hx@0@diagnostics"]));
+		runHaxe(args);
+		assertErrorMessage("Expected }");
+	}
 }
 
 class Main {

--- a/tests/server/test/templates/BrokenSyntax.hx
+++ b/tests/server/test/templates/BrokenSyntax.hx
@@ -1,0 +1,6 @@
+class BrokenSyntax {
+	static public function main() {
+		{}.foo();
+		trace("ok");
+	}
+}


### PR DESCRIPTION
This PR changes how we communicate with our parser. I acknowledge that it looks scary, but I think it's a necessary step and I would like to make that step now rather than later.

First of all, when we're not in display mode, the parser still raises `Parser.Error` early as it did before. However, when we're in display mode (including diagnostics), it returns an element of this ADT:

```ocaml
type 'a parse_result =
	(* Parsed display file. There can be errors. *)
	| ParseDisplayFile of 'a * parse_error list
	(* Parsed non-display-file without errors. *)
	| ParseSuccess of 'a
	(* Parsed non-display file with errors *)
	| ParseError of 'a * parse_error * parse_error list
```

It might still raise `Parser.Error` in some (rare?) cases. The endgame here is to eliminate all these cases so it always parses _something_. This is going to require some more refactoring though and is not something we have to do for 4.0.

The idea is to look at all occurrences of `ParseDisplayFile` and friends (there are only 14 at the moment) and adjust what we want to do. For instance, the compilation server naturally reacts like this:

```ocaml
| ParseError(_,_,_) -> "not cached, has parse error",true
| ParseDisplayFile _ -> "not cached, is display file",true
| ParseSuccess data ->"cached",false
```

This addresses #7793. Once we cleaned up error handling completely, we could also cache the display file if it has no errors (useful for hover-mode where the AST is often intact).

As another example `--macro` parsing does this:

```ocaml
| ParseSuccess data -> data
| ParseError(_,(msg,p),_) -> (Parser.error msg p)
| ParseDisplayFile _ -> assert false (* cannot happen *)
```

There are some `PARSERTODO`s I have to look at still, but I would like to know if people agree that this is the right way forward.

As a more or less unintended side-effect, we collect syntax errors on the diagnostics file which should allow us to address #5306.