### PR TITLE
preserve flags across connect() and bind() for ipv6

### DIFF
--- a/std/cpp/_std/sys/net/Socket.hx
+++ b/std/cpp/_std/sys/net/Socket.hx
@@ -117,6 +117,14 @@ private class SocketOutput extends haxe.io.Output {
 class Socket {
 
    private var __s : Dynamic;
+
+   // We need to keep these values so that we can restore
+   // them if we re-create the socket for ipv6 as in 
+   // connect() and bind() below.
+   private var __timeout:Float = 0.0;
+   private var __blocking:Bool = true;
+   private var __fastSend:Bool = false;
+
    public var input(default,null) : haxe.io.Input;
    public var output(default,null) : haxe.io.Output;
    public var custom : Dynamic;
@@ -127,6 +135,11 @@ class Socket {
 
    private function init() : Void {
       if( __s == null )__s = NativeSocket.socket_new(false);
+      // Restore these values if they changed. This can happen
+      // in connect() and bind() if using an ipv6 address.
+      setTimeout(__timeout);
+      setBlocking(__blocking);
+      setFastSend(__fastSend);
       input = new SocketInput(__s);
       output = new SocketOutput(__s);
    }
@@ -239,6 +252,7 @@ class Socket {
    }
 
    public function setTimeout( timeout : Float ) : Void {
+      __timeout = timeout;
       NativeSocket.socket_set_timeout(__s, timeout);
    }
 
@@ -247,10 +261,12 @@ class Socket {
    }
 
    public function setBlocking( b : Bool ) : Void {
+      __blocking = b;
       NativeSocket.socket_set_blocking(__s,b);
    }
 
    public function setFastSend( b : Bool ) : Void {
+      __fastSend = b;
       NativeSocket.socket_set_fast_send(__s,b);
    }
 


### PR DESCRIPTION
This change fixes [this issue](https://github.com/HaxeFoundation/haxe/issues/7978) in which socket flags changed that were set prior to connect() or bind() were being lost if the connection was to an ipv6 address.

I chose to fix this by storing the value of these flags when initially set and restoring them in the init() method after the new ipv6 socket is created in connect() and bind().

Additions to Socket.hx include:
- private member variables for the three flags we need to restore: timeout, blocking, and fastSend
- restoring these flags in the init() method
- caching these flags in the individual flag setting methods

Pros to this solution are that it solves the problem is localized to a single file. Cons are that it requires some additional memory for every socket and the default flag values are unnecessarily set in init() when the socket is first created.
