### PR TITLE
Date improvements

### DIFF
--- a/std/Date.hx
+++ b/std/Date.hx
@@ -32,7 +32,18 @@
 	There are some extra functions available in the `DateTools` class.
 
 	In the context of Haxe dates, a timestamp is defined as the number of
-	milliseconds elapsed since 1st January 1970.
+	milliseconds elapsed since 1st January 1970 UTC.
+
+	## Supported range
+
+	Most Haxe targets support dates outside the range of years 1970 through 2038.
+	Due to platform limitations, there are some exceptions:
+
+	- hl, cpp, and eval only support years 1970 and up
+	- neko only supports the range 1902 to 2038
+
+	Additionally, the `Date.fromTime()` function will not work with timestamps
+	outside the 1970 through 2038 range on any platform.
 **/
 extern class Date {
 	/**

--- a/std/Date.hx
+++ b/std/Date.hx
@@ -36,14 +36,10 @@
 
 	## Supported range
 
-	Most Haxe targets support dates outside the range of years 1970 through 2038.
-	Due to platform limitations, there are some exceptions:
-
-	- hl, cpp, and eval only support years 1970 and up
-	- neko only supports the range 1902 to 2038
-
-	Additionally, the `Date.fromTime()` function will not work with timestamps
-	outside the 1970 through 2038 range on any platform.
+	Due to platform limitations, only dates in the range 1970 through 2038 are
+	supported consistently. Some targets may support dates outside this range,
+	depending on the OS at runtime. The `Date.fromTime` method will not work with
+	timestamps outside the range on any target.
 **/
 extern class Date {
 	/**
@@ -52,7 +48,7 @@ extern class Date {
 		The behaviour of a Date instance is only consistent across platforms if
 		the the arguments describe a valid date.
 
-		- month: 0 to 11
+		- month: 0 to 11 (note that this is zero-based)
 		- day: 1 to 31
 		- hour: 0 to 23
 		- min: 0 to 59
@@ -73,44 +69,92 @@ extern class Date {
 	function getTime():Float;
 
 	/**
-		Returns the hours of `this` Date (0-23 range).
+		Returns the hours of `this` Date (0-23 range) in the local timezone.
 	**/
 	function getHours():Int;
 
 	/**
-		Returns the minutes of `this` Date (0-59 range).
+		Returns the minutes of `this` Date (0-59 range) in the local timezone.
 	**/
 	function getMinutes():Int;
 
 	/**
-		Returns the seconds of `this` Date (0-59 range).
+		Returns the seconds of `this` Date (0-59 range) in the local timezone.
 	**/
 	function getSeconds():Int;
 
 	/**
-		Returns the full year of `this` Date (4-digits).
+		Returns the full year of `this` Date (4 digits) in the local timezone.
 	**/
 	function getFullYear():Int;
 
 	/**
-		Returns the month of `this` Date (0-11 range).
+		Returns the month of `this` Date (0-11 range) in the local timezone.
+		Note that the month number is zero-based.
 	**/
 	function getMonth():Int;
 
 	/**
-		Returns the day of `this` Date (1-31 range).
+		Returns the day of `this` Date (1-31 range) in the local timezone.
 	**/
 	function getDate():Int;
 
 	/**
-		Returns the day of the week of `this` Date (0-6 range) where `0` is Sunday.
+		Returns the day of the week of `this` Date (0-6 range, where `0` is Sunday)
+		in the local timezone.
 	**/
 	function getDay():Int;
 
 	/**
-		Returns a string representation of `this` Date, by using the
-		standard format [YYYY-MM-DD HH:MM:SS]. See `DateTools.format` for
-		other formating rules.
+		Returns the hours of `this` Date (0-23 range) in UTC.
+	**/
+	function getUTCHours():Int;
+
+	/**
+		Returns the minutes of `this` Date (0-59 range) in UTC.
+	**/
+	function getUTCMinutes():Int;
+
+	/**
+		Returns the seconds of `this` Date (0-59 range) in UTC.
+	**/
+	function getUTCSeconds():Int;
+
+	/**
+		Returns the full year of `this` Date (4 digits) in UTC.
+	**/
+	function getUTCFullYear():Int;
+
+	/**
+		Returns the month of `this` Date (0-11 range) in UTC.
+		Note that the month number is zero-based.
+	**/
+	function getUTCMonth():Int;
+
+	/**
+		Returns the day of `this` Date (1-31 range) in UTC.
+	**/
+	function getUTCDate():Int;
+
+	/**
+		Returns the day of the week of `this` Date (0-6 range, where `0` is Sunday)
+		in UTC.
+	**/
+	function getUTCDay():Int;
+
+	/**
+		Returns the time zone difference of `this` Date in the current locale
+		to UTC, in minutes.
+
+		Assuming the function is executed on a machine in a UTC+2 timezone,
+		`Date.now().getTimezoneOffset()` will return `-120`.
+	**/
+	function getTimezoneOffset():Int;
+
+	/**
+		Returns a string representation of `this` Date in the local timezone
+		using the standard format `YYYY-MM-DD HH:MM:SS`. See `DateTools.format` for
+		other formatting rules.
 	**/
 	function toString():String;
 
@@ -120,67 +164,20 @@ extern class Date {
 	static function now():Date;
 
 	/**
-		Returns a Date from timestamp (in milliseconds) `t`.
+		Creates a Date from the timestamp (in milliseconds) `t`.
 	**/
 	static function fromTime(t:Float):Date;
 
 	/**
-		Returns a Date from a formatted string `s`, with the following accepted
-		formats:
+		Creates a Date from the formatted string `s`. The following formats are
+		accepted by the function:
 
 		- `"YYYY-MM-DD hh:mm:ss"`
 		- `"YYYY-MM-DD"`
 		- `"hh:mm:ss"`
 
-		The first two formats are expressed in local time, the third in UTC
-		Epoch.
+		The first two formats expressed a date in local time. The third is a time
+		relative to the UTC epoch.
 	**/
 	static function fromString(s:String):Date;
-
-	#if flash
-	private static function __init__():Void
-		untyped {
-			var d:Dynamic = Date;
-			d.now = function() {
-				return __new__(Date);
-			};
-			d.fromTime = function(t) {
-				var d:Date = __new__(Date);
-				d.setTime(t);
-				return d;
-			};
-			d.fromString = function(s:String) {
-				switch (s.length) {
-					case 8: // hh:mm:ss
-						var k = s.split(":");
-						var d:Date = __new__(Date);
-						d.setTime(0);
-						d.setUTCHours(k[0]);
-						d.setUTCMinutes(k[1]);
-						d.setUTCSeconds(k[2]);
-						return d;
-					case 10: // YYYY-MM-DD
-						var k = s.split("-");
-						return new Date(cast k[0], cast k[1] - 1, cast k[2], 0, 0, 0);
-					case 19: // YYYY-MM-DD hh:mm:ss
-						var k = s.split(" ");
-						var y = k[0].split("-");
-						var t = k[1].split(":");
-						return new Date(cast y[0], cast y[1] - 1, cast y[2], cast t[0], cast t[1], cast t[2]);
-					default:
-						throw "Invalid date format : " + s;
-				}
-			};
-			d.prototype[#if (as3 || no_flash_override) "toStringHX" #else "toString" #end] = function() {
-				var date:Date = __this__;
-				var m = date.getMonth() + 1;
-				var d = date.getDate();
-				var h = date.getHours();
-				var mi = date.getMinutes();
-				var s = date.getSeconds();
-				return date.getFullYear() + "-" + (if (m < 10) "0" + m else "" + m) + "-" + (if (d < 10) "0" + d else "" + d) + " "
-					+ (if (h < 10) "0" + h else "" + h) + ":" + (if (mi < 10) "0" + mi else "" + mi) + ":" + (if (s < 10) "0" + s else "" + s);
-			};
-		}
-	#end
 }

--- a/std/Date.hx
+++ b/std/Date.hx
@@ -61,8 +61,11 @@ extern class Date {
 	function new(year:Int, month:Int, day:Int, hour:Int, min:Int, sec:Int):Void;
 
 	/**
-		Returns the timestamp (in milliseconds) of the date. It might
-		only have a per-second precision depending on the platforms.
+		Returns the timestamp (in milliseconds) of `this` date.
+		On cpp and neko, this function only has a second resolution, so the
+		result will always be a multiple of `1000.0`, e.g. `1454698271000.0`.
+		To obtain the current timestamp with better precision on cpp and neko,
+		see the `Sys.time` API.
 
 		For measuring time differences with millisecond accuracy on
 		all platforms, see `haxe.Timer.stamp`.

--- a/std/cpp/_std/Date.hx
+++ b/std/cpp/_std/Date.hx
@@ -58,6 +58,38 @@
 		return untyped __global__.__hxcpp_get_day(mSeconds);
 	}
 
+	public function getUTCHours():Int {
+		return untyped __global__.__hxcpp_get_utc_hours(mSeconds);
+	}
+
+	public function getUTCMinutes():Int {
+		return untyped __global__.__hxcpp_get_utc_minutes(mSeconds);
+	}
+
+	public function getUTCSeconds():Int {
+		return untyped __global__.__hxcpp_get_utc_seconds(mSeconds);
+	}
+
+	public function getUTCFullYear():Int {
+		return untyped __global__.__hxcpp_get_utc_year(mSeconds);
+	}
+
+	public function getUTCMonth():Int {
+		return untyped __global__.__hxcpp_get_utc_month(mSeconds);
+	}
+
+	public function getUTCDate():Int {
+		return untyped __global__.__hxcpp_get_utc_date(mSeconds);
+	}
+
+	public function getUTCDay():Int {
+		return untyped __global__.__hxcpp_get_utc_day(mSeconds);
+	}
+
+	public function getTimezoneOffset():Int {
+		return -Std.int((untyped __global__.__hxcpp_timezone_offset(mSeconds)) / 60);
+	}
+
 	public function toString():String {
 		return untyped __global__.__hxcpp_to_string(mSeconds);
 	}
@@ -80,8 +112,7 @@
 		switch (s.length) {
 			case 8: // hh:mm:ss
 				var k = s.split(":");
-				var d:Date = new Date(0, 0, 0, Std.parseInt(k[0]), Std.parseInt(k[1]), Std.parseInt(k[2]));
-				return d;
+				return Date.fromTime(Std.parseInt(k[0]) * 3600000. + Std.parseInt(k[1]) * 60000. + Std.parseInt(k[2]) * 1000.);
 			case 10: // YYYY-MM-DD
 				var k = s.split("-");
 				return new Date(Std.parseInt(k[0]), Std.parseInt(k[1]) - 1, Std.parseInt(k[2]), 0, 0, 0);

--- a/std/flash/Boot.hx
+++ b/std/flash/Boot.hx
@@ -251,6 +251,47 @@ class Boot extends flash.display.MovieClip {
 
 	static function __init__()
 		untyped {
+			var d:Dynamic = Date;
+			d.now = function() {
+				return __new__(Date);
+			};
+			d.fromTime = function(t) {
+				var d:Date = __new__(Date);
+				d.setTime(t);
+				return d;
+			};
+			d.fromString = function(s:String) {
+				switch (s.length) {
+					case 8: // hh:mm:ss
+						var k = s.split(":");
+						var d:Date = __new__(Date);
+						d.setTime(0);
+						d.setUTCHours(k[0]);
+						d.setUTCMinutes(k[1]);
+						d.setUTCSeconds(k[2]);
+						return d;
+					case 10: // YYYY-MM-DD
+						var k = s.split("-");
+						return new Date(cast k[0], cast k[1] - 1, cast k[2], 0, 0, 0);
+					case 19: // YYYY-MM-DD hh:mm:ss
+						var k = s.split(" ");
+						var y = k[0].split("-");
+						var t = k[1].split(":");
+						return new Date(cast y[0], cast y[1] - 1, cast y[2], cast t[0], cast t[1], cast t[2]);
+					default:
+						throw "Invalid date format : " + s;
+				}
+			};
+			d.prototype[#if (as3 || no_flash_override) "toStringHX" #else "toString" #end] = function() {
+				var date:Date = __this__;
+				var m = date.getMonth() + 1;
+				var d = date.getDate();
+				var h = date.getHours();
+				var mi = date.getMinutes();
+				var s = date.getSeconds();
+				return date.getFullYear() + "-" + (if (m < 10) "0" + m else "" + m) + "-" + (if (d < 10) "0" + d else "" + d) + " "
+					+ (if (h < 10) "0" + h else "" + h) + ":" + (if (mi < 10) "0" + mi else "" + mi) + ":" + (if (s < 10) "0" + s else "" + s);
+			};
 			var aproto = Array.prototype;
 			aproto.copy = function() {
 				return __this__.slice();

--- a/std/hl/_std/Date.hx
+++ b/std/hl/_std/Date.hx
@@ -75,6 +75,59 @@ import hl.Ref;
 		return v;
 	}
 
+	public function getUTCFullYear():Int {
+		var v = 0;
+		date_get_utc_inf(t, v, null, null, null, null, null, null);
+		return v;
+	}
+
+	public function getUTCMonth():Int {
+		var v = 0;
+		date_get_utc_inf(t, null, v, null, null, null, null, null);
+		return v;
+	}
+
+	public function getUTCDate():Int {
+		var v = 0;
+		date_get_utc_inf(t, null, null, v, null, null, null, null);
+		return v;
+	}
+
+	public function getUTCHours():Int {
+		var v = 0;
+		date_get_utc_inf(t, null, null, null, v, null, null, null);
+		return v;
+	}
+
+	public function getUTCMinutes():Int {
+		var v = 0;
+		date_get_utc_inf(t, null, null, null, null, v, null, null);
+		return v;
+	}
+
+	public function getUTCSeconds():Int {
+		var v = 0;
+		date_get_utc_inf(t, null, null, null, null, null, v, null);
+		return v;
+	}
+
+	public function getUTCDay():Int {
+		var v = 0;
+		date_get_utc_inf(t, null, null, null, null, null, null, v);
+		return v;
+	}
+
+	public function getTimezoneOffset():Int {
+		var y = 0;
+		var mo = 0;
+		var d = 0;
+		var h = 0;
+		var m = 0;
+		var s = 0;
+		date_get_utc_inf(t, y, mo, d, h, m, s, null);
+		return Std.int((date_new(y, mo, d, h, m, s) - t) / 60);
+	}
+
 	@:keep public function toString():String {
 		var outLen = 0;
 		var bytes = date_to_string(t, outLen);
@@ -132,6 +185,9 @@ import hl.Ref;
 
 	@:hlNative
 	static function date_get_inf(t:Int, year:Ref<Int>, month:Ref<Int>, day:Ref<Int>, hours:Ref<Int>, minutes:Ref<Int>, seconds:Ref<Int>, wday:Ref<Int>):Void {}
+
+	@:hlNative
+	static function date_get_utc_inf(t:Int, year:Ref<Int>, month:Ref<Int>, day:Ref<Int>, hours:Ref<Int>, minutes:Ref<Int>, seconds:Ref<Int>, wday:Ref<Int>):Void {}
 
 	@:hlNative
 	static function date_to_string(t:Int, outLen:Ref<Int>):hl.Bytes {

--- a/std/java/_std/Date.hx
+++ b/std/java/_std/Date.hx
@@ -23,68 +23,107 @@
 package;
 
 import haxe.Int64;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
-@:SuppressWarnings("deprecation")
 @:coreApi class Date {
-	private var date:java.util.Date;
+	private var date:Calendar;
+	private var dateUTC:Calendar;
 
 	public function new(year:Int, month:Int, day:Int, hour:Int, min:Int, sec:Int):Void {
-		// issue #1769
-		year = year != 0 ? year - 1900 : 0;
-		date = new java.util.Date(year, month, day, hour, min, sec);
+		date = new GregorianCalendar(year, month, day, hour, min, sec);
+		dateUTC = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+		dateUTC.setTimeInMillis(date.getTimeInMillis());
 	}
 
 	public inline function getTime():Float {
-		return cast date.getTime();
+		return cast date.getTimeInMillis();
 	}
 
 	public inline function getHours():Int {
-		return date.getHours();
+		return date.get(Calendar.HOUR_OF_DAY);
 	}
 
 	public inline function getMinutes():Int {
-		return date.getMinutes();
+		return date.get(Calendar.MINUTE);
 	}
 
 	public inline function getSeconds():Int {
-		return date.getSeconds();
+		return date.get(Calendar.SECOND);
 	}
 
 	public inline function getFullYear():Int {
-		return date.getYear() + 1900;
+		return date.get(Calendar.YEAR);
 	}
 
 	public inline function getMonth():Int {
-		return date.getMonth();
+		return date.get(Calendar.MONTH);
 	}
 
 	public inline function getDate():Int {
-		return date.getDate();
+		return date.get(Calendar.DAY_OF_MONTH);
 	}
 
 	public inline function getDay():Int {
-		return date.getDay();
+		// SUNDAY in Java == 1, MONDAY == 2, ...
+		return cast date.get(Calendar.DAY_OF_WEEK) - 1;
+	}
+
+	public inline function getUTCHours():Int {
+		return dateUTC.get(Calendar.HOUR_OF_DAY);
+	}
+
+	public inline function getUTCMinutes():Int {
+		return dateUTC.get(Calendar.MINUTE);
+	}
+
+	public inline function getUTCSeconds():Int {
+		return dateUTC.get(Calendar.SECOND);
+	}
+
+	public inline function getUTCFullYear():Int {
+		return dateUTC.get(Calendar.YEAR);
+	}
+
+	public inline function getUTCMonth():Int {
+		return dateUTC.get(Calendar.MONTH);
+	}
+
+	public inline function getUTCDate():Int {
+		return dateUTC.get(Calendar.DAY_OF_MONTH);
+	}
+
+	public inline function getUTCDay():Int {
+		// SUNDAY in Java == 1, MONDAY == 2, ...
+		return cast dateUTC.get(Calendar.DAY_OF_WEEK) - 1;
+	}
+
+	public inline function getTimezoneOffset():Int {
+		return -Std.int(date.get(Calendar.ZONE_OFFSET) / 60000);
 	}
 
 	public function toString():String {
-		var m = date.getMonth() + 1;
-		var d = date.getDate();
-		var h = date.getHours();
-		var mi = date.getMinutes();
-		var s = date.getSeconds();
-		return (date.getYear() + 1900) + "-" + (if (m < 10) "0" + m else "" + m) + "-" + (if (d < 10) "0" + d else "" + d) + " "
+		var m = getMonth() + 1;
+		var d = getDate();
+		var h = getHours();
+		var mi = getMinutes();
+		var s = getSeconds();
+		return getFullYear() + "-" + (if (m < 10) "0" + m else "" + m) + "-" + (if (d < 10) "0" + d else "" + d) + " "
 			+ (if (h < 10) "0" + h else "" + h) + ":" + (if (mi < 10) "0" + mi else "" + mi) + ":" + (if (s < 10) "0" + s else "" + s);
 	}
 
 	static public function now():Date {
 		var d = new Date(0, 0, 0, 0, 0, 0);
-		d.date = new java.util.Date();
+		d.date = Calendar.getInstance();
+		d.dateUTC.setTimeInMillis(d.date.getTimeInMillis());
 		return d;
 	}
 
 	static public function fromTime(t:Float):Date {
 		var d = new Date(0, 0, 0, 0, 0, 0);
-		d.date = new java.util.Date(cast(t, Int64));
+		d.date.setTimeInMillis(cast t);
+		d.dateUTC.setTimeInMillis(cast t);
 		return d;
 	}
 
@@ -92,8 +131,7 @@ import haxe.Int64;
 		switch (s.length) {
 			case 8: // hh:mm:ss
 				var k = s.split(":");
-				var d:Date = new Date(0, 0, 0, Std.parseInt(k[0]), Std.parseInt(k[1]), Std.parseInt(k[2]));
-				return d;
+				return Date.fromTime(Std.parseInt(k[0]) * 3600000. + Std.parseInt(k[1]) * 60000. + Std.parseInt(k[2]) * 1000.);
 			case 10: // YYYY-MM-DD
 				var k = s.split("-");
 				return new Date(Std.parseInt(k[0]), Std.parseInt(k[1]) - 1, Std.parseInt(k[2]), 0, 0, 0);

--- a/std/js/_std/Date.hx
+++ b/std/js/_std/Date.hx
@@ -30,6 +30,15 @@
 	@:pure function getDate():Int;
 	@:pure function getDay():Int;
 
+	@:pure function getUTCHours():Int;
+	@:pure function getUTCMinutes():Int;
+	@:pure function getUTCSeconds():Int;
+	@:pure function getUTCFullYear():Int;
+	@:pure function getUTCMonth():Int;
+	@:pure function getUTCDate():Int;
+	@:pure function getUTCDay():Int;
+	@:pure function getTimezoneOffset():Int;
+
 	@:pure inline function toString():String {
 		return @:privateAccess HxOverrides.dateStr(this);
 	}

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -308,15 +308,7 @@ class Boot {
 		switch (s.length) {
 			case 8: // hh:mm:ss
 				var k = s.split(":");
-				var t = lua.Os.time({
-					year: 0,
-					month: 1,
-					day: 1,
-					hour: Lua.tonumber(k[0]),
-					min: Lua.tonumber(k[1]),
-					sec: Lua.tonumber(k[2])
-				});
-				return std.Date.fromTime(t);
+				return std.Date.fromTime(Lua.tonumber(k[0]) * 3600000. + Lua.tonumber(k[1]) * 60000. + Lua.tonumber(k[2]) * 1000.);
 			case 10: // YYYY-MM-DD
 				var k = s.split("-");
 				return new std.Date(Lua.tonumber(k[0]), Lua.tonumber(k[1]) - 1, Lua.tonumber(k[2]), 0, 0, 0);
@@ -324,7 +316,7 @@ class Boot {
 				var k = s.split(" ");
 				var y = k[0].split("-");
 				var t = k[1].split(":");
-				return new std.Date(cast y[0], Lua.tonumber(y[1]) - 1, Lua.tonumber(y[2]), Lua.tonumber(t[0]), Lua.tonumber(t[1]), Lua.tonumber(t[2]));
+				return new std.Date(Lua.tonumber(y[0]), Lua.tonumber(y[1]) - 1, Lua.tonumber(y[2]), Lua.tonumber(t[0]), Lua.tonumber(t[1]), Lua.tonumber(t[2]));
 			default:
 				throw "Invalid date format : " + s;
 		}

--- a/std/lua/Os.hx
+++ b/std/lua/Os.hx
@@ -114,9 +114,9 @@ extern class Os {
 	A typedef that matches the date parameter `Os.time()` will accept.
 **/
 typedef TimeParam = {
-	year:Float,
-	month:Float,
-	day:Float,
+	year:Int,
+	month:Int,
+	day:Int,
 	?hour:Int,
 	?min:Int,
 	?sec:Int,

--- a/std/lua/_std/Date.hx
+++ b/std/lua/_std/Date.hx
@@ -21,6 +21,7 @@
  */
 @:coreApi class Date {
 	var d:lua.Os.DateType;
+	var dUTC:lua.Os.DateType;
 	var t:lua.Time;
 
 	public function new(year:Int, month:Int, day:Int, hour:Int, min:Int, sec:Int) {
@@ -33,6 +34,7 @@
 			sec: sec
 		});
 		d = lua.Os.date("*t", t);
+		dUTC = lua.Os.date("!*t", t);
 	};
 
 	public function getTime():Float
@@ -59,6 +61,32 @@
 	public function getDay():Int
 		return d.wday - 1;
 
+	public function getUTCHours():Int
+		return dUTC.hour;
+
+	public function getUTCMinutes():Int
+		return dUTC.min;
+
+	public function getUTCSeconds():Int
+		return dUTC.sec;
+
+	public function getUTCFullYear():Int
+		return dUTC.year;
+
+	public function getUTCMonth():Int
+		return dUTC.month - 1;
+
+	public function getUTCDate():Int
+		return dUTC.day;
+
+	public function getUTCDay():Int
+		return dUTC.wday - 1;
+
+	public function getTimezoneOffset():Int {
+		var tUTC = lua.Os.time(dUTC);
+		return Std.int((tUTC - t) / 60);
+	}
+
 	public inline function toString():String {
 		return lua.Boot.dateStr(this);
 	}
@@ -73,6 +101,7 @@
 			lua.Lua.setmetatable(d, untyped {__index: Date.prototype});
 			d.t = t / 1000;
 			d.d = lua.Os.date("*t", Std.int(d.t));
+			d.dUTC = lua.Os.date("!*t", Std.int(d.t));
 		}
 		return d;
 	}

--- a/std/neko/_std/Date.hx
+++ b/std/neko/_std/Date.hx
@@ -62,6 +62,38 @@ import neko.Lib;
 		return Std.parseInt(new String(date_format(__t, untyped "%w".__s)));
 	}
 
