### PR TITLE
[js] Use higher precision measure for Timer.stamp()

### DIFF
--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -173,7 +173,7 @@ class Timer {
 			return Sys.time();
 		#elseif js
 			#if nodejs
-			var hrtime: Array<Int> = untyped process.hrtime();
+			var hrtime = js.Node.process.hrtime();
 			return (hrtime[0] * 1000000 + hrtime[1] / 1000) / 1000;
 			#else
 			return @:privateAccess HxOverrides.now() / 1000;

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -174,7 +174,7 @@ class Timer {
 		#elseif js
 			#if nodejs
 			var hrtime: Array<Int> = untyped process.hrtime();
-			return hrtime[0] * 1000000 + hrtime[1] / 1000;
+			return (hrtime[0] * 1000000 + hrtime[1] / 1000) / 1000;
 			#else
 			return @:privateAccess HxOverrides.now() / 1000;
 			#end

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -172,7 +172,12 @@ class Timer {
 		#elseif (neko || php)
 			return Sys.time();
 		#elseif js
-			return js.Date.now() / 1000;
+			#if nodejs
+			var hrtime: Array<Int> = untyped process.hrtime();
+			return hrtime[0] * 1000000 + hrtime[1] / 1000;
+			#else
+			return @:privateAccess HxOverrides.now() / 1000;
+			#end
 		#elseif cpp
 			return untyped __global__.__time_stamp();
 		#elseif python

--- a/std/js/_std/HxOverrides.hx
+++ b/std/js/_std/HxOverrides.hx
@@ -147,7 +147,7 @@ class HxOverrides {
 	}
 
 	@:pure
-	static function now(): Float return untyped performance.now();
+	static function now(): Float return js.Browser.window.performance.now();
 
 	@:ifFeature("String.iterator")
 	static function strIter( s : String ) : StringIterator {

--- a/std/js/_std/HxOverrides.hx
+++ b/std/js/_std/HxOverrides.hx
@@ -146,6 +146,9 @@ class HxOverrides {
 		};
 	}
 
+	@:pure
+	static function now(): Float return untyped performance.now();
+
 	@:ifFeature("String.iterator")
 	static function strIter( s : String ) : StringIterator {
 		return new StringIterator(s);
@@ -161,6 +164,20 @@ class HxOverrides {
 		__feature__('HxOverrides.indexOf', if( Array.prototype.indexOf ) __js__("HxOverrides").indexOf = function(a,o,i) return Array.prototype.indexOf.call(a, o, i));
 		__feature__('HxOverrides.lastIndexOf', if( Array.prototype.lastIndexOf ) __js__("HxOverrides").lastIndexOf = function(a,o,i) return Array.prototype.lastIndexOf.call(a, o, i));
 #end
+
+		// if no global performance object is available then replace now() with process.hrtime() or Date.now()
+		__feature__('HxOverrides.now',
+			if (js.Syntax.typeof(performance) == 'undefined') {
+				if (js.Syntax.typeof(process) != 'undefined') {
+					HxOverrides.now = function() {
+						var hrtime = process.hrtime();
+						return (hrtime[0] * 1000000 + hrtime[1] / 1000);
+					}
+				} else {
+					HxOverrides.now = js.Date.now;
+				}
+			}
+		);
 	}
 
 }


### PR DESCRIPTION
`haxe.Timer.stamp()` currently uses `js.Date.now()` but `Date.now()` is limited to millisecond precision. Since `stamp()` is used to measure execution times, millisecond precision is likely not enough. For submillisecond precision we need to alternative timing functions.

This PR switches to using `performance.now()` when running in a web browser and `process.hrtime()` if running under node.js. It falls back to Date.now only if both of these are not available

When `-D nodejs` then the boot-time environment check is not included