### PR TITLE
[std] make Std.is() compatible with null-safety

### DIFF
--- a/std/Std.hx
+++ b/std/Std.hx
@@ -31,7 +31,7 @@ extern class Std {
 	/**
 		Tells if a value `v` is of the type `t`. Returns `false` if `v` or `t` are null.
 	**/
-	public static function is( v : Dynamic, t : Dynamic ) : Bool;
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool;
 
 	/**
 		Checks if object `value` is an instance of class `c`.

--- a/std/cpp/_std/Std.hx
+++ b/std/cpp/_std/Std.hx
@@ -22,7 +22,7 @@
 
 @:headerClassCode("\t\tstatic inline String string(String &s) { return s; }")
 @:coreApi class Std {
-	@:keep public static function is( v : Dynamic, t : Dynamic ) : Bool {
+	@:keep public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		return untyped __global__.__instanceof(v,t);
 	}
 

--- a/std/cs/_std/Std.hx
+++ b/std/cs/_std/Std.hx
@@ -24,7 +24,7 @@ import cs.Lib;
 import cs.internal.Exceptions;
 
 @:coreApi @:nativeGen class Std {
-	public static function is( v : Dynamic, t : Dynamic ) : Bool
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool
 	{
 		if (v == null)
 			return false;

--- a/std/flash/_std/Std.hx
+++ b/std/flash/_std/Std.hx
@@ -23,7 +23,7 @@ import flash.Boot;
 
 @:coreApi class Std {
 
-	public static function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		return untyped flash.Boot.__instanceof(v,t);
 	}
 

--- a/std/hl/_std/Std.hx
+++ b/std/hl/_std/Std.hx
@@ -40,7 +40,7 @@ class Std {
 		return x <= 0 ? 0 : (rnd_int(rnd) & 0x3FFFFFFF) % x;
 	}
 
-	public static function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		var t : hl.BaseType = t;
 		if( t == null ) return false;
 		switch( t.__type__.kind ) {

--- a/std/java/_std/Std.hx
+++ b/std/java/_std/Std.hx
@@ -25,7 +25,7 @@ import java.Lib;
 import java.internal.Exceptions;
 
 @:coreApi @:nativeGen class Std {
-	public static function is( v : Dynamic, t : Dynamic ) : Bool
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool
 	{
 		if (v == null)
 			return false;

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -24,7 +24,7 @@ import js.Boot;
 @:keepInit
 @:coreApi class Std {
 
-	public static inline function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static inline function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		return @:privateAccess js.Boot.__instanceof(v,t);
 	}
 

--- a/std/lua/_std/Std.hx
+++ b/std/lua/_std/Std.hx
@@ -25,7 +25,7 @@ import lua.NativeStringTools;
 @:keepInit
 @:coreApi class Std {
 
-	public static inline function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static inline function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		return untyped lua.Boot.__instanceof(v,t);
 	}
 

--- a/std/neko/_std/Std.hx
+++ b/std/neko/_std/Std.hx
@@ -22,7 +22,7 @@
 @:coreApi class Std {
 
 	@:ifFeature("typed_cast")
-	public static function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		return untyped neko.Boot.__instanceof(v,t);
 	}
 

--- a/std/php/_std/Std.hx
+++ b/std/php/_std/Std.hx
@@ -28,7 +28,7 @@ import php.Syntax;
 
 @:coreApi class Std {
 
-	public static inline function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static inline function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 		return Boot.is(v, t);
 	}
 

--- a/std/python/_std/Std.hx
+++ b/std/python/_std/Std.hx
@@ -46,7 +46,7 @@ import python.Syntax;
 
 	@:access(python.Boot)
 	@:ifFeature("typed_cast")
-	public static function is( v : Dynamic, t : Dynamic ) : Bool {
+	public static function is( v : Null<Dynamic>, t : Null<Dynamic> ) : Bool {
 
 		if (v == null && t == null) {
 			return false;


### PR DESCRIPTION
This is a particularly annoying case of #7897 since it's implementation is `inline` on some platforms like JS.

Let's see what Travis says..