+	public function getUTCFullYear():Int {
+		return date_get_utc_day(__t).y;
+	}
+
+	public function getUTCMonth():Int {
+		return date_get_utc_day(__t).m - 1;
+	}
+
+	public function getUTCDate():Int {
+		return date_get_utc_day(__t).d;
+	}
+
+	public function getUTCHours():Int {
+		return date_get_utc_hour(__t).h;
+	}
+
+	public function getUTCMinutes():Int {
+		return date_get_utc_hour(__t).m;
+	}
+
+	public function getUTCSeconds():Int {
+		return date_get_utc_hour(__t).s;
+	}
+
+	public function getUTCDay():Int {
+		return Std.parseInt(new String(date_utc_format(__t, untyped "%w".__s)));
+	}
+
+	public function getTimezoneOffset():Int {
+		return -date_get_tz(__t);
+	}
+
 	@:keep public function toString():String {
 		return new String(date_format(__t, null));
 	}
@@ -91,10 +123,14 @@ import neko.Lib;
 	static var date_new = Lib.load("std", "date_new", 1);
 	static var date_now = Lib.load("std", "date_now", 0);
 	static var date_format = Lib.load("std", "date_format", 2);
+	static var date_utc_format = Lib.load("std", "date_utc_format", 2);
 	static var date_set_hour = Lib.load("std", "date_set_hour", 4);
 	static var date_set_day = Lib.load("std", "date_set_day", 4);
 	static var date_get_day:Dynamic->{y: Int, m: Int, d: Int} = Lib.load("std", "date_get_day", 1);
 	static var date_get_hour:Dynamic->{h: Int, m: Int, s: Int} = Lib.load("std", "date_get_hour", 1);
