### PR TITLE
Fix implicit return of arrow function for Void

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -509,6 +509,13 @@
 		"internal": true
 	},
 	{
+		"name": "ImplicitReturn",
+		"metadata": ":implicitReturn",
+		"doc": "Generated automatically on the AST when an implicit return is inserted for arrow function.",
+		"targets": ["TExpr"],
+		"internal": true
+	},
+	{
 		"name": "Include",
 		"metadata": ":include",
 		"doc": "",

--- a/src/context/display/displayEmitter.ml
+++ b/src/context/display/displayEmitter.ml
@@ -15,7 +15,12 @@ open Display
 open DisplayPosition
 
 let get_expected_name with_type = match with_type with
-	| WithType.Value (Some s) | WithType.WithType(_,Some s) -> Some s
+	| WithType.Value (Some src) | WithType.WithType(_,Some src) ->
+		(match src with
+		| WithType.FunctionArgument name -> Some name
+		| WithType.StructureField name -> Some name
+		| WithType.ImplicitReturn -> None
+		)
 	| _ -> None
 
 let sort_fields l with_type tk =
@@ -25,7 +30,7 @@ let sort_fields l with_type tk =
 	in
 	let expected_name = get_expected_name with_type in
 	let l = List.map (fun ci ->
-		let i = get_sort_index tk ci (Option.default Globals.null_pos p) (Option.map fst expected_name) in
+		let i = get_sort_index tk ci (Option.default Globals.null_pos p) expected_name in
 		ci,i
 	) l in
 	let sort l =

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -136,6 +136,7 @@ let make_call_ref : (typer -> texpr -> texpr list -> t -> ?force_inline:bool -> 
 let type_expr_ref : (typer -> expr -> WithType.t -> texpr) ref = ref (fun _ _ _ -> assert false)
 let type_block_ref : (typer -> expr list -> WithType.t -> pos -> texpr) ref = ref (fun _ _ _ _ -> assert false)
 let unify_min_ref : (typer -> texpr list -> t) ref = ref (fun _ _ -> assert false)
+let unify_min_for_type_source_ref : (typer -> texpr list -> WithType.with_type_source option -> t) ref = ref (fun _ _ _ -> assert false)
 let analyzer_run_on_expr_ref : (Common.context -> texpr -> texpr) ref = ref (fun _ _ -> assert false)
 
 let pass_name = function
@@ -156,6 +157,7 @@ let make_call ctx e el t p = (!make_call_ref) ctx e el t p
 let type_expr ctx e with_type = (!type_expr_ref) ctx e with_type
 
 let unify_min ctx el = (!unify_min_ref) ctx el
+let unify_min_for_type_source ctx el src = (!unify_min_for_type_source_ref) ctx el src
 
 let make_static_this c p =
 	let ta = TAnon { a_fields = c.cl_statics; a_status = ref (Statics c) } in

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -2825,7 +2825,7 @@ end
 
 module ExtType = struct
 	let is_mono = function
-		| TMono _ -> true
+		| TMono { contents = None } -> true
 		| _ -> false
 
 	let is_void = function

--- a/src/core/type.ml
+++ b/src/core/type.ml
@@ -2824,6 +2824,10 @@ module TExprToExpr = struct
 end
 
 module ExtType = struct
+	let is_mono = function
+		| TMono _ -> true
+		| _ -> false
+
 	let is_void = function
 		| TAbstract({a_path=[],"Void"},_) -> true
 		| _ -> false

--- a/src/core/withType.ml
+++ b/src/core/withType.ml
@@ -1,31 +1,31 @@
 open Type
 
-type expected_name_source =
-	| FunctionArgument
-	| StructureField
-
-type expected_name = string * expected_name_source
+type with_type_source =
+	| FunctionArgument of string
+	| StructureField of string
+	| ImplicitReturn
 
 type t =
 	| NoValue
-	| Value of expected_name option
-	| WithType of Type.t * expected_name option
+	| Value of with_type_source option
+	| WithType of Type.t * with_type_source option
 
 let with_type t = WithType(t,None)
-let with_argument t name = WithType(t,Some(name,FunctionArgument))
-let with_structure_field t name = WithType(t,Some(name,StructureField))
+let of_implicit_return t = WithType(t,Some ImplicitReturn)
+let with_argument t name = WithType(t,Some(FunctionArgument name))
+let with_structure_field t name = WithType(t,Some(StructureField name))
 let value = Value None
-let named_argument name = Value (Some(name,FunctionArgument))
-let named_structure_field name = Value (Some(name,StructureField))
+let named_argument name = Value (Some(FunctionArgument name))
+let named_structure_field name = Value (Some(StructureField name))
 let no_value = NoValue
 
 let to_string = function
 	| NoValue -> "NoValue"
-	| Value None -> "Value"
-	| Value (Some(s,_)) -> "Value " ^ s
+	| Value (None | Some ImplicitReturn) -> "Value"
+	| Value (Some(FunctionArgument s | StructureField s)) -> "Value " ^ s
 	| WithType(t,s) ->
 		let name = match s with
-			| None -> "None"
-			| Some(s,_) -> s
+			| Some(FunctionArgument s | StructureField s) -> s
+			| _ -> "None"
 		in
 		Printf.sprintf "WithType(%s, %s)" (s_type (print_context()) t) name

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1108,7 +1108,9 @@ and arrow_expr = parser
 
 and arrow_function p1 al er s =
 	let make e =
-		EFunction(None, { f_params = []; f_type = None; f_args = al; f_expr = Some (EReturn(Some e), (snd e));  }), punion p1 (pos e)
+		let p = pos e in
+		let return = (EMeta((Meta.ImplicitReturn, [], null_pos), (EReturn(Some e), p)), p) in
+		EFunction(None, { f_params = []; f_type = None; f_args = al; f_expr = Some return;  }), punion p1 p
 	in
 	List.iter (fun (_,_,ml,_,_) ->	match ml with
 		| (_,_,p) :: _ -> syntax_error (Custom "Metadata on arrow function arguments is not allowed") ~pos:(Some p) s ()

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -1551,8 +1551,9 @@ module Match = struct
 		in
 		let tmono,with_type,allow_min_void = match with_type with
 			| WithType.WithType(t,src) ->
-				(match follow t with
-				| TMono _ -> Some t,WithType.value,(match src with Some WithType.ImplicitReturn -> true | _ -> false)
+				(match follow t, src with
+				| TMono _, Some ImplicitReturn -> Some t, WithType.Value src, true
+				| TMono _, _ -> Some t,WithType.value,false
 				| _ -> None,with_type,false)
 			| _ -> None,with_type,false
 		in

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -1549,9 +1549,12 @@ module Match = struct
 			| None -> cases
 			| Some (eo,p) -> cases @ [[EConst (Ident "_"),p],None,eo,p]
 		in
-		let tmono,with_type = match with_type with
-			| WithType.WithType(t,_) -> (match follow t with TMono _ -> Some t,WithType.value | _ -> None,with_type)
-			| _ -> None,with_type
+		let tmono,with_type,allow_min_void = match with_type with
+			| WithType.WithType(t,src) ->
+				(match follow t with
+				| TMono _ -> Some t,WithType.value,(match src with Some WithType.ImplicitReturn -> true | _ -> false)
+				| _ -> None,with_type,false)
+			| _ -> None,with_type,false
 		in
 		let cases = List.map (fun (el,eg,eo,p) ->
 			let p = match eo with Some e when p = null_pos -> pos e | _ -> p in
@@ -1580,7 +1583,8 @@ module Match = struct
 								(* If we have no block we have to use the `case pattern` position because that's all we have. *)
 								mk (TBlock []) ctx.t.tvoid case.Case.case_pos
 						) cases in
-						unify_min ctx el
+						if allow_min_void then unify_min_for_type_source ctx el (Some WithType.ImplicitReturn)
+						else unify_min ctx el
 					end
 				| WithType.WithType(t,_) -> t
 		in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1897,7 +1897,7 @@ and type_try ctx e1 catches with_type p =
 	let e1,catches,t = match with_type with
 		| WithType.NoValue -> e1,catches,ctx.t.tvoid
 		| WithType.Value _ -> e1,catches,unify_min ctx el
-		| WithType.WithType(t,src) when (match follow t with TMono _ -> true | _ -> false) ->
+		| WithType.WithType(t,src) when (match follow t with TMono _ -> true | t -> ExtType.is_void t) ->
 			e1,catches,unify_min_for_type_source ctx el src
 		| WithType.WithType(t,_) ->
 			let e1 = AbstractCast.cast_or_unify ctx t e1 e1.epos in
@@ -2264,7 +2264,7 @@ and type_if ctx e e1 e2 with_type p =
 		let e1,e2,t = match with_type with
 			| WithType.NoValue -> e1,e2,ctx.t.tvoid
 			| WithType.Value _ -> e1,e2,unify_min ctx [e1; e2]
-			| WithType.WithType(t,src) when (match follow t with TMono _ -> true | _ -> false) ->
+			| WithType.WithType(t,src) when (match follow t with TMono _ -> true | t -> ExtType.is_void t) ->
 				e1,e2,unify_min_for_type_source ctx [e1; e2] src
 			| WithType.WithType(t,_) ->
 				let e1 = AbstractCast.cast_or_unify ctx t e1 e1.epos in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2181,6 +2181,7 @@ and type_return ?(implicit=false) ctx e with_type p =
 		unify ctx v ctx.ret p;
 		let expect_void = match with_type with
 			| WithType.WithType(t,_) -> ExtType.is_void (follow t)
+			| WithType.Value (Some ImplicitReturn) -> true
 			| _ -> false
 		in
 		mk (TReturn None) (if expect_void then v else t_dynamic) p

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -283,6 +283,13 @@ let unify_min ctx el =
 		if not ctx.untyped then display_error ctx (error_msg (Unify l)) p;
 		(List.hd el).etype
 
+let unify_min_for_type_source ctx el src =
+	match src with
+	| Some WithType.ImplicitReturn when List.exists (fun e -> ExtType.is_void (follow e.etype)) el ->
+		ctx.com.basic.tvoid
+	| _ ->
+		unify_min ctx el
+
 let rec type_ident_raise ctx i p mode =
 	match i with
 	| "true" ->
@@ -1890,7 +1897,8 @@ and type_try ctx e1 catches with_type p =
 	let e1,catches,t = match with_type with
 		| WithType.NoValue -> e1,catches,ctx.t.tvoid
 		| WithType.Value _ -> e1,catches,unify_min ctx el
-		| WithType.WithType(t,_) when (match follow t with TMono _ -> true | _ -> false) -> e1,catches,unify_min ctx el
+		| WithType.WithType(t,src) when (match follow t with TMono _ -> true | _ -> false) ->
+			e1,catches,unify_min_for_type_source ctx el src
 		| WithType.WithType(t,_) ->
 			let e1 = AbstractCast.cast_or_unify ctx t e1 e1.epos in
 			let catches = List.map (fun (v,e) ->
@@ -2184,17 +2192,12 @@ and type_return ?(implicit=false) ctx e with_type p =
 	| Some e ->
 		try
 			let with_expected_type =
-				match implicit, follow ctx.ret with
-				| true, t when ExtType.is_void t -> WithType.NoValue
-				| true, TMono _ ->
-					(*
-						Treat `(...) -> {}` as an empty function (just like `function(...) {}`)
-						instead of returning an object
-					*)
-					(match fst e with
-					| EBlock [] -> WithType.NoValue
-					| _ -> WithType.with_type ctx.ret)
-				| _ -> WithType.with_type ctx.ret
+				if implicit then
+					match follow ctx.ret, fst e with
+					| t, _ when ExtType.is_void t -> WithType.NoValue
+					| _ -> WithType.of_implicit_return ctx.ret
+				else
+					WithType.with_type ctx.ret
 			in
 			let e = type_expr ctx e with_expected_type in
 			let e =
@@ -2261,7 +2264,8 @@ and type_if ctx e e1 e2 with_type p =
 		let e1,e2,t = match with_type with
 			| WithType.NoValue -> e1,e2,ctx.t.tvoid
 			| WithType.Value _ -> e1,e2,unify_min ctx [e1; e2]
-			| WithType.WithType(t,_) when (match follow t with TMono _ -> true | _ -> false) -> e1,e2,unify_min ctx [e1; e2]
+			| WithType.WithType(t,src) when (match follow t with TMono _ -> true | _ -> false) ->
+				e1,e2,unify_min_for_type_source ctx [e1; e2] src
 			| WithType.WithType(t,_) ->
 				let e1 = AbstractCast.cast_or_unify ctx t e1 e1.epos in
 				let e2 = AbstractCast.cast_or_unify ctx t e2 e2.epos in
@@ -2464,7 +2468,15 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 		Texpr.type_constant ctx.com.basic c p
 	| EBinop (op,e1,e2) ->
 		type_binop ctx op e1 e2 false with_type p
-	| EBlock [] when with_type <> WithType.NoValue ->
+	| EBlock [] when (match with_type with
+			| NoValue -> false
+			(*
+				If expected type is unknown then treat `(...) -> {}` as an empty function
+				(just like `function(...) {}`) instead of returning an object.
+			*)
+			| WithType (t, Some ImplicitReturn) -> not (ExtType.is_mono (follow t))
+			| _ -> true
+		) ->
 		type_expr ctx (EObjectDecl [],p) with_type
 	| EBlock l ->
 		let locals = save_locals ctx in
@@ -2709,6 +2721,7 @@ let rec create com =
 
 ;;
 unify_min_ref := unify_min;
+unify_min_for_type_source_ref := unify_min_for_type_source;
 make_call_ref := make_call;
 build_call_ref := build_call;
 type_call_target_ref := type_call_target;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2007,14 +2007,9 @@ and type_local_function ctx name inline f with_type p =
 					| TMono _ -> unify ctx t2 t1 p
 					| _ -> ()
 				) args args2;
-				let is_arrow_function =
-					match f.f_expr with
-					| Some (EMeta((Meta.ImplicitReturn,_,_), (EReturn _,_)),_) -> true
-					| _ -> false
-				in
-				(* unify for top-down inference unless we are expecting Void for non-arrow function *)
+				(* unify for top-down inference unless we are expecting Void *)
 				begin match follow tr,follow rt with
-					| TAbstract({a_path = [],"Void"},_),_ when not is_arrow_function -> ()
+					| TAbstract({a_path = [],"Void"},_),_ -> ()
 					| _,TMono _ -> unify ctx rt tr p
 					| _ -> ()
 				end
@@ -2194,7 +2189,7 @@ and type_return ?(implicit=false) ctx e with_type p =
 			let with_expected_type =
 				if implicit then
 					match follow ctx.ret, fst e with
-					| t, _ when ExtType.is_void t -> WithType.NoValue
+					(* | t, _ when ExtType.is_void t -> WithType.NoValue *)
 					| _ -> WithType.of_implicit_return ctx.ret
 				else
 					WithType.with_type ctx.ret

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2187,18 +2187,11 @@ and type_return ?(implicit=false) ctx e with_type p =
 	| Some e ->
 		try
 			let with_expected_type =
-				if implicit then
-					match follow ctx.ret, fst e with
-					(* | t, _ when ExtType.is_void t -> WithType.NoValue *)
-					| _ -> WithType.of_implicit_return ctx.ret
-				else
-					WithType.with_type ctx.ret
+				if implicit then WithType.of_implicit_return ctx.ret
+				else WithType.with_type ctx.ret
 			in
 			let e = type_expr ctx e with_expected_type in
-			let e =
-				if implicit && with_expected_type = WithType.NoValue then e
-				else AbstractCast.cast_or_unify ctx ctx.ret e p
-			in
+			let e = AbstractCast.cast_or_unify ctx ctx.ret e p in
 			begin match follow e.etype with
 			| TAbstract({a_path=[],"Void"},_) ->
 				begin match (Texpr.skip e).eexpr with

--- a/tests/optimization/src/issues/Issue8128.hx
+++ b/tests/optimization/src/issues/Issue8128.hx
@@ -1,0 +1,15 @@
+package issues;
+
+class Issue8128 {
+	static var tmp:Any;
+	@:js('
+		issues_Issue8128.tmp = function() {
+			return;
+		}
+	')
+	static function test() {
+		tmp = () -> {};
+	}
+
+	public function new() {}
+}

--- a/tests/optimization/src/issues/Issue8128.hx
+++ b/tests/optimization/src/issues/Issue8128.hx
@@ -5,7 +5,7 @@ class Issue8128 {
 	@:js('
 		issues_Issue8128.tmp = function() {
 			return;
-		}
+		};
 	')
 	static function test() {
 		tmp = () -> {};

--- a/tests/unit/src/unit/issues/Issue7376.hx
+++ b/tests/unit/src/unit/issues/Issue7376.hx
@@ -1,0 +1,28 @@
+package unit.issues;
+
+import utest.Assert;
+
+class Issue7376 extends unit.Test {
+	function test() {
+		foo(bool -> {
+			try {
+				intJob();
+			} catch(e:Dynamic) {
+				voidJob();
+			}
+		});
+
+		foo(bool -> switch bool {
+			case true: intJob();
+			case false:
+		});
+
+		foo(bool -> bool ? intJob() : voidJob());
+
+		noAssert();
+	}
+
+	@:pure(false) static function foo(f:Bool->Void) f(true);
+	@:pure(false) static function intJob():Int return 0;
+	@:pure(false) static function voidJob():Void {}
+}

--- a/tests/unit/src/unit/issues/Issue7376.hx
+++ b/tests/unit/src/unit/issues/Issue7376.hx
@@ -3,7 +3,7 @@ package unit.issues;
 import utest.Assert;
 
 class Issue7376 extends unit.Test {
-	function test() {
+	function testTryCatch() {
 		foo(bool -> {
 			try {
 				intJob();
@@ -12,17 +12,43 @@ class Issue7376 extends unit.Test {
 			}
 		});
 
+		var fn = bool -> {
+			try {
+				intJob();
+			} catch(e:Dynamic) {
+				voidJob();
+			}
+		}
+		foo(fn);
+
+		noAssert();
+	}
+
+	function testSwitch() {
 		foo(bool -> switch bool {
 			case true: intJob();
 			case false:
 		});
 
-		foo(bool -> bool ? intJob() : voidJob());
+		var fn = bool -> switch bool {
+			case true: intJob();
+			case false:
+		}
+		foo(fn);
 
 		noAssert();
 	}
 
-	@:pure(false) static function foo(f:Bool->Void) f(true);
+	function testIfElse() {
+		foo(bool -> bool ? intJob() : voidJob());
+
+		var fn = bool -> if(bool) intJob() else {};
+		foo(fn);
+
+		noAssert();
+	}
+
+	@:pure(false) static function foo(f:(Bool)->Void) f(true);
 	@:pure(false) static function intJob():Int return 0;
 	@:pure(false) static function voidJob():Void {}
 }

--- a/tests/unit/src/unit/issues/Issue7376.hx
+++ b/tests/unit/src/unit/issues/Issue7376.hx
@@ -21,6 +21,15 @@ class Issue7376 extends unit.Test {
 		}
 		foo(fn);
 
+		var fn = bool -> {
+			try {
+				intJob();
+			} catch(e:Dynamic) {
+				return;
+			}
+		}
+		foo(fn);
+
 		noAssert();
 	}
 
@@ -36,6 +45,13 @@ class Issue7376 extends unit.Test {
 		}
 		foo(fn);
 
+		// TODO
+		// var fn = bool -> switch bool {
+		// 	case true: intJob();
+		// 	case false: return;
+		// }
+		// foo(fn);
+
 		noAssert();
 	}
 
@@ -43,6 +59,9 @@ class Issue7376 extends unit.Test {
 		foo(bool -> bool ? intJob() : voidJob());
 
 		var fn = bool -> if(bool) intJob() else {};
+		foo(fn);
+
+		var fn = bool -> if (bool) intJob() else return;
 		foo(fn);
 
 		noAssert();

--- a/tests/unit/src/unit/issues/Issue7376.hx
+++ b/tests/unit/src/unit/issues/Issue7376.hx
@@ -45,12 +45,11 @@ class Issue7376 extends unit.Test {
 		}
 		foo(fn);
 
-		// TODO
-		// var fn = bool -> switch bool {
-		// 	case true: intJob();
-		// 	case false: return;
-		// }
-		// foo(fn);
+		var fn = bool -> switch bool {
+			case true: intJob();
+			case false: return;
+		}
+		foo(fn);
 
 		noAssert();
 	}


### PR DESCRIPTION
Fixes #7376
Fixes #8128
Closes #7890

This PR adds `@:implicitReturn` meta for auto-generated `return` of arrow functions and handles that meta during typing process.
Non-arrow functions and manually-written `return`s should not be affected.

If expected return type for arrow function is unknown, then typing goes as usual. But in case of the need to unify multiple branches with the return type  (e.g. `var f = () -> try intJob() catch(e:Dynamic) voidJob()`) we look for a `Void` branch among  them, and if found, then `Void` is used instead of running `unify_min`.

Special case: if expected return type is `Void` or unknown, then `() -> {}` is explicitly handled to generate an empty block instead of an empty object. Just like (and by the same code as) `function() {}`

```haxe
$type(() -> {}); //Void -> Void

$type(() ->
    try
        intJob()
    catch(e:Dynamic) {
    }
); //Void -> Void

$type(bool -> bool ? intJob() : voidJob()); //(bool : Bool) -> Void

$type(
    bool -> switch bool {
        case false: intJob();
        case true:
    }
); //(bool : Bool) -> Void
```