### PR TITLE
[js] [html-externs] restore ArrayBufferView back to extern interface

### DIFF
--- a/std/js/lib/ArrayBufferView.hx
+++ b/std/js/lib/ArrayBufferView.hx
@@ -29,11 +29,7 @@ package js.lib;
 
 	@see <https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView>
 **/
-@:forward
-abstract ArrayBufferView(_ArrayBufferView) from Int8Array from Uint8Array from Uint8ClampedArray from Int16Array from Uint16Array from Int32Array
-	from Uint32Array from Float32Array from Float64Array from DataView {}
-
-private typedef _ArrayBufferView = {
+extern interface ArrayBufferView {
 	final buffer:ArrayBuffer;
 	final byteOffset:Int;
 	final byteLength:Int;

--- a/std/js/lib/DataView.hx
+++ b/std/js/lib/DataView.hx
@@ -23,7 +23,7 @@
 package js.lib;
 
 @:native("DataView")
-extern class DataView {
+extern class DataView implements ArrayBufferView {
 	final buffer:ArrayBuffer;
 	final byteOffset:Int;
 	final byteLength:Int;

--- a/std/js/lib/Float32Array.hx
+++ b/std/js/lib/Float32Array.hx
@@ -34,7 +34,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Float32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Float32Array")
-extern class Float32Array implements ArrayAccess<Float> {
+extern class Float32Array implements ArrayBufferView implements ArrayAccess<Float> {
 	/**
 		Returns a number value of the element size. 4 in the case of an `Float32Array`.
 	 */

--- a/std/js/lib/Float64Array.hx
+++ b/std/js/lib/Float64Array.hx
@@ -34,7 +34,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Float64Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Float64Array")
-extern class Float64Array implements ArrayAccess<Float> {
+extern class Float64Array implements ArrayBufferView implements ArrayAccess<Float> {
 	/**
 		Returns a number value of the element size. 8 in the case of an `Float64Array`.
 	 */

--- a/std/js/lib/Int16Array.hx
+++ b/std/js/lib/Int16Array.hx
@@ -33,7 +33,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Int16Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Int16Array")
-extern class Int16Array implements ArrayAccess<Int> {
+extern class Int16Array implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 2 in the case of an `Int16Array`.
 	 */

--- a/std/js/lib/Int32Array.hx
+++ b/std/js/lib/Int32Array.hx
@@ -33,7 +33,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Int32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Int32Array")
-extern class Int32Array implements ArrayAccess<Int> {
+extern class Int32Array implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 4 in the case of an `Int32Array`.
 	 */

--- a/std/js/lib/Int8Array.hx
+++ b/std/js/lib/Int8Array.hx
@@ -32,7 +32,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Int8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Int8Array")
-extern class Int8Array implements ArrayAccess<Int> {
+extern class Int8Array implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 1 in the case of an `Int8Array`.
 	 */

--- a/std/js/lib/Uint16Array.hx
+++ b/std/js/lib/Uint16Array.hx
@@ -33,7 +33,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Uint16Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Uint16Array")
-extern class Uint16Array implements ArrayAccess<Int> {
+extern class Uint16Array implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 2 in the case of an `Uint16Array`.
 	 */

--- a/std/js/lib/Uint32Array.hx
+++ b/std/js/lib/Uint32Array.hx
@@ -33,7 +33,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Uint32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Uint32Array")
-extern class Uint32Array implements ArrayAccess<Int> {
+extern class Uint32Array implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 4 in the case of an `Uint32Array`.
 	 */

--- a/std/js/lib/Uint8Array.hx
+++ b/std/js/lib/Uint8Array.hx
@@ -32,7 +32,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Uint8Array")
-extern class Uint8Array implements ArrayAccess<Int> {
+extern class Uint8Array implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 1 in the case of an `Uint8Array`.
 	 */

--- a/std/js/lib/Uint8ClampedArray.hx
+++ b/std/js/lib/Uint8ClampedArray.hx
@@ -34,7 +34,7 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	Documentation [Uint8ClampedArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("Uint8ClampedArray")
-extern class Uint8ClampedArray implements ArrayAccess<Int> {
+extern class Uint8ClampedArray implements ArrayBufferView implements ArrayAccess<Int> {
 	/**
 		Returns a number value of the element size. 1 in the case of an `Uint8ClampedArray`.
 	 */


### PR DESCRIPTION
Fixes #8529 

PR #8422 swapped ArrayBufferView to an abstract rather than an extern interface, but it's not clear there's any advantage to this