### PR TITLE
Disallow UTF-16 surrogates in strings

### DIFF
--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -524,6 +524,8 @@ let unescape s =
 							| Invalid_escape_sequence (c,i,msg) as e -> raise e
 							| _ -> fail_no_hex ()
 					in
+					if u >= 0xD800 && u < 0xE000 then
+						fail (Some "UTF-16 surrogates are not allowed in strings.");
 					UTF8.add_uchar b (UChar.uchar_of_int u);
 					inext := !inext + a;
 				| _ ->

--- a/tests/misc/projects/Issue8205/Main.hx
+++ b/tests/misc/projects/Issue8205/Main.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		trace("\u{1F404}");
+		trace("\uD83D\uDC04");
+	}
+}

--- a/tests/misc/projects/Issue8205/compile-fail.hxml
+++ b/tests/misc/projects/Issue8205/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue8205/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8205/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:4: character 10 : Invalid escape sequence \u. UTF-16 surrogates are not allowed in strings.


### PR DESCRIPTION
Closes #8205.

Anything Unicode codepoint between `0xD800` and `0xDFFF` is reserved for UTF-16 surrogates, so `\u{...}` and `\uXXXX` syntax should never contain it. Parser error, consistent with higher-than-10FFFF codepoints.