### PR TITLE
[server] detect recursive dependencies, which cause inifinite loops

### DIFF
--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -309,7 +309,7 @@ let rec wait_loop process_params verbose accept =
 					*)
 					if not ctx.complete then
 						raise (ServerError ("Infinite loop in Haxe server detected. "
-							^ "Probably caused by shadowing a module of standard library. "
+							^ "Probably caused by shadowing a module of the standard library. "
 							^ "Make sure shadowed module does not pull macro context."));
 					let _, mctx = MacroContext.get_macro_context ctx p in
 					check_module_shadowing mctx.Typecore.com (get_changed_directories mctx) m

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -10,6 +10,7 @@ open DisplayOutput
 open Json
 
 exception Dirty of module_def
+exception ServerError of string
 
 let measure_times = ref false
 let prompt = ref false
@@ -300,6 +301,16 @@ let rec wait_loop process_params verbose accept =
 				| MCode -> check_module_shadowing com2 directories m
 				| MMacro when ctx.Typecore.in_macro -> check_module_shadowing com2 directories m
 				| MMacro ->
+					(*
+						Creating another context while the previous one is incomplete means we have an infinite loop in the compiler.
+						Most likely because of circular dependencies in base modules (e.g. `StdTypes` or `String`)
+						Prevents spending another 5 hours for debugging.
+						@see https://github.com/HaxeFoundation/haxe/issues/8174
+					*)
+					if not ctx.complete then
+						raise (ServerError ("Infinite loop in Haxe server detected. "
+							^ "Probably caused by shadowing a module of standard library. "
+							^ "Make sure shadowed module does not pull macro context."));
 					let _, mctx = MacroContext.get_macro_context ctx p in
 					check_module_shadowing mctx.Typecore.com (get_changed_directories mctx) m
 			in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -307,7 +307,7 @@ let rec wait_loop process_params verbose accept =
 						Prevents spending another 5 hours for debugging.
 						@see https://github.com/HaxeFoundation/haxe/issues/8174
 					*)
-					if not ctx.complete then
+					if not ctx.g.complete then
 						raise (ServerError ("Infinite loop in Haxe server detected. "
 							^ "Probably caused by shadowing a module of the standard library. "
 							^ "Make sure shadowed module does not pull macro context."));

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -75,6 +75,8 @@ type typer_globals = {
 	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	mutable module_check_policies : (string list * module_check_policy list * bool) list;
 	mutable global_using : (tclass * pos) list;
+	(* Indicates that Typer.create() finished building this instance *)
+	mutable complete : bool;
 	(* api *)
 	do_inherit : typer -> Type.tclass -> pos -> (bool * placed_type_path) -> bool;
 	do_create : Common.context -> typer;
@@ -123,8 +125,6 @@ and typer = {
 	mutable in_call_args : bool;
 	(* events *)
 	mutable on_error : typer -> string -> pos -> unit;
-	(* Indicates that Typer.create() finished building this instance *)
-	complete : bool;
 }
 exception Forbid_package of (string * path * pos) * pos list * string
 

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -123,6 +123,8 @@ and typer = {
 	mutable in_call_args : bool;
 	(* events *)
 	mutable on_error : typer -> string -> pos -> unit;
+	(* Indicates that Typer.create() finished building this instance *)
+	complete : bool;
 }
 exception Forbid_package of (string * path * pos) * pos list * string
 

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -862,6 +862,7 @@ let type_types_into_module ctx m tdecls p =
 		opened = [];
 		in_call_args = false;
 		vthis = None;
+		complete = ctx.complete;
 	} in
 	if ctx.g.std != null_module then begin
 		add_dependency m ctx.g.std;

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -862,7 +862,6 @@ let type_types_into_module ctx m tdecls p =
 		opened = [];
 		in_call_args = false;
 		vthis = None;
-		complete = ctx.complete;
 	} in
 	if ctx.g.std != null_module then begin
 		add_dependency m ctx.g.std;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2498,6 +2498,7 @@ let rec create com =
 			hook_generate = [];
 			std = null_module;
 			global_using = [];
+			complete = false;
 			do_inherit = MagicTypes.on_inherit;
 			do_create = create;
 			do_macro = MacroContext.type_macro;
@@ -2541,7 +2542,6 @@ let rec create com =
 		vthis = None;
 		in_call_args = false;
 		on_error = (fun ctx msg p -> ctx.com.error msg p);
-		complete = false;
 	} in
 	ctx.g.std <- (try
 		TypeloadModule.load_module ctx ([],"StdTypes") null_pos
@@ -2608,7 +2608,8 @@ let rec create com =
 		| [TClassDecl c2 ] -> ctx.g.global_using <- (c1,c1.cl_pos) :: (c2,c2.cl_pos) :: ctx.g.global_using
 		| _ -> assert false);
 	| _ -> assert false);
-	{ ctx with complete = true }
+	ctx.g.complete <- true;
+	ctx
 
 ;;
 unify_min_ref := unify_min;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2541,6 +2541,7 @@ let rec create com =
 		vthis = None;
 		in_call_args = false;
 		on_error = (fun ctx msg p -> ctx.com.error msg p);
+		complete = false;
 	} in
 	ctx.g.std <- (try
 		TypeloadModule.load_module ctx ([],"StdTypes") null_pos
@@ -2607,7 +2608,7 @@ let rec create com =
 		| [TClassDecl c2 ] -> ctx.g.global_using <- (c1,c1.cl_pos) :: (c2,c2.cl_pos) :: ctx.g.global_using
 		| _ -> assert false);
 	| _ -> assert false);
-	ctx
+	{ ctx with complete = true }
 
 ;;
 unify_min_ref := unify_min;


### PR DESCRIPTION
Closes #8174 

This PR detects circular dependencies in base modules (e.g. `StdTypes`, `String` etc.) and throws an exception instead of letting the server to enter an infinite loop.
For example in #8174 infinite loop was caused because of JStack lib shadows `haxe.CallStack`, which pulls a macro context, which leads to the following dependency chain:
`String` -> `StringIterator` -> `StringTools` -> `Array` -> `HxOverrides` -> `js.Lib` -> `Boot` -> `Type` -> `js.lib.Object` -> `DynamicAccess` -> `Reflect` -> `CallStack` (shadowed) ->  `jstack.JStack` -> `jstack.Tools` (invokes a macro) -> `String`

Now instead of hanging the server throws an error. It looks like this in vscode output panel:
```
Building Cache...
Restarted Haxe server: User configuration was changed
Parsing Classpaths...
Failed - Server.ServerError("Infinite loop in Haxe server detected. Probably caused by shadowing a module of standard library. Make sure shadowed module does not pull macro context.")
```
And code completion keeps working.