### PR TITLE
[eval] Rework capture variable handling

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -379,6 +379,7 @@ let get_config com =
 			pf_pad_nulls = true;
 			pf_uses_utf16 = false;
 			pf_supports_threads = true;
+			pf_capture_policy = CPWrapRef;
 		}
 
 let memory_marker = [|Unix.time()|]

--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -90,7 +90,7 @@ type env = {
 	env_locals : value array;
 	(* The reference to the environment's captured local variables. Indices are determined during compile-time,
 	   or can be obtained through `env_info.capture_infos`. *)
-	env_captures : value ref array;
+	env_captures : value array;
 	(* Map of extra variables added while debugging. Keys are hashed variable names. *)
 	mutable env_extra_locals : value IntMap.t;
 	(* The parent of the current environment, if exists. *)
@@ -394,7 +394,7 @@ let push_environment ctx info num_locals num_captures =
 	let captures = if num_captures = 0 then
 		empty_array
 	else
-		Array.make num_captures (ref vnull)
+		Array.make num_captures vnull
 	in
 	let env = {
 		env_info = info;

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -124,7 +124,7 @@ let get_variable env capture_infos scopes name env =
 	with Not_found ->
 		let slot = get_capture_slot_by_name capture_infos name in
 		let value = try env.env_captures.(slot) with _ -> raise Not_found in
-		!value
+		value
 
 (* Expr to value *)
 

--- a/src/macro/eval/evalDebugSocket.ml
+++ b/src/macro/eval/evalDebugSocket.ml
@@ -200,7 +200,7 @@ let output_scopes ctx env =
 
 let output_capture_vars infos env =
 	let vars = Hashtbl.fold (fun slot vi acc ->
-		let value = !(env.env_captures.(slot)) in
+		let value = (env.env_captures.(slot)) in
 		(var_to_json vi.vi_name value (Some vi) env) :: acc
 	) infos [] in
 	JArray vars
@@ -660,7 +660,7 @@ let handler =
 			| CaptureScope(infos,env) ->
 				let value = get_value env in
 				let slot = get_capture_slot_by_name infos name in
-				env.env_captures.(slot) := value;
+				env.env_captures.(slot) <- value;
 				var_to_json "" value None env
 			| DebugScope _ | StackFrame _ ->
 				JNull

--- a/src/macro/eval/evalJitContext.ml
+++ b/src/macro/eval/evalJitContext.ml
@@ -17,7 +17,7 @@ type t = {
 	(* The scope stack. *)
 	mutable scopes : scope list;
 	(* The captured variables declared in this context. Maps variable IDs to capture slots. *)
-	mutable captures : (int,int) Hashtbl.t;
+	mutable captures : (int,int * bool) Hashtbl.t;
 	(* The current number of locals. *)
 	mutable num_locals : int;
 	(* The maximum number of locals. *)
@@ -28,6 +28,8 @@ type t = {
 	mutable has_nonfinal_return : bool;
 	(* The name of capture variables. Maps local slots to variable names. Only filled in debug mode. *)
 	mutable capture_infos : (int,var_info) Hashtbl.t;
+	(* Variables which are accessed but not declared in this scope. *)
+	mutable captures_outside_scope : tvar list;
 }
 
 let var_info_of_var var =
@@ -47,6 +49,7 @@ let create ctx = {
 	num_closures = 0;
 	has_nonfinal_return = false;
 	capture_infos = Hashtbl.create 0;
+	captures_outside_scope = []
 }
 
 (* Returns the number of locals in [scope]. *)
@@ -78,9 +81,9 @@ let increase_num_locals jit =
 	if jit.num_locals > jit.max_num_locals then jit.max_num_locals <- jit.num_locals
 
 (* Adds capture variable [var] to context [jit]. *)
-let add_capture jit var =
+let add_capture jit var declared =
 	let i = Hashtbl.length jit.captures in
-	Hashtbl.add jit.captures var.v_id i;
+	Hashtbl.add jit.captures var.v_id (i,declared);
 	if jit.ctx.debug.support_debugger then begin
 		Hashtbl.replace jit.capture_infos i (var_info_of_var var)
 	end;
@@ -108,7 +111,7 @@ let add_local jit var = match jit.scopes with
 	Returns either [Env slot] if the variable is captured or [Local slot] otherwise.
 *)
 let declare_local jit var =
-	if var.v_capture then Env (add_capture jit var)
+	if var.v_capture then Env (add_capture jit var true)
 	else Local (add_local jit var)
 
 (*
@@ -119,7 +122,7 @@ let declare_local jit var =
 *)
 let declare_arg jit var =
 	let varacc = add_local jit var in
-	if var.v_capture then add_capture jit var,Some varacc else varacc,None
+	if var.v_capture then add_capture jit var true,Some varacc else varacc,None
 
 (* Declares a variable for `this` in context [jit]. *)
 let declare_local_this jit = match jit.scopes with
@@ -151,5 +154,8 @@ let get_slot jit vid p =
 	with Not_found -> EvalMisc.throw_string "Unbound variable" p
 
 (* Gets the slot of captured variable id [vid] in context [jit]. *)
-let get_capture_slot jit vid =
-	Hashtbl.find jit.captures vid
+let get_capture_slot jit var =
+	try fst (Hashtbl.find jit.captures var.v_id)
+	with Not_found ->
+		jit.captures_outside_scope <- var :: jit.captures_outside_scope;
+		add_capture jit var false


### PR DESCRIPTION
I know I know, another typical Haxe-rc change. But I have to do it.

Here's the good news from the benchmarks:

what | before | after | change
--- | --- | --- | ---
static closure | 3,937,595 | 4,128,581 | +5%
field closure | 3,352,771 | 3,492,588 | +4%
local closure | 2,595,895 | 3,172,965 | +22%
local function | 2,496,921 | 4,080,627 | +63%

In particular, local functions that don't capture anything are now treated just like normal static functions, giving them a huge speedup.

closes #7983