### PR TITLE
Make compilation server aware of native libs

### DIFF
--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -1222,7 +1222,8 @@ let add_net_lib com file std =
 	let net_lib = new net_library com file real_file std in
 	CompilationServer.handle_native_lib com net_lib;
 	com.native_libs.net_libs <- (net_lib :> (net_lib_type,unit) native_library) :: com.native_libs.net_libs;
-	com.native_libs.all_libs <- net_lib#get_file_path :: com.native_libs.all_libs
+	com.native_libs.all_libs <- net_lib#get_file_path :: com.native_libs.all_libs;
+	CompilationServer.handle_native_lib com net_lib
 
 let before_generate com =
 	(* netcore version *)

--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -1220,9 +1220,7 @@ let add_net_lib com file std =
 			failwith (".NET lib " ^ file ^ " not found")
 	in
 	let net_lib = new net_library com file real_file std in
-	CompilationServer.handle_native_lib com net_lib;
 	com.native_libs.net_libs <- (net_lib :> (net_lib_type,unit) native_library) :: com.native_libs.net_libs;
-	com.native_libs.all_libs <- net_lib#get_file_path :: com.native_libs.all_libs;
 	CompilationServer.handle_native_lib com net_lib
 
 let before_generate com =

--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -1301,7 +1301,4 @@ let before_generate com =
 				Unix.closedir f
 		in
 		loop()
