### PR TITLE
UTF8Strict encoding

### DIFF
--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -25,6 +25,8 @@ package haxe.io;
 using cpp.NativeArray;
 #end
 
+import haxe.io.Encoding.UnicodeDecodingError;
+
 class Bytes {
 
 	public var length(default,null) : Int;
@@ -361,41 +363,41 @@ class Bytes {
 					//if( c == 0 ) break;
 					s += fcc(c);
 				} else if( c < 0xC0 ) { // invalid continuation byte
-					throw haxe.io.Encoding.UnicodeDecodingError.InvalidContinuation(i - 1);
+					throw UnicodeDecodingError.InvalidContinuation(i - 1);
 				} else if( c < 0xC2 ) { // overlong sequence
-					throw haxe.io.Encoding.UnicodeDecodingError.Overlong(i - 1);
+					throw UnicodeDecodingError.Overlong(i - 1);
 				} else if( c < 0xE0 ) {
-					if( i + 1 > max ) throw haxe.io.Encoding.UnicodeDecodingError.InsufficientData(i - 1);
+					if( i + 1 > max ) throw UnicodeDecodingError.InsufficientData(i - 1);
 					var c2:Int = fastGet(b, i++);
-					if( c2 < 0x80 || c2 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.ExpectedContinuation(i - 2);
+					if( c2 < 0x80 || c2 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 2);
 					s += fcc( ((c & 0x3F) << 6) | (c2 & 0x7F) );
 				} else if( c < 0xF0 ) {
-					if( i + 2 > max ) throw haxe.io.Encoding.UnicodeDecodingError.InsufficientData(i - 1);
+					if( i + 2 > max ) throw UnicodeDecodingError.InsufficientData(i - 1);
 					var c2:Int = fastGet(b, i++);
 					var c3:Int = fastGet(b, i++);
 					if( c == 0xE0 ) {
-						if( c2 < 0xA0 || c2 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.Overlong(i - 3);
+						if( c2 < 0xA0 || c2 > 0xBF ) throw UnicodeDecodingError.Overlong(i - 3);
 					} else {
-						if( c2 < 0x80 || c2 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.ExpectedContinuation(i - 3);
+						if( c2 < 0x80 || c2 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 3);
 					}
-					if( c3 < 0x80 || c3 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.ExpectedContinuation(i - 3);
+					if( c3 < 0x80 || c3 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 3);
 					s += fcc( ((c & 0x1F) << 12) | ((c2 & 0x7F) << 6) | (c3 & 0x7F) );
 				} else if( c > 0xF4 ) {
-					throw haxe.io.Encoding.UnicodeDecodingError.OutOfRange(i - 1);
+					throw UnicodeDecodingError.OutOfRange(i - 1);
 				} else {
-					if( i + 3 > max ) throw haxe.io.Encoding.UnicodeDecodingError.InsufficientData(i - 1);
+					if( i + 3 > max ) throw UnicodeDecodingError.InsufficientData(i - 1);
 					var c2:Int = fastGet(b, i++);
 					var c3:Int = fastGet(b, i++);
 					var c4:Int = fastGet(b, i++);
 					if( c == 0xF0 ) {
-						if( c2 < 0x90 || c2 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.Overlong(i - 4);
+						if( c2 < 0x90 || c2 > 0xBF ) throw UnicodeDecodingError.Overlong(i - 4);
 					} else if( c == 0xF4 ) {
-						if( c2 < 0x80 || c2 > 0x8F ) throw haxe.io.Encoding.UnicodeDecodingError.OutOfRange(i - 4);
+						if( c2 < 0x80 || c2 > 0x8F ) throw UnicodeDecodingError.OutOfRange(i - 4);
 					} else {
-						if( c2 < 0x80 || c2 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.ExpectedContinuation(i - 4);
+						if( c2 < 0x80 || c2 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 4);
 					}
-					if( c3 < 0x80 || c3 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.ExpectedContinuation(i - 4);
-					if( c4 < 0x80 || c4 > 0xBF ) throw haxe.io.Encoding.UnicodeDecodingError.ExpectedContinuation(i - 4);
+					if( c3 < 0x80 || c3 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 4);
+					if( c4 < 0x80 || c4 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 4);
 					var u = ((c & 0x0F) << 18) | ((c2 & 0x7F) << 12) | ((c3 & 0x7F) << 6) | (c4 & 0x7F);
 					// surrogate pair
 					s += fcc( (u >> 10) + 0xD7C0 );

--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -349,10 +349,9 @@ class Bytes {
 	}
 
 	public function getString( pos : Int, len : Int, ?encoding : Encoding ) : String {
-		inline function fcc(c) return String.fromCharCode(c);
 		if( encoding == null ) encoding == UTF8;
 		if( encoding == UTF8Strict ) {
-			var s = "";
+			var s = new StringBuf();
 			var b = b;
 			var i = pos;
 			var max = pos+len;
@@ -361,7 +360,7 @@ class Bytes {
 				var c:Int = fastGet(b, i++);
 				if( c < 0x80 ) {
 					//if( c == 0 ) break;
-					s += fcc(c);
+					s.addChar(c);
 				} else if( c < 0xC0 ) { // invalid continuation byte
 					throw UnicodeDecodingError.InvalidContinuation(i - 1);
 				} else if( c < 0xC2 ) { // overlong sequence
@@ -370,7 +369,7 @@ class Bytes {
 					if( i + 1 > max ) throw UnicodeDecodingError.InsufficientData(i - 1);
 					var c2:Int = fastGet(b, i++);
 					if( c2 < 0x80 || c2 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 2);
-					s += fcc( ((c & 0x3F) << 6) | (c2 & 0x7F) );
+					s.addChar( ((c & 0x3F) << 6) | (c2 & 0x7F) );
 				} else if( c < 0xF0 ) {
 					if( i + 2 > max ) throw UnicodeDecodingError.InsufficientData(i - 1);
 					var c2:Int = fastGet(b, i++);
@@ -381,7 +380,7 @@ class Bytes {
 						if( c2 < 0x80 || c2 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 3);
 					}
 					if( c3 < 0x80 || c3 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 3);
-					s += fcc( ((c & 0x1F) << 12) | ((c2 & 0x7F) << 6) | (c3 & 0x7F) );
+					s.addChar( ((c & 0x1F) << 12) | ((c2 & 0x7F) << 6) | (c3 & 0x7F) );
 				} else if( c > 0xF4 ) {
 					throw UnicodeDecodingError.OutOfRange(i - 1);
 				} else {
@@ -400,11 +399,11 @@ class Bytes {
 					if( c4 < 0x80 || c4 > 0xBF ) throw UnicodeDecodingError.ExpectedContinuation(i - 4);
 					var u = ((c & 0x0F) << 18) | ((c2 & 0x7F) << 12) | ((c3 & 0x7F) << 6) | (c4 & 0x7F);
 					// surrogate pair
-					s += fcc( (u >> 10) + 0xD7C0 );
-					s += fcc( (u & 0x3FF) | 0xDC00 );
+					s.addChar( (u >> 10) + 0xD7C0 );
+					s.addChar( (u & 0x3FF) | 0xDC00 );
 				}
 			}
-			return s;
+			return s.toString();
 		}
 		#if !neko
 		if( pos < 0 || len < 0 || pos + len > length ) throw Error.OutsideBounds;
@@ -453,7 +452,7 @@ class Bytes {
 			return lua.Table.concat(tbl, '');
 		}
 		#else
-		var s = "";
+		var s = new StringBuf();
 		var b = b;
 		var i = pos;
 		var max = pos+len;
@@ -462,22 +461,22 @@ class Bytes {
 			var c = b[i++];
 			if( c < 0x80 ) {
 				if( c == 0 ) break;
-				s += fcc(c);
+				s.addChar(c);
 			} else if( c < 0xE0 )
-				s += fcc( ((c & 0x3F) << 6) | (b[i++] & 0x7F) );
+				s.addChar( ((c & 0x3F) << 6) | (b[i++] & 0x7F) );
 			else if( c < 0xF0 ) {
 				var c2 = b[i++];
-				s += fcc( ((c & 0x1F) << 12) | ((c2 & 0x7F) << 6) | (b[i++] & 0x7F) );
+				s.addChar( ((c & 0x1F) << 12) | ((c2 & 0x7F) << 6) | (b[i++] & 0x7F) );
 			} else {
 				var c2 = b[i++];
 				var c3 = b[i++];
 				var u = ((c & 0x0F) << 18) | ((c2 & 0x7F) << 12) | ((c3 & 0x7F) << 6) | (b[i++] & 0x7F);
 				// surrogate pair
-				s += fcc( (u >> 10) + 0xD7C0 );
-				s += fcc( (u & 0x3FF) | 0xDC00 );
+				s.addChar( (u >> 10) + 0xD7C0 );
+				s.addChar( (u & 0x3FF) | 0xDC00 );
 			}
 		}
-		return s;
+		return s.toString();
 		#end
 	}
 

--- a/std/haxe/io/Encoding.hx
+++ b/std/haxe/io/Encoding.hx
@@ -32,8 +32,8 @@ enum Encoding {
 	RawNative;
 	/**
 		Strict UTF-8 mode. A decoded string is guaranteed to be valid Unicode, any
-		error is indicated by throwing an error during decoding. Uses a native Haxe
-		implementation, so is slower than `UTF8` on most platforms.
+		error is indicated by throwing an error during decoding. Uses a pure Haxe
+		implementation, so it is slower than `UTF8` on most platforms.
 	**/
 	UTF8Strict;
 }

--- a/std/haxe/io/Encoding.hx
+++ b/std/haxe/io/Encoding.hx
@@ -30,4 +30,10 @@ enum Encoding {
 		Output the string the way the platform represent it in memory. This is the most efficient but is platform-specific
 	**/
 	RawNative;
+	/**
+		Strict UTF-8 mode. A decoded string is guaranteed to be valid Unicode, any
+		error is indicated by throwing an error during decoding. Uses a native Haxe
+		implementation, so is slower than `UTF8` on most platforms.
+	**/
+	UTF8Strict;
 }

--- a/std/haxe/io/Encoding.hx
+++ b/std/haxe/io/Encoding.hx
@@ -37,3 +37,31 @@ enum Encoding {
 	**/
 	UTF8Strict;
 }
+
+/**
+	This exception is raised when decoding invalid Unicode data using
+	Encoding.UTF8Strict. The `byteIndex` value indicates the position in the
+	`Bytes` object at which the erroneous Unicode sequence started.
+**/
+enum UnicodeDecodingError {
+	/**
+		A continuation byte was found, but a Unicode sequence was not started.
+	**/
+	InvalidContinuation(byteIndex:Int);
+	/**
+		A continuation byte was expected next.
+	**/
+	ExpectedContinuation(byteIndex:Int);
+	/**
+		An overlong Unicode sequence was found.
+	**/
+	Overlong(byteIndex:Int);
+	/**
+		The codepoint is out of Unicode range.
+	**/
+	OutOfRange(byteIndex:Int);
+	/**
+		More data was expected.
+	**/
+	InsufficientData(byteIndex:Int);
+}

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -295,6 +295,63 @@ test("()", "ä", "[]", ~/:(\w):/);
 test("a", "É", "b", ~/:(é):/i);
 test("a", "é", "b", ~/:(É):/i);
 
+function strictlyValid(str:String):Bool {
+	return try {
+		var bytes = haxe.io.Bytes.ofHex(str);
+		bytes.getString(0, bytes.length, UTF8Strict);
+		true;
+	} catch (e:Dynamic) false;
+}
+
+strictlyValid("00") == true;
+strictlyValid("01") == true;
+strictlyValid("7f") == true;
+strictlyValid("c280") == true;
+
+strictlyValid("dfbf") == true;
+strictlyValid("e0a080") == true;
+strictlyValid("ed9fbf") == true;
+
+// PUA codepoints are valid, although they do not have a character assigned
+strictlyValid("ee8080") == true;
+
+// last valid codepoint in the BMP with a character
+strictlyValid("efbfbd") == true;
+
+// last two codepoints on any plane are invalid
+// but the encoding is valid UTF-8
+strictlyValid("efbfbe") == true; // U+FFFE
+strictlyValid("efbfbf") == true; // U+FFFF
+
+// incomplete or overlong sequences
+// http://www.unicode.org/versions/corrigendum1.html
+strictlyValid("c0") == false;
+strictlyValid("c07f") == false;
+strictlyValid("c080") == false;
+strictlyValid("c1") == false;
+strictlyValid("c17f") == false;
+strictlyValid("c180") == false;
+
+strictlyValid("e0") == false;
+strictlyValid("e0a0") == false;
+strictlyValid("e0a000") == false;
+strictlyValid("e08080") == false;
+strictlyValid("e09f80") == false;
+strictlyValid("e1") == false;
+strictlyValid("e180") == false;
+strictlyValid("e17f80") == false;
+strictlyValid("e1807f") == false;
+
+// non-BMP incomplete or overlong
+strictlyValid("f0") == false;
+strictlyValid("f090") == false;
+strictlyValid("f09080") == false;
+strictlyValid("f0808080") == false;
+strictlyValid("f18080") == false;
+strictlyValid("f480807f") == false;
+strictlyValid("f5808080") == false;
+strictlyValid("ff808080") == false;
+
 #else
 1 == 1;
 #end

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -300,7 +300,7 @@ function strictlyValid(str:String):Bool {
 		var bytes = haxe.io.Bytes.ofHex(str);
 		bytes.getString(0, bytes.length, UTF8Strict);
 		true;
-	} catch (e:Dynamic) false;
+	} catch (e:haxe.io.Encoding.UnicodeDecodingError) false;
 }
 
 strictlyValid("00") == true;


### PR DESCRIPTION
Adds a pure Haxe implementation of a strict UTF-8 encoding. Throws on decoding errors. Likely much slower than any native implementation (or even the default `UTF8` Haxe implementation).