### PR TITLE
@:noClosure meta to prevent usage of methods as values

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -719,6 +719,12 @@
 		"links": ["https://haxe.org/manual/cr-completion.html"]
 	},
 	{
+		"name": "NoClosure",
+		"metadata": ":noClosure",
+		"doc": "Prevents a method or all methods in a class from being used as a value.",
+		"targets": ["TClass", "TClassField"]
+	},
+	{
 		"name": "NoDebug",
 		"metadata": ":noDebug",
 		"doc": "Does not generate debug information even if `--debug` is set.",

--- a/std/js/Syntax.hx
+++ b/std/js/Syntax.hx
@@ -28,6 +28,7 @@ import haxe.extern.Rest;
 	Generate JavaScript syntax not directly supported by Haxe.
 	Use only at low-level when specific target-specific code-generation is required.
 **/
+@:noClosure
 extern class Syntax {
 	/**
 		Inject `code` directly into generated source.

--- a/std/php/Syntax.hx
+++ b/std/php/Syntax.hx
@@ -30,6 +30,7 @@ import haxe.extern.EitherType;
 	Special extern class to support PHP language specifics.
 	Don't use these functions unless you are really sure what you are doing.
 **/
+@:noClosure
 extern class Syntax {
 	/**
 		Embeds plain php code.

--- a/std/python/Syntax.hx
+++ b/std/python/Syntax.hx
@@ -30,6 +30,7 @@ import haxe.macro.ExprTools;
 import haxe.extern.Rest;
 
 @:noPackageRestrict
+@:noClosure
 extern class Syntax {
 	#if macro
 	static var self = macro python.Syntax;

--- a/tests/misc/projects/Issue8618/Main.hx
+++ b/tests/misc/projects/Issue8618/Main.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		trace(NoClosureClass.notMethod);
+		trace(NoClosureClass.staticMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/Main2.hx
+++ b/tests/misc/projects/Issue8618/Main2.hx
@@ -1,0 +1,5 @@
+class Main2 {
+	static function main() {
+		trace((null:NoClosureClass).instanceMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/Main3.hx
+++ b/tests/misc/projects/Issue8618/Main3.hx
@@ -1,0 +1,5 @@
+class Main3 {
+	static function main() {
+		trace(NormalClass.noClosureStaticMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/Main4.hx
+++ b/tests/misc/projects/Issue8618/Main4.hx
@@ -1,0 +1,5 @@
+class Main4 {
+	static function main() {
+		trace((null:NormalClass).noClosureInstanceMethod);
+	}
+}

--- a/tests/misc/projects/Issue8618/NoClosureClass.hx
+++ b/tests/misc/projects/Issue8618/NoClosureClass.hx
@@ -1,0 +1,6 @@
+@:noClosure
+class NoClosureClass {
+	static public var notMethod:Void->Void;
+	static public function staticMethod() {}
+	public function instanceMethod() {}
+}

--- a/tests/misc/projects/Issue8618/NormalClass.hx
+++ b/tests/misc/projects/Issue8618/NormalClass.hx
@@ -1,0 +1,6 @@
+class NormalClass {
+	@:noClosure
+	static public function noClosureStaticMethod() {}
+	@:noClosure
+	public function noClosureInstanceMethod() {}
+}

--- a/tests/misc/projects/Issue8618/compile-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile-fail.hxml
@@ -1,0 +1,1 @@
+-main Main

--- a/tests/misc/projects/Issue8618/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main.hx:4: characters 9-36 : Method staticMethod cannot be used as a value
+Main.hx:4: characters 9-36 : For function argument 'v'

--- a/tests/misc/projects/Issue8618/compile2-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile2-fail.hxml
@@ -1,0 +1,1 @@
+-main Main2

--- a/tests/misc/projects/Issue8618/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile2-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main2.hx:3: characters 9-45 : Method instanceMethod cannot be used as a value
+Main2.hx:3: characters 9-45 : For function argument 'v'

--- a/tests/misc/projects/Issue8618/compile3-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile3-fail.hxml
@@ -1,0 +1,1 @@
+-main Main3

--- a/tests/misc/projects/Issue8618/compile3-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile3-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main3.hx:3: characters 9-42 : Method noClosureStaticMethod cannot be used as a value
+Main3.hx:3: characters 9-42 : For function argument 'v'

--- a/tests/misc/projects/Issue8618/compile4-fail.hxml
+++ b/tests/misc/projects/Issue8618/compile4-fail.hxml
@@ -1,0 +1,1 @@
+-main Main4

--- a/tests/misc/projects/Issue8618/compile4-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8618/compile4-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main4.hx:3: characters 9-51 : Method noClosureInstanceMethod cannot be used as a value
+Main4.hx:3: characters 9-51 : For function argument 'v'


### PR DESCRIPTION
Closes #8618 