+	static var date_get_utc_day:Dynamic->{y: Int, m: Int, d: Int} = Lib.load("std", "date_get_utc_day", 1);
+	static var date_get_utc_hour:Dynamic->{h: Int, m: Int, s: Int} = Lib.load("std", "date_get_utc_hour", 1);
+	static var date_get_tz = Lib.load("std", "date_get_tz", 1);
 	static var int32_to_float = Lib.load("std", "int32_to_float", 1);
 	static var int32_add = Lib.load("std", "int32_add", 2);
 	static var int32_shl = Lib.load("std", "int32_shl", 2);

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -1302,6 +1302,11 @@ extern class Global {
 	static function date(format:String, ?timestamp:Int):EitherType<String, Bool>;
 
 	/**
+		@see http://php.net/manual/en/function.gmdate.php
+	**/
+	static function gmdate(format:String, ?timestamp:Int):EitherType<String, Bool>;
+
+	/**
 		@see http://php.net/manual/en/function.time.php
 	**/
 	static function time():Int;

--- a/std/php/_std/Date.hx
+++ b/std/php/_std/Date.hx
@@ -67,6 +67,39 @@ import php.Syntax.*;
 		return int(date("w", int(__t)));
 	}
 
+	public function getUTCFullYear():Int {
+		return int(gmdate("Y", int(__t)));
+	}
+
+	public function getUTCMonth():Int {
+		var m:Int = int(gmdate("n", int(__t)));
+		return -1 + m;
+	}
+
+	public function getUTCDate():Int {
+		return int(gmdate("j", int(__t)));
+	}
+
+	public function getUTCHours():Int {
+		return int(gmdate("G", int(__t)));
+	}
+
+	public function getUTCMinutes():Int {
+		return int(gmdate("i", int(__t)));
+	}
+
+	public function getUTCSeconds():Int {
+		return int(gmdate("s", int(__t)));
+	}
+
+	public function getUTCDay():Int {
+		return int(gmdate("w", int(__t)));
+	}
+
+	public function getTimezoneOffset():Int {
+		return -Std.int(int(date("Z", int(__t))) / 60);
+	}
+
 	public function toString():String {
 		return date("Y-m-d H:i:s", int(__t));
 	}
