### PR TITLE
Restrict @:allow(some.pack) to types located in that package only

### DIFF
--- a/tests/misc/projects/Issue6525/Main.hx
+++ b/tests/misc/projects/Issue6525/Main.hx
@@ -1,0 +1,21 @@
+import pack.BasePack;
+import pack.IPack;
+import pack.Pvt;
+
+class Main {
+	static function main() {
+
+	}
+}
+
+class Sub extends BasePack implements IPack {
+	override public function test() {
+		// should fail, because it allows access to specific package - pack
+		Pvt1.testPack();
+		Pvt2.testPack();
+		// should pass, because it allows access to all instances of pack.BasePack (including descendant classes)
+		Pvt2.testClass();
+		// should pass, because it allows access to all implementers of pack.IPack
+		Pvt2.testInterface();
+	}
+}

--- a/tests/misc/projects/Issue6525/compile-fail.hxml
+++ b/tests/misc/projects/Issue6525/compile-fail.hxml
@@ -1,0 +1,1 @@
+-main Main

--- a/tests/misc/projects/Issue6525/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6525/compile-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main.hx:14: characters 3-16 : Cannot access private field testPack
+Main.hx:15: characters 3-16 : Cannot access private field testPack

--- a/tests/misc/projects/Issue6525/pack/BasePack.hx
+++ b/tests/misc/projects/Issue6525/pack/BasePack.hx
@@ -1,0 +1,12 @@
+package pack;
+
+import pack.Pvt;
+
+class BasePack {
+	public function new() {}
+
+	public function test() {
+		Pvt1.testPack();
+		Pvt2.testPack();
+	}
+}

--- a/tests/misc/projects/Issue6525/pack/IPack.hx
+++ b/tests/misc/projects/Issue6525/pack/IPack.hx
@@ -1,0 +1,3 @@
+package pack;
+
+interface IPack {}

--- a/tests/misc/projects/Issue6525/pack/Pvt.hx
+++ b/tests/misc/projects/Issue6525/pack/Pvt.hx
@@ -1,0 +1,17 @@
+package pack;
+
+@:allow(pack)
+class Pvt1 {
+	static function testPack() {}
+}
+
+class Pvt2 {
+	@:allow(pack)
+	static function testPack() {}
+
+	@:allow(pack.BasePack)
+	static function testClass() {}
+
+	@:allow(pack.IPack)
+	static function testInterface() {}
+}


### PR DESCRIPTION
And don't allow access to their descendandts in other packages.

Fixes #6525