### PR TITLE
Fix #7949: [nullsafety] unify a null-checked value with a non-nullable field

### DIFF
--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -859,6 +859,16 @@ class TestStrict {
 		shouldFail(a + b);
 		shouldFail(a += b);
 	}
+
+	static function anonFields_checkedForNull() {
+		var i:Null<Int> = null;
+		shouldFail(({a: i} : {a:Int}));
+		if (i != null) {
+			({a: i} : {a:Int});
+			({a: i} : {a:Null<Int>});
+			({a: 0, b: i} : {a:Int, b: Int});
+		}
+	}
 }
 
 private class FinalNullableFields {


### PR DESCRIPTION
Fixes #7949 

Previous error path was `check_cast` > `can_pass_expr` > `unify`. In order to not change `unify`'s signature I modified `can_pass_expr` to unify each field during a cast.

I was hacking around in `nullSafety.ml` and decided to tackle an issue for practice. I'm new to the code base and ocaml, so any tips are appreciated. If this isn't helpful, you're welcome to be curt. :)