### PR TITLE
[flash] always use DoABC tag

### DIFF
--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -102,7 +102,6 @@ type strict_defined =
 	| SwfPreloaderFrame
 	| SwfProtected
 	| SwfScriptTimeout
-	| SwfUseDoAbc
 	| Sys
 	| Unsafe
 	| UseNekoc
@@ -216,7 +215,6 @@ let infos = function
 	| SwfPreloaderFrame -> "swf_preloader_frame",("Insert empty first frame in swf",[Platform Flash])
 	| SwfProtected -> "swf_protected",("Compile Haxe private as protected in the SWF instead of public",[Platform Flash])
 	| SwfScriptTimeout -> "swf_script_timeout",("Maximum ActionScript processing time before script stuck dialog box displays (in seconds)",[Platform Flash])
-	| SwfUseDoAbc -> "swf_use_doabc",("Use DoAbc swf-tag instead of DoAbcDefine",[Platform Flash])
 	| Sys -> "sys",("Defined for all system platforms",[])
 	| Unsafe -> "unsafe",("Allow unsafe code when targeting C#",[Platform Cs])
 	| UseNekoc -> "use_nekoc",("Use nekoc compiler instead of internal one",[Platform Neko])

--- a/src/generators/genswf.ml
+++ b/src/generators/genswf.ml
@@ -246,7 +246,7 @@ let build_swf9 com file swc =
 				hls_fields = [|f|];
 			}
 		) code in
-		[tag (TActionScript3 ((if Common.defined com Define.SwfUseDoAbc then Some(1,boot_name) else None), As3hlparse.flatten inits))]
+		[tag (TActionScript3 ((Some (1,boot_name)), As3hlparse.flatten inits))]
 	) in
 	let cid = ref 0 in
 	let classes = ref [{ f9_cid = None; f9_classname = boot_name }] in


### PR DESCRIPTION
According to [these](https://www.m2osw.com/swf_tag_doabc) [docs](https://www.m2osw.com/swf_tag_doabcdefine) and as far as I understood `DoABCDefine` is obsolete. Adobe's `swfdump` util seems to confirm this, because it can only dump Haxe-generated ABC if I do `-D swf_use_doabc`. So I thought it makes sense to just always write the `DoABC` tag.