### PR TITLE
Add Context.info(msg,pos)

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -487,6 +487,7 @@ try
 	Common.raw_define com "haxe4";
 	Common.define_value com Define.Haxe (s_version false);
 	Common.define_value com Define.Dce "std";
+	com.info <- (fun msg p -> message ctx (CMInfo(msg,p)));
 	com.warning <- (fun msg p -> message ctx (CMWarning(msg,p)));
 	com.error <- error ctx;
 	if CompilationServer.runs() then com.run_command <- run_command ctx;

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -589,7 +589,7 @@ try
 			com.debug <- true;
 		),"","add debug information to the compiled code");
 		("Miscellaneous",["--version"],["-version"],Arg.Unit (fun() ->
-			message ctx (CMInfo(s_version true,null_pos));
+			com.info (s_version true) null_pos;
 			did_something := true;
 		),"","print version and exit");
 		("Miscellaneous", ["-h";"--help"], ["-help"], Arg.Unit (fun () ->
@@ -1022,7 +1022,7 @@ with
 	| Failure msg when not (is_debug_run()) ->
 		error ctx ("Error: " ^ msg) null_pos
 	| HelpMessage msg ->
-		message ctx (CMInfo(msg,null_pos))
+		com.info msg null_pos
 	| DisplayException(DisplayHover _ | DisplayPositions _ | DisplayFields _ | DisplayPackage _  | DisplaySignatures _ as de) when ctx.com.json_out <> None ->
 		begin
 			DisplayPosition.display_position#reset;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -178,6 +178,7 @@ type context = {
 	mutable main_class : path option;
 	mutable package_rules : (string,package_rule) PMap.t;
 	mutable error : string -> pos -> unit;
+	mutable info : string -> pos -> unit;
 	mutable warning : string -> pos -> unit;
 	mutable load_extern_type : (path -> pos -> (string * Ast.package) option) list; (* allow finding types which are not in sources *)
 	callbacks : compiler_callbacks;
@@ -448,6 +449,7 @@ let create version s_version args =
 			values = defines;
 		};
 		get_macros = (fun() -> None);
+		info = (fun _ _ -> assert false);
 		warning = (fun _ _ -> assert false);
 		error = (fun _ _ -> assert false);
 		pass_debug_messages = DynArray.create();

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1496,6 +1496,12 @@ let macro_api ccom get_api =
 			(ccom()).warning msg p;
 			vnull
 		);
+		"info", vfun2 (fun msg p ->
+			let msg = decode_string msg in
+			let p = decode_pos p in
+			(ccom()).info msg p;
+			vnull
+		);
 		"class_path", vfun0 (fun() ->
 			encode_array (List.map encode_string (ccom()).class_path);
 		);

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -62,6 +62,13 @@ class Context {
 	}
 
 	/**
+		Displays a compilation info `msg` at the given `Position` `pos`.
+	**/
+	public static function info( msg : String, pos : Position ) {
+		load("info",2)(msg, pos);
+	}
+
+	/**
 		Resolves a file name `file` based on the current class paths.
 
 		The resolution follows the usual class path rules where the last


### PR DESCRIPTION
This adds a new function to `haxe.macro.Context`: `info(msg:String, pos:Position):Void` to display an information message (`CMInfo`, like `--version`)

_(API to get or filter messages (both info and warning) is implemented independently in #8471)_
 