### PR TITLE
Generic stack overflow

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -144,7 +144,7 @@ let is_extern_field f =
 
 let is_array_class name =
 	match name with
-	| "hl.types.ArrayDyn" | "hl.types.ArrayBytes_Int" | "hl.types.ArrayBytes_Float" | "hl.types.ArrayObj" | "hl.types.ArrayBytes_Single" | "hl.types.ArrayBytes_hl_UI16" -> true
+	| "hl.types.ArrayDyn" | "hl.types.ArrayBytes_Int" | "hl.types.ArrayBytes_Float" | "hl.types.ArrayObj" | "hl.types.ArrayBytes_F32" | "hl.types.ArrayBytes_hl_UI16" -> true
 	| _ -> false
 
 let is_array_type t =
@@ -3919,7 +3919,7 @@ let create_context com is_macro dump =
 			aobj = get_class "ArrayObj";
 			aui16 = get_class "ArrayBytes_hl_UI16";
 			ai32 = get_class "ArrayBytes_Int";
-			af32 = get_class "ArrayBytes_Single";
+			af32 = get_class "ArrayBytes_hl_F32";
 			af64 = get_class "ArrayBytes_Float";
 		};
 		base_class = get_class "Class";

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -53,7 +53,7 @@ let make_generic ctx ps pt p =
 					| Some t -> loop top t
 					| _ -> raise (Generic_Exception (("Could not determine type for parameter " ^ s), p)))
 				| TDynamic _ -> "Dynamic"
-				| t -> raise (Generic_Exception (("Type parameter must be a class or enum instance (found " ^ (s_type (print_context()) t) ^ ")"), p))
+				| TFun(params,ret) -> "fun_" ^ String.concat "_" (List.map (loop top) (List.map (fun (_,_,t) -> t) params)) ^ (loop top ret)
 			and loop_tl top tl = match tl with
 				| [] -> ""
 				| tl -> "_" ^ String.concat "_" (List.map (loop top) tl)

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -41,12 +41,12 @@ let make_generic ctx ps pt p =
 			let rec loop top t = match t with
 				| TInst(c,tl) -> (match c.cl_kind with
 					| KExpr e -> ident_safe (Ast.s_expr e)
-					| _ -> (ident_safe (s_type_path_underscore c.cl_path)) ^ (loop_tl tl))
-				| TEnum(en,tl) -> (s_type_path_underscore en.e_path) ^ (loop_tl tl)
+					| _ -> (ident_safe (s_type_path_underscore c.cl_path)) ^ (loop_tl top tl))
+				| TEnum(en,tl) -> (s_type_path_underscore en.e_path) ^ (loop_tl top tl)
 				| TAnon(a) -> "anon_" ^ String.concat "_" (PMap.foldi (fun s f acc -> (s ^ "_" ^ (loop false f.cf_type)) :: acc) a.a_fields [])
-				| TType(t,tl) -> (s_type_path_underscore t.t_path) ^ (loop_tl tl)
+				| TType(t,tl) -> (s_type_path_underscore t.t_path) ^ (loop_tl top tl)
 				| TLazy(f) -> loop top (lazy_type f)
-				| TAbstract(a,tl) -> (s_type_path_underscore a.a_path) ^ (loop_tl tl)
+				| TAbstract(a,tl) -> (s_type_path_underscore a.a_path) ^ (loop_tl top tl)
 				| _ when not top -> "_" (* allow unknown/incompatible types as type parameters to retain old behavior *)
 				| TMono(r) ->
 					(match !r with
@@ -54,9 +54,9 @@ let make_generic ctx ps pt p =
 					| _ -> raise (Generic_Exception (("Could not determine type for parameter " ^ s), p)))
 				| TDynamic _ -> "Dynamic"
 				| t -> raise (Generic_Exception (("Type parameter must be a class or enum instance (found " ^ (s_type (print_context()) t) ^ ")"), p))
-			and loop_tl tl = match tl with
+			and loop_tl top tl = match tl with
 				| [] -> ""
