### PR TITLE
[parser] improve some error message terminology

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -30,7 +30,7 @@ unreleased: 4.0.0-rc.2
 
 	all : improved unification error messages (#7547)
 	all : added `haxe4` define
-	all : do not require semicolon for XML literals (#7438)
+	all : do not require semicolon for markup literals (#7438)
 	all : made `@:expose` imply `@:keep` (#7695)
 	all : unified cast, catch and Std.is behavior of null-values (#7532)
 	macro : static variables are now always re-initialized when using the compilation server (#5746)
@@ -66,7 +66,7 @@ unreleased: 4.0.0-rc.2
 	all : added support for write-mode `@:op(a.b)`
 	all : support `inline call()` and `inline new` expressions (#7425)
 	all : support `@:using` on type declarations (#7462)
-	all : support XML literal strings but require them to be macro-processed (#7438)
+	all : support markup literal strings but require them to be macro-processed (#7438)
 	all : allow enum values without arguments as default function argument values (#7439)
 	lua : add -D lua-vanilla, which emits code with reduced functionality but no additional lib dependencies
 

--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -30,7 +30,7 @@ type error_msg =
 	| Unclosed_code
 	| Invalid_escape of char
 	| Invalid_option
-	| Unterminated_xml
+	| Unterminated_markup
 
 exception Error of error_msg * pos
 
@@ -49,7 +49,7 @@ let error_msg = function
 	| Unclosed_code -> "Unclosed code string"
 	| Invalid_escape c -> Printf.sprintf "Invalid escape sequence \\%s" (Char.escaped c)
 	| Invalid_option -> "Invalid regular expression option"
-	| Unterminated_xml -> "Unterminated XML literal"
+	| Unterminated_markup -> "Unterminated markup literal"
 
 type lexer_file = {
 	lfile : string;
@@ -605,4 +605,4 @@ let lex_xml p lexbuf =
 	try
 		not_xml ctx 0 (name <> "") (* don't allow self-closing fragments *)
 	with Exit ->
-		error Unterminated_xml p
+		error Unterminated_markup p

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -27,7 +27,7 @@ type error_msg =
 	| Unexpected of token
 	| Duplicate_default
 	| Missing_semicolon
-	| Unclosed_macro
+	| Unclosed_conditional
 	| Unimplemented
 	| Missing_type
 	| Expected of string list
@@ -59,7 +59,7 @@ let error_msg = function
 	| Unexpected t -> "Unexpected "^(s_token t)
 	| Duplicate_default -> "Duplicate default"
 	| Missing_semicolon -> "Missing ;"
-	| Unclosed_macro -> "Unclosed macro"
+	| Unclosed_conditional -> "Unclosed conditional compilation block"
 	| Unimplemented -> "Not implemented for current platform"
 	| Missing_type -> "Missing type declaration"
 	| Expected sl -> "Expected " ^ (String.concat " or " sl)

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -160,7 +160,7 @@ let parse ctx code file =
 		| Sharp "if" ->
 			skip_tokens_loop p test (skip_tokens p false)
 		| Eof ->
-			syntax_error Unclosed_macro ~pos:(Some p) sraw tk
+			syntax_error Unclosed_conditional ~pos:(Some p) sraw tk
 		| _ ->
 			skip_tokens p test
 
@@ -174,7 +174,7 @@ let parse ctx code file =
 	) in
 	try
 		let l = parse_file s in
-		(match !mstack with p :: _ -> syntax_error Unclosed_macro ~pos:(Some p) sraw () | _ -> ());
+		(match !mstack with p :: _ -> syntax_error Unclosed_conditional ~pos:(Some p) sraw () | _ -> ());
 		let was_display_file = !in_display_file in
 		restore();
 		Lexer.restore old;


### PR DESCRIPTION
- `Unterminated XML literal` -> `Unterminated markup literal`, since that's what the [HXP](https://github.com/HaxeFoundation/haxe-evolution/blob/master/proposals/0006-inline-markup.md) calls it and they're not meant to be only for XML.
- `Unclosed macro` -> `Unclosed conditional compilation block`, since this might be the only place left that calls these macros? At least the manual calls it conditional compilation, and given what "macro" in Haxe usually refers to, there's some potential for confusion here.