### PR TITLE
Restrict `\x` escape sequence  to values less than `\x80`

### DIFF
--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -48,7 +48,7 @@ let error_msg = function
 	| Unclosed_comment -> "Unclosed comment"
 	| Unclosed_code -> "Unclosed code string"
 	| Invalid_escape (c,None) -> Printf.sprintf "Invalid escape sequence \\%s" (Char.escaped c)
-	| Invalid_escape (c,Some msg) -> Printf.sprintf "Invalid escape sequence \\%s: %s" (Char.escaped c) msg
+	| Invalid_escape (c,Some msg) -> Printf.sprintf "Invalid escape sequence \\%s. %s" (Char.escaped c) msg
 	| Invalid_option -> "Invalid regular expression option"
 	| Unterminated_markup -> "Unterminated markup literal"
 

--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -28,7 +28,7 @@ type error_msg =
 	| Unterminated_regexp
 	| Unclosed_comment
 	| Unclosed_code
-	| Invalid_escape of char
+	| Invalid_escape of char * (string option)
 	| Invalid_option
 	| Unterminated_markup
 
@@ -47,7 +47,8 @@ let error_msg = function
 	| Unterminated_regexp -> "Unterminated regular expression"
 	| Unclosed_comment -> "Unclosed comment"
 	| Unclosed_code -> "Unclosed code string"
-	| Invalid_escape c -> Printf.sprintf "Invalid escape sequence \\%s" (Char.escaped c)
+	| Invalid_escape (c,None) -> Printf.sprintf "Invalid escape sequence \\%s" (Char.escaped c)
+	| Invalid_escape (c,Some msg) -> Printf.sprintf "Invalid escape sequence \\%s: %s" (Char.escaped c) msg
 	| Invalid_option -> "Invalid regular expression option"
 	| Unterminated_markup -> "Unterminated markup literal"
 
@@ -370,13 +371,13 @@ let rec token lexbuf =
 		reset();
 		let pmin = lexeme_start lexbuf in
 		let pmax = (try string lexbuf with Exit -> error Unterminated_string pmin) in
-		let str = (try unescape (contents()) with Invalid_escape_sequence(c,i) -> error (Invalid_escape c) (pmin + i)) in
+		let str = (try unescape (contents()) with Invalid_escape_sequence(c,i,msg) -> error (Invalid_escape (c,msg)) (pmin + i)) in
 		mk_tok (Const (String str)) pmin pmax;
 	| "'" ->
 		reset();
 		let pmin = lexeme_start lexbuf in
 		let pmax = (try string2 lexbuf with Exit -> error Unterminated_string pmin) in
-		let str = (try unescape (contents()) with Invalid_escape_sequence(c,i) -> error (Invalid_escape c) (pmin + i)) in
+		let str = (try unescape (contents()) with Invalid_escape_sequence(c,i,msg) -> error (Invalid_escape (c,msg)) (pmin + i)) in
 		let t = mk_tok (Const (String str)) pmin pmax in
 		fast_add_fmt_string (snd t);
 		t

--- a/tests/misc/projects/Issue8119/Main.hx
+++ b/tests/misc/projects/Issue8119/Main.hx
@@ -1,0 +1,5 @@
+class Main {
+	static public function main() {
+		"\x80";
+	}
+}

--- a/tests/misc/projects/Issue8119/compile-fail.hxml
+++ b/tests/misc/projects/Issue8119/compile-fail.hxml
@@ -1,0 +1,1 @@
+-main Main

--- a/tests/misc/projects/Issue8119/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8119/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:3: character 4 : Invalid escape sequence \x: Values greater than \x7f are not allowed. Use \u0080 instead.

--- a/tests/misc/projects/Issue8119/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8119/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:3: character 4 : Invalid escape sequence \x: Values greater than \x7f are not allowed. Use \u0080 instead.
+Main.hx:3: character 4 : Invalid escape sequence \x. Values greater than \x7f are not allowed. Use \u0080 instead.

--- a/tests/unit/src/unit/issues/Issue7449.hx
+++ b/tests/unit/src/unit/issues/Issue7449.hx
@@ -1,9 +1,12 @@
 package unit.issues;
 
 class Issue7449 extends unit.Test {
-	#if !(neko || (cpp && !cppia && !hxcpp_smart_strings))
-	function test() {
-		eq(220, "\xDC".charCodeAt(0));
-	}
-	#end
+	/**
+	 * Not happens since https://github.com/HaxeFoundation/haxe/pull/8141
+	 */
+	// #if !(neko || (cpp && !cppia && !hxcpp_smart_strings))
+	// function test() {
+	// 	eq(220, "\xDC".charCodeAt(0));
+	// }
+	// #end
 }


### PR DESCRIPTION
Closes #8119
```haxe
"\x80";
```
Emits an error:
```
Main.hx:3: character 4 : Invalid escape sequence \x. Values greater than \x7f are not allowed. Use \u0080 instead.
```