### PR TITLE
Allow nullable class name for `StackItem.Method(className, method)`

### DIFF
--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -278,7 +278,7 @@ class CallStack {
 				if (s != null)
 					b.add(")");
 			case Method(cname, meth):
-				b.add(cname);
+				b.add(cname == null ? "<unknown>" : cname);
 				b.add(".");
 				b.add(meth);
 			case LocalFunction(n):

--- a/std/haxe/CallStack.hx
+++ b/std/haxe/CallStack.hx
@@ -29,7 +29,7 @@ enum StackItem {
 	CFunction;
 	Module(m:String);
 	FilePos(s:Null<StackItem>, file:String, line:Int, ?column:Null<Int>);
-	Method(classname:String, method:String);
+	Method(classname:Null<String>, method:String);
 	LocalFunction(?v:Int);
 }
 
@@ -137,7 +137,7 @@ class CallStack {
 		infos.pop();
 		infos.reverse();
 		for (elem in infos)
-			stack.push(FilePos(null, elem._1, elem._2));
+			stack.push(FilePos(Method(null, elem._3), elem._1, elem._2));
 		return stack;
 		#elseif lua
 		var stack = [];
@@ -232,7 +232,7 @@ class CallStack {
 			var infos = python.lib.Traceback.extract_tb(exc._3);
 			infos.reverse();
 			for (elem in infos)
-				stack.push(FilePos(null, elem._1, elem._2));
+				stack.push(FilePos(Method(null, elem._3), elem._1, elem._2));
 		}
 		return stack;
 		#elseif js

--- a/std/php/_std/haxe/CallStack.hx
+++ b/std/php/_std/haxe/CallStack.hx
@@ -33,7 +33,7 @@ enum StackItem {
 	CFunction;
 	Module(m:String);
 	FilePos(s:Null<StackItem>, file:String, line:Int, ?column:Null<Int>);
-	Method(classname:String, method:String);
+	Method(classname:Null<String>, method:String);
 	LocalFunction(?v:Int);
 }
 
@@ -94,7 +94,7 @@ class CallStack {
 				if (s != null)
 					b.add(")");
 			case Method(cname, meth):
-				b.add(cname);
+				b.add(cname == null ? "<unknown>" : cname);
 				b.add(".");
 				b.add(meth);
 			case LocalFunction(n):


### PR DESCRIPTION
Closes #7801 

Currently on python and lua the first parameter of `StackItem.FilePos()` is always null:
https://github.com/HaxeFoundation/haxe/blob/5cb43a38ed4a6735395a0928b93e036ea9fbbfc4/std/haxe/CallStack.hx#L140
Unfortunately python runtime does not provide class name, which is required for `StackItem.Method`.
Here is an example:
```haxe
var stack = python.lib.Traceback.extract_stack();
for(item in stack) {
	trace({file:item._1, line: item._2, method:item._3, text:item._4});
}
```
and the output:
```
{'file': 'bin/test.py', 'line': 81, 'method': '<module>', 'text': 'Main.main()'}
{'file': 'bin/test.py', 'line': 41, 'method': 'main', 'text': '_Main_Abstr_Impl_.level2(10)'}
{'file': 'bin/test.py', 'line': 49, 'method': 'level2', 'text': 'stack = python_lib_Traceback.extract_stack()'}
```
Our `StackItem.Method(classname:String, method:String)` currently requires `classname` to be set. 
This PR suggests to make `classname` nullable to be able to provide method name at least: `StackItem.Method(classname:Null<String>, method:String)`.
Before this PR callstack on python looks like this:
```
Called from bin/test.py line 47
Called from bin/test.py line 42
Called from bin/test.py line 464
```
completely useless.
After this PR:
```
Called from <unknown>.level2 (bin/test.py line 52)
Called from <unknown>.main (bin/test.py line 42)
Called from <unknown>.<module> (bin/test.py line 470)
```
this already allows to understand where these positions are located in Haxe code.

If this PR is accepted, I'll check what can be done for lua.