### PR TITLE
haxe.macro.Context.localTypeHasMeta(meta) to speed up global build macros

### DIFF
--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1685,6 +1685,16 @@ let macro_api ccom get_api =
 			| None -> vnull
 			| Some t -> encode_type t
 		);
+		"local_type_has_meta", vfun1 (fun meta_name ->
+			let meta_name = decode_string meta_name in
+			match (get_api()).get_local_type() with
+			| None -> vbool false
+			| Some t -> match follow t with
+				| TEnum ({ e_meta = meta }, _)
+				| TInst ({ cl_meta = meta }, _)
+				| TAbstract ({ a_meta = meta }, _) -> vbool (Meta.has (Meta.from_string meta_name) meta)
+				| _ -> vbool false
+		);
 		"get_expected_type", vfun0 (fun() ->
 			match (get_api()).get_expected_type() with
 			| None -> vnull

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -146,6 +146,13 @@ class Context {
 	}
 
 	/**
+		Check if current type is annotated with specified `meta`.
+	**/
+	public static function localTypeHasMeta(meta:String) : Bool {
+		return load("local_type_has_meta", 0)(meta);
+	}
+
+	/**
 		Returns the name of the method from which the macro was called.
 
 		If no such method exists, `null` is returned.


### PR DESCRIPTION
This PR proposes a method to speed up global build macros, which rely on a special meta being added to types (e.g. something like [tink_lang](https://haxetink.github.io/tink_lang)).

Here is a comparison to current approach on Haxe unit test:
```haxe
import haxe.macro.Context;

class SugarBuilder {
	static public function build() {
		var cls = Context.getLocalClass();
		if(cls == null || !cls.get().meta.has(':sugar')) return null;

		//do magic
		return null;
	}

	static public function buildWithHasMeta() {
		if(!Context.localTypeHasMeta(':sugar')) return null;

		//do magic
		return null;
	}
}
```
With `--macro addGlobalMetadata('', '@:build(SugarBuilder.build())')`
```
name                     | time(s) |   % |  p% |     # | info
--------------------------------------------------------
<...>
    build                |   0.032 |   1 |  10 |  1941 | SugarBuilder
 <...> 
--------------------------------------------------------
total                    |   3.556 | 100 | 100 | 85538 |
```
With `--macro addGlobalMetadata('', '@:build(SugarBuilder.buildWithHasMeta())')`
```
name                     | time(s) |   % |  p% |     # | info
--------------------------------------------------------
<..>
    buildWithHasMeta     |   0.008 |   0 |   3 |  1941 | SugarBuilder
<...>
--------------------------------------------------------
total                    |   3.523 | 100 | 100 | 85538 |
```
4 times faster. 
While it's not noticable on a project with the total compile time of 3 seconds, it could be a big difference for projects with compilation times of minutes.