### PR TITLE
[eval] emit user-friendly exception on infinite recursion

### DIFF
--- a/src/macro/eval/evalEmitter.ml
+++ b/src/macro/eval/evalEmitter.ml
@@ -210,7 +210,7 @@ let emit_try exec catches env =
 		List.iter (fun (_,path,_) -> Hashtbl.remove eval.caught_types path) catches
 	in
 	let v = try
-		let v = exec env in
+		let v = handle_stack_overflow eval (fun() -> exec env) in
 		restore();
 		v
 	with RunTimeException(v,_,_) as exc ->

--- a/src/macro/eval/evalExceptions.ml
+++ b/src/macro/eval/evalExceptions.ml
@@ -128,7 +128,11 @@ let catch_exceptions ctx ?(final=(fun() -> ())) f p =
 	let eval = get_eval ctx in
 	let env = eval.env in
 	let r = try
-		let v = f() in
+		let v =
+			try f()
+			with Stack_overflow as e ->
+				raise (RunTimeException (EvalString.create_unknown "Stack overflow", call_stack eval, null_pos))
+		in
 		get_ctx_ref := prev;
 		final();
 		Some v

--- a/src/macro/eval/evalExceptions.ml
+++ b/src/macro/eval/evalExceptions.ml
@@ -124,8 +124,7 @@ let build_exception_stack ctx env =
 
 let handle_stack_overflow eval f =
 	try f()
-	with Stack_overflow ->
-		raise (RunTimeException (EvalString.create_unknown "Stack overflow", call_stack eval, null_pos))
+	with Stack_overflow -> exc_string "Stack overflow"
 
 let catch_exceptions ctx ?(final=(fun() -> ())) f p =
 	let prev = !get_ctx_ref in


### PR DESCRIPTION
Closes #8303 

```haxe
class Main {
	static function main(){
		some();
	}

	macro static function some() {
		function impl() {
			impl();         // infinite recursion
		}
		impl(); 
		return macro {}
	}
}
```
```
$ haxe -main Main
```
Before this PR:
```
Fatal error: exception Stack overflow
Raised by primitive operation at file "_build/src/macro/eval/evalContext.ml", line 397, characters 2-31
Called from file "_build/src/macro/eval/evalEmitter.ml", line 764, characters 11-81
<...>
Called from file "_build/src/macro/eval/evalEmitter.ml", line 767, characters 13-21
```
Now:
```
src/Main.hx:3: characters 3-9 : Uncaught exception Stack overflow
src/Main.hx:8: characters 4-10 : Called from here
src/Main.hx:8: characters 4-10 : Called from here
<...>
src/Main.hx:8: characters 4-10 : Called from here
src/Main.hx:8: characters 4-10 : Called from here
src/Main.hx:10: characters 3-9 : Called from here
src/Main.hx:3: characters 3-9 : Called from here
src/Main.hx:1: lines 1-13 : Defined in this class
```