@@ -88,6 +121,20 @@ import php.Syntax.*;
 	}
 
 	public static function fromString(s:String):Date {
-		return fromPhpTime(strtotime(s));
+		switch (s.length) {
+			case 8: // hh:mm:ss
+				var k = s.split(":");
+				return Date.fromTime(Std.parseInt(k[0]) * 3600000. + Std.parseInt(k[1]) * 60000. + Std.parseInt(k[2]) * 1000.);
+			case 10: // YYYY-MM-DD
+				var k = s.split("-");
+				return new Date(Std.parseInt(k[0]), Std.parseInt(k[1]) - 1, Std.parseInt(k[2]), 0, 0, 0);
+			case 19: // YYYY-MM-DD hh:mm:ss
+				var k = s.split(" ");
+				var y = k[0].split("-");
+				var t = k[1].split(":");
+				return new Date(Std.parseInt(y[0]), Std.parseInt(y[1]) - 1, Std.parseInt(y[2]), Std.parseInt(t[0]), Std.parseInt(t[1]), Std.parseInt(t[2]));
+			default:
+				throw "Invalid date format : " + s;
+		}
 	}
 }

--- a/std/python/_std/Date.hx
+++ b/std/python/_std/Date.hx
@@ -121,11 +121,14 @@ import python.Syntax;
 	}
 
 	static function makeLocal(date:Datetime):Datetime {
-		var ver = python.lib.Sys.version_info;
-		if (ver[0] > 3 || (ver[0] == 3 && ver[1] >= 6)) // >= 3.6
+		try {
 			return date.astimezone();
-		var tzinfo = Datetime.now(Timezone.utc).astimezone().tzinfo;
-		return date.replace({tzinfo: tzinfo});
+		} catch (e:Dynamic) {
+			// No way in vanilla Python <=3.5 to get the local timezone
+			// Additionally dates close to the epoch <86400 will throw on astimezone
+			var tzinfo = Datetime.now(Timezone.utc).astimezone().tzinfo;
+			return date.replace({tzinfo: tzinfo});
+		}
 	}
 
 	static function UTC(year:Int, month:Int, day:Int, hour:Int, min:Int, sec:Int):Float {

--- a/std/python/_std/Date.hx
+++ b/std/python/_std/Date.hx
@@ -66,7 +66,7 @@ import python.Syntax;
 	}
 
 	public inline function getDay():Int {
-		return date.isoweekday();
+		return date.isoweekday() % 7;
 	}
 
 	public function toString():String {

--- a/std/python/_std/Date.hx
+++ b/std/python/_std/Date.hx
@@ -107,14 +107,14 @@ import python.Syntax;
 	}
 
 	static public function now():Date {
-		var d = new Date(1970, 0, 1, 0, 0, 0);
+		var d = new Date(2000, 0, 1, 0, 0, 0);
 		d.date = Datetime.now().astimezone();
 		d.dateUTC = d.date.astimezone(Timezone.utc);
 		return d;
 	}
 
 	static public function fromTime(t:Float):Date {
-		var d = new Date(1970, 0, 1, 0, 0, 0);
+		var d = new Date(2000, 0, 1, 0, 0, 0);
 		d.date = Datetime.fromtimestamp(t / 1000.0).astimezone();
 		d.dateUTC = d.date.astimezone(Timezone.utc);
 		return d;

--- a/std/python/_std/Date.hx
+++ b/std/python/_std/Date.hx
@@ -34,7 +34,7 @@ import python.Syntax;
 			year = Datetime.min.year;
 		if (day == 0)
 			day = 1;
-		date = new Datetime(year, month + 1, day, hour, min, sec, 0).astimezone();
+		date = makeLocal(new Datetime(year, month + 1, day, hour, min, sec, 0));
 		dateUTC = date.astimezone(Timezone.utc);
 	}
 
