### PR TITLE
Allow `#if (some.field)`

### DIFF
--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -262,12 +262,15 @@ let defined_value_safe ?default ctx v =
 	try defined_value ctx v
 	with Not_found -> match default with Some s -> s | None -> ""
 
-let raw_define ctx v =
-	let k,v = try ExtString.String.split v "=" with _ -> v,"1" in
+let raw_define_value ctx k v =
 	ctx.values <- PMap.add k v ctx.values;
 	let k = String.concat "_" (ExtString.String.nsplit k "-") in
 	ctx.values <- PMap.add k v ctx.values;
 	ctx.defines_signature <- None
+
+let raw_define ctx v =
+	let k,v = try ExtString.String.split v "=" with _ -> v,"1" in
+	raw_define_value ctx k v
 
 let define_value ctx k v =
 	raw_define ctx (fst (infos k) ^ "=" ^ v)

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1462,6 +1462,7 @@ let rec validate_macro_cond s e = match fst e with
 	| EUnop (op,p,e1) -> (EUnop (op, p, validate_macro_cond s e1), snd e)
 	| EBinop (op,e1,e2) -> (EBinop(op, (validate_macro_cond s e1), (validate_macro_cond s e2)), snd e)
 	| EParenthesis (e1) -> (EParenthesis (validate_macro_cond s e1), snd e)
+	| EField(e1,name) -> (EField(validate_macro_cond s e1,name), snd e)
 	| _ -> syntax_error (Custom ("Invalid conditional expression")) ~pos:(Some (pos e)) s ((EConst (Ident "false"),(pos e)))
 
 let parse_macro_ident t p s =

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -68,6 +68,14 @@ let rec eval ctx (e,p) =
 		| OpLt -> compare (<)
 		| OpLte -> compare (<=)
 		| _ -> error (Custom "Unsupported operation") p)
+	| EField _ ->
+		begin try
+			let sl = string_list_of_expr_path_raise (e,p) in
+			let i = String.concat "." (List.rev sl) in
+			(try TString (Define.raw_defined_value ctx i) with Not_found -> TNull)
+		with Exit ->
+			error (Custom "Invalid condition expression") p
+		end
 	| _ ->
 		error (Custom "Invalid condition expression") p
 


### PR DESCRIPTION
This PR allows parsing `#if (some.field)` and adds a bunch of `target` defines: `target.name`, `target.static`, `target.sys`, `target.utf16` and `target.threaded`.

This isn't the cleanest implementation: We should actually add all these to the list of defines. This will also allow us to provide completion, simply by comparing some strings.

I would like to merge this now though so I can rely on `target.threaded` for the sys.thread PR.