### PR TITLE
@:noClosure meta to prevent usage of methods as values

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -22,7 +22,7 @@
 	{
 		"name": "Accessor",
 		"metadata": ":accessor",
-		"doc": "Used internally by DCE to mark property accoessors.",
+		"doc": "Used internally by DCE to mark property accessors.",
 		"targets": ["TClassField"],
 		"internal": true
 	},

--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -22,7 +22,7 @@
 	{
 		"name": "Accessor",
 		"metadata": ":accessor",
-		"doc": "Used internally by DCE to mark property accessors.",
+		"doc": "Used internally by DCE to mark property accoessors.",
 		"targets": ["TClassField"],
 		"internal": true
 	},
@@ -779,6 +779,12 @@
 		"doc": "Prevents a field from being used with static extension.",
 		"targets": ["TClassField"],
 		"links": ["https://haxe.org/manual/lf-static-extension.html"]
+	},
+	{
+		"name": "NoClosure",
+		"metadata": ":noClosure",
+		"doc": "Prevents a method or all methods in a class from being used as a value.",
+		"targets": ["TClass", "TClassField"]
 	},
 	{
 		"name": "Ns",

--- a/std/js/Syntax.hx
+++ b/std/js/Syntax.hx
@@ -28,6 +28,7 @@ import haxe.extern.Rest;
 	Generate JavaScript syntax not directly supported by Haxe.
 	Use only at low-level when specific target-specific code-generation is required.
 **/
+@:noClosure
 extern class Syntax {
 	/**
 		Inject `code` directly into generated source.

--- a/std/php/Syntax.hx
+++ b/std/php/Syntax.hx
@@ -30,6 +30,7 @@ import haxe.extern.EitherType;
 	Special extern class to support PHP language specifics.
 	Don't use these functions unless you are really sure what you are doing.
 **/
+@:noClosure
 extern class Syntax {
 	/**
 		Embeds plain php code.

--- a/std/python/Syntax.hx
+++ b/std/python/Syntax.hx
@@ -30,6 +30,7 @@ import haxe.macro.ExprTools;
 import haxe.extern.Rest;
 
 @:noPackageRestrict
+@:noClosure
 extern class Syntax {
 	#if macro
 	static var self = macro python.Syntax;

--- a/tests/misc/projects/Issue8618/Main.hx
+++ b/tests/misc/projects/Issue8618/Main.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		trace(NoClosureClass.notMethod);
+		trace(NoClosureClass.staticMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/Main2.hx
+++ b/tests/misc/projects/Issue8618/Main2.hx
@@ -1,0 +1,5 @@
+class Main2 {
+	static function main() {
+		trace((null:NoClosureClass).instanceMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/Main3.hx
+++ b/tests/misc/projects/Issue8618/Main3.hx
@@ -1,0 +1,5 @@
+class Main3 {
+	static function main() {
+		trace(NormalClass.noClosureStaticMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/Main4.hx
+++ b/tests/misc/projects/Issue8618/Main4.hx
@@ -1,0 +1,5 @@
+class Main4 {
+	static function main() {
+		trace((null:NormalClass).noClosureInstanceMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/NoClosureClass.hx
+++ b/tests/misc/projects/Issue8618/NoClosureClass.hx
@@ -1,0 +1,6 @@
+@:noClosure
+class NoClosureClass {
+	static public var notMethod:Void->Void;
+	static public function staticMethod() {}
+	public function instanceMethod() {}
+}

--- a/tests/misc/projects/Issue8618/NormalClass.hx
+++ b/tests/misc/projects/Issue8618/NormalClass.hx
@@ -1,0 +1,6 @@
+class NormalClass {
+	@:noClosure
+	static public function noClosureStaticMethod() {}
+	@:noClosure
+	public function noClosureInstanceMethod() {}
+}

--- a/tests/misc/projects/Issue8618/compile-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile-fail.hxml
@@ -1,0 +1,1 @@
+-main Main

--- a/tests/misc/projects/Issue8618/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:4: characters 9-36 : Field staticMethod cannot be used as a value

--- a/tests/misc/projects/Issue8618/compile2-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile2-fail.hxml
@@ -1,0 +1,1 @@
+-main Main2

--- a/tests/misc/projects/Issue8618/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile2-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main2.hx:3: characters 9-45 : Field instanceMethod cannot be used as a value

--- a/tests/misc/projects/Issue8618/compile3-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile3-fail.hxml
@@ -1,0 +1,1 @@
+-main Main3

--- a/tests/misc/projects/Issue8618/compile3-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile3-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main3.hx:3: characters 9-42 : Field noClosureStaticMethod cannot be used as a value

--- a/tests/misc/projects/Issue8618/compile4-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile4-fail.hxml
@@ -1,0 +1,1 @@
+-main Main4

--- a/tests/misc/projects/Issue8618/compile4-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile4-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main4.hx:3: characters 9-51 : Field noClosureInstanceMethod cannot be used as a value


### PR DESCRIPTION
Closes #8618 
Implemented as a filter, because creation of field access cannot be encapsulated and already spread among many places in code and the check needs to know if parent expression is a call.