### PR TITLE
[display] reset display position after an initial DisplayException

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -1003,11 +1003,13 @@ with
 	| HelpMessage msg ->
 		message ctx (CMInfo(msg,null_pos))
 	| DisplayException(DisplayHover _ | DisplayPosition _ | DisplayFields _ | DisplayPackage _  | DisplaySignatures _ as de) when ctx.com.json_out <> None ->
-		begin match ctx.com.json_out with
-		| Some (f,_) ->
-			let ctx = DisplayJson.create_json_context (match de with DisplayFields _ -> true | _ -> false) in
-			f (DisplayException.to_json ctx de)
-		| _ -> assert false
+		begin
+			DisplayPosition.display_position := null_pos;
+			match ctx.com.json_out with
+			| Some (f,_) ->
+				let ctx = DisplayJson.create_json_context (match de with DisplayFields _ -> true | _ -> false) in
+				f (DisplayException.to_json ctx de)
+			| _ -> assert false
 		end
 	(* | Parser.TypePath (_,_,_,p) when ctx.com.json_out <> None ->
 		begin match com.json_out with
@@ -1019,8 +1021,10 @@ with
 		| _ -> assert false
 		end *)
 	| DisplayException(DisplayPackage pack) ->
+		DisplayPosition.display_position := null_pos;
 		raise (DisplayOutput.Completion (String.concat "." pack))
 	| DisplayException(DisplayFields(fields,cr,_)) ->
+		DisplayPosition.display_position := null_pos;
 		let fields = if !measure_times then begin
 			Timer.close_times();
 			(List.map (fun (name,value) ->
@@ -1050,14 +1054,17 @@ with
 		in
 		raise (DisplayOutput.Completion s)
 	| DisplayException(DisplayHover ({hitem = {CompletionItem.ci_type = Some (t,_)}} as hover)) ->
+		DisplayPosition.display_position := null_pos;
 		let doc = CompletionItem.get_documentation hover.hitem in
 		raise (DisplayOutput.Completion (DisplayOutput.print_type t hover.hpos doc))
 	| DisplayException(DisplaySignatures(signatures,_,display_arg,_)) ->
+		DisplayPosition.display_position := null_pos;
 		if ctx.com.display.dms_kind = DMSignature then
 			raise (DisplayOutput.Completion (DisplayOutput.print_signature signatures display_arg))
 		else
 			raise (DisplayOutput.Completion (DisplayOutput.print_signatures signatures))
 	| DisplayException(DisplayPosition pl) ->
+		DisplayPosition.display_position := null_pos;
 		raise (DisplayOutput.Completion (DisplayOutput.print_positions pl))
 	| Parser.TypePath (p,c,is_import,pos) ->
 		let fields =
@@ -1089,6 +1096,7 @@ with
 		DisplayOutput.handle_syntax_completion com kind pos;
 		error ctx ("Error: No completion point was found") null_pos
 	| DisplayException(ModuleSymbols s | Diagnostics s | Statistics s | Metadata s) ->
+		DisplayPosition.display_position := null_pos;
 		raise (DisplayOutput.Completion s)
 	| EvalExceptions.Sys_exit i | Hlinterp.Sys_exit i ->
 		ctx.flush();

--- a/src/core/display/displayPosition.ml
+++ b/src/core/display/displayPosition.ml
@@ -6,7 +6,7 @@ let is_display_file file =
 	file <> "?" && Path.unique_full_path file = !display_position.pfile
 
 let encloses_position p_target p =
-	p.pmin <= p_target.pmin && p.pmax >= p_target.pmax
+	p.pmin <> -1 && p.pmax <> -1 && p.pmin <= p_target.pmin && p.pmax >= p_target.pmax
 
 let encloses_position_gt p_target p =
 	p.pmin <= p_target.pmin && p.pmax > p_target.pmax


### PR DESCRIPTION
Fixes #8049 

After catching an initial DisplayException compiler tries to json it.
While doing that it spots a lazy type and tries to resolve it:
https://github.com/HaxeFoundation/haxe/blob/8a2b8bc2b8bd42e839d6bdcd85b89e1c46522ef5/src/core/json/genjson.ml#L180-L183

Which emits another DisplayException.
<details><summary>Here is the call stack</summary>

```
Raised at file "_build/src/context/display/displayException.ml", line 36, characters 34-118
Called from file "_build/src/context/display/displayEmitter.ml", line 163, characters 2-51
Called from file "_build/src/typing/typer.ml", line 1756, characters 1-51
Called from file "_build/src/typing/typer.ml", line 1418, characters 9-45
Called from file "_build/src/typing/typer.ml", line 1185, characters 23-31
Called from file "list.ml", line 111, characters 24-34
Called from file "_build/src/typing/typer.ml", line 1184, characters 10-189
Called from file "_build/src/typing/typer.ml", line 1377, characters 1-19
Called from file "_build/src/typing/typer.ml", line 2252, characters 10-104
Called from file "_build/src/typing/typer.ml", line 2118, characters 11-55
Called from file "_build/src/context/typecore.ml" (inlined), line 151, characters 32-64
Called from file "_build/src/typing/typeloadFunction.ml", line 133, characters 3-26
Called from file "std.ml", line 26, characters 6-9
Re-raised at file "std.ml", line 28, characters 23-30
Called from file "_build/src/typing/typeloadFields.ml", line 1071, characters 21-97
Called from file "_build/src/context/typecore.ml", line 275, characters 11-14
Called from file "_build/src/core/json/genjson.ml", line 182, characters 11-22
Called from file "_build/src/core/json/genjson.ml", line 193, characters 17-23
Called from file "_build/src/core/json/genjson.ml", line 515, characters 9-37
Called from file "_build/src/core/json/genjson.ml" (inlined), line 529, characters 9-43
Called from file "_build/src/core/json/genjson.ml", line 581, characters 17-53
Called from file "list.ml", line 82, characters 20-23
Called from file "_build/src/core/json/genjson.ml" (inlined), line 26, characters 23-37
Called from file "_build/src/core/json/genjson.ml", line 581, characters 11-73
Called from file "_build/src/core/json/genjson.ml", line 652, characters 28-48
Called from file "_build/src/core/display/completionItem.ml", line 262, characters 9-38
```

</details>
And this is the exception reported in the #8049.

At this point, we clearly don't seek any completion, so display position should be reset immediately after an initial DisplayException was caught.
However, some auto-generated position still satisfies `DisplayPosition.encloses_position` which leads to the second DisplayException because of the lazy type function captured a typer context with `in_display_file == true`. 
That is why I had to make an additional check in `DisplayPosition.encloses_position` to make sure the display position is not in "empty" state.

