### PR TITLE
[cs] Enable sys.thread API

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -355,6 +355,7 @@ let get_config com =
 			pf_capture_policy = CPWrapRef;
 			pf_pad_nulls = true;
 			pf_overload = true;
+			pf_supports_threads = true;
 		}
 	| Java ->
 		{


### PR DESCRIPTION
C# seems to have been left out in https://github.com/HaxeFoundation/haxe/commit/2bb054b0bedd6f5e665e0c1ab4b586cac310bb27, although it has [an implementation of the sys.thread package](https://github.com/HaxeFoundation/haxe/tree/development/std/cs/_std/sys/thread).

Fixes #8431 