### PR TITLE
Flush PBuildClass on macro.Context.getType()

### DIFF
--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -74,20 +74,11 @@ let build_instance ctx mtype p =
 				let tf = (f()) in
 				unify_raise ctx tf t p;
 				link_dynamic t tf;
-				if ctx.pass >= PBuildClass then
-					flush_pass ctx PBuildClass "after_build_instance"
-				else begin
-					match tf with
-						| TInst (c, _) -> ignore(c.cl_build())
-						| TMono _
-						| TEnum _
-						| TType _
-						| TFun _
-						| TAnon _
-						| TDynamic _
-						| TLazy _
-						| TAbstract _ -> (* TODO *) ()
-				end;
+				(match tf with
+					| TInst (c, _) -> ignore(c.cl_build())
+					| TAbstract (a, _) -> Abstract.build_abstract a
+					| _ -> ()
+				);
 				t
 			) s in
 			TLazy r

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -74,7 +74,20 @@ let build_instance ctx mtype p =
 				let tf = (f()) in
 				unify_raise ctx tf t p;
 				link_dynamic t tf;
-				if ctx.pass >= PBuildClass then flush_pass ctx PBuildClass "after_build_instance";
+				if ctx.pass >= PBuildClass then
+					flush_pass ctx PBuildClass "after_build_instance"
+				else begin
+					match tf with
+						| TInst (c, _) -> ignore(c.cl_build())
+						| TMono _
+						| TEnum _
+						| TType _
+						| TFun _
+						| TAnon _
+						| TDynamic _
+						| TLazy _
+						| TAbstract _ -> (* TODO *) ()
+				end;
 				t
 			) s in
 			TLazy r

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -164,10 +164,6 @@ let make_macro_api ctx p =
 				with Error (Module_not_found _,p2) when p == p2 ->
 					None
 				in
-				(match m with
-					| Some (TInst (c, _)) -> ignore(c.cl_build())
-					| _ -> ()
-				);
 				m
 			)
 		);

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -158,11 +158,14 @@ let make_macro_api ctx p =
 					| _ ->
 						{ tpackage = fst path; tname = snd path; tparams = []; tsub = None }
 				in
-				try
+				let m = try
 					let m = Some (Typeload.load_instance ctx (tp,p) true) in
 					m
 				with Error (Module_not_found _,p2) when p == p2 ->
 					None
+				in
+				Option.may (fun _ -> flush_pass ctx PBuildClass "macro.get_type") m;
+				m
 			)
 		);
 		MacroApi.resolve_type = (fun t p ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -164,7 +164,10 @@ let make_macro_api ctx p =
 				with Error (Module_not_found _,p2) when p == p2 ->
 					None
 				in
-				Option.may (fun _ -> flush_pass ctx PBuildClass "macro.get_type") m;
+				(match m with
+					| Some (TInst (c, _)) -> ignore(c.cl_build())
+					| _ -> ()
+				);
 				m
 			)
 		);

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -158,13 +158,11 @@ let make_macro_api ctx p =
 					| _ ->
 						{ tpackage = fst path; tname = snd path; tparams = []; tsub = None }
 				in
-				let m = try
+				try
 					let m = Some (Typeload.load_instance ctx (tp,p) true) in
 					m
 				with Error (Module_not_found _,p2) when p == p2 ->
 					None
-				in
-				m
 			)
 		);
 		MacroApi.resolve_type = (fun t p ->

--- a/tests/misc/projects/Issue7905/Main.hx
+++ b/tests/misc/projects/Issue7905/Main.hx
@@ -1,0 +1,25 @@
+#if !macro
+typedef Huh = GenericBuild<Int>;
+@:genericBuild(Main.GenericBuild.build())
+#end
+class GenericBuild<T> {
+  #if macro
+  static var counter = 0;
+  static function build() {
+    var name = 'Cls${counter++}';
+    var ret = macro class $name {
+      public function new() {}
+    }
+    haxe.macro.Context.defineType(ret);
+    return haxe.macro.Context.getType(name);
+  }
+  #end
+}
+
+class Main {
+  static function main() {
+    #if !macro
+    $type(Huh.new);
+    #end
+  }
+}

--- a/tests/misc/projects/Issue7905/compile.hxml
+++ b/tests/misc/projects/Issue7905/compile.hxml
@@ -1,0 +1,1 @@
+-main Main

--- a/tests/misc/projects/Issue7905/compile.hxml.stderr
+++ b/tests/misc/projects/Issue7905/compile.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:22: characters 11-18 : Warning : Void -> Cls0


### PR DESCRIPTION
Fixes #7905
Fixes #6959
Fixes #4272

An issue happens only if  attempting to "getType" the type, which was "defineType" in the same macro context. 
That is, if a macro defines a type (e.g. "MyClass") and then that type is directly referenced in user's code, then no additional flushing is required and everything works correctly.
But if `Context.getType("MyClass")` is executed then "MyClass" is returned without being fully built. That's why I propose to flush PBuildClass on `Context.getType()`.
Additionally, we can have a register of types declared via "defineType" and flush only if "getType" is called for one of the types in that register.
Tests suite for "macro" target passes locally. Though, I don't know what possible implications may occur because of this change.

Edit: 
The above reasoning is outdated. The type declared with `defineType` may be requested in a macro in different ways, not only through `getType`.
So, the current idea is to ensure the type is built on `TLazy` resolving since all macro-defined types goes through `TLazy`.