### PR TITLE
print no-argument function types as `()->...`, not `Void->...` (closes #8148)

### DIFF
--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -160,7 +160,7 @@ module BetterErrors = struct
 		| TAbstract (a,tl) ->
 			s_type_path a.a_path ^ s_type_params ctx tl
 		| TFun ([],_) ->
-			"Void -> ..."
+			"() -> ..."
 		| TFun (l,t) ->
 			let args = match l with
 				| [] -> "()"

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -55,7 +55,7 @@ let rec s_type ctx t =
 	| TAbstract (a,tl) ->
 		s_type_path a.a_path ^ s_type_params ctx tl
 	| TFun ([],t) ->
-		"Void -> " ^ s_fun ctx t false
+		"() -> " ^ s_fun ctx t false
 	| TFun (l,t) ->
 		let args = match l with
 			| [] -> "()"

--- a/src/generators/genhxold.ml
+++ b/src/generators/genhxold.ml
@@ -107,7 +107,7 @@ let generate_type com t =
 		| TDynamic t2 ->
 			if t == t2 then "Dynamic" else "Dynamic<" ^ stype t2 ^ ">"
 		| TFun ([],ret) ->
-			"Void -> " ^ ftype ret
+			"() -> " ^ ftype ret
 		| TFun (args,ret) ->
 			String.concat " -> " (List.map (fun (_,_,t) -> ftype t) args) ^ " -> " ^ ftype ret
 	and ftype t =

--- a/tests/display/src/DisplayTestContext.hx
+++ b/tests/display/src/DisplayTestContext.hx
@@ -93,7 +93,7 @@ class DisplayTestContext {
 		return if (result == null) [] else result.diagnostics;
 	}
 
-	public function hasErrorMessage(f:Void->Void, message:String) {
+	public function hasErrorMessage(f:()->Void, message:String) {
 		return try {
 			f();
 			false;

--- a/tests/display/src/cases/Abstract.hx
+++ b/tests/display/src/cases/Abstract.hx
@@ -33,15 +33,15 @@ class Abstract extends DisplayTestCase {
 	**/
 	function test2() {
 		var top1 = toplevel(pos(1));
-		eq(true, hasToplevel(top1, "member", "instanceField", "Void -> Void"));
-		eq(true, hasToplevel(top1, "static", "staticField", "Void -> Void"));
+		eq(true, hasToplevel(top1, "member", "instanceField", "() -> Void"));
+		eq(true, hasToplevel(top1, "static", "staticField", "() -> Void"));
 
 		var top2 = toplevel(pos(2));
-		eq(false, hasToplevel(top2, "member", "instanceField", "Void -> Void"));
-		eq(true, hasToplevel(top2, "static", "staticField", "Void -> Void"));
+		eq(false, hasToplevel(top2, "member", "instanceField", "() -> Void"));
+		eq(true, hasToplevel(top2, "static", "staticField", "() -> Void"));
 
 		var fields = fields(pos(3));
-		eq(false, hasField(fields, "instanceField", "Void -> Void"));
-		eq(true, hasField(fields, "staticField", "Void -> Void"));
+		eq(false, hasField(fields, "instanceField", "() -> Void"));
+		eq(true, hasField(fields, "staticField", "() -> Void"));
 	}
 }

--- a/tests/display/src/cases/ArrowFunctions.hx
+++ b/tests/display/src/cases/ArrowFunctions.hx
@@ -10,7 +10,7 @@ class ArrowFunctions extends DisplayTestCase {
 	**/
 	@:funcCode function testBodyCompletion1() {
 		eq(true, hasField(fields(pos(1)), "foo", "Int"));
-		eq(true, hasField(fields(pos(2)), "copy", "Void -> Array<Int>"));
+		eq(true, hasField(fields(pos(2)), "copy", "() -> Array<Int>"));
 	}
 
 	/**
@@ -22,7 +22,7 @@ class ArrowFunctions extends DisplayTestCase {
 		}
 	**/
 	function testBodyCompletion2() {
-		eq(true, hasField(fields(pos(1)), "getName", "Void -> String"));
+		eq(true, hasField(fields(pos(1)), "getName", "() -> String"));
 	}
 
 	/**

--- a/tests/display/src/cases/Issue6405.hx
+++ b/tests/display/src/cases/Issue6405.hx
@@ -22,6 +22,6 @@ class Issue6405 extends DisplayTestCase {
 		eq("haxe.macro.Expr", type(pos(1)));
 		var fields = fields(pos(4));
 		eq(true, hasField(fields, "expr", "haxe.macro.ExprDef"));
-		eq(true, hasField(fields, "toString", "Void -> String"));
+		eq(true, hasField(fields, "toString", "() -> String"));
 	}
 }

--- a/tests/display/src/cases/Issue6421.hx
+++ b/tests/display/src/cases/Issue6421.hx
@@ -16,6 +16,6 @@ class Issue6421 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq(false, hasField(fields(pos(1)), "foo", "Void -> Void"));
+		eq(false, hasField(fields(pos(1)), "foo", "() -> Void"));
 	}
 }

--- a/tests/display/src/cases/Issue6442.hx
+++ b/tests/display/src/cases/Issue6442.hx
@@ -8,6 +8,6 @@ class Issue6442 extends DisplayTestCase {
 	**/
 	function test() {
 		eq(range(1, 3), position(pos(2)));
-		eq("Void -> Void", type(pos(2)));
+		eq("() -> Void", type(pos(2)));
 	}
 }

--- a/tests/display/src/cases/Issue6756.hx
+++ b/tests/display/src/cases/Issue6756.hx
@@ -7,6 +7,6 @@ class Issue6756 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq("Void -> Void", type(pos(1)));
+		eq("() -> Void", type(pos(1)));
 	}
 }

--- a/tests/display/src/cases/Issue6779.hx
+++ b/tests/display/src/cases/Issue6779.hx
@@ -13,6 +13,6 @@ class Issue6779 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq(true, hasField(fields(pos(1)), "f", "Void -> Void", "method"));
+		eq(true, hasField(fields(pos(1)), "f", "() -> Void", "method"));
 	}
 }

--- a/tests/display/src/cases/Issue7022.hx
+++ b/tests/display/src/cases/Issue7022.hx
@@ -11,6 +11,6 @@ class Issue7022 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq("Void -> cases.Main", type(pos(1)));
+		eq("() -> cases.Main", type(pos(1)));
 	}
 }