-	) !matched;
-
-	(* now force all libraries to initialize *)
-	List.iter (function net_lib -> ignore (net_lib#lookup ([],""))) com.native_libs.net_libs
+	) !matched

--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -1220,7 +1220,7 @@ let add_net_lib com file std =
 			failwith (".NET lib " ^ file ^ " not found")
 	in
 	let net_lib = new net_library com file real_file std in
-	com.load_extern_type <- com.load_extern_type @ [net_lib#build];
+	CompilationServer.handle_native_lib com net_lib;
 	com.native_libs.net_libs <- (net_lib :> (net_lib_type,unit) native_library) :: com.native_libs.net_libs;
 	com.native_libs.all_libs <- net_lib#get_file_path :: com.native_libs.all_libs
 

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -1204,7 +1204,6 @@ let add_java_lib com name std =
 	in
 	if std then java_lib#add_flag FlagIsStd;
 	com.native_libs.java_libs <- (java_lib :> (java_lib_type,unit) native_library) :: com.native_libs.java_libs;
-	com.native_libs.all_libs <- java_lib#get_file_path :: com.native_libs.all_libs;
 	CompilationServer.handle_native_lib com java_lib
 
 let before_generate con =

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -1203,9 +1203,9 @@ let add_java_lib com name std =
 			(new java_library_jar com name file :> java_library)
 	in
 	if std then java_lib#add_flag FlagIsStd;
-	CompilationServer.handle_native_lib com java_lib;
 	com.native_libs.java_libs <- (java_lib :> (java_lib_type,unit) native_library) :: com.native_libs.java_libs;
-	com.native_libs.all_libs <- java_lib#get_file_path :: com.native_libs.all_libs
+	com.native_libs.all_libs <- java_lib#get_file_path :: com.native_libs.all_libs;
+	CompilationServer.handle_native_lib com java_lib
 
 let before_generate con =
 	let java_ver = try

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -625,7 +625,7 @@ end
 let add_swf_lib com file extern =
 	let real_file = (try Common.find_file com file with Not_found -> failwith (" Library not found : " ^ file)) in
 	let swf_lib = new swf_library com file real_file in
-	com.load_extern_type <- com.load_extern_type @ [swf_lib#build];
+	CompilationServer.handle_native_lib com swf_lib;
 	if not extern then com.native_libs.swf_libs <- (swf_lib :> (swf_lib_type,Swf.swf) native_library) :: com.native_libs.swf_libs;
 	com.native_libs.all_libs <- swf_lib#get_file_path :: com.native_libs.all_libs
 

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -625,9 +625,9 @@ end
 let add_swf_lib com file extern =
 	let real_file = (try Common.find_file com file with Not_found -> failwith (" Library not found : " ^ file)) in
 	let swf_lib = new swf_library com file real_file in
-	CompilationServer.handle_native_lib com swf_lib;
 	if not extern then com.native_libs.swf_libs <- (swf_lib :> (swf_lib_type,Swf.swf) native_library) :: com.native_libs.swf_libs;
-	com.native_libs.all_libs <- swf_lib#get_file_path :: com.native_libs.all_libs
+	com.native_libs.all_libs <- swf_lib#get_file_path :: com.native_libs.all_libs;
+	CompilationServer.handle_native_lib com swf_lib
 
 let remove_classes toremove lib l =
 	match !toremove with

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -626,7 +626,6 @@ let add_swf_lib com file extern =
 	let real_file = (try Common.find_file com file with Not_found -> failwith (" Library not found : " ^ file)) in
 	let swf_lib = new swf_library com file real_file in
 	if not extern then com.native_libs.swf_libs <- (swf_lib :> (swf_lib_type,Swf.swf) native_library) :: com.native_libs.swf_libs;
-	com.native_libs.all_libs <- swf_lib#get_file_path :: com.native_libs.all_libs;
 	CompilationServer.handle_native_lib com swf_lib
 
 let remove_classes toremove lib l =

--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -328,6 +328,7 @@ module Memory = struct
 				"haxelibCache",jint (mem_size cs.cache.c_haxelib);
 				"parserCache",jint (mem_size cs.cache.c_files);
 				"moduleCache",jint (mem_size cs.cache.c_modules);
+				"nativeLibCache",jint (mem_size cs.cache.c_native_libs);
 			]
 		]
 

--- a/src/context/compilationServer.ml
+++ b/src/context/compilationServer.ml
@@ -236,8 +236,9 @@ let get_native_lib cs key =
 
 let handle_native_lib com lib =
 	let build = lib#build in
+	com.native_libs.all_libs <- lib#get_file_path :: com.native_libs.all_libs;
 	begin match get() with
-	| Some cs ->
+	| Some cs when Define.raw_defined com.defines "haxe.cacheNativeLibs" ->
 		let init () =
 			let file = lib#get_file_path in
 			let key = file in
@@ -280,7 +281,7 @@ let handle_native_lib com lib =
 			with Not_found -> None
 		in
 		com.load_extern_type <- old @ [build];
-	| None ->
+	| _ ->
 		(* Offline mode, just read library as usual. *)
 		lib#load;
 		com.load_extern_type <- com.load_extern_type @ [build];

--- a/src/context/compilationServer.ml
+++ b/src/context/compilationServer.ml
@@ -16,12 +16,18 @@ type cached_directory = {
 	mutable c_mtime : float;
 }
 
+type cached_native_lib = {
+	c_nl_mtime : float;
+	c_nl_files : (path,(string * Ast.package)) Hashtbl.t;
+}
+
 type cache = {
 	c_haxelib : (string list, string list) Hashtbl.t;
 	c_files : ((string * string), cached_file) Hashtbl.t;
 	c_modules : (path * string, module_def) Hashtbl.t;
 	c_directories : (string, cached_directory list) Hashtbl.t;
 	c_removed_files : (string * string,unit) Hashtbl.t;
+	c_native_libs : (string,cached_native_lib) Hashtbl.t;
 }
 
 type context_sign = {
@@ -48,6 +54,7 @@ let create_cache () = {
 	c_modules = Hashtbl.create 0;
 	c_directories = Hashtbl.create 0;
 	c_removed_files = Hashtbl.create 0;
+	c_native_libs = Hashtbl.create 0;
 }
 
 let create () =
@@ -215,6 +222,71 @@ let add_directory cs key value =
 
 let clear_directories cs key =
 	Hashtbl.remove cs.cache.c_directories key
+
+(* native lib *)
+
+let add_native_lib cs key files timestamp =
+	Hashtbl.replace cs.cache.c_native_libs key { c_nl_files = files; c_nl_mtime = timestamp }
+
+let get_native_lib cs key =
+	try Some (Hashtbl.find cs.cache.c_native_libs key)
+	with Not_found -> None
+
+let handle_native_lib com lib =
+	let build = lib#build in
+	begin match get() with
+	| Some cs ->
+		let init () =
+			let file = lib#get_file_path in
+			let key = file in
+			let ftime = file_time file in
+			let setup_lookup lut =
+				let build path p =
+					try Some (Hashtbl.find lut path)
+					with Not_found -> None
+				in
+				com.load_extern_type <- com.load_extern_type @ [build];
+			in
+			begin match get_native_lib cs key with
+			| Some lib when ftime <= lib.c_nl_mtime ->
+				(* Cached lib is good, set up lookup into cached files. *)
+				setup_lookup lib.c_nl_files;
+			| _ ->
+				(* Cached lib is outdated or doesn't exist yet, read library. *)
+				lib#load;
+				(* Created lookup and eagerly read each known type. *)
+				let h = Hashtbl.create 0 in
+				List.iter (fun path ->
+					if not (Hashtbl.mem h path) then begin
+						let p = { pfile = file ^ " @ " ^ Globals.s_type_path path; pmin = 0; pmax = 0; } in
+						try begin match lib#build path p with
+						| Some r ->
+							Hashtbl.add h path r
+						| None -> ()
+						end with _ ->
+							()
+					end
+				) lib#list_modules;
+				(* Remove temp lookup, see below. *)
+				com.load_extern_type <- List.filter (fun f -> f != build) com.load_extern_type;
+				(* Save and set up lookup. *)
+				add_native_lib cs key h ftime;
+				setup_lookup h;
+			end;
+		in
+		(* This is some dicey nonsense: Native library handlers might actually
+			lookup something during the conversion to Haxe AST. For instance, the
+			SWF loader has a `is_valid_path` check in some cases which relies on
+			`load_extern_type`. In order to deal with this, we temporarily register
+			the standard resolver and then remove it again after the handling.
+		*)
+		com.load_extern_type <- com.load_extern_type @ [build];
+		com.callbacks#add_before_typer_create init
+	| None ->
+		(* Offline mode, just read library as usual. *)
+		lib#load;
+		com.load_extern_type <- com.load_extern_type @ [build];
+	end
 
 (* context *)
 

--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -417,10 +417,13 @@ let collect ctx tk with_type =
 			end
 		) files;
 		List.iter (fun file ->
-			let lib = Hashtbl.find cs.cache.c_native_libs file in
-			Hashtbl.iter (fun path (_,(pack,decls)) ->
-				if process_decls pack (snd path) decls then check_package pack;
-			) lib.c_nl_files
+			try
+				let lib = Hashtbl.find cs.cache.c_native_libs file in
+				Hashtbl.iter (fun path (_,(pack,decls)) ->
+					if process_decls pack (snd path) decls then check_package pack;
+				) lib.c_nl_files
+			with Not_found ->
+				()
 		) ctx.com.native_libs.all_libs
 	end;
 

--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -196,6 +196,11 @@ let collect ctx tk with_type =
 	in
 
 	let process_decls pack name decls =
+		let added_something = ref false in
+		let add item name =
+			added_something := true;
+			add item name
+		in
 		let run () = List.iter (fun (d,p) ->
 			begin try
 				let tname,is_private,meta = match d with
@@ -218,7 +223,8 @@ let collect ctx tk with_type =
 				()
 			end
 		) decls in
-		if is_pack_visible pack then run()
+		if is_pack_visible pack then run();
+		!added_something
 	in
 
 	(* Collection starts here *)
@@ -383,7 +389,7 @@ let collect ctx tk with_type =
 		explore_class_paths ctx.com ["display";"toplevel"] class_paths true add_package (fun path ->
 			if not (path_exists cctx path) then begin
 				let _,decls = Display.parse_module ctx path Globals.null_pos in
-				process_decls (fst path) (snd path) decls
+				ignore(process_decls (fst path) (snd path) decls)
 			end
 		)
 	| Some cs ->
@@ -396,20 +402,26 @@ let collect ctx tk with_type =
 			(file,cfile),i
 		) files in
 		let files = List.sort (fun (_,i1) (_,i2) -> -compare i1 i2) files in
+		let check_package pack = match List.rev pack with
+			| [] -> ()
+			| s :: sl -> add_package (List.rev sl,s)
+		in
 		List.iter (fun ((file,cfile),_) ->
 			let module_name = CompilationServer.get_module_name_of_cfile file cfile in
 			let dot_path = s_type_path (cfile.c_package,module_name) in
 			if (List.exists (fun e -> ExtString.String.starts_with dot_path (e ^ ".")) !exclude) then
 				()
 			else begin
-				begin match List.rev cfile.c_package with
-					| [] -> ()
-					| s :: sl -> add_package (List.rev sl,s)
-				end;
 				Hashtbl.replace ctx.com.module_to_file (cfile.c_package,module_name) file;
-				process_decls cfile.c_package module_name cfile.c_decls
+				if process_decls cfile.c_package module_name cfile.c_decls then check_package cfile.c_package;
 			end
-		) files
+		) files;
+		List.iter (fun file ->
+			let lib = Hashtbl.find cs.cache.c_native_libs file in
+			Hashtbl.iter (fun path (_,(pack,decls)) ->
+				if process_decls pack (snd path) decls then check_package pack;
+			) lib.c_nl_files
+		) ctx.com.native_libs.all_libs
 	end;
 
 	(* packages *)