-				| tl -> "_" ^ String.concat "_" (List.map (loop false) tl)
+				| tl -> "_" ^ String.concat "_" (List.map (loop top) tl)
 			in
 			loop true t
 		) ps pt)

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -45,12 +45,12 @@ let make_generic ctx ps pt p =
 				| TEnum(en,tl) -> (s_type_path_underscore en.e_path) ^ (loop_tl tl)
 				| TAnon(a) -> "anon_" ^ String.concat "_" (PMap.foldi (fun s f acc -> (s ^ "_" ^ (loop false f.cf_type)) :: acc) a.a_fields [])
 				| TType(t,tl) -> (s_type_path_underscore t.t_path) ^ (loop_tl tl)
-				| TLazy(f) -> loop false (lazy_type f)
+				| TLazy(f) -> loop top (lazy_type f)
 				| TAbstract(a,tl) -> (s_type_path_underscore a.a_path) ^ (loop_tl tl)
 				| _ when not top -> "_" (* allow unknown/incompatible types as type parameters to retain old behavior *)
 				| TMono(r) ->
 					(match !r with
-					| Some t -> loop false t
+					| Some t -> loop top t
 					| _ -> raise (Generic_Exception (("Could not determine type for parameter " ^ s), p)))
 				| TDynamic _ -> "Dynamic"
 				| t -> raise (Generic_Exception (("Type parameter must be a class or enum instance (found " ^ (s_type (print_context()) t) ^ ")"), p))

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -43,6 +43,7 @@ let make_generic ctx ps pt p =
 					| KExpr e -> ident_safe (Ast.s_expr e)
 					| _ -> (ident_safe (s_type_path_underscore c.cl_path)) ^ (loop_tl tl))
 				| TEnum(en,tl) -> (s_type_path_underscore en.e_path) ^ (loop_tl tl)
+				| TAnon(a) -> "anon_" ^ String.concat "_" (PMap.foldi (fun s f acc -> (s ^ "_" ^ (loop false f.cf_type)) :: acc) a.a_fields [])
 				| TType(t,tl) -> (s_type_path_underscore t.t_path) ^ (loop_tl tl)
 				| TLazy(f) -> loop false (lazy_type f)
 				| TAbstract(a,tl) -> (s_type_path_underscore a.a_path) ^ (loop_tl tl)

--- a/tests/unit/src/unit/Test.hx
+++ b/tests/unit/src/unit/Test.hx
@@ -63,18 +63,18 @@ class Test implements utest.ITest {
 	}
 
 	function hf(c:Class<Dynamic>, n:String, ?pos:haxe.PosInfos) {
-		t(Lambda.has(Type.getInstanceFields(c), n));
+		t(Lambda.has(Type.getInstanceFields(c), n), pos);
 	}
 
 	function nhf(c:Class<Dynamic>, n:String, ?pos:haxe.PosInfos) {
-		f(Lambda.has(Type.getInstanceFields(c), n));
+		f(Lambda.has(Type.getInstanceFields(c), n), pos);
 	}
 
 	function hsf(c:Class<Dynamic> , n:String, ?pos:haxe.PosInfos) {
-		t(Lambda.has(Type.getClassFields(c), n));
+		t(Lambda.has(Type.getClassFields(c), n), pos);
 	}
 
 	function nhsf(c:Class<Dynamic> , n:String, ?pos:haxe.PosInfos) {
-		f(Lambda.has(Type.getClassFields(c), n));
+		f(Lambda.has(Type.getClassFields(c), n), pos);
 	}
 }

--- a/tests/unit/src/unit/TestType.hx
+++ b/tests/unit/src/unit/TestType.hx
@@ -554,8 +554,10 @@ class TestType extends Test {
 
 		eq("foo[1,2]", gf2("foo", [1, 2]));
 		eq("foo[[1,2]]", gf2("foo", [[1, 2]]));
+		eq("foo[[true,false]]", gf2("foo", [[true, false]]));
 		hsf(TestType, "gf2_String_Int");
 		hsf(TestType, "gf2_String_Array_Int");
+		hsf(TestType, "gf2_String_Array_Bool");
 
 		var a = gf3("foo", ["bar", "baz"]);
 		eq(a[0], "bar");


### PR DESCRIPTION
When using an anon too big and/or recursive as a type parameter it stack overflow,
so use its tpath when available.