### PR TITLE
Make host name public for the c# target

### DIFF
--- a/std/cs/_std/sys/net/Host.hx
+++ b/std/cs/_std/sys/net/Host.hx
@@ -41,7 +41,7 @@ class Host {
 	/**
 		The provided host string.
 	**/
-	var host(default,null) : String;
+	public var host(default,null) : String;
 
 	/**
 		The actual IP corresponding to the host.


### PR DESCRIPTION
Sorry @Simn for my failure in https://github.com/HaxeFoundation/haxe/pull/7902 :confused: