### PR TITLE
Limit octal string escapes to ASCII range as well

### DIFF
--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -496,9 +496,11 @@ let unescape s =
 				| 'r' -> Buffer.add_char b '\r'
 				| 't' -> Buffer.add_char b '\t'
 				| '"' | '\'' | '\\' -> Buffer.add_char b c
-				| '0'..'1' ->
-					let c = (try char_of_int (int_of_string ("0o" ^ String.sub s i 3)) with _ -> fail None) in
-					Buffer.add_char b c;
+				| '0'..'3' ->
+					let u = (try (int_of_string ("0o" ^ String.sub s i 3)) with _ -> fail None) in
+					if u > 127 then
+						fail (Some ("Values greater than \\177 are not allowed. Use \\u00" ^ (Printf.sprintf "%02x" u) ^ " instead."));
+					Buffer.add_char b (char_of_int u);
 					inext := !inext + 2;
 				| 'x' ->
 					let fail_no_hex () = fail (Some "Must be followed by a hexadecimal sequence.") in
@@ -506,7 +508,7 @@ let unescape s =
 					let u = (try (int_of_string ("0x" ^ hex)) with _ -> fail_no_hex ()) in
 					if u > 127 then
 						fail (Some ("Values greater than \\x7f are not allowed. Use \\u00" ^ hex ^ " instead."));
-					UTF8.add_uchar b (UChar.uchar_of_int u);
+					Buffer.add_char b (char_of_int u);
 					inext := !inext + 2;
 				| 'u' ->
 					let fail_no_hex () = fail (Some "Must be followed by a hexadecimal sequence enclosed in curly brackets.") in

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -496,7 +496,7 @@ let unescape s =
 				| 'r' -> Buffer.add_char b '\r'
 				| 't' -> Buffer.add_char b '\t'
 				| '"' | '\'' | '\\' -> Buffer.add_char b c
-				| '0'..'3' ->
+				| '0'..'1' ->
 					let c = (try char_of_int (int_of_string ("0o" ^ String.sub s i 3)) with _ -> fail None) in
 					Buffer.add_char b c;
 					inext := !inext + 2;

--- a/tests/misc/projects/Issue8119/Main2.hx
+++ b/tests/misc/projects/Issue8119/Main2.hx
@@ -1,0 +1,5 @@
+class Main2 {
+	static public function main() {
+		"\200";
+	}
+}

--- a/tests/misc/projects/Issue8119/compile2-fail.hxml
+++ b/tests/misc/projects/Issue8119/compile2-fail.hxml
@@ -1,0 +1,1 @@
+-main Main2

--- a/tests/misc/projects/Issue8119/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8119/compile2-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:3: Invalid escape sequence \2. Values greater than \177 are not allowed. Use \u0080 instead.

--- a/tests/misc/projects/Issue8119/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8119/compile2-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:3: Invalid escape sequence \2. Values greater than \177 are not allowed. Use \u0080 instead.
+Main2.hx:3: character 4 : Invalid escape sequence \2. Values greater than \177 are not allowed. Use \u0080 instead.


### PR DESCRIPTION
`\xNN` is limited to `\x7F`, but `\377` still produced a 255 byte value. `177` in octal is 127.