### PR TITLE
[py] Fix #8197

### DIFF
--- a/std/python/io/NativeTextOutput.hx
+++ b/std/python/io/NativeTextOutput.hx
@@ -40,6 +40,10 @@ class NativeTextOutput extends NativeOutput<TextIOBase> {
 		IoTools.seekInTextMode(stream, tell, p, pos);
 	}
 
+	override public function writeBytes(s:haxe.io.Bytes, pos:Int, len:Int):Int {
+		return stream.buffer.write(python.Syntax.arrayAccess(@:privateAccess s.b, pos, pos + len));
+	}
+
 	override public function writeByte(c:Int):Void
 	{
 		stream.write(String.fromCharCode(c));


### PR DESCRIPTION
Prior to this PR, when using `Sys.stdout().writeString(...)` with a Unicode string:

 - string is encoded into a UTF-8 byte array
 - the byte array is iterated byte by byte
 - each byte is written separately via `String.fromCharCode`
 - any byte over 127 is re-encoded by Python into UTF-8 (so `0x80` turns into the incorrect `0xC2 0x80`)

Test for this is part of #8135 .