### PR TITLE
[cpp] Add fromStar to Pointer and ConstPointer

### DIFF
--- a/std/cpp/ConstPointer.hx
+++ b/std/cpp/ConstPointer.hx
@@ -51,6 +51,8 @@ extern class ConstPointer<T>
 
    public static function fromRaw<T>(ptr:RawConstPointer<T>) : ConstPointer<T>;
 
+   @:native("::cpp::Pointer_obj::fromRaw")
+   public static function fromStar<T>(star:Star<T>) : ConstPointer<T>;
 
    public static function fromPointer<T>(inNativePointer:Dynamic) : ConstPointer<T>;
 

--- a/std/cpp/Pointer.hx
+++ b/std/cpp/Pointer.hx
@@ -36,6 +36,9 @@ extern class Pointer<T> extends ConstPointer<T> implements ArrayAccess<T>
 
    public static function fromRaw<T>(ptr:RawPointer<T>) : Pointer<T>;
 
+   @:native("::cpp::Pointer_obj::fromRaw")
+   public static function fromStar<T>(star:Star<T>) : Pointer<T>;
+
    @:native("::cpp::Pointer_obj::fromHandle")
    static function nativeFromHandle<T>(inHandle:Dynamic,?inKind:String):AutoCast;
    inline public static function fromHandle<T>(inHandle:Dynamic,?inKind:String) : Pointer<T>


### PR DESCRIPTION
Hello,
I've started using `cpp.Star` for my externs and the only complaint I've got is the lack of an equivalent `Pointer.fromRaw` for going from a `cpp.Star` to `cpp.Pointer`. You can do it currently by using fromRaw and casting the `cpp.Star` to a `cpp.RawPointer`.

```haxe
var int = 4;
var star = Native.addressOf(int);

var ptr1 : Pointer<Int> = Pointer.fromRaw(cast star);
var ptr2 = (Pointer.fromRaw(cast star) : Pointer<Int>);
var ptr3 = Pointer.fromRaw((cast star : RawPointer<Int>));
```
But its not as nice as a dedicated `fromStar` function.
These changes add that `fromStar` function to `Pointer` and `ConstPointer`! The existing `fromRaw` function can be reused by changing the externs argument type, and the generated c++ code is the same as if you had cast the star to a raw pointer in the above example.

```haxe
var ptr4 = Pointer.fromStar(star);
```

Cheers.