### PR TITLE
[display] use a separate diagnostics kind for deprecation warnings

### DIFF
--- a/src/context/display/deprecationCheck.ml
+++ b/src/context/display/deprecationCheck.ml
@@ -9,8 +9,10 @@ let warned_positions = Hashtbl.create 0
 
 let warn_deprecation com s p_usage =
 	if not (Hashtbl.mem warned_positions p_usage) then begin
-		Hashtbl.replace warned_positions p_usage true;
-		com.warning s p_usage;
+		Hashtbl.replace warned_positions p_usage s;
+		match com.display.dms_kind with
+		| DMDiagnostics _ -> ()
+		| _ -> com.warning s p_usage;
 	end
 
 let print_deprecation_message com meta s p_usage =

--- a/src/context/display/diagnostics.ml
+++ b/src/context/display/diagnostics.ml
@@ -190,6 +190,9 @@ module Printer = struct
 		List.iter (fun (s,p,prange) ->
 			add DKRemovableCode p DiagnosticsSeverity.Warning (JObject ["description",JString s;"range",if prange = null_pos then JNull else Genjson.generate_pos_as_range prange])
 		) dctx.removable_code;
+		Hashtbl.iter (fun p s ->
+			add DKDeprecationWarning p DiagnosticsSeverity.Warning (JString s);
+		) DeprecationCheck.warned_positions;
 		let jl = Hashtbl.fold (fun file diag acc ->
 			let jl = Hashtbl.fold (fun _ (dk,p,sev,jargs) acc ->
 				(JObject [

--- a/src/core/displayTypes.ml
+++ b/src/core/displayTypes.ml
@@ -70,6 +70,7 @@ module DiagnosticsKind = struct
 		| DKCompilerError
 		| DKRemovableCode
 		| DKParserError
+		| DKDeprecationWarning
 
 	let to_int = function
 		| DKUnusedImport -> 0
@@ -77,6 +78,7 @@ module DiagnosticsKind = struct
 		| DKCompilerError -> 2
 		| DKRemovableCode -> 3
 		| DKParserError -> 4
+		| DKDeprecationWarning -> 5
 end
 
 module CompletionResultKind = struct

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -254,7 +254,7 @@ let rec load_instance' ctx (t,p) allow_no_params =
 							| _,[EConst(String s),_],_ -> s
 							| _ -> "This typedef is deprecated in favor of " ^ (s_type (print_context()) td.t_type)
 						in
-						ctx.com.warning msg p
+						DeprecationCheck.warn_deprecation ctx.com msg p
 					with Not_found ->
 						()
 					end;


### PR DESCRIPTION
This lets us add support for [`DiagnosticTag.Deprecated`](https://code.visualstudio.com/updates/v1_37#_diagnosticstagdeprecated) in vshaxe (without this, we can't really tell deprecation warnings apart from other warnings).

![](https://i.imgur.com/bVbmxM6.png)