### PR TITLE
Add tests for #5953

### DIFF
--- a/tests/misc/projects/Issue5953/Main.hx
+++ b/tests/misc/projects/Issue5953/Main.hx
@@ -1,0 +1,17 @@
+class Main {
+	static function main() {
+		var map = foo(null);
+		trace(map);
+	}
+
+	static function foo(m:NativeStringMap<String>)
+		return m.toMap();
+}
+
+abstract NativeStringMap<V>(Impl<V>) {
+	@:to public function toMap():Map<String, V> {
+		return new Map();
+	}
+}
+
+typedef Impl<V> = cs.system.collections.generic.IDictionary_2<String, V>;

--- a/tests/misc/projects/Issue5953/Reduced.hx
+++ b/tests/misc/projects/Issue5953/Reduced.hx
@@ -1,0 +1,10 @@
+@:nativeGen
+class C<T> {}
+
+class C2<T> {}
+
+abstract A<T>(C<T>) {
+	function f():C2<T> return null;
+
+	static function foo(a:A<String>) return a.f();
+}

--- a/tests/misc/projects/Issue5953/compile.hxml
+++ b/tests/misc/projects/Issue5953/compile.hxml
@@ -1,0 +1,3 @@
+-main Main
+Reduced
+-cs bin


### PR DESCRIPTION
Original example + first reduced (@nadako's comment) have been fixed by #8387, but examples involving `Null<Int>` have not (and are not tested in this PR).

Tests should pass now.