### PR TITLE
[js] improve downcasting generation

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -49,7 +49,7 @@ type ctx = {
 	js_modern : bool;
 	js_flatten : bool;
 	has_resolveClass : bool;
-	has_instanceof : bool;
+	has_interface_check : bool;
 	es_version : int;
 	mutable current : tclass;
 	mutable statics : (tclass * string * texpr) list;
@@ -1113,7 +1113,7 @@ let generate_class_es3 ctx c =
 	generate_class___name__ ctx c;
 	generate_class___isInterface__ ctx c;
 
-	if ctx.has_instanceof then
+	if ctx.has_interface_check then
 		(match c.cl_implements with
 		| [] -> ()
 		| l ->
@@ -1268,7 +1268,7 @@ let generate_class_es6 ctx c =
 	generate_class___name__ ctx c;
 	generate_class___isInterface__ ctx c;
 
-	if ctx.has_instanceof then
+	if ctx.has_interface_check then
 		(match c.cl_implements with
 		| [] -> ()
 		| l ->
@@ -1294,7 +1294,7 @@ let generate_class_es6 ctx c =
 
 	(match c.cl_super with
 	| Some (csup,_) ->
-		if ctx.has_instanceof || has_feature ctx "Type.getSuperClass" then begin
+		if ctx.has_interface_check || has_feature ctx "Type.getSuperClass" then begin
 			let psup = ctx.type_accessor (TClassDecl csup) in
 			print ctx "%s.__super__ = %s" p psup;
 			newline ctx
@@ -1471,7 +1471,7 @@ let generate_require ctx path meta =
 
 let need_to_generate_interface ctx cl_iface =
 	ctx.has_resolveClass (* generate so we can resolve it for whatever reason *)
-	|| ctx.has_instanceof (* generate because we need __interfaces__ for run-time type checks *)
+	|| ctx.has_interface_check (* generate because we need __interfaces__ for run-time type checks *)
 	|| is_directly_used ctx.com cl_iface.cl_meta (* generate because it's just directly accessed in code *)
 
 let generate_type ctx = function
@@ -1529,7 +1529,7 @@ let alloc_ctx com es_version =
 		js_modern = not (Common.defined com Define.JsClassic);
 		js_flatten = not (Common.defined com Define.JsUnflatten);
 		has_resolveClass = Common.has_feature com "Type.resolveClass";
-		has_instanceof = Common.has_feature com "js.Boot.__instanceof";
+		has_interface_check = Common.has_feature com "js.Boot.__interfLoop";
 		es_version = es_version;
 		statics = [];
 		inits = [];

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -57,10 +57,12 @@ class Boot {
 		return untyped __define_feature__("js.Boot.isEnum", e.__ename__);
 	}
 
-	static function getClass(o:Dynamic) : Dynamic {
-		if (Std.is(o, Array))
+	static function getClass(o:Null<Dynamic>) : Null<Dynamic> {
+		if (o == null) {
+			return null;
+		} else if (Std.is(o, Array)) {
 			return Array;
-		else {
+		} else {
 			var cl = untyped __define_feature__("js.Boot.getClass", o.__class__);
 			if (cl != null)
 				return cl;
@@ -194,12 +196,9 @@ class Boot {
 			if( o != null ) {
 				// Check if o is an instance of a Haxe class or a native JS object
 				if( js.Syntax.typeof(cl) == "function" ) {
-					if( js.Syntax.instanceof(o, cl) )
+					if (__downcastCheck(o, cl))
 						return true;
-					if( __interfLoop(getClass(o),cl) )
-						return true;
-				}
-				else if ( js.Syntax.typeof(cl) == "object" && __isNativeObj(cl) ) {
+				} else if ( js.Syntax.typeof(cl) == "object" && __isNativeObj(cl) ) {
 					if( js.Syntax.instanceof(o, cl) )
 						return true;
 				}
@@ -217,8 +216,12 @@ class Boot {
 		}
 	}
 
-	static inline function __implements(o : Dynamic, t : Class<Dynamic>) : Bool {
-		return o != null && isInterface(t) && __interfLoop(getClass(o), t);
+	static function __downcastCheck(o : Dynamic, cl : Class<Dynamic>) : Bool {
+		return js.Syntax.instanceof(o, cl) || (isInterface(cl) && inline __implements(o, cl));
+	}
+
+	static function __implements(o : Dynamic, iface : Class<Dynamic>) : Bool {
+		return __interfLoop(getClass(o), iface);
 	}
 
 	@:ifFeature("typed_cast") private static function __cast(o : Dynamic, t : Dynamic) {

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -57,7 +57,7 @@ class Boot {
 		return untyped __define_feature__("js.Boot.isEnum", e.__ename__);
 	}
 
-	static function getClass(o:Null<Dynamic>) : Null<Dynamic> {
+	@:pure static function getClass(o:Null<Dynamic>) : Null<Dynamic> {
 		if (o == null) {
 			return null;
 		} else if (Std.is(o, Array)) {
@@ -160,7 +160,7 @@ class Boot {
 		}
 	}
 
-	private static function __interfLoop(cc : Dynamic,cl : Dynamic) {
+	@:pure private static function __interfLoop(cc : Dynamic,cl : Dynamic) {
 		if( cc == null )
 			return false;
 		if( cc == cl )

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -29,7 +29,7 @@ import js.Boot;
 	}
 
 	public static inline function downcast<T:{},S:T>( value : T, c : Class<S> ) : S @:privateAccess {
-		return js.Syntax.instanceof(value, c) || Boot.__implements(value, c) ? cast value : null;
+		return if (js.Boot.__downcastCheck(value, c)) cast value else null;
 	}
 
 	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -33,7 +33,7 @@ enum ValueType {
 
 @:coreApi class Type {
 	public static inline function getClass<T>(o:T):Class<T> {
-		return if (o == null) null else @:privateAccess js.Boot.getClass(o);
+		return @:privateAccess js.Boot.getClass(o);
 	}
 
 	public static function getEnum(o:EnumValue):Enum<Dynamic>


### PR DESCRIPTION
This improves generated code for `Std.is` and `Std.downcast`:

---

`Std.is` (aka `js.Boot.__instanceof`) now has an additional optimization when checking against a known interface: instead of generating full `js.Boot.__instanceof` call, we generate `js.Boot.__implements` that does the bare minimum for checking interface implementation.

```haxe
Std.is(v, I)
```
generates simply
```js
js_Boot.__implements(v,I)
```

---

`Std.downcast` is now once again suitable for inlining and uses the new `js.Boot.__downcastCheck` method which is optimized for the known class and interface cases:

```haxe
var c = Std.downcast(v, C);
var i = Std.downcast(v, I);
var d = Std.downcast(v, unknown);
```

BEFORE:
```js
var c = C;
var c1;
if(!((v) instanceof c)) {
	var o = v;
	c1 = o != null && c.__isInterface__ && js_Boot.__interfLoop(js_Boot.getClass(o),c);
} else {
	c1 = true;
}
var c2 = c1 ? v : null;
var c3 = I;
var i;
if(!((v) instanceof c3)) {
	var o1 = v;
	i = o1 != null && c3.__isInterface__ && js_Boot.__interfLoop(js_Boot.getClass(o1),c3);
} else {
	i = true;
}
var i1 = i ? v : null;
var c4 = unknown;
var d;
if(!((v) instanceof c4)) {
	var o2 = v;
	d = o2 != null && c4.__isInterface__ && js_Boot.__interfLoop(js_Boot.getClass(o2),c4);
} else {
	d = true;
}
var d1 = d ? v : null;
```

AFTER:
```js
var c = ((v) instanceof C) ? v : null;
var i = js_Boot.__implements(v,I) ? v : null;
var d = js_Boot.__downcastCheck(v,unknown) ? v : null;
```