### PR TITLE
[cpp] Added decBy and sub externs to cpp.Pointer and cpp.ConstPointer

### DIFF
--- a/std/cpp/ConstPointer.hx
+++ b/std/cpp/ConstPointer.hx
@@ -63,7 +63,9 @@ extern class ConstPointer<T> {
 
 	public function inc():ConstPointer<T>;
 	public function dec():ConstPointer<T>;
-	public function postIncVal():Reference<T>;
 	public function incBy(inT:Int):ConstPointer<T>;
+	public function decBy(inT:Int):ConstPointer<T>;
 	public function add(inT:Int):ConstPointer<T>;
+	public function sub(inT:Int):ConstPointer<T>;
+	public function postIncVal():Reference<T>;
 }

--- a/std/cpp/Pointer.hx
+++ b/std/cpp/Pointer.hx
@@ -75,7 +75,9 @@ extern class Pointer<T> extends ConstPointer<T> implements ArrayAccess<T> {
 	override public function inc():Pointer<T>;
 	override public function dec():Pointer<T>;
 	override public function incBy(inT:Int):Pointer<T>;
+	override public function decBy(inT:Int):Pointer<T>;
 	override public function add(inT:Int):Pointer<T>;
+	override public function sub(inT:Int):Pointer<T>;
 
 	public function postIncRef():Reference<T>;
 


### PR DESCRIPTION
Requires this hxcpp PR https://github.com/HaxeFoundation/hxcpp/pull/824.

Adds the externs to Pointer and ConstPointer for the hxcpp sub and decBy functions.