### PR TITLE
Fast version of startsWith/endsWith

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -209,7 +209,7 @@ class StringTools {
 		#elseif python
 		return python.NativeStringTools.startswith(s, start);
 		#else
-		return( s.length >= start.length && s.substr(0, start.length) == start );
+		return( s.length >= start.length && s.lastIndexOf(start, 0) == 0 );
 		#end
 	}
 
@@ -243,7 +243,7 @@ class StringTools {
 		#else
 		var elen = end.length;
 		var slen = s.length;
-		return( slen >= elen && s.substr(slen - elen, elen) == end );
+		return( slen >= elen && s.indexOf(end, (slen - elen)) == (slen - elen) );
 		#end
 	}
 


### PR DESCRIPTION
This PR improves the implementation of `String.startsWith` and `String.endsWith` to improve performance and memory usage in the JS and AS3 targets.

- Hidden object allocation removed (in the present implementation a new string is created and then compared with the prefix/postfix)
- High speed platform methods (`indexOf` and `lastIndexOf`) are used in a novel way to provide "begins with" and "ends with" functionality
- **startsWith** : we run `lastIndexOf` with the prefix, starting at character 0. This means it performs a single check starting at character 0, instead of searching through the whole string.
- **endsWith** : we run `indexOf` with the postfix, starting at `mainStr.length - end.length`. This means it performs a single check starting at character `mainLen - endLen`, instead of searching through the whole string.