### PR TITLE
Revert "[lexer] leave open-mode on `>` so we don't parse `<div>/>`"

### DIFF
--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -592,10 +592,7 @@ and not_xml ctx depth in_open =
 		let depth = if in_open then depth - 1 else depth in
 		if depth < 0 then lexeme_end lexbuf
 		else not_xml ctx depth false
-	| '>' ->
-		store lexbuf;
-		not_xml ctx depth false
-	| '<' | '/' ->
+	| '<' | '/' | '>' ->
 		store lexbuf;
 		not_xml ctx depth in_open
 	| Plus (Compl ('<' | '/' | '>' | '\n' | '\r')) ->

--- a/tests/misc/projects/Issue8404/Main.hx
+++ b/tests/misc/projects/Issue8404/Main.hx
@@ -1,0 +1,13 @@
+class Main {
+	public static function main() {
+		trace(markup(<something onClick={e -> e.preventDefault()} />));
+		trace(markup(<something isSelected={42 > 0} />));
+	}
+
+	static macro function markup(e) {
+		return switch e {
+			case macro @:markup $v: macro "ok";
+			case _: throw 'Not markup';
+		};
+	}
+}

--- a/tests/misc/projects/Issue8404/compile.hxml
+++ b/tests/misc/projects/Issue8404/compile.hxml
@@ -1,0 +1,1 @@
+-main Main


### PR DESCRIPTION
This reverts commit b17bac736c9eb52708fc90251ce7a0ddf25a8185 which breaks inline markup with these kind of self-closing tags:

```haxe
var a = <something onClick={e -> e.preventDefault()} />;
var b = <something isSelected={42 > 0} />;
``` 