@@ -108,16 +108,24 @@ import python.Syntax;
 
 	static public function now():Date {
 		var d = new Date(2000, 0, 1, 0, 0, 0);
-		d.date = Datetime.now().astimezone();
+		d.date = makeLocal(Datetime.now());
 		d.dateUTC = d.date.astimezone(Timezone.utc);
 		return d;
 	}
 
 	static public function fromTime(t:Float):Date {
 		var d = new Date(2000, 0, 1, 0, 0, 0);
-		d.date = Datetime.fromtimestamp(t / 1000.0).astimezone();
+		d.date = makeLocal(Datetime.fromtimestamp(t / 1000.0));
 		d.dateUTC = d.date.astimezone(Timezone.utc);
 		return d;
+	}
+
+	static function makeLocal(date:Datetime):Datetime {
+		var ver = python.lib.Sys.version_info;
+		if (ver[0] > 3 || (ver[0] == 3 && ver[1] >= 6)) // >= 3.6
+			return date.astimezone();
+		var tzinfo = Datetime.now(Timezone.utc).astimezone().tzinfo;
+		return date.replace({tzinfo: tzinfo});
 	}
 
 	static function UTC(year:Int, month:Int, day:Int, hour:Int, min:Int, sec:Int):Float {

--- a/std/python/_std/Date.hx
+++ b/std/python/_std/Date.hx
@@ -38,7 +38,7 @@ import python.Syntax;
 	}
 
 	public inline function getTime():Float {
-		return python.lib.Time.mktime(date.timetuple()) * 1000;
+		return date.timestamp() * 1000;
 	}
 
 	public inline function getHours():Int {
@@ -70,16 +70,7 @@ import python.Syntax;
 	}
 
 	public function toString():String {
-		inline function st(x)
-			return Std.string(x);
-
-		var m = getMonth() + 1;
-		var d = getDate();
-		var h = getHours();
-		var mi = getMinutes();
-		var s = getSeconds();
-		return st(getFullYear()) + "-" + (if (m < 10) "0" + st(m) else "" + st(m)) + "-" + (if (d < 10) "0" + st(d) else "" + st(d)) + " "
-			+ (if (h < 10) "0" + st(h) else "" + st(h)) + ":" + (if (mi < 10) "0" + st(mi) else "" + st(mi)) + ":" + (if (s < 10) "0" + st(s) else "" + st(s));
+		return date.strftime("%Y-%m-%d %H:%M:%S");
 	}
 
 	static public function now():Date {

--- a/std/python/lib/datetime/Datetime.hx
+++ b/std/python/lib/datetime/Datetime.hx
@@ -50,8 +50,16 @@ extern class Datetime {
 
 	public function timetuple():StructTime;
 	public function strftime(format:String):String;
-	public function replace(?year:Int = 1970, ?month:Int = 1, ?day:Int = 1, ?hour:Int = 0, ?minute:Int = 0, ?second:Int, ?microsecond:Int,
-		?tzinfo:Tzinfo):Datetime;
+	public function replace(kwargs:python.KwArgs<{
+		?year:Int,
+		?month:Int,
+		?day:Int,
+		?hour:Int,
+		?minute:Int,
+		?second:Int,
+		?microsecond:Int,
+		?tzinfo:Tzinfo
+	}>):Datetime;
 	/* 0-6 */
 	public function weekday():Int;
 	/* 1-7 */

--- a/std/python/lib/datetime/Datetime.hx
+++ b/std/python/lib/datetime/Datetime.hx
@@ -56,7 +56,9 @@ extern class Datetime {
 	public function weekday():Int;
 	/* 1-7 */
 	public function isoweekday():Int;
+	public function utcoffset():Int;
 
 	// python 3.3
 	public function timestamp():Float;
+	public function astimezone(?tz:Tzinfo):Datetime;
 }

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -25,16 +25,20 @@ date.getTime() == 405781340000;
 // timezone issues
 var date1 = Date.fromTime(1455555555 * 1000.); // 15 Feb 2016 16:59:15 GMT
 var date2 = new Date(2016, 1, 15, 16, 59, 15);
+#if azure
 date1.getTime() == date2.getTime(); // depends on Azure timezone setting!
+#end
 
 var referenceDate = new Date(1970, 0, 1, 2, 0, 0);
 referenceDate.toString() == "1970-01-01 02:00:00";
+#if azure
 referenceDate.getTime() == 7200000.; // depends on Azure timezone setting!
+#end
 
 var date = new Date(1970, 0, 1, 1, 59, 59);
 date.getTime() < referenceDate.getTime();
 
-// < 1970
+// < 1970 (negative timestamp)
 var date = new Date(1904, 11, 12, 1, 4, 1);
 date.getHours() == 1;
 date.getMinutes() == 4;
@@ -45,7 +49,12 @@ date.getDate() == 12;
 date.getDay() == 1;
 date.getTime() < referenceDate.getTime();
 
-// < 1902
+var date = Date.fromTime(-2052910800.0);
+date.getFullYear() == 1904;
+date.getMonth() == 11;
+date.getDate() == 12; // could fail on very large UTC offsets
+
+// < 1902 (negative timestamp, outside of signed 32-bit integer range)
 var date = new Date(1888, 0, 1, 15, 4, 2);
 date.getHours() == 15;
 date.getMinutes() == 4;
@@ -56,7 +65,12 @@ date.getDate() == 1;
 date.getDay() == 0;
 date.getTime() < referenceDate.getTime();
 
-// Y2038
+var date = Date.fromTime(-2587294800.0);
+date.getFullYear() == 1888;
+date.getMonth() == 0;
+date.getDate() == 5; // could fail on very large UTC offsets
+
+// Y2038 (outside of signed 32-bit integer range)
 var date = new Date(2039, 0, 1, 1, 59, 59);
 date.getHours() == 1;
 date.getMinutes() == 59;
@@ -66,6 +80,27 @@ date.getMonth() == 0;
 date.getDate() == 1;
 date.getDay() == 6;
 date.getTime() > referenceDate.getTime();
+
+var date = Date.fromTime(2177838000.0);
+date.getFullYear() == 2039;
+date.getMonth() == 0;
+date.getDate() == 5; // could fail on very large UTC offsets
+
+// Y2112 (outside of unsigned 32-bit integer range)
+var date = new Date(2112, 0, 1, 1, 59, 59);
+date.getHours() == 1;
+date.getMinutes() == 59;
+date.getSeconds() == 59;
+date.getFullYear() == 2112;
+date.getMonth() == 0;
+date.getDate() == 1;
+date.getDay() == 5;
+date.getTime() > referenceDate.getTime();
+
+var date = Date.fromTime(4481434800.0);
+date.getFullYear() == 2039;
+date.getMonth() == 0;
+date.getDate() == 5; // could fail on very large UTC offsets
 
 // weekdays
 (new Date(2019, 6, 1, 12, 0, 0)).getDay() == 1;

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -21,6 +21,13 @@ date.toString() == "1982-11-10 14:02:20";
 
 var date = Date.fromTime(405781340000);
 date.getTime() == 405781340000;
+date.getUTCHours() == 13;
+date.getUTCMinutes() == 2;
+date.getUTCSeconds() == 20;
+date.getUTCFullYear() == 1982;
+date.getUTCMonth() == 10;
+date.getUTCDate() == 10;
+date.getUTCDay() == 3;
 
 // timezone issues
 var date1 = Date.fromTime(1455555555 * 1000.); // 15 Feb 2016 16:59:15 GMT
@@ -121,3 +128,50 @@ date.getDate() == 5; // could fail on very large UTC offsets
 (new Date(2019, 6, 5, 12, 0, 0)).getDay() == 5;
 (new Date(2019, 6, 6, 12, 0, 0)).getDay() == 6;
 (new Date(2019, 6, 7, 12, 0, 0)).getDay() == 0;
+
+// fromString
+var date = Date.fromString("2019-07-08 12:22:00");
+date.getHours() == 12;
+date.getMinutes() == 22;
+date.getSeconds() == 0;
+date.getFullYear() == 2019;
+date.getMonth() == 6;
+date.getDate() == 8;
+date.getDay() == 1;
+
+var date = Date.fromString("2019-03-02");
+date.getHours() == 0;
+date.getMinutes() == 0;
+date.getSeconds() == 0;
+date.getFullYear() == 2019;
+date.getMonth() == 2;
+date.getDate() == 2;
+date.getDay() == 6;
+
+// fromString HH:MM:SS should interpret the time as UTC
+var date = Date.fromString("04:05:06");
+date.getUTCHours() == 4;
+date.getUTCMinutes() == 5;
+date.getUTCSeconds() == 6;
+date.getUTCFullYear() == 1970;
+date.getUTCMonth() == 0;
+date.getUTCDate() == 1;
+date.getUTCDay() == 4;
+date.getTime() == 14706000.;
+
+// timezone offset
+// see https://en.wikipedia.org/wiki/UTC_offset
+Date.fromString("2015-01-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-02-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-03-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-04-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-05-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-06-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-07-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-08-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-09-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-10-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-11-08 12:22:00").getTimezoneOffset() % 15 == 0;
+Date.fromString("2015-12-08 12:22:00").getTimezoneOffset() % 15 == 0;
+
+Date.fromString("2015-06-15 10:00:00").getTimezoneOffset() == Date.fromString("2014-06-15 10:00:00").getTimezoneOffset();

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -39,6 +39,7 @@ var date = new Date(1970, 0, 1, 1, 59, 59);
 date.getTime() < referenceDate.getTime();
 
 // < 1970 (negative timestamp)
+#if !(hl || eval)
 var date = new Date(1904, 11, 12, 1, 4, 1);
 date.getHours() == 1;
 date.getMinutes() == 4;
@@ -48,8 +49,10 @@ date.getMonth() == 11;
 date.getDate() == 12;
 date.getDay() == 1;
 date.getTime() < referenceDate.getTime();
+#end
 
 // < 1902 (negative timestamp, outside of signed 32-bit integer range)
+#if !(hl, neko, eval, cpp)
 var date = new Date(1888, 0, 1, 15, 4, 2);
 date.getHours() == 15;
 date.getMinutes() == 4;
@@ -59,9 +62,10 @@ date.getMonth() == 0;
 date.getDate() == 1;
 date.getDay() == 0;
 date.getTime() < referenceDate.getTime();
-
+#end
 
 // Y2038 (outside of signed 32-bit integer range)
+#if !neko
 var date = new Date(2039, 0, 1, 1, 59, 59);
 date.getHours() == 1;
 date.getMinutes() == 59;
@@ -71,8 +75,10 @@ date.getMonth() == 0;
 date.getDate() == 1;
 date.getDay() == 6;
 date.getTime() > referenceDate.getTime();
+#end
 
 // Y2112 (outside of unsigned 32-bit integer range)
+#if !(hl || neko)
 var date = new Date(2112, 0, 1, 1, 59, 59);
 date.getHours() == 1;
 date.getMinutes() == 59;
@@ -82,6 +88,7 @@ date.getMonth() == 0;
 date.getDate() == 1;
 date.getDay() == 5;
 date.getTime() > referenceDate.getTime();
+#end
 
 /*
 // fromTime outside the 1970...2038 range (not supported)

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -52,7 +52,7 @@ date.getTime() < referenceDate.getTime();
 #end
 
 // < 1902 (negative timestamp, outside of signed 32-bit integer range)
-#if !(hl, neko, eval, cpp)
+#if !(hl || neko || eval || cpp)
 var date = new Date(1888, 0, 1, 15, 4, 2);
 date.getHours() == 15;
 date.getMinutes() == 4;

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -31,7 +31,7 @@ date1.getTime() == date2.getTime();
 
 var referenceDate = new Date(1970, 0, 1, 2, 0, 0);
 referenceDate.toString() == "1970-01-01 02:00:00";
-referenceDate.getTime() == 3600000.;
+referenceDate.getTime() == 7200000.;
 
 var date = new Date(1970, 0, 1, 1, 59, 59);
 date.getTime() < referenceDate.getTime();

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -39,7 +39,8 @@ var date = new Date(1970, 0, 1, 1, 59, 59);
 date.getTime() < referenceDate.getTime();
 
 // < 1970 (negative timestamp)
-#if !(hl || eval)
+// neko, cpp, and python only fail on Windows
+#if !(hl || eval || neko || cpp || python)
 var date = new Date(1904, 11, 12, 1, 4, 1);
 date.getHours() == 1;
 date.getMinutes() == 4;
@@ -52,7 +53,9 @@ date.getTime() < referenceDate.getTime();
 #end
 
 // < 1902 (negative timestamp, outside of signed 32-bit integer range)
-#if !(hl || neko || eval || cpp)
+// lua only fails on Mac
+// python only fails on Windows
+#if !(hl || neko || eval || cpp || lua || python)
 var date = new Date(1888, 0, 1, 15, 4, 2);
 date.getHours() == 15;
 date.getMinutes() == 4;

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -29,13 +29,13 @@ var date2 = new Date(2016, 1, 15, 16, 59, 15);
 date1.getTime() == date2.getTime(); // depends on Azure timezone setting!
 #end
 
-var referenceDate = new Date(1970, 0, 1, 2, 0, 0);
-referenceDate.toString() == "1970-01-01 02:00:00";
+var referenceDate = new Date(1970, 0, 12, 2, 0, 0);
+referenceDate.toString() == "1970-01-12 02:00:00";
 #if azure
-referenceDate.getTime() == 7200000.; // depends on Azure timezone setting!
+referenceDate.getTime() == 957600000.; // depends on Azure timezone setting!
 #end
 
-var date = new Date(1970, 0, 1, 1, 59, 59);
+var date = new Date(1970, 0, 12, 1, 59, 59);
 date.getTime() < referenceDate.getTime();
 
 // < 1970 (negative timestamp)

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -7,7 +7,6 @@ date.getFullYear() == 1982;
 date.getMonth() == 10;
 date.getDate() == 10;
 date.getDay() == 3;
-//date.getTime() == 405781340000.;
 date.toString() == "1982-11-10 14:02:20";
 
 var date = Date.fromTime(date.getTime());
@@ -18,7 +17,6 @@ date.getFullYear() == 1982;
 date.getMonth() == 10;
 date.getDate() == 10;
 date.getDay() == 3;
-//date.getTime() == 405781340000.;
 date.toString() == "1982-11-10 14:02:20";
 
 var date = Date.fromTime(405781340000);
@@ -27,21 +25,44 @@ date.getTime() == 405781340000;
 // timezone issues
 var date1 = Date.fromTime(1455555555 * 1000.); // 15 Feb 2016 16:59:15 GMT
 var date2 = new Date(2016, 1, 15, 16, 59, 15);
-date1.getTime() == date2.getTime();
+date1.getTime() == date2.getTime(); // depends on Azure timezone setting!
 
 var referenceDate = new Date(1970, 0, 1, 2, 0, 0);
 referenceDate.toString() == "1970-01-01 02:00:00";
-referenceDate.getTime() == 7200000.;
+referenceDate.getTime() == 7200000.; // depends on Azure timezone setting!
 
 var date = new Date(1970, 0, 1, 1, 59, 59);
 date.getTime() < referenceDate.getTime();
 
-// < 1970 problems
+// < 1970
 var date = new Date(1904, 11, 12, 1, 4, 1);
-date.getFullYear() == 1904;
 date.getHours() == 1;
+date.getMinutes() == 4;
+date.getSeconds() == 1;
+date.getFullYear() == 1904;
+date.getMonth() == 10;
+date.getDate() == 12;
+date.getDay() == 1;
+date.getTime() < referenceDate.getTime();
 
-// Y2038 problems
+// < 1902
+var date = new Date(1888, 0, 1, 15, 4, 2);
+date.getHours() == 15;
+date.getMinutes() == 4;
+date.getSeconds() == 2;
+date.getFullYear() == 1888;
+date.getMonth() == 0;
+date.getDate() == 1;
+date.getDay() == 0;
+date.getTime() < referenceDate.getTime();
+
+// Y2038
 var date = new Date(2039, 0, 1, 1, 59, 59);
+date.getHours() == 1;
+date.getMinutes() == 59;
+date.getSeconds() == 59;
 date.getFullYear() == 2039;
+date.getMonth() == 0;
+date.getDate() == 1;
+date.getDay() == 6;
 date.getTime() > referenceDate.getTime();

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -49,11 +49,6 @@ date.getDate() == 12;
 date.getDay() == 1;
 date.getTime() < referenceDate.getTime();
 
-var date = Date.fromTime(-2052910800.0);
-date.getFullYear() == 1904;
-date.getMonth() == 11;
-date.getDate() == 12; // could fail on very large UTC offsets
-
 // < 1902 (negative timestamp, outside of signed 32-bit integer range)
 var date = new Date(1888, 0, 1, 15, 4, 2);
 date.getHours() == 15;
@@ -65,10 +60,6 @@ date.getDate() == 1;
 date.getDay() == 0;
 date.getTime() < referenceDate.getTime();
 
-var date = Date.fromTime(-2587294800.0);
-date.getFullYear() == 1888;
-date.getMonth() == 0;
-date.getDate() == 5; // could fail on very large UTC offsets
 
 // Y2038 (outside of signed 32-bit integer range)
 var date = new Date(2039, 0, 1, 1, 59, 59);
@@ -81,11 +72,6 @@ date.getDate() == 1;
 date.getDay() == 6;
 date.getTime() > referenceDate.getTime();
 
-var date = Date.fromTime(2177838000.0);
-date.getFullYear() == 2039;
-date.getMonth() == 0;
-date.getDate() == 5; // could fail on very large UTC offsets
-
 // Y2112 (outside of unsigned 32-bit integer range)
 var date = new Date(2112, 0, 1, 1, 59, 59);
 date.getHours() == 1;
@@ -97,10 +83,25 @@ date.getDate() == 1;
 date.getDay() == 5;
 date.getTime() > referenceDate.getTime();
 
+/*
+// fromTime outside the 1970...2038 range (not supported)
+var date = Date.fromTime(-2052910800.0);
+date.getFullYear() == 1904;
+date.getMonth() == 11;
+date.getDate() == 12; // could fail on very large UTC offsets
+var date = Date.fromTime(-2587294800.0);
+date.getFullYear() == 1888;
+date.getMonth() == 0;
+date.getDate() == 5; // could fail on very large UTC offsets
+var date = Date.fromTime(2177838000.0);
+date.getFullYear() == 2039;
+date.getMonth() == 0;
+date.getDate() == 5; // could fail on very large UTC offsets
 var date = Date.fromTime(4481434800.0);
 date.getFullYear() == 2039;
 date.getMonth() == 0;
 date.getDate() == 5; // could fail on very large UTC offsets
+*/
 
 // weekdays
 (new Date(2019, 6, 1, 12, 0, 0)).getDay() == 1;

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -66,3 +66,12 @@ date.getMonth() == 0;
 date.getDate() == 1;
 date.getDay() == 6;
 date.getTime() > referenceDate.getTime();
+
+// weekdays
+(new Date(2019, 6, 1, 12, 0, 0)).getDay() == 1;
+(new Date(2019, 6, 2, 12, 0, 0)).getDay() == 2;
+(new Date(2019, 6, 3, 12, 0, 0)).getDay() == 3;
+(new Date(2019, 6, 4, 12, 0, 0)).getDay() == 4;
+(new Date(2019, 6, 5, 12, 0, 0)).getDay() == 5;
+(new Date(2019, 6, 6, 12, 0, 0)).getDay() == 6;
+(new Date(2019, 6, 7, 12, 0, 0)).getDay() == 0;

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -23,3 +23,25 @@ date.toString() == "1982-11-10 14:02:20";
 
 var date = Date.fromTime(405781340000);
 date.getTime() == 405781340000;
+
+// timezone issues
+var date1 = Date.fromTime(1455551955 * 1000.); // 15 Feb 2016 16:59:15 GMT
+var date2 = new Date(2016, 1, 15, 16, 59, 15);
+date1.getTime() == date2.getTime();
+
+var referenceDate = new Date(1970, 0, 1, 2, 0, 0);
+referenceDate.toString() == "1970-01-01 02:00:00";
+referenceDate.getTime() == 3600000.;
+
+var date = new Date(1970, 0, 1, 1, 59, 59);
+date.getTime() < referenceDate.getTime();
+
+// < 1970 problems
+var date = new Date(1904, 11, 12, 1, 4, 1);
+date.getFullYear() == 1904;
+date.getHours() == 1;
+
+// Y2038 problems
+var date = new Date(2039, 0, 1, 1, 59, 59);
+date.getFullYear() == 2039;
+date.getTime() > referenceDate.getTime();

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -40,7 +40,7 @@ date.getHours() == 1;
 date.getMinutes() == 4;
 date.getSeconds() == 1;
 date.getFullYear() == 1904;
-date.getMonth() == 10;
+date.getMonth() == 11;
 date.getDate() == 12;
 date.getDay() == 1;
 date.getTime() < referenceDate.getTime();

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -149,15 +149,22 @@ date.getDate() == 2;
 date.getDay() == 6;
 
 // fromString HH:MM:SS should interpret the time as UTC
+#if python
+// disabled on Windows due to https://bugs.python.org/issue37527
+if (Sys.systemName() != "Windows") {
+#end
 var date = Date.fromString("04:05:06");
-date.getUTCHours() == 4;
-date.getUTCMinutes() == 5;
-date.getUTCSeconds() == 6;
-date.getUTCFullYear() == 1970;
-date.getUTCMonth() == 0;
-date.getUTCDate() == 1;
-date.getUTCDay() == 4;
-date.getTime() == 14706000.;
+t(date.getUTCHours() == 4);
+t(date.getUTCMinutes() == 5);
+t(date.getUTCSeconds() == 6);
+t(date.getUTCFullYear() == 1970);
+t(date.getUTCMonth() == 0);
+t(date.getUTCDate() == 1);
+t(date.getUTCDay() == 4);
+t(date.getTime() == 14706000.);
+#if python
+}
+#end
 
 // timezone offset
 // see https://en.wikipedia.org/wiki/UTC_offset

--- a/tests/unit/src/unitstd/Date.unit.hx
+++ b/tests/unit/src/unitstd/Date.unit.hx
@@ -25,7 +25,7 @@ var date = Date.fromTime(405781340000);
 date.getTime() == 405781340000;
 
 // timezone issues
-var date1 = Date.fromTime(1455551955 * 1000.); // 15 Feb 2016 16:59:15 GMT
+var date1 = Date.fromTime(1455555555 * 1000.); // 15 Feb 2016 16:59:15 GMT
 var date2 = new Date(2016, 1, 15, 16, 59, 15);
 date1.getTime() == date2.getTime();
 


### PR DESCRIPTION
 - Closes #7303 (documentation issue).
 - Closes #6353 (added `getTimezoneOffset`).
 - Closes #4834 (improved documentation).

Will need to wait for CI confirmation on #5294 (uses non-deprecated Java API now; all targets are tested).

 - [x] add tests
 - fixes
   - [x] (python) fix `getDay()` - used to return `7` for a Sunday
   - [x] (python) fix `getTime()` - used to throw exceptions outside of the C mktime range
   - [x] (php) fix `fromString()` - did not interpret "HH:MM:SS" correctly
   - [x] use `strftime` or similar where available
 - [x] update `Date` documentation
   - most targets limited to 1970...2038 year range
 - add UTC-based methods (`getUTCDay`, ..., `getTimezoneOffset`)
   - [x] js
   - [x] flash, as3
   - [x] php
   - [x] java, jvm
   - [x] cs
   - [x] eval
   - [x] python
   - [x] lua
   - [x] cpp
   - [x] neko (HaxeFoundation/neko#195)
   - [x] hl (HaxeFoundation/hashlink#266)
