### PR TITLE
Lex dot-idents for `#if`/`#elseif` conditionals

### DIFF
--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -279,14 +279,12 @@ let ident = [%sedlex.regexp?
 
 let sharp_ident = [%sedlex.regexp?
 	(
-		Plus ('a'..'z' | '_'),
+		('a'..'z' | '_'),
+		Star ('a'..'z' | 'A'..'Z' | '0'..'9' | '_'),
 		Star (
-			(
-				'.',
-				Plus ('_' | 'a'..'z' | 'A'..'Z' | '0'..'9')
-			)
-			|
-			Star ('_' | 'a'..'z' | 'A'..'Z' | '0'..'9')
+			'.',
+			('a'..'z' | '_'),
+			Star ('a'..'z' | 'A'..'Z' | '0'..'9' | '_')
 		)
 	)
 ]

--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -277,6 +277,20 @@ let ident = [%sedlex.regexp?
 	)
 ]
 
+let sharp_ident = [%sedlex.regexp?
+	(
+		Plus ('a'..'z' | '_'),
+		Star (
+			(
+				'.',
+				Plus ('_' | 'a'..'z' | 'A'..'Z' | '0'..'9')
+			)
+			|
+			Star ('_' | 'a'..'z' | 'A'..'Z' | '0'..'9')
+		)
+	)
+]
+
 let idtype = [%sedlex.regexp? Star '_', 'A'..'Z', Star ('_' | 'a'..'z' | 'A'..'Z' | '0'..'9')]
 
 let integer = [%sedlex.regexp? ('1'..'9', Star ('0'..'9')) | '0']
@@ -591,6 +605,14 @@ and not_xml ctx depth in_open =
 		not_xml ctx depth in_open
 	| _ ->
 		assert false
+
+let rec sharp_token lexbuf =
+	match%sedlex lexbuf with
+	| sharp_ident -> mk_ident lexbuf
+	| Plus (Chars " \t") -> sharp_token lexbuf
+	| "\r\n" -> newline lexbuf; sharp_token lexbuf
+	| '\n' | '\r' -> newline lexbuf; sharp_token lexbuf
+	| _ -> token lexbuf
 
 let lex_xml p lexbuf =
 	let name,pmin = match%sedlex lexbuf with

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -114,7 +114,7 @@ let parse ctx code file =
 	in_macro := Define.defined ctx Define.Macro;
 	Lexer.skip_header code;
 
-	let sraw = Stream.from (fun _ -> Some (Lexer.token code)) in
+	let sraw = Stream.from (fun _ -> Some (Lexer.sharp_token code)) in
 	let rec next_token() = process_token (Lexer.token code)
 
 	and process_token tk =

--- a/tests/unit/src/unit/issues/Issue8032.hx
+++ b/tests/unit/src/unit/issues/Issue8032.hx
@@ -1,0 +1,22 @@
+package unit.issues;
+
+import utest.Assert;
+
+class Issue8032 extends unit.Test {
+	function test() {
+		// crude but effective way to test this
+		#if sys
+			#if target.sys
+			Assert.pass();
+			#else
+			Assert.fail();
+			#end
+		#else
+			#if target.sys
+			Assert.fail();
+			#else
+			Assert.pass();
+			#end
+		#end
+	}
+}


### PR DESCRIPTION
After trying an failing to solve this at parser-level, I finally realized that we can simply lex `target.sys` as a single token when dealing with conditionals.

Closes #8032