### PR TITLE
target.unicode define

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -514,8 +514,8 @@ try
 			Initialize.set_platform com Cpp dir;
 		),"<directory>","generate C++ code into target directory");
 		("Target",["--cppia"],["-cppia"],Arg.String (fun file ->
-			Initialize.set_platform com Cpp file;
 			Common.define com Define.Cppia;
+			Initialize.set_platform com Cpp file;
 		),"<file>","generate Cppia code into target file");
 		("Target",["--cs"],["-cs"],Arg.String (fun dir ->
 			cp_libs := "hxcs" :: !cp_libs;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -102,6 +102,8 @@ type platform_config = {
 	pf_this_before_super : bool;
 	(** target supports threads **)
 	pf_supports_threads : bool;
+	(** target supports Unicode **)
+	pf_supports_unicode : bool;
 }
 
 class compiler_callbacks = object(self)
@@ -284,6 +286,7 @@ let default_config =
 		pf_uses_utf16 = true;
 		pf_this_before_super = true;
 		pf_supports_threads = false;
+		pf_supports_unicode = true;
 	}
 
 let get_config com =
@@ -314,6 +317,7 @@ let get_config com =
 			pf_pad_nulls = true;
 			pf_uses_utf16 = false;
 			pf_supports_threads = true;
+			pf_supports_unicode = false;
 		}
 	| Flash when defined Define.As3 ->
 		{
@@ -344,6 +348,7 @@ let get_config com =
 			pf_pad_nulls = true;
 			pf_add_final_return = true;
 			pf_supports_threads = true;
+			pf_supports_unicode = (defined Define.Cppia) || not (defined Define.DisableUnicodeStrings);
 		}
 	| Cs ->
 		{
@@ -542,6 +547,9 @@ let init_platform com pf =
 	end;
 	if com.config.pf_supports_threads then begin
 		raw_define_value com.defines "target.threaded" "true";
+	end;
+	if com.config.pf_supports_unicode then begin
+		raw_define_value com.defines "target.unicode" "true";
 	end;
 	raw_define_value com.defines "target.name" name;
 	raw_define com name

--- a/std/haxe/crypto/Md5.hx
+++ b/std/haxe/crypto/Md5.hx
@@ -133,7 +133,7 @@ class Md5 {
 	}
 
 	static function str2blks( str : String ){
-#if !(neko || (cpp && !hxcpp_smart_strings))
+#if (target.unicode)
 		var str = haxe.io.Bytes.ofString(str);
 #end
 		var nblk = ((str.length + 8) >> 6) + 1;
@@ -153,7 +153,7 @@ class Md5 {
 		var max = str.length;
 		var l = max * 8;
 		while( i < max ) {
-			blks[i >> 2] |= #if !(neko || (cpp && !hxcpp_smart_strings)) str.get(i) #else StringTools.fastCodeAt(str, i) #end << (((l + i) % 4) * 8);
+			blks[i >> 2] |= #if (target.unicode) str.get(i) #else StringTools.fastCodeAt(str, i) #end << (((l + i) % 4) * 8);
 			i++;
 		}
 		blks[i >> 2] |= 0x80 << (((l + i) % 4) * 8);

--- a/std/haxe/crypto/Sha1.hx
+++ b/std/haxe/crypto/Sha1.hx
@@ -95,7 +95,7 @@ class Sha1 {
 		Append padding bits and the length, as described in the SHA1 standard.
 	 */
 	static function str2blks( s :String ) : Array<Int> {
-#if !(neko || (cpp && !hxcpp_smart_strings))
+#if (target.unicode)
 		var s = haxe.io.Bytes.ofString(s);
 #end
 		var nblk = ((s.length + 8) >> 6) + 1;
@@ -105,7 +105,7 @@ class Sha1 {
 			blks[i] = 0;
 		for (i in 0...s.length){
 			var p = i >> 2;
-			blks[p] |= #if !(neko || (cpp && !hxcpp_smart_strings)) s.get(i) #else StringTools.fastCodeAt(s,i) #end << (24 - ((i & 3) << 3));
+			blks[p] |= #if (target.unicode) s.get(i) #else StringTools.fastCodeAt(s,i) #end << (24 - ((i & 3) << 3));
 		}
 		var i = s.length;
 		var p = i >> 2;

--- a/std/haxe/crypto/Sha256.hx
+++ b/std/haxe/crypto/Sha256.hx
@@ -105,7 +105,7 @@ class Sha256 {
 		Append padding bits and the length, as described in the SHA1 standard.
 	 */
 	static function str2blks( s :String ) : Array<Int> {
-#if !(neko || (cpp && !hxcpp_smart_strings))
+#if (target.unicode)
 		var s = haxe.io.Bytes.ofString(s);
 #end
 		var nblk = ((s.length + 8) >> 6) + 1;
@@ -115,7 +115,7 @@ class Sha256 {
 			blks[i] = 0;
 		for (i in 0...s.length){
 			var p = i >> 2;
-			blks[p] |= #if !(neko || (cpp && !hxcpp_smart_strings)) s.get(i) #else s.charCodeAt(i) #end << (24 - ((i & 3) << 3));
+			blks[p] |= #if (target.unicode) s.get(i) #else s.charCodeAt(i) #end << (24 - ((i & 3) << 3));
 		}
 		var i = s.length;
 		var p = i >> 2;

--- a/std/haxe/format/JsonParser.hx
+++ b/std/haxe/format/JsonParser.hx
@@ -172,7 +172,7 @@ class JsonParser {
 				case 'u'.code:
 					var uc = Std.parseInt("0x" + str.substr(pos, 4));
 					pos += 4;
-					#if (neko || (cpp&&!hxcpp_smart_strings))
+					#if !(target.unicode)
 					if( uc <= 0x7F )
 						buf.addChar(uc);
 					else if( uc <= 0x7FF ) {
@@ -196,7 +196,7 @@ class JsonParser {
 				}
 				start = pos;
 			}
-			#if (neko || (cpp&&!hxcpp_smart_strings) )
+			#if !(target.unicode)
 			// ensure utf8 chars are not cut
 			else if( c >= 0x80 ) {
 				pos++;

--- a/std/haxe/xml/Parser.hx
+++ b/std/haxe/xml/Parser.hx
@@ -380,7 +380,7 @@ class Parser
 							var c = s.fastCodeAt(1) == 'x'.code
 								? Std.parseInt("0" +s.substr(1, s.length - 1))
 								: Std.parseInt(s.substr(1, s.length - 1));
-							#if (neko || (cpp && !hxcpp_smart_strings))
+							#if !(target.unicode)
 							if( c >= 128 ) {
 								// UTF8-encode it
 								if( c <= 0x7FF ) {

--- a/tests/unit/src/unit/issues/Issue7449.hx
+++ b/tests/unit/src/unit/issues/Issue7449.hx
@@ -4,7 +4,7 @@ class Issue7449 extends unit.Test {
 	/**
 	 * Not happens since https://github.com/HaxeFoundation/haxe/pull/8141
 	 */
-	// #if !(neko || (cpp && !cppia && !hxcpp_smart_strings))
+	// #if (target.unicode)
 	// function test() {
 	// 	eq(220, "\xDC".charCodeAt(0));
 	// }

--- a/tests/unit/src/unitstd/String.unit.hx
+++ b/tests/unit/src/unitstd/String.unit.hx
@@ -172,7 +172,7 @@ String.fromCharCode(65) == "A";
 
 // iterators
 var s = 'zя𠜎';
-#if (neko || (cpp && !cppia && !hxcpp_smart_strings))
+#if !(target.unicode)
 var expectedCodes = [122, 209, 143, 240, 160, 156, 142];
 #elseif utf16
 var expectedCodes = [122, 1103, 55361, 57102];

--- a/tests/unit/src/unitstd/Unicode.unit.hx
+++ b/tests/unit/src/unitstd/Unicode.unit.hx
@@ -1,4 +1,4 @@
-#if !(neko || (cpp && !cppia && !hxcpp_smart_strings)) // these platforms will not be made unicode-compatible
+#if (target.unicode) // neko and cpp with -D disable_unicode_strings will not be made Unicode compatible
 
 
 var s = String.fromCharCode(0xE9);

--- a/tests/unit/src/unitstd/haxe/iterators/StringIteratorUnicode.unit.hx
+++ b/tests/unit/src/unitstd/haxe/iterators/StringIteratorUnicode.unit.hx
@@ -6,7 +6,7 @@ function traverse(s:String) {
 	return a;
 }
 
-#if !(neko || (cpp && !cppia && !hxcpp_smart_strings))
+#if (target.unicode)
 
 traverse("abcde") == ["a".code, "b".code, "c".code, "d".code, "e".code];
 traverse("aa😂éé") == ["a".code, "a".code, "😂".code, "é".code, "é".code];

--- a/tests/unit/src/unitstd/haxe/iterators/StringKeyValueIteratorUnicode.unit.hx
+++ b/tests/unit/src/unitstd/haxe/iterators/StringKeyValueIteratorUnicode.unit.hx
@@ -8,7 +8,7 @@ function traverse(s:String) {
 	return { k: ak, v: av };
 }
 
-#if !(neko || (cpp && !cppia && !hxcpp_smart_strings))
+#if (target.unicode)
 
 var r = traverse("abcde");
 r.k == [0, 1, 2, 3, 4];


### PR DESCRIPTION
 - [x] add a `(target.unicode)` define - false on neko, false on cpp with `-D disable_unicode_strings` and not cppia, true everywhere else
 - [x] replace various `#if (neko ...` and` #if !(neko ...` conditions
