### PR TITLE
Use 64bit neko on win64

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -71,7 +71,7 @@ package_choco:
 	rm -rf out/choco
 
 $(INSTALLER_TMP_DIR)/neko-win.zip: $(INSTALLER_TMP_DIR)
-	wget -nv http://nekovm.org/media/neko-2.1.0-$(NEKO_ARCH_STR).zip -O installer/neko-win.zip
+	wget -nv http://nekovm.org/media/neko-2.2.0-$(NEKO_ARCH_STR).zip -O installer/neko-win.zip
 
 package_installer_win: $(INSTALLER_TMP_DIR)/neko-win.zip package_win
 	$(eval OUTFILE := $(PACKAGE_OUT_DIR)/$(PACKAGE_FILE_NAME)_installer.zip)

--- a/Makefile.win
+++ b/Makefile.win
@@ -6,6 +6,11 @@ HAXELIB_OUTPUT=haxelib.exe
 PREBUILD_OUTPUT=prebuild.exe
 EXTENSION=.exe
 PACKAGE_SRC_EXTENSION=.zip
+ARCH?=32
+
+ifeq ($(ARCH),64)
+NEKO_ARCH_STR=64
+endif
 
 kill:
 	-@taskkill /F /IM haxe.exe
@@ -66,7 +71,7 @@ package_choco:
 	rm -rf out/choco
 
 $(INSTALLER_TMP_DIR)/neko-win.zip: $(INSTALLER_TMP_DIR)
-	wget -nv http://nekovm.org/media/neko-2.1.0-win.zip -O installer/neko-win.zip
+	wget -nv http://nekovm.org/media/neko-2.1.0-$(NEKO_ARCH_STR).zip -O installer/neko-win.zip
 
 package_installer_win: $(INSTALLER_TMP_DIR)/neko-win.zip package_win
 	$(eval OUTFILE := $(PACKAGE_OUT_DIR)/$(PACKAGE_FILE_NAME)_installer.zip)

--- a/extra/azure-pipelines/build-windows.yml
+++ b/extra/azure-pipelines/build-windows.yml
@@ -53,6 +53,7 @@ jobs:
       - powershell: Write-Host "##vso[task.prependpath]${env:CYG_ROOT}/usr/$(MINGW_ARCH)-w64-mingw32/sys-root/mingw/bin"
         displayName: Expose mingw dll files
       - powershell: |
+          $env:PATH = "$(CYG_ROOT)/usr/x86_64-w64-mingw32/sys-root/mingw/bin;$(PATH)"
           Set-PSDebug -Trace 1
           & "$(CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam config exec -- make -s -f Makefile.win libs prebuild 2>&1')
           & "$(CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam config exec -- make -s -f Makefile.win -j`nproc` haxe 2>&1')

--- a/extra/azure-pipelines/build-windows.yml
+++ b/extra/azure-pipelines/build-windows.yml
@@ -53,7 +53,6 @@ jobs:
       - powershell: Write-Host "##vso[task.prependpath]${env:CYG_ROOT}/usr/$(MINGW_ARCH)-w64-mingw32/sys-root/mingw/bin"
         displayName: Expose mingw dll files
       - powershell: |
-          $env:PATH = "$(CYG_ROOT)/usr/x86_64-w64-mingw32/sys-root/mingw/bin;$(PATH)"
           Set-PSDebug -Trace 1
           & "$(CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam config exec -- make -s -f Makefile.win libs prebuild 2>&1')
           & "$(CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam config exec -- make -s -f Makefile.win -j`nproc` haxe 2>&1')

--- a/extra/azure-pipelines/build-windows.yml
+++ b/extra/azure-pipelines/build-windows.yml
@@ -31,7 +31,10 @@ jobs:
         displayName: Install dependencies
       - template: install-neko-snapshot.yaml
         parameters:
-          platform: windows
+          ${{ if eq(parameters.arch, '64') }}:
+            platform: windows64
+          ${{ if eq(parameters.arch, '32') }}:
+            platform: windows
       - powershell: |
           Set-PSDebug -Trace 1
           curl.exe -fsSL -o cygwin-setup.exe --retry 3 $(CYGWIN_SETUP)

--- a/extra/installer.nsi
+++ b/extra/installer.nsi
@@ -20,7 +20,7 @@
 !define VERLONG "%%VERLONG%%"
 
 ; Define Neko info
-!define NEKO_VERSION "2.1.0"
+!define NEKO_VERSION "2.2.0"
 
 ; Installer details
 VIAddVersionKey "CompanyName" "Haxe Foundation"


### PR DESCRIPTION
Closes #8419 
I've changed azure setup to use 64bit neko on win64, but then haxelib started to emit an error, which looks like an issue we had with ocaml and newest intel CPUs:
```
Starting: Setup haxelib |  
-- | --
  | ============================================================================== |  
  | Task         : Command line |  
  | Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows |  
  | Version      : 2.151.1 |  
  | Author       : Microsoft Corporation |  
  | Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line |  
  | ============================================================================== |  
  | Generating script. |  
  | ========================== Starting Command Output =========================== |  
  | "C:\windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "d:\a\_temp\baf13136-068e-4a7f-9639-397370d3e64a.cmd"" |  
  | ##[error]Cmd.exe exited with code '-1073741701'. |  
  | Finishing: Setup haxelib
```
It fails on `haxelib setup C:\haxelib`. Here are azure logs: https://github.com/HaxeFoundation/haxe/runs/179586766
I tried `haxelib version` it fails with the same error.
And I didn't find what to do with that. Any ideas?
In a local VirtualBox VM it works fine.