### PR TITLE
[server] Implicit dependencies

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -427,10 +427,10 @@ module Dump = struct
 		let dep = Hashtbl.create 0 in
 		List.iter (fun m ->
 			print "%s:\n" m.m_extra.m_file;
-			PMap.iter (fun _ m2 ->
-				print "\t%s\n" (m2.m_extra.m_file);
-				let l = try Hashtbl.find dep m2.m_extra.m_file with Not_found -> [] in
-				Hashtbl.replace dep m2.m_extra.m_file (m :: l)
+			PMap.iter (fun _ mdep ->
+				print "\t%s\n" (mdep.md_module.m_extra.m_file);
+				let l = try Hashtbl.find dep mdep.md_module.m_extra.m_file with Not_found -> [] in
+				Hashtbl.replace dep mdep.md_module.m_extra.m_file (m :: l)
 			) m.m_extra.m_deps;
 		) com.Common.modules;
 		close();

--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -199,7 +199,7 @@ module Memory = struct
 			()
 		else begin
 			Hashtbl.add h m.m_id m;
-			PMap.iter (fun _ m -> scan_module_deps m h) m.m_extra.m_deps
+			PMap.iter (fun _ dep -> scan_module_deps dep.md_module h) m.m_extra.m_deps
 		end
 
 	let get_out out =
@@ -379,8 +379,8 @@ module Memory = struct
 					());
 				if verbose then begin
 					print (Printf.sprintf "      %d total deps" (List.length deps));
-					PMap.iter (fun _ md ->
-						print (Printf.sprintf "      dep %s%s" (s_type_path md.m_path) (sign md));
+					PMap.iter (fun _ dep ->
+						print (Printf.sprintf "      dep %s%s" (s_type_path dep.md_module.m_path) (sign dep.md_module));
 					) m.m_extra.m_deps;
 				end;
 				flush stdout

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -330,9 +330,11 @@ let rec wait_loop process_params verbose accept =
 				end
 			in
 			let check_dependencies () =
-				PMap.iter (fun _ m2 -> match check m2 with
-					| None -> ()
-					| Some m -> raise (Dirty m)
+				PMap.iter (fun _ dep ->
+					if dep.md_explicit then
+						match check dep.md_module with
+						| None -> ()
+						| Some m -> raise (Dirty m)
 				) m.m_extra.m_deps;
 			in
 			begin match m.m_extra.m_dirty with
@@ -389,7 +391,9 @@ let rec wait_loop process_params verbose accept =
 					) m.m_types;
 					TypeloadModule.add_module ctx m p;
 					PMap.iter (Hashtbl.replace com2.resources) m.m_extra.m_binded_res;
-					PMap.iter (fun _ m2 -> add_modules (tabs ^ "  ") m0 m2) m.m_extra.m_deps
+					PMap.iter
+						(fun _ dep -> if dep.md_explicit then add_modules (tabs ^ "  ") m0 dep.md_module)
+						m.m_extra.m_deps
 				)
 			end
 		in

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -666,9 +666,9 @@ let generate_module ctx m =
 		"types",jlist (fun mt -> generate_type_path m.m_path (t_infos mt).mt_path) m.m_types;
 		"file",jstring m.m_extra.m_file;
 		"sign",jstring (Digest.to_hex m.m_extra.m_sign);
-		"dependencies",jarray (PMap.fold (fun m acc -> (jobject [
-			"path",jstring (s_type_path m.m_path);
-			"sign",jstring (Digest.to_hex m.m_extra.m_sign);
+		"dependencies",jarray (PMap.fold (fun dep acc -> (jobject [
+			"path",jstring (s_type_path dep.md_module.m_path);
+			"sign",jstring (Digest.to_hex dep.md_module.m_extra.m_sign);
 		]) :: acc) m.m_extra.m_deps []);
 	]
 

--- a/src/filters/jsExceptions.ml
+++ b/src/filters/jsExceptions.ml
@@ -192,7 +192,7 @@ let inject_callstack com type_filters =
 				| TTry (etry,[(v,ecatch)]) ->
 					let etry = loop etry in
 					let ecatch = loop ecatch in
-					add_dependency (t_infos mt).mt_module cCallStack.cl_module;
+					add_dependency ~explicit:false (t_infos mt).mt_module cCallStack.cl_module;
 					let eCallStack = make_static_this cCallStack ecatch.epos in
 					let elastException = field eCallStack "lastException" t_dynamic ecatch.epos in
 					let elocal = make_local v ecatch.epos in


### PR DESCRIPTION
Closes #8174 [see comment](https://github.com/HaxeFoundation/haxe/issues/8174#issuecomment-484700298)

Adding dependencies in the filters step makes subsequent compilation through compilation server behave differently, because of the added dependencies are being examined during the typing of the next compilation.
E.g. adding a `CallStack` dependency to all modules with `try..catch` [here](https://github.com/HaxeFoundation/haxe/blob/032d959//src/filters/jsExceptions.ml#L195) makes `Reflect` to depend on `CallStack` but only on the _second_ compilation.

This PR adds a flag to a dependency reference, which is used to determine if the dependency is required for typing.