### PR TITLE
[cpp] Enabled `-D hxcpp_smart_strings` by default

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -797,7 +797,9 @@ try
 				end;
 			with Not_found ->
 				raise (Arg.Bad new_msg));
-		arg_delays := []
+		arg_delays := [];
+		if com.platform = Globals.Cpp && not (Define.defined com.defines DisableUnicodeStrings) && not (Define.defined com.defines HxcppSmartStings) then
+			Define.define com.defines HxcppSmartStings;
 	in
 	process_ref := process;
 	process ctx.com.args;

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -19,6 +19,7 @@ type strict_defined =
 	| Dce
 	| DceDebug
 	| Debug
+	| DisableUnicodeStrings
 	| Display
 	| DisplayStdin
 	| DllExport
@@ -131,6 +132,7 @@ let infos = function
 	| Dce -> "dce",("<mode:std|full|no> Set the dead code elimination mode (default std)",[])
 	| DceDebug -> "dce_debug",("Show DCE log",[])
 	| Debug -> "debug",("Activated when compiling with -debug",[])
+	| DisableUnicodeStrings -> "disable_unicode_strings",("Disable unicode support in String type on some platforms",[Platform Cpp])
 	| Display -> "display",("Activated during completion",[])
 	| DisplayStdin -> "display_stdin",("Read the contents of a file specified in --display from standard input",[])
 	| DllExport -> "dll_export",("GenCPP experimental linking",[Platform Cpp])

--- a/tests/sys/compile-cpp.hxml
+++ b/tests/sys/compile-cpp.hxml
@@ -1,13 +1,16 @@
 compile-each.hxml
+--define disable-unicode-strings
 --main Main
 -cpp bin/cpp
 
 --next
 compile-each.hxml
+--define disable-unicode-strings
 --main TestArguments
 -cpp bin/cpp
 
 --next
 compile-each.hxml
+--define disable-unicode-strings
 --main ExitCode
 -cpp bin/cpp

--- a/tests/unit/compile-cpp.hxml
+++ b/tests/unit/compile-cpp.hxml
@@ -1,5 +1,4 @@
 compile-each.hxml
 --main unit.TestMain
--D hxcpp_smart_strings
 -cpp bin/cpp
 -D HXCPP_NO_DEBUG_LINK

--- a/tests/unit/compile-cppia-host.hxml
+++ b/tests/unit/compile-cppia-host.hxml
@@ -1,7 +1,6 @@
 --main cpp.cppia.Host
 -D source-header=''
 -D scriptable
--D hxcpp_smart_strings
 -D dll_export=bin/cppia.classes
 --debug
 --dce no


### PR DESCRIPTION
See #8087 
Also, introduces `-D disable-unicode-strings`. 

Disabled unicode strings for sys tests because they are failing with unicode.