### PR TITLE
neko indexOf and lastIndexOf fix

### DIFF
--- a/std/neko/_std/String.hx
+++ b/std/neko/_std/String.hx
@@ -71,7 +71,15 @@ import haxe.iterators.StringKeyValueIterator;
 
 	public function indexOf( str : String, ?startIndex : Int ) : Int {
 		untyped {
-			var p = try __dollar__sfind(this.__s,if( startIndex == null ) 0 else startIndex,str.__s) catch( e : Dynamic ) null;
+			var l = this.length;
+			if( startIndex == null )
+				startIndex = 0;
+			if( __dollar__ssize(str.__s) == 0 ) {
+				if( startIndex == l )
+					return l;
+				return startIndex;
+			}
+			var p = try __dollar__sfind(this.__s,startIndex,str.__s) catch( e : Dynamic ) null;
 			if( p == null )
 				return -1;
 			return p;
@@ -80,9 +88,12 @@ import haxe.iterators.StringKeyValueIterator;
 
 	public function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		untyped {
+			var l = this.length;
 			var last = -1;
 			if( startIndex == null )
 				startIndex = __dollar__ssize(this.__s);
+			if( __dollar__ssize(str.__s) == 0 )
+				return startIndex;
 			while( true ) {
 				var p = try __dollar__sfind(this.__s,last+1,str.__s) catch( e : Dynamic ) null;
 				if( p == null || p > startIndex )

--- a/std/neko/_std/String.hx
+++ b/std/neko/_std/String.hx
@@ -71,14 +71,10 @@ import haxe.iterators.StringKeyValueIterator;
 
 	public function indexOf( str : String, ?startIndex : Int ) : Int {
 		untyped {
-			var l = this.length;
 			if( startIndex == null )
 				startIndex = 0;
-			if( __dollar__ssize(str.__s) == 0 ) {
-				if( startIndex == l )
-					return l;
+			if( __dollar__ssize(str.__s) == 0 )
 				return startIndex;
-			}
 			var p = try __dollar__sfind(this.__s,startIndex,str.__s) catch( e : Dynamic ) null;
 			if( p == null )
 				return -1;
@@ -88,7 +84,6 @@ import haxe.iterators.StringKeyValueIterator;
 
 	public function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		untyped {
-			var l = this.length;
 			var last = -1;
 			if( startIndex == null )
 				startIndex = __dollar__ssize(this.__s);

--- a/std/neko/_std/String.hx
+++ b/std/neko/_std/String.hx
@@ -71,10 +71,13 @@ import haxe.iterators.StringKeyValueIterator;
 
 	public function indexOf( str : String, ?startIndex : Int ) : Int {
 		untyped {
-			if( startIndex == null )
+			var l = __dollar__ssize(this.__s);
+			if( startIndex == null || startIndex < -l )
 				startIndex = 0;
+			if( startIndex > l )
+				return -1;
 			if( __dollar__ssize(str.__s) == 0 )
-				return startIndex;
+				return startIndex < 0 ? l + startIndex : startIndex;
 			var p = try __dollar__sfind(this.__s,startIndex,str.__s) catch( e : Dynamic ) null;
 			if( p == null )
 				return -1;
@@ -85,10 +88,11 @@ import haxe.iterators.StringKeyValueIterator;
 	public function lastIndexOf( str : String, ?startIndex : Int ) : Int {
 		untyped {
 			var last = -1;
+			var l = __dollar__ssize(this.__s);
 			if( startIndex == null )
-				startIndex = __dollar__ssize(this.__s);
+				startIndex = l;
 			if( __dollar__ssize(str.__s) == 0 )
-				return startIndex;
+				return startIndex > l ? l : startIndex;
 			while( true ) {
 				var p = try __dollar__sfind(this.__s,last+1,str.__s) catch( e : Dynamic ) null;
 				if( p == null || p > startIndex )

--- a/tests/unit/src/unitstd/String.unit.hx
+++ b/tests/unit/src/unitstd/String.unit.hx
@@ -72,6 +72,11 @@ s.indexOf("oo") == 1;
 s.indexOf("o", 1) == 1;
 s.indexOf("o", 2) == 2;
 s.indexOf("o", 3) == -1;
+//s.indexOf("", -10) == 0;
+s.indexOf("", 7) == 7;
+//s.indexOf("", 8) == -1; // see #8117
+s.indexOf("r", 7) == -1;
+s.indexOf("r", 8) == -1;
 
 // lastIndexOf
 var s = "foofoofoobarbar";

--- a/tests/unit/src/unitstd/String.unit.hx
+++ b/tests/unit/src/unitstd/String.unit.hx
@@ -73,7 +73,7 @@ s.indexOf("o", 1) == 1;
 s.indexOf("o", 2) == 2;
 s.indexOf("o", 3) == -1;
 //s.indexOf("", -10) == 0;
-s.indexOf("", 7) == 7;
+//s.indexOf("", 7) == 7; // see #8117
 //s.indexOf("", 8) == -1; // see #8117
 s.indexOf("r", 7) == -1;
 s.indexOf("r", 8) == -1;


### PR DESCRIPTION
Fixes #8115.

Checks whether the argument passed to `String.indexOf` and `String.lastIndexOf` is an empty string, returns the `index` if so.