--- a/tests/display/src/cases/Issue7023.hx
+++ b/tests/display/src/cases/Issue7023.hx
@@ -9,8 +9,8 @@ class Issue7023 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		// eq("Void -> String", type(pos(1)));
-		eq("Void -> String", type(pos(2)));
-		eq("Void -> String", type(pos(3)));
+		// eq("() -> String", type(pos(1)));
+		eq("() -> String", type(pos(2)));
+		eq("() -> String", type(pos(3)));
 	}
 }

--- a/tests/display/src/cases/Issue7047.hx
+++ b/tests/display/src/cases/Issue7047.hx
@@ -3,7 +3,7 @@ package cases;
 class Issue7047 extends DisplayTestCase {
 	/**
 		class Main {
-			var f:Void->{-1-}
+			var f:()->{-1-}
 
 			static function main() {}
 		}

--- a/tests/display/src/cases/Issue7057.hx
+++ b/tests/display/src/cases/Issue7057.hx
@@ -5,7 +5,7 @@ class Issue7057 extends DisplayTestCase {
 		import haxe.Constraints.Constructible;
 
 		class Main {
-			@:generic static function main<T, TConstructible:Constructible<Void->Void>>() {
+			@:generic static function main<T, TConstructible:Constructible<()->Void>>() {
 				new {-1-}
 			}
 		}

--- a/tests/display/src/cases/Issue7061.hx
+++ b/tests/display/src/cases/Issue7061.hx
@@ -17,7 +17,7 @@ class Issue7061 extends DisplayTestCase {
 			static function main() {}
 			function new() f{-6-}oo(b{-1-}ar);
 			function notNew() foo(b{-7-}ar2);
-			function {-2-}foo{-3-}<T>(value:Either<Void->T,Void->Void>) {}
+			function {-2-}foo{-3-}<T>(value:Either<()->T,()->Void>) {}
 			function {-4-}bar{-5-}() {}
 			function bar2() return 1;
 		}
@@ -25,7 +25,7 @@ class Issue7061 extends DisplayTestCase {
 	function test() {
 		eq(range(4, 5), position(pos(1)));
 		eq(range(2, 3), position(pos(6)));
-		eq("Void -> Void", type(pos(1)));
-		eq("Void -> Int", type(pos(7)));
+		eq("() -> Void", type(pos(1)));
+		eq("() -> Int", type(pos(7)));
 	}
 }

--- a/tests/display/src/cases/Issue7102.hx
+++ b/tests/display/src/cases/Issue7102.hx
@@ -4,7 +4,7 @@ class Issue7102 extends DisplayTestCase {
 	/**
 		import haxe.Constraints.Constructible;
 		class Main {
-			@:generic static function main<T, TConstructible:Constructible<Void->Void>>() {
+			@:generic static function main<T, TConstructible:Constructible<()->Void>>() {
 				new TConstructible({-1-});
 			}
 		}

--- a/tests/display/src/cases/Issue7248.hx
+++ b/tests/display/src/cases/Issue7248.hx
@@ -13,7 +13,7 @@ class Issue7248 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq(true, hasField(fields(pos(1)), "AStatic", "Void -> Void"));
+		eq(true, hasField(fields(pos(1)), "AStatic", "() -> Void"));
 		eq(false, hasField(fields(pos(1)), "NonStatic", "this : Int -> Void"));
 	}
 }

--- a/tests/display/src/cases/Issue7761.hx
+++ b/tests/display/src/cases/Issue7761.hx
@@ -16,6 +16,6 @@ class Issue7761 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq(true, hasField(fields(pos(1)), "foo", "Void -> Int"));
+		eq(true, hasField(fields(pos(1)), "foo", "() -> Int"));
 	}
 }

--- a/tests/display/src/cases/Issue8078.hx
+++ b/tests/display/src/cases/Issue8078.hx
@@ -16,6 +16,6 @@ class Issue8078 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq(true, hasField(fields(pos(1)), "append", "Void -> Void"));
+		eq(true, hasField(fields(pos(1)), "append", "() -> Void"));
 	}
 }

--- a/tests/display/src/cases/Issue8789.hx
+++ b/tests/display/src/cases/Issue8789.hx
@@ -18,6 +18,6 @@ class Issue8789 extends DisplayTestCase {
 	function test() {
 		var r = toplevel(pos(1));
 		eq(true, hasToplevel(r, "type", "Int8"));
-		eq(true, hasField(fields(pos(2)), "pvt", "Void -> Void"));
+		eq(true, hasField(fields(pos(2)), "pvt", "() -> Void"));
 	}
 }

--- a/tests/display/src/cases/Override.hx
+++ b/tests/display/src/cases/Override.hx
@@ -14,8 +14,8 @@ class Override extends DisplayTestCase {
 	**/
 	function test1() {
 		var fields = fields(pos(1));
-		eq(true, hasField(fields, "test2", "Void -> Int"));
-		eq(false, hasField(fields, "test1", "Void -> Int"));
+		eq(true, hasField(fields, "test2", "() -> Int"));
+		eq(false, hasField(fields, "test1", "() -> Int"));
 	}
 
 	/**
@@ -31,8 +31,8 @@ class Override extends DisplayTestCase {
 	**/
 	function test2() {
 		var fields = fields(pos(1));
-		eq(true, hasField(fields, "test2", "Void -> Int"));
-		eq(false, hasField(fields, "test1", "Void -> Int"));
+		eq(true, hasField(fields, "test2", "() -> Int"));
+		eq(false, hasField(fields, "test1", "() -> Int"));
 	}
 
 	/**
@@ -50,7 +50,7 @@ class Override extends DisplayTestCase {
 	**/
 	function test3() {
 		var fields = fields(pos(1));
-		eq(true, hasField(fields, "test2", "Void -> Int"));
-		eq(false, hasField(fields, "test1", "Void -> Int"));
+		eq(true, hasField(fields, "test2", "() -> Int"));
+		eq(false, hasField(fields, "test1", "() -> Int"));
 	}
 }

