### PR TITLE
Add timeout to default socket in Http.hx

### DIFF
--- a/std/lua/_std/sys/net/Socket.hx
+++ b/std/lua/_std/sys/net/Socket.hx
@@ -55,6 +55,7 @@ class Socket {
 	var _socket:LuaSocket;
 
 	var blocking = false;
+	var timeout = null;
 
 	/**
 		Creates a new unconnected socket.
@@ -92,6 +93,7 @@ class Socket {
 		input = new SocketInput(res.result);
 		output = new SocketOutput(res.result);
 		_socket = res.result;
+		_socket.settimeout(timeout);
 	}
 
 	/**
@@ -103,6 +105,7 @@ class Socket {
 			throw 'Socket Listen Error : ${res.message}';
 		res.result.listen(connections);
 		_socket = res.result;
+		_socket.settimeout(timeout);
 	}
 
 	/**
@@ -171,8 +174,11 @@ class Socket {
 		Gives a timeout after which blocking socket operations (such as reading and writing) will abort and throw an exception.
 	**/
 	public inline function setTimeout(timeout:Float):Void {
-		var client:TcpClient = cast _socket;
-		client.settimeout(timeout);
+		this.timeout = timeout;
+		if (_socket != null) {
+			var client:TcpClient = cast _socket;
+			client.settimeout(timeout);
+		}
 	}
 
 	/**

--- a/std/lua/lib/luasocket/Socket.hx
+++ b/std/lua/lib/luasocket/Socket.hx
@@ -35,4 +35,5 @@ extern class Socket {
 	public static function select(recvt:Table<Int, Socket>, sendt:Table<Int, Socket>, ?timeout:Float):SelectResult;
 	public function close():Void;
 	public function getsockname():AddrInfo;
+	public function settimeout(value:Float, ?mode:TimeoutMode):Void;
 }

--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -116,6 +116,7 @@ class Http extends haxe.http.HttpBase {
 				sock = new Socket();
 				#end
 			}
+			sock.setTimeout(10);
 		}
 		var host = url_regexp.matched(2);
 		var portString = url_regexp.matched(3);

--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -110,11 +110,7 @@ class Http extends haxe.http.HttpBase {
 				throw "Https is only supported with -lib hxssl";
 				#end
 			} else {
-				#if php
-				sock = new php.net.Socket();
-				#else
 				sock = new Socket();
-				#end
 			}
 			sock.setTimeout(cnxTimeout);
 		}

--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -116,7 +116,7 @@ class Http extends haxe.http.HttpBase {
 				sock = new Socket();
 				#end
 			}
-			sock.setTimeout(10);
+			sock.setTimeout(cnxTimeout);
 		}
 		var host = url_regexp.matched(2);
 		var portString = url_regexp.matched(3);


### PR DESCRIPTION
Updated the default socket to have a timeout of 10 seconds. This change was mad ein response to the discussion in this PR: https://github.com/HaxeFoundation/haxelib/pull/462/files.