### PR TITLE
Use from/to position in incompatible from/to errors

### DIFF
--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -744,12 +744,13 @@ let init_module_type ctx context_init do_init (decl,p) =
 		let ctx = { ctx with type_params = a.a_params } in
 		let is_type = ref false in
 		let load_type t from =
+			let _, pos = t in
 			let t = load_complex_type ctx true t in
 			let t = if not (Meta.has Meta.CoreType a.a_meta) then begin
 				if !is_type then begin
 					let r = exc_protect ctx (fun r ->
 						r := lazy_processing (fun() -> t);
-						(try (if from then Type.unify t a.a_this else Type.unify a.a_this t) with Unify_error _ -> error "You can only declare from/to with compatible types" p);
+						(try (if from then Type.unify t a.a_this else Type.unify a.a_this t) with Unify_error _ -> error "You can only declare from/to with compatible types" pos);
 						t
 					) "constraint" in
 					TLazy r

--- a/tests/misc/projects/Issue8354/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8354/compile1-fail.hxml.stderr
@@ -1,1 +1,1 @@
-FailTo.hx:10: characters 1-56 : You can only declare from/to with compatible types
+FailTo.hx:10: characters 42-53 : You can only declare from/to with compatible types

--- a/tests/misc/projects/Issue8354/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8354/compile2-fail.hxml.stderr
@@ -1,1 +1,1 @@
-FailFrom.hx:10: characters 1-57 : You can only declare from/to with compatible types
+FailFrom.hx:10: characters 44-54 : You can only declare from/to with compatible types


### PR DESCRIPTION
Change the `You can only declare from/to with compatible types` error position to the `from`/`to` declaration (now points to `X` in `from X` instead of pointing to the whole abstract).

I did not add specific tests as tests for #8354 seem enough to check the position.

Fixes #8423 