### PR TITLE
[js] Add `self` field to represent worker global context

### DIFF
--- a/std/js/Browser.hx
+++ b/std/js/Browser.hx
@@ -28,6 +28,9 @@ import js.html.XMLHttpRequest;
 class Browser {
 	/** The global window object. */
 	public static var window(get, never):js.html.Window;
+	
+        /** The global scope with additional fields available only in a worker context. */
+	public static var self(get, never):js.html.DedicatedWorkerGlobalScope;
 
 	extern inline static function get_window()
 		return untyped __js__("window");


### PR DESCRIPTION
In a web worker context the global scope has a few addition fields (see https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope). In js the `self` keyword is often used to access these fields so to make these available in haxe `self` has been added to `js.Browser`

closes #4435

