### PR TITLE
Fix non-BMP characters in StringBuf

### DIFF
--- a/std/cs/_std/StringBuf.hx
+++ b/std/cs/_std/StringBuf.hx
@@ -44,7 +44,7 @@ class StringBuf {
 		b.Append(s, pos, (len == null) ? (s.length - pos) : len);
 	}
 
-	public inline function addChar( c : Int ) : Void untyped {
+	public function addChar( c : Int ) : Void untyped {
 		if (c >= 0x10000) {
 			b.Append(cast((c >> 10) + 0xD7C0, cs.StdTypes.Char16));
 			b.Append(cast((c & 0x3FF) + 0xDC00, cs.StdTypes.Char16));

--- a/std/cs/_std/StringBuf.hx
+++ b/std/cs/_std/StringBuf.hx
@@ -45,7 +45,12 @@ class StringBuf {
 	}
 
 	public inline function addChar( c : Int ) : Void untyped {
-		b.Append(cast(c, cs.StdTypes.Char16));
+		if (c >= 0x10000) {
+			b.Append(cast((c >> 10) + 0xD7C0, cs.StdTypes.Char16));
+			b.Append(cast((c & 0x3FF) + 0xDC00, cs.StdTypes.Char16));
+		} else {
+			b.Append(cast(c, cs.StdTypes.Char16));
+		}
 	}
 
 	public inline function toString() : String {

--- a/std/java/_std/StringBuf.hx
+++ b/std/java/_std/StringBuf.hx
@@ -52,12 +52,7 @@ class StringBuf {
 	}
 
 	public function addChar( c : Int ) : Void untyped {
-		if (c >= 0x10000) {
-			b.append(cast((c >> 10) + 0xD7C0, java.StdTypes.Char16));
-			b.append(cast((c & 0x3FF) + 0xDC00, java.StdTypes.Char16));
-		} else {
-			b.append(cast(c, java.StdTypes.Char16));
-		}
+		b.appendCodePoint(c);
 	}
 
 	public function toString() : String {

--- a/std/java/_std/StringBuf.hx
+++ b/std/java/_std/StringBuf.hx
@@ -52,7 +52,12 @@ class StringBuf {
 	}
 
 	public function addChar( c : Int ) : Void untyped {
-		b.append(cast(c, java.StdTypes.Char16));
+		if (c >= 0x10000) {
+			b.append(cast((c >> 10) + 0xD7C0, java.StdTypes.Char16));
+			b.append(cast((c & 0x3FF) + 0xDC00, java.StdTypes.Char16));
+		} else {
+			b.append(cast(c, java.StdTypes.Char16));
+		}
 	}
 
 	public function toString() : String {

--- a/tests/unit/src/unitstd/StringBuf.unit.hx
+++ b/tests/unit/src/unitstd/StringBuf.unit.hx
@@ -3,17 +3,11 @@ var x = new StringBuf();
 x.toString() == "";
 x.add(null);
 x.toString() == "null";
-var x = new StringBuf();
-x.add("👽");
-x.toString() == "👽";
 
 // addChar
 var x = new StringBuf();
 x.addChar(32);
 x.toString() == " ";
-var x = new StringBuf();
-x.addChar(0x1F47D);
-x.toString() == "👽";
 
 // addSub
 var x = new StringBuf();
@@ -25,6 +19,15 @@ x.toString() == "bcdefg";
 var x = new StringBuf();
 x.addSub("abcdefg", 1, 3);
 x.toString() == "bcd";
+
+// surrogate characters
+#if !(neko)
+var x = new StringBuf();
+x.add("👽");
+x.toString() == "👽";
+var x = new StringBuf();
+x.addChar(0x1F47D);
+x.toString() == "👽";
 var x = new StringBuf();
 #if utf16
 x.addSub("a👽b", 1, 2);
@@ -32,6 +35,7 @@ x.addSub("a👽b", 1, 2);
 x.addSub("a👽b", 1, 1);
 #end
 x.toString() == "👽";
+#end
 
 // identity
 function identityTest(s:StringBuf) {

--- a/tests/unit/src/unitstd/StringBuf.unit.hx
+++ b/tests/unit/src/unitstd/StringBuf.unit.hx
@@ -3,11 +3,17 @@ var x = new StringBuf();
 x.toString() == "";
 x.add(null);
 x.toString() == "null";
+var x = new StringBuf();
+x.add("👽");
+x.toString() == "👽";
 
 // addChar
 var x = new StringBuf();
 x.addChar(32);
 x.toString() == " ";
+var x = new StringBuf();
+x.addChar(0x1F47D);
+x.toString() == "👽";
 
 // addSub
 var x = new StringBuf();
@@ -19,6 +25,13 @@ x.toString() == "bcdefg";
 var x = new StringBuf();
 x.addSub("abcdefg", 1, 3);
 x.toString() == "bcd";
+var x = new StringBuf();
+#if utf16
+x.addSub("a👽b", 1, 2);
+#else
+x.addSub("a👽b", 1, 1);
+#end
+x.toString() == "👽";
 
 // identity
 function identityTest(s:StringBuf) {


### PR DESCRIPTION
(Found in bba3863)

 - [x] add tests to `StringBuf` unit test (used `#if utf16`, but I think that's what we are aiming for with 4.0)
 - [x] fix Java `StringBuf` for non-BMP chars
 - [x] fix C# (copy of Java implementation)

I'll wait for the CI to see if other UTF-16 targets break on this.