### PR TITLE
[cs] Add support for .NET core

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -352,7 +352,7 @@
 		"platforms": ["cs"]
 	},
 	{
-		"name": "NetCoreVer",
+		"name": "NetcoreVer",
 		"define": "netcore_ver",
 		"doc": "<version:x.x.x> Sets the .NET core version to be targeted",
 		"platforms": ["cs"]

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -352,9 +352,15 @@
 		"platforms": ["cs"]
 	},
 	{
+		"name": "NetCoreVer",
+		"define": "netcore_ver",
+		"doc": "<version:x.x.x> Sets the .NET core version to be targeted",
+		"platforms": ["cs"]
+	},
+	{
 		"name": "NetTarget",
 		"define": "net_target",
-		"doc": "<name> Sets the .NET target. Defaults to \"net\". xbox, micro (Micro Framework), compact (Compact Framework) are some valid values",
+		"doc": "<name> Sets the .NET target. Defaults to \"net\". netcore, xbox, micro (Micro Framework), compact (Compact Framework) are some valid values",
 		"platforms": ["cs"]
 	},
 	{


### PR DESCRIPTION
Add support for `-D netcore-ver` to be able to properly use .NET core as cs target. This will be considered as `-D net-ver` 47 (which had similar features) where `-D net-ver` is required.

Will be used when `net_target` is set to `netcore`.

Fixes #5480 
See https://github.com/HaxeFoundation/hxcs/pull/39