--- a/tests/display/src/cases/PropertyAccessors.hx
+++ b/tests/display/src/cases/PropertyAccessors.hx
@@ -14,7 +14,7 @@ class PropertyAccessors extends DisplayTestCase {
 	function test() {
 		eq(range(3, 4), position(pos(1)));
 		eq(range(5, 6), position(pos(2)));
-		eq("Void -> String", type(pos(1)));
+		eq("() -> String", type(pos(1)));
 		eq("(s : String) -> String", type(pos(2)));
 	}
 }

--- a/tests/display/src/cases/StaticExtension.hx
+++ b/tests/display/src/cases/StaticExtension.hx
@@ -19,8 +19,8 @@ class StaticExtension extends DisplayTestCase {
 	**/
 	function test1() {
 		var fields = fields(pos(1));
-		eq(true, hasField(fields, "doSomething", "Void -> Void"));
-		eq(true, hasField(fields, "doSomethingElse", "Void -> Void"));
+		eq(true, hasField(fields, "doSomething", "() -> Void"));
+		eq(true, hasField(fields, "doSomethingElse", "() -> Void"));
 	}
 
 	/**
@@ -41,8 +41,8 @@ class StaticExtension extends DisplayTestCase {
 	**/
 	function test2() {
 		var fields = fields(pos(1));
-		eq(true, hasField(fields, "doSomething", "Void -> Void"));
-		eq(true, hasField(fields, "doSomethingElse", "Void -> Void"));
+		eq(true, hasField(fields, "doSomething", "() -> Void"));
+		eq(true, hasField(fields, "doSomethingElse", "() -> Void"));
 	}
 
 	/**

--- a/tests/display/src/cases/Super.hx
+++ b/tests/display/src/cases/Super.hx
@@ -31,6 +31,6 @@ class Super extends DisplayTestCase {
 		eq(range(1, 2), position(pos(3)));
 		eq("cases.Base<String>", type(pos(3)));
 		eq(range(4, 5), position(pos(6)));
-		eq("Void -> Void", type(pos(6)));
+		eq("() -> Void", type(pos(6)));
 	}
 }

--- a/tests/misc/cs/projects/Issue3526/IncompatibleCombinations.hx
+++ b/tests/misc/cs/projects/Issue3526/IncompatibleCombinations.hx
@@ -2,10 +2,10 @@ import cs.Constraints;
 import haxe.Constraints.Constructible;
 
 @:nativeGen
-class StructAndConstructible<T:CsStruct & Constructible<Void->Void>> {}
+class StructAndConstructible<T:CsStruct & Constructible<()->Void>> {}
 
 @:nativeGen
-class ConstructibleAndStruct<T:Constructible<Void->Void> & CsStruct> {}
+class ConstructibleAndStruct<T:Constructible<()->Void> & CsStruct> {}
 
 @:nativeGen
 class StructAndClass<T:CsStruct & CsClass> {}
@@ -21,8 +21,8 @@ class UnmanagedAndStruct<T:CsUnmanaged & CsStruct> {}
 class StructAndUnmanaged<T:CsStruct & CsUnmanaged> {}
 
 @:nativeGen
-class UnmanagedAndConstructible<T:CsUnmanaged & Constructible<Void->Void>> {}
+class UnmanagedAndConstructible<T:CsUnmanaged & Constructible<()->Void>> {}
 
 @:nativeGen
-class ConstructibleAndUnmanaged<T:Constructible<Void->Void> & CsUnmanaged> {}
+class ConstructibleAndUnmanaged<T:Constructible<()->Void> & CsUnmanaged> {}
 #end

--- a/tests/misc/cs/projects/Issue3526/Main.hx
+++ b/tests/misc/cs/projects/Issue3526/Main.hx
@@ -10,8 +10,8 @@ import haxe.Constraints.Constructible;
 class TestCs {
     extern public static function testClass<T:CsClass>(t:T):Void;
     extern public static function testStruct<T:CsStruct>(t:T):Void;
-    extern public static function testConstructible<T:Constructible<Void->Void>>(t:T):Void;
-    extern public static function testConstructibleClass<T:Constructible<Void->Void> & CsClass>(t:T):Void;
+    extern public static function testConstructible<T:Constructible<()->Void>>(t:T):Void;
+    extern public static function testConstructibleClass<T:Constructible<()->Void> & CsClass>(t:T):Void;
 }
 
 @:nativeGen
@@ -32,8 +32,8 @@ class Main {
 
     static function testClass<T:CsClass>(value:T) TestCs.testClass(value);
     static function testStruct<T:CsStruct>(value:T) TestCs.testStruct(value);
-    static function testConstructible<T:Constructible<Void->Void>>(value:T) TestCs.testConstructible(value);
-    static function testConstructibleClass<T:Constructible<Void->Void> & CsClass>(value:T) TestCs.testConstructibleClass(value);
+    static function testConstructible<T:Constructible<()->Void>>(value:T) TestCs.testConstructible(value);
+    static function testConstructibleClass<T:Constructible<()->Void> & CsClass>(value:T) TestCs.testConstructibleClass(value);
 }
 
 @:nativeGen
@@ -49,13 +49,13 @@ class Struct<T:CsStruct> {
 }
 
 @:nativeGen
-class Constructible_<T:Constructible<Void->Void>> {
+class Constructible_<T:Constructible<()->Void>> {
     public var value:T;
     public function new(value:T) this.value = value;
 }
 
 @:nativeGen
-class ConstructibleClass<T:Constructible<Void->Void> & CsClass> {
+class ConstructibleClass<T:Constructible<()->Void> & CsClass> {
     public var value:T;
     public function new(value:T) this.value = value;
 }

--- a/tests/misc/cs/projects/Issue3526/incompatible-combinations-fail.hxml.stderr
+++ b/tests/misc/cs/projects/Issue3526/incompatible-combinations-fail.hxml.stderr
@@ -1,8 +1,8 @@
-IncompatibleCombinations.hx:5: characters 1-72 : The new() constraint cannot be combined with the struct constraint.
-IncompatibleCombinations.hx:8: characters 1-72 : The new() constraint cannot be combined with the struct constraint.
+IncompatibleCombinations.hx:5: characters 1-70 : The new() constraint cannot be combined with the struct constraint.
+IncompatibleCombinations.hx:8: characters 1-70 : The new() constraint cannot be combined with the struct constraint.
 IncompatibleCombinations.hx:11: characters 1-46 : The class constraint cannot be combined with the struct constraint.
 IncompatibleCombinations.hx:14: characters 1-46 : The class constraint cannot be combined with the struct constraint.
 IncompatibleCombinations.hx:18: characters 1-54 : The unmanaged constraint cannot be combined with the struct constraint.
 IncompatibleCombinations.hx:21: characters 1-54 : The unmanaged constraint cannot be combined with the struct constraint.
-IncompatibleCombinations.hx:24: characters 1-78 : The unmanaged constraint cannot be combined with the new() constraint.
-IncompatibleCombinations.hx:27: characters 1-78 : The unmanaged constraint cannot be combined with the new() constraint.
+IncompatibleCombinations.hx:24: characters 1-76 : The unmanaged constraint cannot be combined with the new() constraint.
+IncompatibleCombinations.hx:27: characters 1-76 : The unmanaged constraint cannot be combined with the new() constraint.

--- a/tests/misc/cs/projects/Issue7875/Main.hx
+++ b/tests/misc/cs/projects/Issue7875/Main.hx
@@ -12,7 +12,7 @@ class Test<T:A> {
 		test(function() return new WeakReference_1(a));
 	}
 
-	function test(cb:Void->WeakReference_1<T>):Void {}
+	function test(cb:()->WeakReference_1<T>):Void {}
 
 
 }

--- a/tests/misc/projects/Issue2263/import-completion.hxml.stderr
+++ b/tests/misc/projects/Issue2263/import-completion.hxml.stderr
@@ -1,6 +1,6 @@
 <list>
 <i n="pubV" k="var"><t>Int</t><d></d></i>
-<i n="pubM" k="method"><t>Void -&gt; Void</t><d></d></i>
+<i n="pubM" k="method"><t>() -&gt; Void</t><d></d></i>
 <i n="MyModule" k="type"><t>MyModule</t><d></d></i>
 <i n="OtherType" k="type"><t>OtherType</t><d></d></i>
 </list>

--- a/tests/misc/projects/Issue2263/subtype-static-completion.hxml.stderr
+++ b/tests/misc/projects/Issue2263/subtype-static-completion.hxml.stderr
@@ -1,4 +1,4 @@
 <list>
 <i n="pubV" k="var"><t>Int</t><d></d></i>
-<i n="pubM" k="method"><t>Void -&gt; Void</t><d></d></i>
+<i n="pubM" k="method"><t>() -&gt; Void</t><d></d></i>
 </list>

--- a/tests/misc/projects/Issue3288/with-type.hxml.stderr
+++ b/tests/misc/projects/Issue3288/with-type.hxml.stderr
@@ -1,6 +1,6 @@
 <list>
 <i n="f1" k="var"><t>Int</t><d></d></i>
-<i n="f2" k="method"><t>Void -&gt; Void</t><d></d></i>
+<i n="f2" k="method"><t>() -&gt; Void</t><d></d></i>
 <i n="AnotherOne" k="type"><t>AnotherOne</t><d></d></i>
 <i n="OtherType" k="type"><t>OtherType</t><d></d></i>
 </list>

--- a/tests/misc/projects/Issue3975/Main.hx
+++ b/tests/misc/projects/Issue3975/Main.hx
@@ -1,6 +1,6 @@
 class Main {
 	static function main() {
 		var a = ["a", "b"];
-		var a2 : { var pop(get,never) : Void -> Void; } = a;
+		var a2 : { var pop(get,never) : () -> Void; } = a;
 	}
 }

--- a/tests/misc/projects/Issue3975/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue3975/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
-Main.hx:4: characters 3-55 : Array<String> should be { pop : Void -> Void }
+Main.hx:4: characters 3-55 : Array<String> should be { pop : () -> Void }
 Main.hx:4: characters 3-55 : Field pop is method but should be (get,never)

--- a/tests/misc/projects/Issue3975/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue3975/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
-Main.hx:4: characters 3-55 : Array<String> should be { pop : () -> Void }
-Main.hx:4: characters 3-55 : Field pop is method but should be (get,never)
+Main.hx:4: characters 3-53 : Array<String> should be { pop : () -> Void }
+Main.hx:4: characters 3-53 : Field pop is method but should be (get,never)

--- a/tests/misc/projects/Issue4364/Main.hx
+++ b/tests/misc/projects/Issue4364/Main.hx
@@ -12,7 +12,7 @@ abstract A(C) to C {
 }
 
 @:generic
-class G<T:haxe.Constraints.Constructible<Void->Void>> {
+class G<T:haxe.Constraints.Constructible<()->Void>> {
 	public function new() {}
 	public function make():T return new T();
 }

--- a/tests/misc/projects/Issue4364/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue4364/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
 Main.hx:22: characters 15-19 : Constraint check failure for G.T
-Main.hx:22: characters 15-19 : A should be haxe.Constructible<Void -> Void>
+Main.hx:22: characters 15-19 : A should be haxe.Constructible<() -> Void>

--- a/tests/misc/projects/Issue4456/Main.hx
+++ b/tests/misc/projects/Issue4456/Main.hx
@@ -9,7 +9,7 @@ class A {
 }
 
 @:generic
-class B<T:haxe.Constraints.Constructible<Void->Void>> {
+class B<T:haxe.Constraints.Constructible<()->Void>> {
 	var items:Map<Int,A>;
 
 	public function new() {

--- a/tests/misc/projects/Issue4651/compile.hxml.stderr
+++ b/tests/misc/projects/Issue4651/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <list>
-<i n="main" k="method"><t>Void -&gt; Unknown&lt;0&gt;</t><d></d></i>
+<i n="main" k="method"><t>() -&gt; Unknown&lt;0&gt;</t><d></d></i>
 </list>

--- a/tests/misc/projects/Issue4764/Main1.hx
+++ b/tests/misc/projects/Issue4764/Main1.hx
@@ -1,6 +1,6 @@
 class F {
     @:generic
-    public static function make<T:haxe.Constraints.Constructible<Void->Void>>() {
+    public static function make<T:haxe.Constraints.Constructible<()->Void>>() {
         return new T();
     }
 }

--- a/tests/misc/projects/Issue4764/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue4764/compile1-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main1.hx:4: characters 16-23 : Cannot construct haxe.Constructible<Void -> Void>
+Main1.hx:4: characters 16-23 : Cannot construct haxe.Constructible<() -> Void>

--- a/tests/misc/projects/Issue4803/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue4803/compile-fail.hxml.stderr
@@ -1,5 +1,5 @@
 Main.hx:16: lines 16-19 : Could not find a suitable overload, reasons follow
-Main.hx:16: lines 16-19 : Overload resolution failed for Void -> JQuery
+Main.hx:16: lines 16-19 : Overload resolution failed for () -> JQuery
 Main.hx:16: lines 16-19 : Too many arguments
 Main.hx:16: lines 16-19 : Overload resolution failed for (handler : (Event -> Void)) -> JQuery
 Main.hx:18: characters 8-17 : Object requires field y

--- a/tests/misc/projects/Issue5122/compile.hxml.stderr
+++ b/tests/misc/projects/Issue5122/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <type p="$$normPath(::cwd::/Main.hx):7: characters 9-14">
-Void -&gt; String
+() -&gt; String
 </type>

--- a/tests/misc/projects/Issue5128/compile.hxml.stderr
+++ b/tests/misc/projects/Issue5128/compile.hxml.stderr
@@ -1,3 +1,3 @@
 <type p="$$normPath(::cwd::/Main.hx):2: characters 18-22">
-Void -&gt; Void
+() -&gt; Void
 </type>

--- a/tests/misc/projects/Issue6030/Main1.hx
+++ b/tests/misc/projects/Issue6030/Main1.hx
@@ -1,5 +1,5 @@
 class Main1 {
-    public var ok(default,null):Void->Void;
+    public var ok(default,null):()->Void;
     public var stillOk(default,never) = (function(){return function(){trace("This works.");};})();
     public var notOk(default,never) = (function(){return function(){trace("This does not work. "+this);};})();
 

--- a/tests/misc/projects/Issue6796/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6796/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
-Main.hx:3: characters 21-25 : Array access is not allowed on Void -> Unknown<0>
+Main.hx:3: characters 21-25 : Array access is not allowed on () -> Unknown<0>
 Main.hx:3: characters 21-25 : For function argument 'v'

--- a/tests/misc/projects/Issue6810/Fail.hx
+++ b/tests/misc/projects/Issue6810/Fail.hx
@@ -10,5 +10,5 @@ class Fail {
 
 	static function void():Void {}
 	static function fakeVoid():FakeVoid {}
-	static function test<T:NotVoid>(f:Void->T):T return f();
+	static function test<T:NotVoid>(f:()->T):T return f();
 }

--- a/tests/misc/projects/Issue6810/Main.hx
+++ b/tests/misc/projects/Issue6810/Main.hx
@@ -6,6 +6,6 @@ class Main {
 		test(function() return "test");
 	}
 
-	static function test<T:NotVoid>(f:Void->T):T return f();
+	static function test<T:NotVoid>(f:()->T):T return f();
 }
 

--- a/tests/misc/projects/Issue7905/compile.hxml.stderr
+++ b/tests/misc/projects/Issue7905/compile.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:22: characters 11-18 : Warning : Void -> Cls0
+Main.hx:22: characters 11-18 : Warning : () -> Cls0

--- a/tests/misc/projects/Issue8618/NoClosureClass.hx
+++ b/tests/misc/projects/Issue8618/NoClosureClass.hx
@@ -1,6 +1,6 @@
 @:noClosure
 class NoClosureClass {
-	static public var notMethod:Void->Void;
+	static public var notMethod:()->Void;
 	static public function staticMethod() {}
 	public function instanceMethod() {}
 }

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -185,12 +185,12 @@ class TestStrict {
 	}
 
 	static function call_onNullableValue_shouldFail() {
-		var fn:Null<Void->Void> = null;
+		var fn:Null<()->Void> = null;
 		shouldFail(fn());
 	}
 
 	static function call_onNotNullableValue_shouldPass() {
-		var fn:Void->Void = function() {}
+		var fn:()->Void = function() {}
 		fn();
 	}
 
@@ -734,8 +734,8 @@ class TestStrict {
 	}
 
 	static function functionWithNullableReturnType_toVoidFunction_shouldPass() {
-		var n:Void->Null<String> = () -> null;
-		var f:Void->Void = n;
+		var n:()->Null<String> = () -> null;
+		var f:()->Void = n;
 	}
 
 	static public function tryBlock_couldNotBeDeadEndForOuterBlock() {
@@ -804,7 +804,7 @@ class TestStrict {
 			recursive(() -> a.length);
 		}
 	}
-	static function recursive(cb:Void->Int) {
+	static function recursive(cb:()->Int) {
 		if(Std.random(10) == 0) {
 			recursive(cb);
 		} else {

--- a/tests/optimization/src/issues/Issue5436.hx
+++ b/tests/optimization/src/issues/Issue5436.hx
@@ -11,10 +11,10 @@ class Issue5436 {
         inlineMe(function() { });
     }
 
-    static inline function inlineMe(f:Void -> Void) {
+    static inline function inlineMe(f:() -> Void) {
         call(f);
         call(f);
     }
 
-	static function call(f:Void -> Void) { }
+	static function call(f:() -> Void) { }
 }

--- a/tests/optimization/src/issues/Issue6715.hx
+++ b/tests/optimization/src/issues/Issue6715.hx
@@ -53,10 +53,10 @@ class Issue6715 {
 		insanity4(function() var x = 1);
 	}
 
-	static var x:Void->Void;
+	static var x:()->Void;
 
 	// Mixed: inline calls, reference reads
-	static inline function insanity(f:Void -> Void)
+	static inline function insanity(f:() -> Void)
 	{
 		x = f;
 		x = f;
@@ -68,7 +68,7 @@ class Issue6715 {
 	}
 
 	// Only calls: inline all
-	static inline function insanity2(f:Void -> Void)
+	static inline function insanity2(f:() -> Void)
 	{
 		f();
 		f();
@@ -76,13 +76,13 @@ class Issue6715 {
 	}
 
 	// Referenced once: inline
-	static inline function insanity3(f:Void -> Void)
+	static inline function insanity3(f:() -> Void)
 	{
 		x = f;
 	}
 
 	// Referenced multiple times: temp var
-	static inline function insanity4(f:Void -> Void)
+	static inline function insanity4(f:() -> Void)
 	{
 		x = f;
 		x = f;

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -37,7 +37,7 @@ class TestCase implements ITest {
 		server.stop();
 	}
 
-	function runHaxe(args:Array<String>, done:Void->Void) {
+	function runHaxe(args:Array<String>, done:()->Void) {
 		messages = [];
 		errorMessages = [];
 		server.rawRequest(args, null, function(result) {
@@ -54,7 +54,7 @@ class TestCase implements ITest {
 		}, sendErrorMessage);
 	}
 
-	function runHaxeJson<TParams, TResponse>(args:Array<String>, method:HaxeRequestMethod<TParams, TResponse>, methodArgs:TParams, done:Void->Void) {
+	function runHaxeJson<TParams, TResponse>(args:Array<String>, method:HaxeRequestMethod<TParams, TResponse>, methodArgs:TParams, done:()->Void) {
 		var methodArgs = {method: method, id: 1, params: methodArgs};
 		args = args.concat(['--display', Json.stringify(methodArgs)]);
 		runHaxe(args, done);

--- a/tests/unit/src/unit/MyAbstract.hx
+++ b/tests/unit/src/unit/MyAbstract.hx
@@ -320,6 +320,6 @@ abstract ExposingAbstract<S>(Array<S>) {
 #end
 
 enum abstract GADTEnumAbstract<T:haxe.Constraints.Function>(Int) {
-	var A:GADTEnumAbstract<Void->Void> = 1;
+	var A:GADTEnumAbstract<()->Void> = 1;
 	var B:GADTEnumAbstract<Int->Void> = 2;
 }

--- a/tests/unit/src/unit/Test.hx
+++ b/tests/unit/src/unit/Test.hx
@@ -39,11 +39,11 @@ class Test implements utest.ITest {
 		Assert.fail(message, pos);
 	}
 
-	function exc( f : Void -> Void, ?pos:haxe.PosInfos ) {
+	function exc( f : () -> Void, ?pos:haxe.PosInfos ) {
 		Assert.raises(f, pos);
 	}
 
-	function unspec( f : Void -> Void, ?pos ) {
+	function unspec( f : () -> Void, ?pos ) {
 		try {
 			f();
 		} catch( e : Dynamic ) {

--- a/tests/unit/src/unit/TestArrowFunctions.hx
+++ b/tests/unit/src/unit/TestArrowFunctions.hx
@@ -6,8 +6,8 @@ abstract W(Int) from Int {
 
 class TestArrowFunctions extends Test {
 
-	var f0_0: Void -> Int;
-	var f0_1: Void -> W;
+	var f0_0: () -> Int;
+	var f0_1: () -> W;
 
 	var f1_0: Int->Int;
 	var f1_1: ?Int->Int;
@@ -44,8 +44,8 @@ class TestArrowFunctions extends Test {
 		f0_0 = () -> 1;
 
 		f0_0 = (() -> 1);
-		f0_0 = (() -> 1:Void->Int);
-		f0_0 = cast (() -> 1:Void->Int);
+		f0_0 = (() -> 1:()->Int);
+		f0_0 = cast (() -> 1:()->Int);
 
 		v0 = f0_0();
 

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -327,7 +327,7 @@ class TestExceptions extends Test {
 		eq("caught Throwable: msg", raise(() -> throw new java.lang.Exception("msg")));
 	}
 
-	function raise<T>(f:Void -> String) {
+	function raise<T>(f:() -> String) {
 		return try {
 			f();
 		} catch(e:NativeExceptionChild) {

--- a/tests/unit/src/unit/TestIO.hx
+++ b/tests/unit/src/unit/TestIO.hx
@@ -8,7 +8,7 @@ class TestIO extends Test {
 		check(true);
 	}
 
-	function excv<T>( f:Void -> Void, e : T, ?pos ) {
+	function excv<T>( f:() -> Void, e : T, ?pos ) {
 		try {
 			f();
 			eq(null,e,pos);

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -6,7 +6,7 @@ import unit.Test.*;
 import haxe.ds.List;
 
 final asyncWaits = new Array<haxe.PosInfos>();
-final asyncCache = new Array<Void -> Void>();
+final asyncCache = new Array<() -> Void>();
 
 @:access(unit.Test)
 #if js

--- a/tests/unit/src/unit/TestPhp.hx
+++ b/tests/unit/src/unit/TestPhp.hx
@@ -173,8 +173,8 @@ class TestPhp extends Test
 	}
 
 	function testClosureComparison() {
-		var fn1:Void->Void;
-		var fn2:Void->Void;
+		var fn1:()->Void;
+		var fn2:()->Void;
 		eq(ClosureDummy.testStatic, ClosureDummy.testStatic);
 		//Waiting for a fix: https://github.com/HaxeFoundation/haxe/issues/6719
 		// t(ClosureDummy.testStatic == ClosureDummy.testStatic);
@@ -345,7 +345,7 @@ enum Annotation {
 	Const(i:String);
 }
 
-private typedef Func = Void->Void;
+private typedef Func = ()->Void;
 
 private abstract FunctionCaller(Func->Void) to Func->Void {
 	public function new(f:Func->Void) this = f;

--- a/tests/unit/src/unit/TestType.hx
+++ b/tests/unit/src/unit/TestType.hx
@@ -249,7 +249,7 @@ class TestType extends Test {
 		eq(7, optfunc.bind(_, 2, _)(1, 4));
 
 		var foo = function ( x : Int, ?p : haxe.PosInfos ) { return "foo" + x; }
-		var f : Void -> String = foo.bind(0);
+		var f : () -> String = foo.bind(0);
  		eq("foo0", f());
 
 		var foo = function(bar = 2) { return bar; };
@@ -799,7 +799,7 @@ class TestType extends Test {
 	}
 
 	function testGADTEnumAbstract() {
-		var expectedA:unit.MyAbstract.GADTEnumAbstract<Void->Void>;
+		var expectedA:unit.MyAbstract.GADTEnumAbstract<()->Void>;
 		var expectedB:unit.MyAbstract.GADTEnumAbstract<Int->Void>;
 		typedAs(unit.MyAbstract.GADTEnumAbstract.A, expectedA);
 		typedAs(unit.MyAbstract.GADTEnumAbstract.B, expectedB);

--- a/tests/unit/src/unit/issues/Issue2184.hx
+++ b/tests/unit/src/unit/issues/Issue2184.hx
@@ -8,6 +8,6 @@ private abstract BoxedInt({ val : Int }) from { val : Int } {
 class Issue2184 extends Test {
 	function test() {
 		var test = function () return new BoxedInt({ val : 5 });
-		t(unit.HelperMacros.typeError(var z:Void->Int = test));
+		t(unit.HelperMacros.typeError(var z:()->Int = test));
 	}
 }

--- a/tests/unit/src/unit/issues/Issue2614.hx
+++ b/tests/unit/src/unit/issues/Issue2614.hx
@@ -1,7 +1,7 @@
 package unit.issues;
 import unit.Test;
 
-abstract Lazy<T>(Void->T) {
+abstract Lazy<T>(()->T) {
 	public function new(f) {
 		this = f;
 	}

--- a/tests/unit/src/unit/issues/Issue2622.hx
+++ b/tests/unit/src/unit/issues/Issue2622.hx
@@ -20,7 +20,7 @@ class Issue2622 extends Test {
 		return test(v);
 	}
 
-	static function bar(test:Void->Void) {
+	static function bar(test:()->Void) {
 
 	}
 }

--- a/tests/unit/src/unit/issues/Issue2668.hx.disabled
+++ b/tests/unit/src/unit/issues/Issue2668.hx.disabled
@@ -22,7 +22,7 @@ class Issue2688 extends Test {
 @:hxGen private class Child<A> extends NativeGen
 {
 	public var task:Array<A> -> Void;
-	public function new(tsk:Void->Void)
+	public function new(tsk:()->Void)
 	{
 		super();
 		task = function(x) {

--- a/tests/unit/src/unit/issues/Issue2688.hx
+++ b/tests/unit/src/unit/issues/Issue2688.hx
@@ -24,7 +24,7 @@ private class A {
 private class B extends A {
   public var tasks:Int->Void;
 
-  public function new(task:Void->Void) {
+  public function new(task:()->Void) {
     super();
     tasks = function(i) {
       for (j in 0...i) {

--- a/tests/unit/src/unit/issues/Issue3303.hx
+++ b/tests/unit/src/unit/issues/Issue3303.hx
@@ -7,7 +7,7 @@ class Issue3303 extends Test {
 		eq(null,ret());
 	}
 
-	static function createClosure<T>(v:Vector<T>):Void->Vector<T>
+	static function createClosure<T>(v:Vector<T>):()->Vector<T>
 	{
 		return function() return v;
 	}

--- a/tests/unit/src/unit/issues/Issue3513.hx
+++ b/tests/unit/src/unit/issues/Issue3513.hx
@@ -5,11 +5,11 @@ private enum Either<L, R> {
 	Right(r:R);
 }
 
-private abstract LazyGenerator<Data, End>(Void->Either<Data, End>) from Void->Either<Data, End> {
+private abstract LazyGenerator<Data, End>(()->Either<Data, End>) from ()->Either<Data, End> {
 	public function next():Either<Data, End>
 		return (this)();
 
-	@:from static function infinite<Data, End>(f:Void->Data):LazyGenerator<Data, End>
+	@:from static function infinite<Data, End>(f:()->Data):LazyGenerator<Data, End>
 		return function () return Left(f());
 }
 

--- a/tests/unit/src/unit/issues/Issue3578.hx
+++ b/tests/unit/src/unit/issues/Issue3578.hx
@@ -14,8 +14,8 @@ class Issue3578 extends Test
 
 private class TestG
 {
-	public var func:Void->Void;
-	public function new(callback:Void->Void)
+	public var func:()->Void;
+	public function new(callback:()->Void)
 	{
 		function x()
 		{

--- a/tests/unit/src/unit/issues/Issue3967.hx
+++ b/tests/unit/src/unit/issues/Issue3967.hx
@@ -19,7 +19,7 @@ class Issue3967 extends Test {
 	}
 
 	function testNicolas() {
-		var x:{ var test(default,never) : Void -> String; } = new A("foo");
+		var x:{ var test(default,never) : () -> String; } = new A("foo");
 		eq("foo", x.test());
 	}
 }

--- a/tests/unit/src/unit/issues/Issue4327.hx
+++ b/tests/unit/src/unit/issues/Issue4327.hx
@@ -1,7 +1,7 @@
 package unit.issues;
 
 @:callable
-abstract Example(Void->String) {
+abstract Example(()->String) {
 	public function new() {
 		this = fun;
 	}

--- a/tests/unit/src/unit/issues/Issue4457.hx
+++ b/tests/unit/src/unit/issues/Issue4457.hx
@@ -5,7 +5,7 @@ private class A {
 }
 
 @:generic
-private class B<T:haxe.Constraints.Constructible<Void->Void>> extends A {
+private class B<T:haxe.Constraints.Constructible<()->Void>> extends A {
 }
 
 class Issue4457 extends Test

--- a/tests/unit/src/unit/issues/Issue4798.hx
+++ b/tests/unit/src/unit/issues/Issue4798.hx
@@ -1,6 +1,6 @@
 package unit.issues;
 
-private abstract Lazy<T>(Void->T) {
+private abstract Lazy<T>(()->T) {
 	inline function new(r) this = r;
 
 	@:to public inline function get():T

--- a/tests/unit/src/unit/issues/Issue5027.hx
+++ b/tests/unit/src/unit/issues/Issue5027.hx
@@ -2,7 +2,7 @@ package unit.issues;
 
 class Issue5027 extends Test {
 	function test() {
-		var f:Void->Void = function() return null;
+		var f:()->Void = function() return null;
 		f();
 		noAssert();
 	}

--- a/tests/unit/src/unit/issues/Issue5108.hx
+++ b/tests/unit/src/unit/issues/Issue5108.hx
@@ -8,12 +8,12 @@ class Issue5108 extends Test {
 }
 
 class Signal implements ISignal {
-	public function add(listener:Void->Void):Void {}
+	public function add(listener:()->Void):Void {}
 	public function destroy():Void {}
 }
 
 interface ISignal extends IDestroyable2 {
-	public function add(listener:Void->Void):Void;
+	public function add(listener:()->Void):Void;
 }
 
 interface IDestroyable2 {

--- a/tests/unit/src/unit/issues/Issue5470.hx
+++ b/tests/unit/src/unit/issues/Issue5470.hx
@@ -1,7 +1,7 @@
 package unit.issues;
 
 class Issue5470 extends unit.Test {
-  var cb:Void->Void;
+  var cb:()->Void;
   
 	function test() {
 		eq(new Issue5470().cb, null);

--- a/tests/unit/src/unit/issues/Issue6036.hx
+++ b/tests/unit/src/unit/issues/Issue6036.hx
@@ -28,6 +28,6 @@ class Issue6036 extends unit.Test {
 	function test() {
 		var a = new ABSTRACT();
 		HelperMacros.typedAs(a.getArray(), true);
-		HelperMacros.typedAs(a.getThisArray(), (null : Void -> Array<Int>));
+		HelperMacros.typedAs(a.getThisArray(), (null : () -> Array<Int>));
 	}
 }

--- a/tests/unit/src/unit/issues/Issue6121.hx
+++ b/tests/unit/src/unit/issues/Issue6121.hx
@@ -4,9 +4,9 @@ class Issue6121 extends unit.Test {
 
    public function add(t:Issue6121) : Issue6121 return this;
 
-   public function start(run:Void->Issue6121) : Issue6121 return null;
+   public function start(run:()->Issue6121) : Issue6121 return null;
 
-   static public function setCallback( cb:Void->Issue6121 ) : Issue6121 return null;
+   static public function setCallback( cb:()->Issue6121 ) : Issue6121 return null;
 
    function callFunction() : Int
    {

--- a/tests/unit/src/unit/issues/Issue6375.hx
+++ b/tests/unit/src/unit/issues/Issue6375.hx
@@ -4,7 +4,7 @@ class Issue6375 extends Test {
 	var memberField(default,set):Int;
 	static var staticField(default,set):Int;
 
-	static var rollback:Void->Void;
+	static var rollback:()->Void;
 
 	function set_memberField(_) {
 		memberField = 1;

--- a/tests/unit/src/unit/issues/Issue7428.hx
+++ b/tests/unit/src/unit/issues/Issue7428.hx
@@ -13,7 +13,7 @@ class Issue7428 extends unit.Test {
 	}
 
 	@:pure(false)
-	static function execute<T>(callback:Void->T):T {
+	static function execute<T>(callback:()->T):T {
 		var result = callback();
 		return result;
 	}

--- a/tests/unit/src/unit/issues/Issue8435.hx
+++ b/tests/unit/src/unit/issues/Issue8435.hx
@@ -2,7 +2,7 @@ package unit.issues;
 
 class Issue8435 extends unit.Test {
 	function test() {
-		var data: Dynamic<Void->String> = {test: () -> "test"};
+		var data: Dynamic<()->String> = {test: () -> "test"};
 		eq("test", data.test());
 	}
 }

--- a/tests/unit/src/unit/issues/Issue8869.hx
+++ b/tests/unit/src/unit/issues/Issue8869.hx
@@ -5,7 +5,7 @@ class Issue8869 extends Test {
 		noAssert();
 	}
 
-	function checkIntersectionConstraintInParentheses<T:(haxe.Constraints.Constructible<Void->Void> & Dummy)>(cl:Class<T>) {}
+	function checkIntersectionConstraintInParentheses<T:(haxe.Constraints.Constructible<()->Void> & Dummy)>(cl:Class<T>) {}
 }
 
 private class Dummy {

--- a/tests/unit/src/unit/issues/Issue9366.hx
+++ b/tests/unit/src/unit/issues/Issue9366.hx
@@ -21,7 +21,7 @@ enum En {
 }
 
 @:generic
-private class VarManager<K, M:IMap<K, String> & Constructible<Void->Void>> {
+private class VarManager<K, M:IMap<K, String> & Constructible<()->Void>> {
 	final nameToVarKey:Map<String, K> = new Map();
 
 	public function new() {}

--- a/tests/unit/src/unit/issues/misc/Issue2003Macro.hx
+++ b/tests/unit/src/unit/issues/misc/Issue2003Macro.hx
@@ -5,7 +5,7 @@ import haxe.macro.Expr;
 class Issue2003Macro {
 	public function new() {}
 
-	public function callMe( cb:Void->Void ) {
+	public function callMe( cb:()->Void ) {
 		cb();
 		return this;
 	}

--- a/tests/unit/src/unitstd/Array.unit.hx
+++ b/tests/unit/src/unitstd/Array.unit.hx
@@ -337,15 +337,15 @@ var it : KeyValueIterable<Int, Int> = a;
 // Can't create this closure on Flash apparently
 // keyValueIterator closure because why not
 var a : Array<Int> = [1,2,3,5,8];
-var itf : Void -> KeyValueIterator<Int, Int> = a.keyValueIterator;
+var itf : () -> KeyValueIterator<Int, Int> = a.keyValueIterator;
 var it = itf();
 var a2 = [for (k=>v in it) k];
 a2 == [0,1,2,3,4];
-var itf : Void -> KeyValueIterator<Int, Int> = a.keyValueIterator;
+var itf : () -> KeyValueIterator<Int, Int> = a.keyValueIterator;
 var it = itf();
 a2 = [for (k=>v in it) v];
 a2 == [1,2,3,5,8];
-var itf : Void -> KeyValueIterator<Int, Int> = a.keyValueIterator;
+var itf : () -> KeyValueIterator<Int, Int> = a.keyValueIterator;
 var it = itf();
 a2 = [for (k=>v in it) k*v];
 a2 == [0,2,6,15,32];


### PR DESCRIPTION
Creating a draft PR to discuss potentially breaking change with the "old" display protocol, e.g.:

```
Expected:
"<type p="c:\code\haxe\tests\misc\projects\issue5122\main.hx:7: characters 9-14">
Void -&gt; String
</type>"
Actual:
"<type p="c:\code\haxe\tests\misc\projects\issue5122\main.hx:7: characters 9-14">
() -&gt; String
</type>"
```

I'm pretty sure some IDEs are parsing these to make sense of a type. At least VSCode did this before switching to the new protocol, so maybe we should preserve backward compat here, but that would mean having two `s_type`s or passing an optional argument to print `Void -> ...`.