### PR TITLE
Replace setTimeout timeout: Int with : Float, fixes #8223

### DIFF
--- a/std/js/html/Window.hx
+++ b/std/js/html/Window.hx
@@ -566,8 +566,8 @@ extern class Window extends EventTarget {
 	/** @throws DOMError */
 	function atob( atob : String ) : String;
 	/** @throws DOMError */
-	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
-	function setTimeout( handler : String, timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
+	@:overload( function( handler : haxe.Constraints.Function, timeout : Float = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
+	function setTimeout( handler : String, timeout : Float = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
 	function clearTimeout( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
 	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )

--- a/std/js/html/Window.hx
+++ b/std/js/html/Window.hx
@@ -570,8 +570,8 @@ extern class Window extends EventTarget {
 	function setTimeout( handler : String, timeout : Float = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
 	function clearTimeout( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
-	@:overload( function( handler : haxe.Constraints.Function, timeout : Int = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
-	function setInterval( handler : String, timeout : Int = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
+	@:overload( function( handler : haxe.Constraints.Function, timeout : Float = 0, arguments : haxe.extern.Rest<Dynamic> ) : Int {} )
+	function setInterval( handler : String, timeout : Float = 0, unused : haxe.extern.Rest<Dynamic> ) : Int;
 	function clearInterval( handle : Int = 0 ) : Void;
 	/** @throws DOMError */
 	@:overload( function( aImage : VideoElement) : Promise<ImageBitmap> {} )


### PR DESCRIPTION
Replaces `timeout: Int` with `timeout: Float` in `Window.setTimeout` to fix issue #8223

I've fixed this in the generator but made the change manually because the generator is not yet caught 
up with the `js.lib` changes.

Corresponding change in the generator
https://github.com/HaxeFoundation/html-externs/commit/42023ac2345b18f106462c19a82515b0d943f436

closes #8223 