--- a/std/haxe/display/Server.hx
+++ b/std/haxe/display/Server.hx
@@ -116,6 +116,7 @@ typedef HaxeMemoryResult = {
 		final haxelibCache:Int;
 		final parserCache:Int;
 		final moduleCache:Int;
+		final nativeLibCache:Int;
 	}
 }
 

--- a/tests/server/src/AsyncMacro.hx
+++ b/tests/server/src/AsyncMacro.hx
@@ -18,7 +18,7 @@ class AsyncMacro {
 					});
 					switch (f.expr.expr) {
 						case EBlock(el):
-							el.push(macro async.done());
+							el.push(macro @:pos(f.expr.pos) async.done());
 							f.expr = transformHaxeCalls(el);
 						case _:
 							Context.error("Block expression expected", f.expr.pos);

--- a/tests/server/src/Main.hx
+++ b/tests/server/src/Main.hx
@@ -4,7 +4,7 @@ import haxe.display.Display;
 import haxe.display.FsPath;
 import haxe.display.Server;
 
-@:timeout(5000)
+@:timeout(10000)
 class ServerTests extends HaxeServerTestCase {
 	function testNoModification() {
 		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));


### PR DESCRIPTION
This is the continuation of my native lib rework. There are still some open questions, but should work in principle. It comes with these amazing features:

## Complete faster

We no longer parse native libraries on every display request which gives us a huge increase in overall display performance.

Before:

![Code_2019-08-14_14-53-48](https://user-images.githubusercontent.com/634365/63022811-fcb24900-bea3-11e9-9ccf-c626a81d5630.png)

After:

![2019-08-14_14-57-46](https://user-images.githubusercontent.com/634365/63022824-050a8400-bea4-11e9-911c-5daed7597d0c.png)

## Find everything

Because we now eagerly check native libraries if the compilation server is running, we no longer miss out and what they contain.

Before:

![2019-08-14_15-00-48](https://user-images.githubusercontent.com/634365/63022958-53b81e00-bea4-11e9-8a03-e6e1a12070ae.png)

After:

![Code_2019-08-14_15-00-01](https://user-images.githubusercontent.com/634365/63022964-574ba500-bea4-11e9-9353-881581c70277.png)

------

Unfortunately, as with most things in life, this isn't free. Being faster and having more information comes at the price of an increased memory cost. For instance, hxjava-std.jar, which is about 15MB on disk, is represented as roughly 180 MB of parsed data on the compilation server.

I don't know if this is acceptable and how bad this turns out in practice, so that's something we have to discuss. There may be ways to optimize this, but it isn't straightforward. The general problem is that toplevel completion needs to know about all the available types, so a lazy approach doesn't work with that.

If anyone has strong feelings about this, feel free to share. We can also consider making this opt-in/out, although I don't see much value in keeping the current behavior around.