### PR TITLE
Fix emitting error on `inlineCall() = value`

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -884,7 +884,7 @@ try
 		Common.log com ("Classpath: " ^ (String.concat ";" com.class_path));
 		Common.log com ("Defines: " ^ (String.concat ";" (PMap.foldi (fun k v acc -> (match v with "1" -> k | _ -> k ^ "=" ^ v) :: acc) com.defines.Define.values [])));
 		let t = Timer.timer ["typing"] in
-		Typecore.type_expr_ref := (fun ctx e with_type -> Typer.type_expr ctx e with_type);
+		Typecore.type_expr_ref := (fun ?(mode=MGet) ctx e with_type -> Typer.type_expr ~mode ctx e with_type);
 		let tctx = Typer.create com in
 		let add_signature desc =
 			Option.may (fun cs -> CompilationServer.maybe_add_context_sign cs com desc) (CompilationServer.get ());

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -44,6 +44,11 @@ type macro_mode =
 	| MMacroType
 	| MDisplay
 
+type access_mode =
+	| MGet
+	| MSet
+	| MCall
+
 type typer_pass =
 	| PBuildModule			(* build the module structure and setup module type parameters *)
 	| PBuildClass			(* build the class structure *)
@@ -133,7 +138,7 @@ exception Forbid_package of (string * path * pos) * pos list * string
 exception WithTypeError of error_msg * pos
 
 let make_call_ref : (typer -> texpr -> texpr list -> t -> ?force_inline:bool -> pos -> texpr) ref = ref (fun _ _ _ _ ?force_inline:bool _ -> assert false)
-let type_expr_ref : (typer -> expr -> WithType.t -> texpr) ref = ref (fun _ _ _ -> assert false)
+let type_expr_ref : (?mode:access_mode -> typer -> expr -> WithType.t -> texpr) ref = ref (fun ?(mode=MGet) _ _ _ -> assert false)
 let type_block_ref : (typer -> expr list -> WithType.t -> pos -> texpr) ref = ref (fun _ _ _ _ -> assert false)
 let unify_min_ref : (typer -> texpr list -> t) ref = ref (fun _ _ -> assert false)
 let analyzer_run_on_expr_ref : (Common.context -> texpr -> texpr) ref = ref (fun _ _ -> assert false)
@@ -153,7 +158,7 @@ let display_error ctx msg p = match ctx.com.display.DisplayMode.dms_error_policy
 
 let make_call ctx e el t p = (!make_call_ref) ctx e el t p
 
-let type_expr ctx e with_type = (!type_expr_ref) ctx e with_type
+let type_expr ?(mode=MGet) ctx e with_type = (!type_expr_ref) ~mode ctx e with_type
 
 let unify_min ctx el = (!unify_min_ref) ctx el
 

--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -290,3 +290,5 @@ let error_require r p =
 		"'" ^ r ^ "' to be enabled"
 	in
 	error ("Accessing this field requires " ^ r) p
+
+let invalid_assign p = error "Invalid assign" p

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -39,7 +39,7 @@ let make_offset_list left right middle other =
 	(ExtList.List.make left other) @ [middle] @ (ExtList.List.make right other)
 
 let type_field_access ctx ?(resume=false) e name =
-	Calls.acc_get ctx (Fields.type_field (Fields.TypeFieldConfig.create resume) ctx e name e.epos TyperBase.MGet) e.epos
+	Calls.acc_get ctx (Fields.type_field (Fields.TypeFieldConfig.create resume) ctx e name e.epos MGet) e.epos
 
 let unapply_type_parameters params monos =
 	List.iter2 (fun (_,t1) t2 -> match t2,follow t2 with TMono m1,TMono m2 when m1 == m2 -> Type.unify t1 t2 | _ -> ()) params monos

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -4,11 +4,6 @@ open Type
 open Typecore
 open Error
 
-type access_mode =
-	| MGet
-	| MSet
-	| MCall
-
 type access_kind =
 	| AKNo of string
 	| AKExpr of texpr

--- a/tests/misc/projects/Issue8517/Fail.hx
+++ b/tests/misc/projects/Issue8517/Fail.hx
@@ -1,0 +1,7 @@
+class Main {
+	public static function main():Void {
+		Macro.notAssignable() = 2;
+		Foo.bar() = 2;
+		Foo.bar() += 2;
+	}
+}

--- a/tests/misc/projects/Issue8517/Foo.hx
+++ b/tests/misc/projects/Issue8517/Foo.hx
@@ -1,0 +1,4 @@
+class Foo {
+	static public var a:Int;
+	static public inline function bar():Int return a;
+}

--- a/tests/misc/projects/Issue8517/Macro.hx
+++ b/tests/misc/projects/Issue8517/Macro.hx
@@ -1,0 +1,4 @@
+class Macro {
+	macro static public function assignable() return macro Foo.a;
+	macro static public function notAssignable() return macro Foo.bar();
+}

--- a/tests/misc/projects/Issue8517/Main.hx
+++ b/tests/misc/projects/Issue8517/Main.hx
@@ -1,0 +1,5 @@
+class Main {
+	public static function main():Void {
+		Macro.assignable() = 2;
+	}
+}

--- a/tests/misc/projects/Issue8517/compile-fail.hxml
+++ b/tests/misc/projects/Issue8517/compile-fail.hxml
@@ -1,0 +1,1 @@
+-main Fail

--- a/tests/misc/projects/Issue8517/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8517/compile-fail.hxml.stderr
@@ -1,0 +1,4 @@
+Macro.hx:3: characters 60-69 : Invalid assign
+Fail.hx:1: lines 1-7 : Defined in this class
+Fail.hx:4: characters 3-12 : Invalid assign
+Fail.hx:5: characters 3-12 : Invalid assign

--- a/tests/misc/projects/Issue8517/compile.hxml
+++ b/tests/misc/projects/Issue8517/compile.hxml
@@ -1,0 +1,1 @@
+-main Main


### PR DESCRIPTION
Fixes #8517

```haxe
class Foobar {
	static var a:Int;
	static inline function foo():Int return a;
}
class Test {
	public static function main():Void {
		Foobar.foo() = 2;
	}
}
```
Inline call in `Foobar.foo() = value` is immediately inlined. And by the time assignment is checked there is no trail of a call. Instead in the check expression looks like this: `Foobar.a = 2`.
This PR adds assignment check right before inlining a call.