### PR TITLE
Final keyword on constructors and static methods

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1413,6 +1413,11 @@ let init_class ctx c p context_init herits fields =
 			| Some r -> cf.cf_kind <- Var { v_read = AccRequire (fst r, snd r); v_write = AccRequire (fst r, snd r) });
 			begin match fctx.field_kind with
 			| FKConstructor ->
+				begin match c.cl_super with
+				| Some ({ cl_constructor = Some ctor_sup }, _) when has_class_field_flag ctor_sup CfFinal ->
+					ctx.com.error "Cannot override final constructor" cf.cf_pos
+				| _ -> ()
+				end;
 				begin match c.cl_constructor with
 				| None ->
 						c.cl_constructor <- Some cf

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1298,8 +1298,8 @@ let create_property (ctx,cctx,fctx) c f (get,set,t,eo) p =
 (**
 	Emit compilation error on `final static function`
 *)
-let reject_final_static_method ctx fctx f =
-	if fctx.is_static && fctx.is_final then
+let reject_final_static_method ctx cctx fctx f =
+	if fctx.is_static && fctx.is_final && not cctx.tclass.cl_extern then
 		let p =
 			try snd (List.find (fun (a,p) -> a = AFinal) f.cff_access)
 			with Not_found ->
@@ -1335,7 +1335,7 @@ let init_field (ctx,cctx,fctx) f =
 	| FVar (t,e) ->
 		create_variable (ctx,cctx,fctx) c f t e p
 	| FFun fd ->
-		reject_final_static_method ctx fctx f;
+		reject_final_static_method ctx cctx fctx f;
 		create_method (ctx,cctx,fctx) c f fd p
 	| FProp (get,set,t,eo) ->
 		create_property (ctx,cctx,fctx) c f (get,set,t,eo) p
@@ -1414,7 +1414,7 @@ let init_class ctx c p context_init herits fields =
 			begin match fctx.field_kind with
 			| FKConstructor ->
 				begin match c.cl_super with
-				| Some ({ cl_constructor = Some ctor_sup }, _) when has_class_field_flag ctor_sup CfFinal ->
+				| Some ({ cl_extern = false; cl_constructor = Some ctor_sup }, _) when has_class_field_flag ctor_sup CfFinal ->
 					ctx.com.error "Cannot override final constructor" cf.cf_pos
 				| _ -> ()
 				end;

--- a/tests/misc/projects/Issue8173/Main.hx
+++ b/tests/misc/projects/Issue8173/Main.hx
@@ -1,4 +1,12 @@
 class Main {
 	final static function main():Void {
 	}
+
+	final function new() {}
+}
+
+class Child extends Main {
+	function new() {
+		super();
+	}
 }

--- a/tests/misc/projects/Issue8173/Main.hx
+++ b/tests/misc/projects/Issue8173/Main.hx
@@ -1,0 +1,4 @@
+class Main {
+	final static function main():Void {
+	}
+}

--- a/tests/misc/projects/Issue8173/compile-fail.hxml
+++ b/tests/misc/projects/Issue8173/compile-fail.hxml
@@ -1,0 +1,1 @@
+-main Main

--- a/tests/misc/projects/Issue8173/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8173/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
 Main.hx:2: characters 2-7 : Static method cannot be final
-Main.hx:11: lines 11-13 : Cannot override final constructor
+Main.hx:9: lines 9-11 : Cannot override final constructor

--- a/tests/misc/projects/Issue8173/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8173/compile-fail.hxml.stderr
@@ -1,1 +1,2 @@
 Main.hx:2: characters 2-7 : Static method cannot be final
+Main.hx:11: lines 11-13 : Cannot override final constructor

--- a/tests/misc/projects/Issue8173/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8173/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:2: characters 2-7 : Static method cannot be final


### PR DESCRIPTION
Closes #8173 

Emits compilation errors on `final static function`: "Static method cannot be final"
Emits compilation error if child class defines a constructor while parent class has `final` constructor: "Cannot override final constructor"