### PR TITLE
[flash] use more generic Sprite instead of MovieClip for flash.Lib.current

### DIFF
--- a/std/flash/Boot.hx
+++ b/std/flash/Boot.hx
@@ -46,7 +46,7 @@ import haxe.iterators.StringKeyValueIterator;
 
 @:dox(hide)
 @:keep
-class Boot extends flash.display.MovieClip {
+class Boot extends flash.display.Sprite {
 
 	static var tf : flash.text.TextField;
 	static var lines : Array<String>;

--- a/std/flash/Lib.hx
+++ b/std/flash/Lib.hx
@@ -27,7 +27,7 @@ package flash;
 **/
 class Lib {
 
-	public static var current : flash.display.MovieClip;
+	public static var current : flash.display.Sprite;
 
 	public inline static function getTimer() : Int {
 		return untyped __global__["flash.utils.getTimer"]();


### PR DESCRIPTION
(also for the Boot class)