### PR TITLE
[js] Fix TypedArray APIs

### DIFF
--- a/std/js/lib/ArrayBuffer.hx
+++ b/std/js/lib/ArrayBuffer.hx
@@ -24,7 +24,8 @@ package js.lib;
 @:native("ArrayBuffer")
 extern class ArrayBuffer {
 	static function isView( value : Dynamic ) : Bool;
-	var byteLength(default,null) : Int;
+	
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	function new( length : Int ) : Void;

--- a/std/js/lib/ArrayBuffer.hx
+++ b/std/js/lib/ArrayBuffer.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("ArrayBuffer")

--- a/std/js/lib/ArrayBufferView.hx
+++ b/std/js/lib/ArrayBufferView.hx
@@ -43,7 +43,7 @@ abstract ArrayBufferView(_ArrayBufferView)
 {}
 
 private typedef _ArrayBufferView = {
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 }

--- a/std/js/lib/ArrayBufferView.hx
+++ b/std/js/lib/ArrayBufferView.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 /**

--- a/std/js/lib/ArrayBufferView.hx
+++ b/std/js/lib/ArrayBufferView.hx
@@ -31,9 +31,22 @@ package js.lib;
 
 	@see <https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView>
 **/
-extern interface ArrayBufferView {
+@:forward
+abstract ArrayBufferView(_ArrayBufferView)
+	from Int8Array
+	from Uint8Array
+	from Uint8ClampedArray
+	from Int16Array
+	from Uint16Array
+	from Int32Array
+	from Uint32Array
+	from Float32Array
+	from Float64Array
+	from DataView
+{}
+
+private typedef _ArrayBufferView = {
 	var buffer(default,null) : ArrayBuffer;
 	var byteOffset(default,null) : Int;
 	var byteLength(default,null) : Int;
-	
 }

--- a/std/js/lib/BufferSource.hx
+++ b/std/js/lib/BufferSource.hx
@@ -33,10 +33,9 @@ import haxe.extern.EitherType;
 
 	@see <https://developer.mozilla.org/en-US/docs/Web/API/BufferSource>
  */
-abstract BufferSource(EitherType<ArrayBuffer, ArrayBufferView>)
-	from ArrayBuffer
-	from ArrayBufferView
-{
-	public var buffer(get, never) : ArrayBuffer;
-	inline function get_buffer() return Std.is(this, ArrayBuffer) ? this : (this: ArrayBufferView).buffer;
+@:forward
+abstract BufferSource(ArrayBuffer) to ArrayBuffer from ArrayBuffer {
+	@:from public static inline function fromBufferView(view: ArrayBufferView) {
+		return cast view.buffer;
+	}
 }

--- a/std/js/lib/BufferSource.hx
+++ b/std/js/lib/BufferSource.hx
@@ -21,6 +21,8 @@
  */
 package js.lib;
 
+import haxe.extern.EitherType;
+
 /**
 	`BufferSource` is a typedef used to represent objects that are either themselves an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer),
 	or which are a [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) providing an [ArrayBufferView](https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView).
@@ -31,7 +33,10 @@ package js.lib;
 
 	@see <https://developer.mozilla.org/en-US/docs/Web/API/BufferSource>
  */
-abstract BufferSource(Dynamic)
+abstract BufferSource(EitherType<ArrayBuffer, ArrayBufferView>)
 	from ArrayBuffer
 	from ArrayBufferView
-{}
+{
+	public var buffer(get, never) : ArrayBuffer;
+	inline function get_buffer() return Std.is(this, ArrayBuffer) ? this : (this: ArrayBufferView).buffer;
+}

--- a/std/js/lib/BufferSource.hx
+++ b/std/js/lib/BufferSource.hx
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package js.lib;
+
+/**
+	`BufferSource` is a typedef used to represent objects that are either themselves an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer),
+	or which are a [TypedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) providing an [ArrayBufferView](https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView).
+
+	This is a helper type to simplify the specification. It isn't an interface and there are no objects implementing it.
+
+	Documentation [BufferSource](https://developer.mozilla.org/en-US/docs/Web/API/BufferSource) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/API/BufferSource$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
+
+	@see <https://developer.mozilla.org/en-US/docs/Web/API/BufferSource>
+ */
+abstract BufferSource(Dynamic)
+	from ArrayBuffer
+	from ArrayBufferView
+{}

--- a/std/js/lib/DataView.hx
+++ b/std/js/lib/DataView.hx
@@ -23,9 +23,9 @@ package js.lib;
 
 @:native("DataView")
 extern class DataView {
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	function new( buffer : ArrayBuffer, ?byteOffset : Int, ?byteLength : Int ) : Void;

--- a/std/js/lib/DataView.hx
+++ b/std/js/lib/DataView.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("DataView")

--- a/std/js/lib/DataView.hx
+++ b/std/js/lib/DataView.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("DataView")
-extern class DataView implements ArrayBufferView {
+extern class DataView {
 	var buffer(default,null) : ArrayBuffer;
 	var byteOffset(default,null) : Int;
 	var byteLength(default,null) : Int;

--- a/std/js/lib/Float32Array.hx
+++ b/std/js/lib/Float32Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Float32Array")

--- a/std/js/lib/Float32Array.hx
+++ b/std/js/lib/Float32Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Float32Array")
-extern class Float32Array implements ArrayBufferView implements ArrayAccess<Float> {
+extern class Float32Array implements ArrayAccess<Float> {
 	static inline var BYTES_PER_ELEMENT : Int = 4;
 	
 	@:pure

--- a/std/js/lib/Float32Array.hx
+++ b/std/js/lib/Float32Array.hx
@@ -29,12 +29,13 @@ extern class Float32Array implements ArrayAccess<Float> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Float32Array;
 	@:pure
 	static function from( source : Array<Float>, ?mapFn : Float -> Float -> Float, ?thisArg : Dynamic ) : Float32Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Float64Array.hx
+++ b/std/js/lib/Float64Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Float64Array")

--- a/std/js/lib/Float64Array.hx
+++ b/std/js/lib/Float64Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Float64Array")
-extern class Float64Array implements ArrayBufferView implements ArrayAccess<Float> {
+extern class Float64Array implements ArrayAccess<Float> {
 	static inline var BYTES_PER_ELEMENT : Int = 8;
 	
 	@:pure

--- a/std/js/lib/Float64Array.hx
+++ b/std/js/lib/Float64Array.hx
@@ -29,12 +29,13 @@ extern class Float64Array implements ArrayAccess<Float> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Float64Array;
 	@:pure
 	static function from( source : Array<Float>, ?mapFn : Float -> Float -> Float, ?thisArg : Dynamic ) : Float64Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Int16Array.hx
+++ b/std/js/lib/Int16Array.hx
@@ -29,12 +29,13 @@ extern class Int16Array implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Int16Array;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Int16Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Int16Array.hx
+++ b/std/js/lib/Int16Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Int16Array")
-extern class Int16Array implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Int16Array implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 2;
 	
 	@:pure

--- a/std/js/lib/Int16Array.hx
+++ b/std/js/lib/Int16Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Int16Array")

--- a/std/js/lib/Int32Array.hx
+++ b/std/js/lib/Int32Array.hx
@@ -29,12 +29,13 @@ extern class Int32Array implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Int32Array;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Int32Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Int32Array.hx
+++ b/std/js/lib/Int32Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Int32Array")

--- a/std/js/lib/Int32Array.hx
+++ b/std/js/lib/Int32Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Int32Array")
-extern class Int32Array implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Int32Array implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 4;
 	
 	@:pure

--- a/std/js/lib/Int8Array.hx
+++ b/std/js/lib/Int8Array.hx
@@ -29,12 +29,13 @@ extern class Int8Array implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Int8Array;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Int8Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Int8Array.hx
+++ b/std/js/lib/Int8Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Int8Array")
-extern class Int8Array implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Int8Array implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 1;
 	
 	@:pure

--- a/std/js/lib/Int8Array.hx
+++ b/std/js/lib/Int8Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Int8Array")

--- a/std/js/lib/Uint16Array.hx
+++ b/std/js/lib/Uint16Array.hx
@@ -29,12 +29,13 @@ extern class Uint16Array implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Uint16Array;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Uint16Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Uint16Array.hx
+++ b/std/js/lib/Uint16Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Uint16Array")
-extern class Uint16Array implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Uint16Array implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 2;
 	
 	@:pure

--- a/std/js/lib/Uint16Array.hx
+++ b/std/js/lib/Uint16Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Uint16Array")

--- a/std/js/lib/Uint32Array.hx
+++ b/std/js/lib/Uint32Array.hx
@@ -29,12 +29,13 @@ extern class Uint32Array implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Uint32Array;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Uint32Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Uint32Array.hx
+++ b/std/js/lib/Uint32Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Uint32Array")

--- a/std/js/lib/Uint32Array.hx
+++ b/std/js/lib/Uint32Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Uint32Array")
-extern class Uint32Array implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Uint32Array implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 4;
 	
 	@:pure

--- a/std/js/lib/Uint8Array.hx
+++ b/std/js/lib/Uint8Array.hx
@@ -29,12 +29,13 @@ extern class Uint8Array implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Uint8Array;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Uint8Array;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Uint8Array.hx
+++ b/std/js/lib/Uint8Array.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Uint8Array")
-extern class Uint8Array implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Uint8Array implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 1;
 	
 	@:pure

--- a/std/js/lib/Uint8Array.hx
+++ b/std/js/lib/Uint8Array.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Uint8Array")

--- a/std/js/lib/Uint8ClampedArray.hx
+++ b/std/js/lib/Uint8ClampedArray.hx
@@ -19,9 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
-// This file is generated from typedarray.webidl. Do not edit!
-
 package js.lib;
 
 @:native("Uint8ClampedArray")

--- a/std/js/lib/Uint8ClampedArray.hx
+++ b/std/js/lib/Uint8ClampedArray.hx
@@ -29,12 +29,13 @@ extern class Uint8ClampedArray implements ArrayAccess<Int> {
 	static function of( items : haxe.extern.Rest<Array<Dynamic>> ) : Uint8ClampedArray;
 	@:pure
 	static function from( source : Array<Int>, ?mapFn : Int -> Int -> Int, ?thisArg : Dynamic ) : Uint8ClampedArray;
+
 	@:native("BYTES_PER_ELEMENT")
-	var BYTES_PER_ELEMENT_(default,null) : Int;
-	var length(default,null) : Int;
-	var buffer(default,null) : ArrayBuffer;
-	var byteOffset(default,null) : Int;
-	var byteLength(default,null) : Int;
+	final BYTES_PER_ELEMENT_ : Int;
+	final length : Int;
+	final buffer : ArrayBuffer;
+	final byteOffset : Int;
+	final byteLength : Int;
 	
 	/** @throws DOMError */
 	@:overload( function( length : Int ) : Void {} )

--- a/std/js/lib/Uint8ClampedArray.hx
+++ b/std/js/lib/Uint8ClampedArray.hx
@@ -25,7 +25,7 @@
 package js.lib;
 
 @:native("Uint8ClampedArray")
-extern class Uint8ClampedArray implements ArrayBufferView implements ArrayAccess<Int> {
+extern class Uint8ClampedArray implements ArrayAccess<Int> {
 	static inline var BYTES_PER_ELEMENT : Int = 1;
 	
 	@:pure


### PR DESCRIPTION
* Make `ArrayBufferView` to abstract. It doesn't really exist.
    * https://heycam.github.io/webidl/#ArrayBufferView
    * `Std.is(x, js.lib.ArrayBufferView)` doesn't work - http://try-haxe.mrcdk.com/#53EA3
* Add `BufferSource`.
* Remove "Do not edit!" comment.
    * [document gerenerator](https://github.com/haxiomic/html-extern-api-docs) #7354 can't generate these.
