### PR TITLE
[hl] Keep track of depth in Array.toString

### DIFF
--- a/std/hl/_std/Std.hx
+++ b/std/hl/_std/Std.hx
@@ -27,6 +27,7 @@ private typedef Rand = hl.Abstract<"hl_random">;
 class Std {
 
 	static var rnd : Rand;
+	static var toStringDepth : Int = 0;
 
 	static function __init__() : Void {
 		rnd = rnd_sys();

--- a/std/hl/types/ArrayObj.hx
+++ b/std/hl/types/ArrayObj.hx
@@ -148,7 +148,12 @@ class ArrayObj<T> extends ArrayBase {
 		b.addChar("[".code);
 		for( i in 0...length ) {
 			if( i > 0 ) b.addChar(",".code);
-			b.add(array[i]);
+			try {
+				b.add(array[i]);
+			} catch( e : Dynamic ) {
+				toStringDepth--;
+				throw e;
+			}
 		}
 		b.addChar("]".code);
 		toStringDepth--;

--- a/std/hl/types/ArrayObj.hx
+++ b/std/hl/types/ArrayObj.hx
@@ -139,24 +139,23 @@ class ArrayObj<T> extends ArrayBase {
 		return ret;
 	}
 
-	var toStringDepth : Int = 0;
-
+	@:access(Std.toStringDepth)
 	override function toString() : String {
-		if (toStringDepth >= 5) return "...";
-		toStringDepth++;
+		if (Std.toStringDepth >= 5) return "...";
+		Std.toStringDepth++;
 		var b = new StringBuf();
 		b.addChar("[".code);
-		for( i in 0...length ) {
-			if( i > 0 ) b.addChar(",".code);
-			try {
+		try {
+			for( i in 0...length ) {
+				if( i > 0 ) b.addChar(",".code);
 				b.add(array[i]);
-			} catch( e : Dynamic ) {
-				toStringDepth--;
-				throw e;
 			}
+		} catch( e : Dynamic ) {
+			Std.toStringDepth--;
+			hl.Api.rethrow(e);
 		}
 		b.addChar("]".code);
-		toStringDepth--;
+		Std.toStringDepth--;
 		return b.toString();
 	}
 

--- a/std/hl/types/ArrayObj.hx
+++ b/std/hl/types/ArrayObj.hx
@@ -139,7 +139,11 @@ class ArrayObj<T> extends ArrayBase {
 		return ret;
 	}
 
+	var toStringDepth : Int = 0;
+
 	override function toString() : String {
+		if (toStringDepth >= 5) return "...";
+		toStringDepth++;
 		var b = new StringBuf();
 		b.addChar("[".code);
 		for( i in 0...length ) {
@@ -147,6 +151,7 @@ class ArrayObj<T> extends ArrayBase {
 			b.add(array[i]);
 		}
 		b.addChar("]".code);
+		toStringDepth--;
 		return b.toString();
 	}
 


### PR DESCRIPTION
Avoids a stack overflow / segfault when stringifying this on HL:

```haxe
var a:Array<Dynamic> = [];
a.push(a);
trace(a);
```

`Array.toString` keeps a depth counter. See https://github.com/HaxeFoundation/haxe/pull/8113

Note: currently the depth counter is an instance field. Making it a `static var` triggers an [assertion failure](https://github.com/HaxeFoundation/haxe/blob/development/src/generators/genhl.ml#L1311) related to field indices.