### PR TITLE
Documentation cleanup in std

### DIFF
--- a/std/cpp/_std/haxe/Int64.hx
+++ b/std/cpp/_std/haxe/Int64.hx
@@ -137,9 +137,6 @@ private typedef __Int64 = ___Int64;
 
 @:coreApi
 abstract Int64(__Int64) from __Int64 to __Int64 {
-	/**
-		Makes a copy of `this` Int64.
-	**/
 	public #if !cppia inline #end function copy():Int64
 		return this;
 
@@ -152,10 +149,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return __Int64.ofInt(x);
 	}
 
-	/**
-		Returns an Int with the value of the Int64 `x`.
-		Throws an exception  if `x` cannot be represented in 32 bits.
-	**/
 	public static #if !cppia inline #end function toInt(x:Int64):Int {
 		if (x.high != x.low >> 31)
 			throw "Overflow";
@@ -163,57 +156,29 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return x.low;
 	}
 
-	/**
-		Returns whether the value `val` is of type `haxe.Int64`
-	**/
 	public static #if !cppia inline #end function is(val:Dynamic):Bool
 		return __Int64.is(val);
 
-	/**
-		Returns the high 32-bit word of `x`.
-	**/
 	@:deprecated("Use high instead")
 	public static #if !cppia inline #end function getHigh(x:Int64):Int32
 		return x.high;
 
-	/**
-		Returns the low 32-bit word of `x`.
-	**/
 	@:deprecated("Use low instead")
 	public static #if !cppia inline #end function getLow(x:Int64):Int32
 		return x.low;
 
-	/**
-		Returns `true` if `x` is less than zero.
-	**/
 	public static #if !cppia inline #end function isNeg(x:Int64):Bool
 		return __Int64.isNeg(x);
 
-	/**
-		Returns `true` if `x` is exactly zero.
-	**/
 	public static #if !cppia inline #end function isZero(x:Int64):Bool
 		return __Int64.isZero(x);
 
-	/**
-		Compares `a` and `b` in signed mode.
-		Returns a negative value if `a < b`, positive if `a > b`,
-		or 0 if `a == b`.
-	**/
 	public static #if !cppia inline #end function compare(a:Int64, b:Int64):Int
 		return __Int64.compare(a, b);
 
-	/**
-		Compares `a` and `b` in unsigned mode.
-		Returns a negative value if `a < b`, positive if `a > b`,
-		or 0 if `a == b`.
-	**/
 	public static #if !cppia inline #end function ucompare(a:Int64, b:Int64):Int
 		return __Int64.ucompare(a, b);
 
-	/**
-		Returns a signed decimal `String` representation of `x`.
-	**/
 	public static #if !cppia inline #end function toStr(x:Int64):String
 		return x.toString();
 
@@ -228,10 +193,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return Int64Helper.fromFloat(f);
 	}
 
-	/**
-		Performs signed integer divison of `dividend` by `divisor`.
-		Returns `{ quotient : Int64, modulus : Int64 }`.
-	**/
 	public static function divMod(dividend:Int64, divisor:Int64):{quotient:Int64, modulus:Int64} {
 		var q = dividend / divisor;
 
@@ -243,9 +204,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return {quotient: q, modulus: m};
 	}
 
-	/**
-		Returns the negative of `x`.
-	**/
 	@:op(-A)
 	public static #if !cppia inline #end function neg(x:Int64):Int64
 		return __Int64.neg(x);
@@ -288,9 +246,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		#end
 	}
 
-	/**
-		Returns the sum of `a` and `b`.
-	**/
 	@:op(A + B)
 	public static #if !cppia inline #end function add(a:Int64, b:Int64):Int64
 		return __Int64.add(a, b);
@@ -300,9 +255,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function addInt(a:Int64, b:Int):Int64
 		return __Int64.addInt(a, b);
 
-	/**
-		Returns `a` minus `b`.
-	**/
 	@:op(A - B)
 	public static #if !cppia inline #end function sub(a:Int64, b:Int64):Int64 {
 		return __Int64.sub(a, b);
@@ -316,9 +268,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function intSub(a:Int, b:Int64):Int64
 		return __Int64.intSub(a, b);
 
-	/**
-		Returns the product of `a` and `b`.
-	**/
 	@:op(A * B)
 	public static #if !cppia inline #end function mul(a:Int64, b:Int64):Int64
 		return __Int64.mul(a, b);
@@ -328,9 +277,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function mulInt(a:Int64, b:Int):Int64
 		return mul(a, b);
 
-	/**
-		Returns the quotient of `a` divided by `b`.
-	**/
 	@:op(A / B)
 	public static #if !cppia inline #end function div(a:Int64, b:Int64):Int64 {
 		if (__Int64.isZero(b))
@@ -346,9 +292,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function intDiv(a:Int, b:Int64):Int64
 		return toInt(div(a, b));
 
-	/**
-		Returns the modulus of `a` divided by `b`.
-	**/
 	@:op(A % B)
 	public static #if !cppia inline #end function mod(a:Int64, b:Int64):Int64 {
 		if (__Int64.isZero(b))
@@ -364,9 +307,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function intMod(a:Int, b:Int64):Int64
 		return toInt(mod(a, b));
 
-	/**
-		Returns `true` if `a` is equal to `b`.
-	**/
 	@:op(A == B)
 	public static #if !cppia inline #end function eq(a:Int64, b:Int64):Bool
 		return __Int64.eq(a, b);
@@ -376,9 +316,6 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function eqInt(a:Int64, b:Int):Bool
 		return __Int64.eqInt(a, b);
 
-	/**
-		Returns `true` if `a` is not equal to `b`.
-	**/
 	@:op(A != B)
 	public static #if !cppia inline #end function neq(a:Int64, b:Int64):Bool
 		return __Int64.neq(a, b);
@@ -436,53 +373,30 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private static #if !cppia inline #end function intGte(a:Int, b:Int64):Bool
 		return gte(a, b);
 
-	/**
-		Returns the bitwise NOT of `a`.
-	**/
 	@:op(~A)
 	private static #if !cppia inline #end function complement(a:Int64):Int64
 		return __Int64.complement(a);
 
-	/**
-		Returns the bitwise AND of `a` and `b`.
-	**/
 	@:op(A & B)
 	public static #if !cppia inline #end function and(a:Int64, b:Int64):Int64
 		return __Int64.bitAnd(a, b);
 
-	/**
-		Returns the bitwise OR of `a` and `b`.
-	**/
 	@:op(A | B)
 	public static #if !cppia inline #end function or(a:Int64, b:Int64):Int64
 		return __Int64.bitOr(a, b);
 
-	/**
-		Returns the bitwise XOR of `a` and `b`.
-	**/
 	@:op(A ^ B)
 	public static #if !cppia inline #end function xor(a:Int64, b:Int64):Int64
 		return __Int64.bitXor(a, b);
 
-	/**
-		Returns `a` left-shifted by `b` bits.
-	**/
 	@:op(A << B)
 	public static #if !cppia inline #end function shl(a:Int64, b:Int):Int64
 		return __Int64.shl(a, b);
 
-	/**
-		Returns `a` right-shifted by `b` bits in signed mode.
-		`a` is sign-extended.
-	**/
 	@:op(A >> B)
 	public static #if !cppia inline #end function shr(a:Int64, b:Int):Int64
 		return __Int64.shr(a, b);
 
-	/**
-		Returns `a` right-shifted by `b` bits in unsigned mode.
-		`a` is padded with zeroes.
-	**/
 	@:op(A >>> B)
 	public static #if !cppia inline #end function ushr(a:Int64, b:Int):Int64
 		return __Int64.ushr(a, b);

--- a/std/cs/_std/haxe/ds/IntMap.hx
+++ b/std/cs/_std/haxe/ds/IntMap.hx
@@ -343,18 +343,10 @@ import cs.NativeArray;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function keys():Iterator<Int> {
 		return new IntMapKeyIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function iterator():Iterator<T> {
 		return new IntMapValueIterator(this);
 	}
@@ -370,9 +362,6 @@ import cs.NativeArray;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/cs/_std/haxe/ds/ObjectMap.hx
+++ b/std/cs/_std/haxe/ds/ObjectMap.hx
@@ -357,18 +357,10 @@ import cs.NativeArray;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public function keys():Iterator<K> {
 		return new ObjectMapKeyIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public function iterator():Iterator<V> {
 		return new ObjectMapValueIterator(this);
 	}
@@ -384,9 +376,6 @@ import cs.NativeArray;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/cs/_std/haxe/ds/StringMap.hx
+++ b/std/cs/_std/haxe/ds/StringMap.hx
@@ -356,18 +356,10 @@ import cs.NativeArray;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function keys():Iterator<String> {
 		return new StringMapKeyIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function iterator():Iterator<T> {
 		return new StringMapValueIterator(this);
 	}
@@ -383,9 +375,6 @@ import cs.NativeArray;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/cs/_std/sys/db/Sqlite.hx
+++ b/std/cs/_std/sys/db/Sqlite.hx
@@ -25,11 +25,6 @@ package sys.db;
 class Sqlite {
 	static var type:Class<cs.system.data.IDbConnection>;
 
-	/**
-		Opens a new SQLite connection on the specified path.
-		Note that you will need a SQLite ADO.NET Provider (see http://www.mono-project.com/docs/database-access/providers/sqlite/).
-		Also note that this will try to open an assembly named `Mono.Data.Sqlite` if it wasn't loaded yet.
-	**/
 	public static function open(file:String):sys.db.Connection {
 		var cnxString = 'Data Source=$file';
 		if (type == null) {

--- a/std/cs/_std/sys/net/Host.hx
+++ b/std/cs/_std/sys/net/Host.hx
@@ -30,32 +30,19 @@ import cs.system.net.sockets.AddressFamily;
 import haxe.io.Bytes;
 import haxe.io.BytesInput;
 
-/**
-	A given IP host name.
-**/
 @:coreapi
 class Host {
 	public var hostEntry(default, null):IPHostEntry;
 	public var ipAddress(default, null):IPAddress;
 
-	/**
-		The provided host string.
-	**/
 	public var host(default, null):String;
 
-	/**
-		The actual IP corresponding to the host.
-	**/
 	public var ip(get, null):Int;
 
 	private function get_ip():Int {
 		return new BytesInput(Bytes.ofData(ipAddress.GetAddressBytes())).readInt32();
 	}
 
-	/**
-		Creates a new Host : the name can be an IP in the form "127.0.0.1" or an host name such as "google.com", in which case
-		the corresponding IP address is resolved using DNS. An exception occur if the host name could not be found.
-	**/
 	public function new(name:String):Void {
 		host = name;
 		hostEntry = Dns.GetHostEntry(name);
@@ -67,23 +54,14 @@ class Host {
 		}
 	}
 
-	/**
-		Returns the IP representation of the host
-	**/
 	public function toString():String {
 		return ipAddress.ToString();
 	}
 
-	/**
-		Perform a reverse-DNS query to resolve a host name from an IP.
-	**/
 	public function reverse():String {
 		return hostEntry.HostName;
 	}
 
-	/**
-		Returns the local computer host name
-	**/
 	static public function localhost():String {
 		return Dns.GetHostName();
 	}

--- a/std/cs/_std/sys/net/Socket.hx
+++ b/std/cs/_std/sys/net/Socket.hx
@@ -38,63 +38,35 @@ import haxe.io.Error;
 import haxe.io.Input;
 import haxe.io.Output;
 
-/**
-	A TCP socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
-**/
-@:coreapi
+@:coreApi
 class Socket {
 	private var sock:NativeSocket = null;
 
-	/**
-		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
-		use `setBlocking(false)` or `setTimeout` to prevent infinite waiting.
-	**/
 	public var input(default, null):haxe.io.Input;
 
-	/**
-		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use `setBlocking(false)` or `setTimeout` to prevent that.
-	**/
 	public var output(default, null):haxe.io.Output;
 
-	/**
-		A custom value that can be associated with the socket. Can be used to retrieve your custom infos after a `select`.
-	**/
 	public var custom:Dynamic;
 
-	/**
-		Creates a new unconnected socket.
-	**/
 	public function new():Void {
 		sock = new NativeSocket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 		sock.Blocking = true;
 	}
 
-	/**
-		Closes the socket : make sure to properly close all your sockets or you will crash when you run out of file descriptors.
-	**/
 	public function close():Void {
 		sock.Close();
 		input = null;
 		output = null;
 	}
 
-	/**
-		Read the whole data available on the socket.
-	**/
 	public function read():String {
 		return input.readAll().toString();
 	}
 
-	/**
-		Write the whole data to the socket output.
-	**/
 	public function write(content:String):Void {
 		output.writeString(content);
 	}
 
-	/**
-		Connect to the given server host/port. Throw an exception in case we couldn't successfully connect.
-	**/
 	public function connect(host:Host, port:Int):Void {
 		sock.Connect(host.ipAddress, port);
 		if (sock.Connected) {
@@ -105,16 +77,10 @@ class Socket {
 		}
 	}
 
-	/**
-		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
-	**/
 	public function listen(connections:Int):Void {
 		sock.Listen(connections);
 	}
 
-	/**
-		Shutdown the socket, either for reading or writing.
-	**/
 	public function shutdown(read:Bool, write:Bool):Void {
 		if (read && write) {
 			sock.Shutdown(SocketShutdown.Both);
@@ -129,17 +95,11 @@ class Socket {
 		}
 	}
 
-	/**
-		Bind the socket to the given host/port so it can afterwards listen for connections there.
-	**/
 	public function bind(host:Host, port:Int):Void {
 		sock = new NativeSocket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 		sock.Bind(new IPEndPoint(host.ipAddress, port));
 	}
 
-	/**
-		Accept a new connected client. This will return a connected socket on which you can read/write some data.
-	**/
 	public function accept():Socket {
 		var r = new Socket();
 		r.sock = sock.Accept();
@@ -148,32 +108,20 @@ class Socket {
 		return r;
 	}
 
-	/**
-		Return the information about the other side of a connected socket.
-	**/
 	public function peer():{host:Host, port:Int} {
 		var remoteIP = cast(sock.RemoteEndPoint, IPEndPoint);
 		return {host: new Host(remoteIP.Address.ToString()), port: remoteIP.Port};
 	}
 
-	/**
-		Return the information about our side of a connected socket.
-	**/
 	public function host():{host:Host, port:Int} {
 		var localIP = cast(sock.LocalEndPoint, IPEndPoint);
 		return {host: new Host(localIP.Address.ToString()), port: localIP.Port};
 	}
 
-	/**
-		Gives a timeout after which blocking socket operations (such as reading and writing) will abort and throw an exception.
-	**/
 	public function setTimeout(timeout:Float):Void {
 		sock.ReceiveTimeout = sock.SendTimeout = Math.round(timeout * 1000);
 	}
 
-	/**
-		Block until some data is available for read on the socket.
-	**/
 	public function waitForRead():Void {
 		var end = Date.now().getTime() + ((sock.ReceiveTimeout <= 0) ? Math.POSITIVE_INFINITY : sock.ReceiveTimeout);
 		while (sock.Available == 0 && Date.now().getTime() < end) {
@@ -181,28 +129,14 @@ class Socket {
 		}
 	}
 
-	/**
-		Change the blocking mode of the socket. A blocking socket is the default behavior. A non-blocking socket will abort blocking operations immediately by throwing a haxe.io.Error.Blocked value.
-	**/
 	public function setBlocking(b:Bool):Void {
 		sock.Blocking = b;
 	}
 
-	/**
-		Allows the socket to immediately send the data when written to its output : this will cause less ping but might increase the number of packets / data size, especially when doing a lot of small writes.
-	**/
 	public function setFastSend(b:Bool):Void {
 		sock.NoDelay = b;
 	}
 
-	/**
-		Wait until one of the sockets groups is ready for the given operation :
-		* `read` contains sockets on which we want to wait for available data to be read,
-		* `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-		* `others` contains sockets on which we want to wait for exceptional conditions.
-		* `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-		In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
-	**/
 	static public function select(read:Array<Socket>, write:Array<Socket>, others:Array<Socket>,
 			?timeout:Float):{read:Array<Socket>, write:Array<Socket>, others:Array<Socket>} {
 		var map:Map<Int, Socket> = new Map();

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -57,11 +57,17 @@ extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 
 	/**
 		See `Map.keys`
+
+		(cs, java) Implementation detail: Do not `set()` any new value while
+		iterating, as it may cause a resize, which will break iteration.
 	**/
 	public function keys():Iterator<Int>;
 
 	/**
 		See `Map.iterator`
+
+		(cs, java) Implementation detail: Do not `set()` any new value while
+		iterating, as it may cause a resize, which will break iteration.
 	**/
 	public function iterator():Iterator<T>;
 

--- a/std/haxe/ds/ObjectMap.hx
+++ b/std/haxe/ds/ObjectMap.hx
@@ -60,11 +60,17 @@ extern class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 
 	/**
 		See `Map.keys`
+
+		(cs, java) Implementation detail: Do not `set()` any new value while
+		iterating, as it may cause a resize, which will break iteration.
 	**/
 	public function keys():Iterator<K>;
 
 	/**
 		See `Map.iterator`
+
+		(cs, java) Implementation detail: Do not `set()` any new value while
+		iterating, as it may cause a resize, which will break iteration.
 	**/
 	public function iterator():Iterator<V>;
 

--- a/std/haxe/ds/StringMap.hx
+++ b/std/haxe/ds/StringMap.hx
@@ -57,11 +57,17 @@ extern class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 
 	/**
 		See `Map.keys`
+
+		(cs, java) Implementation detail: Do not `set()` any new value while
+		iterating, as it may cause a resize, which will break iteration.
 	**/
 	public function keys():Iterator<String>;
 
 	/**
 		See `Map.iterator`
+
+		(cs, java) Implementation detail: Do not `set()` any new value while
+		iterating, as it may cause a resize, which will break iteration.
 	**/
 	public function iterator():Iterator<T>;
 

--- a/std/hl/_std/sys/thread/Deque.hx
+++ b/std/hl/_std/sys/thread/Deque.hx
@@ -31,32 +31,16 @@ package sys.thread;
 }
 #else
 
-/**
-	A message queue for multithread access.
- */
 @:hlNative("std", "deque_")
 abstract Deque<T>(hl.Abstract<"hl_deque">) {
-	/**
-		Create a message queue for multithread access.
-	**/
 	public function new() {
 		this = alloc();
 	}
 
-	/**
-		Add a message at the end of the queue.
-	**/
 	public function add(i:T) {}
 
-	/**
-		Add a message at the head of the queue.
-	**/
 	public function push(i:T) {}
 
-	/**
-		Pop a message from the queue head. Either block until a message
-		is available or return immediately with `null`.
-	**/
 	public function pop(block:Bool):Null<T> {
 		return null;
 	}

--- a/std/hl/_std/sys/thread/Mutex.hx
+++ b/std/hl/_std/sys/thread/Mutex.hx
@@ -32,39 +32,17 @@ extern class Mutex {
 }
 #else
 
-/**
-	Creates a mutex, which can be used to acquire a temporary lock
-	to access some ressource. The main difference with a lock is
-	that a mutex must always be released by the owner thread.
-**/
 abstract Mutex(hl.Abstract<"hl_mutex">) {
-	/**
-		Creates a mutex.
-	**/
 	public function new() {
 		this = alloc(true);
 	}
 
-	/**
-		The current thread acquire the mutex or wait if not available.
-		The same thread can acquire several times the same mutex but
-		must release it as many times it has been acquired.
-	**/
 	@:hlNative("std", "mutex_acquire") public function acquire() {}
 
-	/**
-		Try to acquire the mutex, returns true if acquire or false
-		if it's already locked by another thread.
-	**/
 	@:hlNative("std", "mutex_try_acquire") public function tryAcquire():Bool {
 		return false;
 	}
 
-	/**
-		Release a mutex that has been acquired by the current thread.
-		The behavior is undefined if the current thread does not own
-		the mutex.
-	**/
 	@:hlNative("std", "mutex_release") public function release() {}
 
 	@:hlNative("std", "mutex_alloc") public static function alloc(b:Bool) {

--- a/std/hl/_std/sys/thread/Tls.hx
+++ b/std/hl/_std/sys/thread/Tls.hx
@@ -30,34 +30,18 @@ extern class Tls<T> {
 }
 #else
 
-/**
-	Creates thread local storage.
-	Warning : ATM Tls does not protect the value from being GC'ed. Keep the value reachable to avoid crashes.
- */
 @:hlNative("std")
 abstract Tls<T>(hl.Abstract<"hl_tls">) {
 	public var value(get, set):T;
 
-	/**
-		Creates thread local storage. This is placeholder that can store
-		a value that will be different depending on the local thread.
-		Set the tls value to `null` before exiting the thread
-		or the memory will never be collected.
-	**/
 	public function new() {
 		this = tls_alloc(true);
 	}
 
-	/**
-		Returns the value set by tls_set for the local thread.
-	**/
 	function get_value():T {
 		return tls_get(this);
 	}
 
-	/**
-		Set the value of the TLS for the local thread.
-	**/
 	function set_value(v:T) {
 		tls_set(this, v);
 		return v;

--- a/std/java/_std/haxe/ds/IntMap.hx
+++ b/std/java/_std/haxe/ds/IntMap.hx
@@ -343,18 +343,10 @@ import java.NativeArray;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function keys():Iterator<Int> {
 		return new IntMapKeyIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function iterator():Iterator<T> {
 		return new IntMapValueIterator(this);
 	}
@@ -370,9 +362,6 @@ import java.NativeArray;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/java/_std/haxe/ds/ObjectMap.hx
+++ b/std/java/_std/haxe/ds/ObjectMap.hx
@@ -357,18 +357,10 @@ import java.NativeArray;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public function keys():Iterator<K> {
 		return new ObjectMapKeyIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public function iterator():Iterator<V> {
 		return new ObjectMapValueIterator(this);
 	}
@@ -384,9 +376,6 @@ import java.NativeArray;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/java/_std/haxe/ds/StringMap.hx
+++ b/std/java/_std/haxe/ds/StringMap.hx
@@ -356,10 +356,6 @@ import java.NativeArray;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function keys():Iterator<String> {
 		return new StringMapKeyIterator(this);
 	}
@@ -368,10 +364,6 @@ import java.NativeArray;
 		return new haxe.iterators.MapKeyValueIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function iterator():Iterator<T> {
 		return new StringMapValueIterator(this);
 	}
@@ -383,9 +375,6 @@ import java.NativeArray;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/java/_std/haxe/ds/WeakMap.hx
+++ b/std/java/_std/haxe/ds/WeakMap.hx
@@ -381,27 +381,16 @@ import java.lang.ref.ReferenceQueue;
 		}
 	}
 
-	/**
-		Returns an iterator of all keys in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function keys():Iterator<K> {
 		cleanupRefs();
 		return new WeakMapKeyIterator(this);
 	}
 
-	/**
-		Returns an iterator of all values in the hashtable.
-		Implementation detail: Do not set() any new value while iterating, as it may cause a resize, which will break iteration
-	**/
 	public inline function iterator():Iterator<V> {
 		cleanupRefs();
 		return new WeakMapValueIterator(this);
 	}
 
-	/**
-		See `Map.keyValueIterator`
-	**/
 	public inline function keyValueIterator():KeyValueIterator<K, V> {
 		return new haxe.iterators.MapKeyValueIterator(this);
 	}
@@ -413,9 +402,6 @@ import java.lang.ref.ReferenceQueue;
 		return copied;
 	}
 
-	/**
-		Returns an displayable representation of the hashtable content.
-	**/
 	public function toString():String {
 		var s = new StringBuf();
 		s.add("{");

--- a/std/java/_std/sys/db/Sqlite.hx
+++ b/std/java/_std/sys/db/Sqlite.hx
@@ -25,10 +25,6 @@ package sys.db;
 class Sqlite {
 	static var init = false;
 
-	/**
-		Opens a new SQLite connection on the specified path.
-		Note that you will need a SQLite JDBC driver (like https://bitbucket.org/xerial/sqlite-jdbc).
-	**/
 	public static function open(file:String):sys.db.Connection {
 		if (!init) {
 			try

--- a/std/lua/_std/StringBuf.hx
+++ b/std/lua/_std/StringBuf.hx
@@ -20,32 +20,13 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-/**
-	A String buffer is an efficient way to build a big string by appending small
-	elements together.
-
-	Its cross-platform implementation uses String concatenation internally, but
-	StringBuf may be optimized for different targets.
-
-	Unlike String, an instance of StringBuf is not immutable in the sense that
-	it can be passed as argument to functions which modify it by appending more
-	values. However, the internal buffer cannot be modified.
-**/
 import lua.Table;
 
 class StringBuf {
 	var b:Table<Int, String>;
 
-	/*
-		The length of `this` StringBuf in characters.
-	**/
 	public var length(get, null):Int;
 
-	/**
-		Creates a new StringBuf instance.
-
-		This may involve initialization of the internal buffer.
-	**/
 	public inline function new() {
 		b = Table.create();
 		this.length = 0;
@@ -55,55 +36,23 @@ class StringBuf {
 		return length;
 	}
 
-	/**
-		Appends the representation of `x` to `this` StringBuf.
-
-		The exact representation of `x` may vary per platform. To get more
-		consistent behavior, this function should be called with
-		Std.string(x).
-
-		If `x` is null, the String "null" is appended.
-	**/
 	public inline function add<T>(x:T):Void {
 		var str = Std.string(x);
 		Table.insert(b, str);
 		length += str.length;
 	}
 
-	/**
-		Appends the character identified by `c` to `this` StringBuf.
-
-		If `c` is negative or has another invalid value, the result is
-		unspecified.
-	**/
 	public inline function addChar(c:Int):Void {
 		Table.insert(b, String.fromCharCode(c));
 		length += 1;
 	}
 
-	/**
-		Appends a substring of `s` to `this` StringBuf.
-
-		This function expects `pos` and `len` to describe a valid substring of
-		`s`, or else the result is unspecified. To get more robust behavior,
-		`this.add(s.substr(pos,len))` can be used instead.
-
-		If `s` or `pos` are null, the result is unspecified.
-
-		If `len` is omitted or null, the substring ranges from `pos` to the end
-		of `s`.
-	**/
 	public inline function addSub(s:String, pos:Int, ?len:Int):Void {
 		var part = len == null ? s.substr(pos) : s.substr(pos, len);
 		Table.insert(b, part);
 		length += part.length;
 	}
 
-	/**
-		Returns the content of `this` StringBuf as String.
-
-		The buffer is not emptied by this operation.
-	**/
 	public inline function toString():String {
 		return Table.concat(b);
 	}

--- a/std/lua/_std/sys/net/Host.hx
+++ b/std/lua/_std/sys/net/Host.hx
@@ -25,27 +25,14 @@ package sys.net;
 import haxe.io.Bytes;
 import haxe.io.BytesInput;
 
-/**
-	A given IP host name.
-**/
 @:coreapi
 class Host {
-	/**
-		The provided host string.
-	**/
 	public var host(default, null):String;
 
-	/**
-		The actual IP corresponding to the host.
-	**/
 	public var ip(default, null):Int;
 
 	var _ip:String;
 
-	/**
-		Creates a new Host : the name can be an IP in the form "127.0.0.1" or an host name such as "google.com", in which case
-		the corresponding IP address is resolved using DNS. An exception occur if the host name could not be found.
-	**/
 	public function new(name:String):Void {
 		host = name;
 		if (lua.NativeStringTools.find(name, "(%d+)%.(%d+)%.(%d+)%.(%d+)").begin != null) {
@@ -65,23 +52,14 @@ class Host {
 		ip = num;
 	}
 
-	/**
-		Returns the IP representation of the host
-	**/
 	public function toString():String {
 		return _ip;
 	}
 
-	/**
-		Perform a reverse-DNS query to resolve a host name from an IP.
-	**/
 	public function reverse():String {
 		return lua.lib.luv.net.Dns.getnameinfo({ip: _ip}).result;
 	}
 
-	/**
-		Returns the local computer host name
-	**/
 	static public function localhost():String {
 		return lua.lib.luasocket.socket.Dns.gethostname();
 	}

--- a/std/lua/_std/sys/net/Socket.hx
+++ b/std/lua/_std/sys/net/Socket.hx
@@ -29,62 +29,31 @@ import lua.*;
 import haxe.io.Bytes;
 import haxe.io.Error;
 
-/**
-	A TCP socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
-**/
 class Socket {
-	/**
-		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
-		use `setBlocking(false)` or `setTimeout` to prevent infinite waiting.
-	**/
 	public var input(default, null):haxe.io.Input;
 
-	/**
-		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use `setBlocking(false)` or `setTimeout` to prevent that.
-	**/
 	public var output(default, null):haxe.io.Output;
 
-	/**
-			A custom value that can be associated with the socket. Can be used to retrieve your custom infos after a `select`.
-	***/
 	var custom:Dynamic;
 
-	/**
-		A Lua specific datatype for a tcp server instance
-	**/
 	var _socket:LuaSocket;
 
 	var blocking = false;
 
-	/**
-		Creates a new unconnected socket.
-	**/
 	public function new():Void {}
 
-	/**
-		Closes the socket : make sure to properly close all your sockets or you will crash when you run out of file descriptors.
-	**/
 	public function close():Void {
 		_socket.close();
 	}
 
-	/**
-		Read the whole data available on the socket.
-	**/
 	public function read():String {
 		return input.readAll().toString();
 	}
 
-	/**
-		Write the whole data to the socket output.
-	**/
 	public function write(content:String):Void {
 		output.writeString(content);
 	}
 
-	/**
-		Connect to the given server host/port. Throw an exception in case we couldn't successfully connect.
-	**/
 	public function connect(host:Host, port:Int):Void {
 		var res = LuaSocket.connect(host.host, port);
 		if (res.message != null)
@@ -94,9 +63,6 @@ class Socket {
 		_socket = res.result;
 	}
 
-	/**
-		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
-	**/
 	public function listen(connections:Int):Void {
 		var res = LuaSocket.tcp();
 		if (res.message != null)
@@ -105,9 +71,6 @@ class Socket {
 		_socket = res.result;
 	}
 
-	/**
-		Shutdown the socket, either for reading or writing.
-	**/
 	public function shutdown(read:Bool, write:Bool):Void {
 		var client:TcpClient = cast _socket;
 		switch [read, write] {
@@ -122,9 +85,6 @@ class Socket {
 		}
 	}
 
-	/**
-		Bind the socket to the given host/port so it can afterwards listen for connections there.
-	**/
 	public function bind(host:Host, port:Int):Void {
 		var res = LuaSocket.bind(host.host, port);
 		if (res.message != null)
@@ -132,9 +92,6 @@ class Socket {
 		_socket = res.result;
 	}
 
-	/**
-		Accept a new connected client. This will return a connected socket on which you can read/write some data.
-	**/
 	public function accept():Socket {
 		var server:TcpServer = cast _socket;
 		var res = server.accept();
@@ -147,9 +104,6 @@ class Socket {
 		return sock;
 	}
 
-	/**
-		Return the information about the other side of a connected socket.
-	**/
 	public function peer():{host:Host, port:Int} {
 		var client:TcpClient = cast _socket;
 		var res = client.getpeername();
@@ -157,9 +111,6 @@ class Socket {
 		return {host: host, port: Std.parseInt(res.port)};
 	}
 
-	/**
-		Return the information about our side of a connected socket.
-	**/
 	public function host():{host:Host, port:Int} {
 		var server:TcpServer = cast _socket;
 		var res = server.getsockname();
@@ -167,44 +118,24 @@ class Socket {
 		return {host: host, port: Std.parseInt(res.port)};
 	}
 
-	/**
-		Gives a timeout after which blocking socket operations (such as reading and writing) will abort and throw an exception.
-	**/
 	public inline function setTimeout(timeout:Float):Void {
 		var client:TcpClient = cast _socket;
 		client.settimeout(timeout);
 	}
 
-	/**
-		Block until some data is available for read on the socket.
-	**/
 	public function waitForRead():Void {
 		select([this], null, null);
 	}
 
-	/**
-		Change the blocking mode of the socket. A blocking socket is the default behavior. A non-blocking socket will abort blocking operations immediately by throwing a haxe.io.Error.Blocked value.
-	**/
 	public function setBlocking(b:Bool):Void {
 		blocking = b;
 	}
 
-	/**
-		Allows the socket to immediately send the data when written to its output : this will cause less ping but might increase the number of packets / data size, especially when doing a lot of small writes.
-	**/
 	public function setFastSend(b:Bool):Void {
 		var client:TcpClient = cast _socket;
 		client.setoption(TcpNoDelay, true);
 	}
 
-	/**
-		Wait until one of the sockets groups is ready for the given operation :
-		 - `read`contains sockets on which we want to wait for available data to be read,
-		 - `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-		 - `others` contains sockets on which we want to wait for exceptional conditions.
-		 - `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-		In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
-	**/
 	static public function select(read:Array<Socket>, write:Array<Socket>, others:Array<Socket>,
 			?timeout:Float):{read:Array<Socket>, write:Array<Socket>, others:Array<Socket>} {
 		var read_tbl = read == null ? Table.create() : Table.fromArray([for (r in read) cast r._socket]);

--- a/std/php/_std/StringTools.hx
+++ b/std/php/_std/StringTools.hx
@@ -124,24 +124,10 @@ import haxe.iterators.StringKeyValueIterator;
 		return Boot.unsafeOrd(char);
 	}
 
-	/**
-		Returns an iterator of the char codes.
-
-		Note that char codes may differ across platforms because of different
-		internal encoding of strings in different runtimes.
-		For the consistent cross-platform UTF8 char codes see `haxe.iterators.StringIteratorUnicode`.
-	**/
 	public static inline function iterator(s:String):StringIterator {
 		return new StringIterator(s);
 	}
 
-	/**
-		Returns an iterator of the char indexes and codes.
-
-		Note that char codes may differ across platforms because of different
-		internal encoding of strings in different of runtimes.
-		For the consistent cross-platform UTF8 char codes see `haxe.iterators.StringKeyValueIteratorUnicode`.
-	**/
 	public static inline function keyValueIterator(s:String):StringKeyValueIterator {
 		return new StringKeyValueIterator(s);
 	}

--- a/std/php/_std/haxe/CallStack.hx
+++ b/std/php/_std/haxe/CallStack.hx
@@ -26,9 +26,6 @@ import php.*;
 
 private typedef NativeTrace = NativeIndexedArray<NativeAssocArray<Dynamic>>;
 
-/**
-	Elements return by `CallStack` methods.
-**/
 enum StackItem {
 	CFunction;
 	Module(m:String);
@@ -48,25 +45,14 @@ class CallStack {
 	@:ifFeature("haxe.CallStack.exceptionStack")
 	static var lastExceptionTrace:NativeTrace;
 
-	/**
-		Return the call stack elements, or an empty array if not available.
-	**/
 	public static function callStack():Array<StackItem> {
 		return makeStack(Global.debug_backtrace(Const.DEBUG_BACKTRACE_IGNORE_ARGS));
 	}
 
-	/**
-		Return the exception stack : this is the stack elements between
-		the place the last exception was thrown and the place it was
-		caught, or an empty array if not available.
-	**/
 	public static function exceptionStack():Array<StackItem> {
 		return makeStack(lastExceptionTrace == null ? new NativeIndexedArray() : lastExceptionTrace);
 	}
 
-	/**
-		Returns a representation of the stack as a printable string.
-	**/
 	public static function toString(stack:Array<StackItem>) {
 		var b = new StringBuf();
 		for (s in stack) {

--- a/std/php/_std/haxe/crypto/Md5.hx
+++ b/std/php/_std/haxe/crypto/Md5.hx
@@ -25,9 +25,6 @@ package haxe.crypto;
 import php.Global;
 import haxe.io.Bytes;
 
-/**
-	Creates a MD5 of a String.
-**/
 class Md5 {
 	public static inline function encode(s:String):String {
 		return Global.md5(s);

--- a/std/php/_std/haxe/crypto/Sha1.hx
+++ b/std/php/_std/haxe/crypto/Sha1.hx
@@ -25,9 +25,6 @@ package haxe.crypto;
 import php.Global;
 import haxe.io.Bytes;
 
-/**
-	Creates a Sha1 of a String.
- */
 class Sha1 {
 	public static inline function encode(s:String):String {
 		return Global.sha1(s);

--- a/std/php/_std/haxe/crypto/Sha224.hx
+++ b/std/php/_std/haxe/crypto/Sha224.hx
@@ -25,9 +25,6 @@ package haxe.crypto;
 import php.Global;
 import haxe.io.Bytes;
 
-/**
-	Creates a Sha224 of a String.
- */
 class Sha224 {
 	public static inline function encode(s:String):String {
 		return Global.hash('sha224', s);

--- a/std/php/_std/haxe/crypto/Sha256.hx
+++ b/std/php/_std/haxe/crypto/Sha256.hx
@@ -25,9 +25,6 @@ package haxe.crypto;
 import php.Global;
 import haxe.io.Bytes;
 
-/**
-	Creates a Sha256 of a String.
- */
 class Sha256 {
 	public static inline function encode(s:String):String {
 		return Global.hash('sha256', s);

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -30,37 +30,22 @@ import php.NativeIndexedArray;
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	var data:NativeIndexedArray<T>;
 
-	/**
-		Creates a new IntMap.
-	**/
 	public function new():Void {
 		data = new NativeIndexedArray();
 	}
 
-	/**
-		See `Map.set`
-	**/
 	public inline function set(key:Int, value:T):Void {
 		data[key] = value;
 	}
 
-	/**
-		See `Map.get`
-	**/
 	public inline function get(key:Int):Null<T> {
 		return Syntax.coalesce(data[key], null);
 	}
 
-	/**
-		See `Map.exists`
-	**/
 	public inline function exists(key:Int):Bool {
 		return Global.array_key_exists(key, data);
 	}
 
-	/**
-		See `Map.remove`
-	**/
 	public function remove(key:Int):Bool {
 		if (Global.array_key_exists(key, data)) {
 			Global.unset(data[key]);
@@ -70,23 +55,14 @@ import php.NativeIndexedArray;
 		return false;
 	}
 
-	/**
-		See `Map.keys`
-	**/
 	public inline function keys():Iterator<Int> {
 		return Global.array_keys(data).iterator();
 	}
 
-	/**
-		See `Map.iterator`
-	**/
 	public inline function iterator():Iterator<T> {
 		return Global.array_values(data).iterator();
 	}
 
-	/**
-		See `Map.keyValueIterator`
-	**/
 	@:runtime public inline function keyValueIterator():KeyValueIterator<Int, T> {
 		return new haxe.iterators.MapKeyValueIterator(this);
 	}
@@ -95,9 +71,6 @@ import php.NativeIndexedArray;
 		return Syntax.clone(this);
 	}
 
-	/**
-		See `Map.toString`
-	**/
 	public function toString():String {
 		var parts = new NativeArray();
 		Syntax.foreach(data, function(key:Int, value:T) {

--- a/std/php/_std/haxe/format/JsonParser.hx
+++ b/std/php/_std/haxe/format/JsonParser.hx
@@ -28,25 +28,7 @@ import php.NativeString;
 
 using haxe.format.JsonParser;
 
-/**
-	An implementation of JSON parser in Haxe.
-
-	This class is used by `haxe.Json` when native JSON implementation
-	is not available.
-
-	@see https://haxe.org/manual/std-Json-parsing.html
-**/
 class JsonParser {
-	/**
-		Parses given JSON-encoded `str` and returns the resulting object.
-
-		JSON objects are parsed into anonymous structures and JSON arrays
-		are parsed into `Array<Dynamic>`.
-
-		If given `str` is not valid JSON, an exception will be thrown.
-
-		If `str` is null, the result is unspecified.
-	**/
 	static public inline function parse(str:String):Dynamic {
 		return new JsonParser(str).doParse();
 	}

--- a/std/php/_std/haxe/io/Bytes.hx
+++ b/std/php/_std/haxe/io/Bytes.hx
@@ -67,74 +67,43 @@ class Bytes {
 		return b.compare(other.b);
 	}
 
-	/**
-		Returns the IEEE double precision value at given position (in low endian encoding).
-		Result is unspecified if reading outside of the bounds
-	**/
 	public function getDouble(pos:Int):Float {
 		return FPHelper.i64ToDouble(getInt32(pos), getInt32(pos + 4));
 	}
 
-	/**
-		Returns the IEEE single precision value at given position (in low endian encoding).
-		Result is unspecified if reading outside of the bounds
-	**/
 	public function getFloat(pos:Int):Float {
 		var b = new haxe.io.BytesInput(this, pos, 4);
 		return b.readFloat();
 	}
 
-	/**
-		Store the IEEE double precision value at given position in low endian encoding.
-		Result is unspecified if writing outside of the bounds.
-	**/
 	public function setDouble(pos:Int, v:Float):Void {
 		var i = FPHelper.doubleToI64(v);
 		setInt32(pos, i.low);
 		setInt32(pos + 4, i.high);
 	}
 
-	/**
-		Store the IEEE single precision value at given position in low endian encoding.
-		Result is unspecified if writing outside of the bounds.
-	**/
 	public function setFloat(pos:Int, v:Float):Void {
 		setInt32(pos, FPHelper.floatToI32(v));
 	}
 
-	/**
-		Returns the 16 bit unsigned integer at given position (in low endian encoding).
-	**/
 	public inline function getUInt16(pos:Int):Int {
 		return get(pos) | (get(pos + 1) << 8);
 	}
 
-	/**
-		Store the 16 bit unsigned integer at given position (in low endian encoding).
-	**/
 	public inline function setUInt16(pos:Int, v:Int):Void {
 		set(pos, v);
 		set(pos + 1, v >> 8);
 	}
 
-	/**
-		Returns the 32 bit integer at given position (in low endian encoding).
-	**/
 	public inline function getInt32(pos:Int):Int {
 		var v = get(pos) | (get(pos + 1) << 8) | (get(pos + 2) << 16) | (get(pos + 3) << 24);
 		return if (v & 0x80000000 != 0) v | 0x80000000 else v;
 	}
 
-	/**
-		Returns the 64 bit integer at given position (in low endian encoding).
-	**/
 	public inline function getInt64(pos:Int):haxe.Int64 {
 		return haxe.Int64.make(getInt32(pos + 4), getInt32(pos));
 	}
 
-	/**
-		Store the 32 bit integer at given position (in low endian encoding).
-	**/
 	public inline function setInt32(pos:Int, v:Int):Void {
 		set(pos, v);
 		set(pos + 1, v >> 8);
@@ -142,9 +111,6 @@ class Bytes {
 		set(pos + 3, v >>> 24);
 	}
 
-	/**
-		Store the 64 bit integer at given position (in low endian encoding).
-	**/
 	public inline function setInt64(pos:Int, v:haxe.Int64):Void {
 		setInt32(pos, v.low);
 		setInt32(pos + 4, v.high);
@@ -197,10 +163,6 @@ class Bytes {
 		return new Bytes(Global.strlen(b), b);
 	}
 
-	/**
-		Read the most efficiently possible the n-th byte of the data.
-		Behavior when reading outside of the available data is unspecified.
-	**/
 	public inline static function fastGet(b:BytesData, pos:Int):Int {
 		return b.get(pos);
 	}

--- a/std/php/_std/haxe/io/BytesBuffer.hx
+++ b/std/php/_std/haxe/io/BytesBuffer.hx
@@ -27,7 +27,6 @@ import php.*;
 class BytesBuffer {
 	var b:NativeString;
 
-	/** The length of the buffer in bytes. **/
 	public var length(get, never):Int;
 
 	public function new() {
@@ -74,10 +73,6 @@ class BytesBuffer {
 		}
 	}
 
-	/**
-		Returns either a copy or a reference of the current bytes.
-		Once called, the buffer can no longer be used.
-	**/
 	public function getBytes():Bytes {
 		var bytes = @:privateAccess new Bytes(length, b);
 		b = null;

--- a/std/php/_std/haxe/io/BytesInput.hx
+++ b/std/php/_std/haxe/io/BytesInput.hx
@@ -28,10 +28,8 @@ class BytesInput extends Input {
 	var len:Int;
 	var totlen:Int;
 
-	/** The current position in the stream in bytes. */
 	public var position(get, set):Int;
 
-	/** The length of the stream in bytes. */
 	public var length(get, never):Int;
 
 	public function new(b:Bytes, ?pos:Int, ?len:Int) {

--- a/std/php/_std/haxe/io/BytesOutput.hx
+++ b/std/php/_std/haxe/io/BytesOutput.hx
@@ -25,7 +25,6 @@ package haxe.io;
 class BytesOutput extends Output {
 	var b:BytesBuffer;
 
-	/** The length of the stream in bytes. **/
 	public var length(get, never):Int;
 
 	public function new() {
@@ -41,12 +40,6 @@ class BytesOutput extends Output {
 		return len;
 	}
 
-	/**
-		Returns the `Bytes` of this output.
-
-		This function should not be called more than once on a given
-		`BytesOutput` instance.
-	**/
 	public function getBytes():Bytes {
 		return b.getBytes();
 	}

--- a/std/php/_std/haxe/io/FPHelper.hx
+++ b/std/php/_std/haxe/io/FPHelper.hx
@@ -24,10 +24,6 @@ package haxe.io;
 
 import php.*;
 
-/**
-	Helper that converts between floating point and binary representation.
-	Always works in low-endian encoding.
-**/
 class FPHelper {
 	static var isLittleEndian:Bool = Global.unpack('S', '\x01\x00')[1] == 1;
 	static var i64tmp = Int64.ofInt(0);
@@ -44,11 +40,6 @@ class FPHelper {
 		return Global.unpack('d', Global.pack('ii', isLittleEndian ? low : high, isLittleEndian ? high : low))[1];
 	}
 
-	/**
-		Returns an Int64 representing the bytes representation of the double precision IEEE float value.
-		WARNING : for performance reason, the same Int64 value might be reused every time. Copy its low/high values before calling again.
-		We still ensure that this is safe to use in a multithread environment
-	**/
 	public static function doubleToI64(v:Float):Int64 {
 		var a = Global.unpack(isLittleEndian ? 'V2' : 'N2', Global.pack('d', v));
 		var i64 = i64tmp;

--- a/std/php/_std/haxe/xml/Parser.hx
+++ b/std/php/_std/haxe/xml/Parser.hx
@@ -51,29 +51,14 @@ private enum abstract S(Int) {
 }
 
 class XmlParserException {
-	/**
-		the XML parsing error message
-	**/
 	public var message:String;
 
-	/**
-		the line number at which the XML parsing error occurred
-	**/
 	public var lineNumber:Int;
 
-	/**
-		the character position in the reported line at which the parsing error occurred
-	**/
 	public var positionAtLine:Int;
 
-	/**
-		the character position in the XML string at which the parsing error occurred
-	**/
 	public var position:Int;
 
-	/**
-		the invalid XML string
-	**/
 	public var xml:String;
 
 	public function new(message:String, xml:String, position:Int) {
@@ -111,11 +96,6 @@ class Parser {
 		h;
 	}
 
-	/**
-		Parses the String into an XML Document. Set strict parsing to true in order to enable a strict check of XML attributes and entities.
-
-		@throws haxe.xml.XmlParserException
-	**/
 	static public function parse(str:String, strict = false) {
 		var doc = Xml.createDocument();
 		doParse(str, strict, 0, doc);

--- a/std/php/_std/sys/io/Process.hx
+++ b/std/php/_std/sys/io/Process.hx
@@ -112,19 +112,10 @@ private class WritablePipe extends Output {
 }
 
 class Process {
-	/**
-		Standard output. The output stream where a process writes its output data.
-	**/
 	public var stdout(default, null):Input;
 
-	/**
-		Standard error. The output stream to output error messages or diagnostics.
-	**/
 	public var stderr(default, null):Input;
 
-	/**
-		Standard input. The stream data going into a process.
-	**/
 	public var stdin(default, null):Output;
 
 	var process:Resource;
@@ -133,19 +124,6 @@ class Process {
 	var running:Bool = true;
 	var _exitCode:Int = -1;
 
-	/**
-		Construct a `Process` object, which run the given command immediately.
-
-		Command arguments can be passed in two ways: 1. using `args`, 2. appending to `cmd` and leaving `args` as `null`.
-
-		 1. When using `args` to pass command arguments, each argument will be automatically quoted, and shell meta-characters will be escaped if needed.
-		`cmd` should be an executable name that can be located in the `PATH` environment variable, or a path to an executable.
-
-		 2. When `args` is not given or is `null`, command arguments can be appended to `cmd`. No automatic quoting/escaping will be performed. `cmd` should be formatted exactly as it would be when typed at the command line.
-		It can run executables, as well as shell commands that are not executables (e.g. on Windows: `dir`, `cd`, `echo` etc).
-
-		`close()` should be called when the `Process` is no longer used.
-	**/
 	public function new(cmd:String, ?args:Array<String>, ?detached:Bool):Void {
 		if (detached)
 			throw "Detached process is not supported on this platform";
@@ -162,9 +140,6 @@ class Process {
 		stderr = new ReadablePipe(pipes.stderr);
 	}
 
-	/**
-		Return the process ID.
-	**/
 	public function getPid():Int {
 		return pid;
 	}
@@ -182,10 +157,6 @@ class Process {
 		return _exitCode;
 	}
 
-	/**
-		Close the process handle and release the associated resources.
-		All `Process` fields should not be used after `close()` is called.
-	**/
 	public function close():Void {
 		if (!running)
 			return;
@@ -195,9 +166,6 @@ class Process {
 		process.proc_close();
 	}
 
-	/**
-		Kill the process.
-	**/
 	public function kill():Void {
 		process.proc_terminate();
 	}

--- a/std/python/_std/sys/net/Socket.hx
+++ b/std/python/_std/sys/net/Socket.hx
@@ -107,31 +107,15 @@ private class SocketOutput extends haxe.io.Output {
 	}
 }
 
-/**
-	A TCP socket class : allow you to both connect to a given server and exchange messages or start your own server and wait for connections.
-**/
 @:coreApi class Socket {
 	var __s:PSocket;
 
-	/**
-		The stream on which you can read available data. By default the stream is blocking until the requested data is available,
-		use `setBlocking(false)` or `setTimeout` to prevent infinite waiting.
-	**/
 	public var input(default, null):haxe.io.Input;
 
-	/**
-		The stream on which you can send data. Please note that in case the output buffer you will block while writing the data, use [setBlocking(false)] or [setTimeout] to prevent that.
-	**/
 	public var output(default, null):haxe.io.Output;
 
-	/**
-			A custom value that can be associated with the socket. Can be used to retrieve your custom infos after a `select`.
-	***/
 	public var custom:Dynamic;
 
-	/**
-		Creates a new unconnected socket.
-	**/
 	public function new():Void {
 		__initSocket();
 		input = new SocketInput(__s);
@@ -142,59 +126,35 @@ private class SocketOutput extends haxe.io.Output {
 		__s = new PSocket();
 	}
 
-	/**
-		Closes the socket : make sure to properly close all your sockets or you will crash when you run out of file descriptors.
-	**/
 	public function close():Void {
 		__s.close();
 	}
 
-	/**
-		Read the whole data available on the socket.
-	**/
 	public function read():String {
 		return input.readAll().toString();
 	}
 
-	/**
-		Write the whole data to the socket output.
-	**/
 	public function write(content:String):Void {
 		output.writeString(content);
 	}
 
-	/**
-		Connect to the given server host/port. Throw an exception in case we couldn't successfully connect.
-	**/
 	public function connect(host:Host, port:Int):Void {
 		var host_str = host.toString();
 		__s.connect(Tuple2.make(host_str, port));
 	}
 
-	/**
-		Allow the socket to listen for incoming questions. The parameter tells how many pending connections we can have until they get refused. Use `accept()` to accept incoming connections.
-	**/
 	public function listen(connections:Int):Void {
 		__s.listen(connections);
 	}
 
-	/**
-		Shutdown the socket, either for reading or writing.
-	**/
 	public function shutdown(read:Bool, write:Bool):Void
 		__s.shutdown((read && write) ? PSocketModule.SHUT_RDWR : read ? PSocketModule.SHUT_RD : PSocketModule.SHUT_WR);
 
-	/**
-		Bind the socket to the given host/port so it can afterwards listen for connections there.
-	**/
 	public function bind(host:Host, port:Int):Void {
 		var host_str = host.toString();
 		__s.bind(Tuple2.make(host_str, port));
 	}
 
-	/**
-		Accept a new connected client. This will return a connected socket on which you can read/write some data.
-	**/
 	public function accept():Socket {
 		var tp2:Tuple2<PSocket, PAddress> = __s.accept();
 		var s = new Socket();
@@ -204,46 +164,28 @@ private class SocketOutput extends haxe.io.Output {
 		return s;
 	}
 
-	/**
-		Return the information about the other side of a connected socket.
-	**/
 	public function peer():{host:Host, port:Int} {
 		var pn = __s.getpeername();
 		return {host: new Host(pn._1), port: pn._2}
 	}
 
-	/**
-		Return the information about our side of a connected socket.
-	**/
 	public function host():{host:Host, port:Int} {
 		var pn = __s.getsockname();
 		return {host: new Host(pn._1), port: pn._2};
 	}
 
-	/**
-		Gives a timeout after which blocking socket operations (such as reading and writing) will abort and throw an exception.
-	**/
 	public function setTimeout(timeout:Float):Void {
 		__s.settimeout(timeout);
 	}
 
-	/**
-		Block until some data is available for read on the socket.
-	**/
 	public function waitForRead():Void {
 		Select.select([this], [], []);
 	}
 
-	/**
-		Change the blocking mode of the socket. A blocking socket is the default behavior. A non-blocking socket will abort blocking operations immediately by throwing a haxe.io.Error.Blocked value.
-	**/
 	public function setBlocking(b:Bool):Void {
 		__s.setblocking(b);
 	}
 
-	/**
-		Allows the socket to immediately send the data when written to its output : this will cause less ping but might increase the number of packets / data size, especially when doing a lot of small writes.
-	**/
 	public function setFastSend(b:Bool):Void {
 		__s.setsockopt(PSocketModule.SOL_TCP, PSocketModule.TCP_NODELAY, b);
 	}
@@ -251,14 +193,6 @@ private class SocketOutput extends haxe.io.Output {
 	@:keep function fileno():Int
 		return __s.fileno();
 
-	/**
-		Wait until one of the sockets groups is ready for the given operation :
-		- `read` contains sockets on which we want to wait for available data to be read,
-		- `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
-		- `others` contains sockets on which we want to wait for exceptional conditions.
-		- `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-		In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
-	**/
 	public static function select(read:Array<Socket>, write:Array<Socket>, others:Array<Socket>,
 			?timeout:Float):{read:Array<Socket>, write:Array<Socket>, others:Array<Socket>} {
 		var t3 = Select.select(read, write, others, timeout);

--- a/std/sys/db/Sqlite.hx
+++ b/std/sys/db/Sqlite.hx
@@ -26,10 +26,13 @@ class Sqlite {
 	/**
 		Opens a new SQLite connection on the specified path.
 
-		(cs) Note that you will need a SQLite ADO.NET Provider
+		(cs) You will need a SQLite ADO.NET Provider
 		(see http://www.mono-project.com/docs/database-access/providers/sqlite/).
 		Also note that this will try to open an assembly named `Mono.Data.Sqlite`
 		if it wasn't loaded yet.
+
+		(java) You will need a SQLite JDBC driver (e.g. 
+		https://bitbucket.org/xerial/sqlite-jdbc).
 	**/
 	public static function open(file:String):Connection {
 		throw "Not implemented for this platform";

--- a/std/sys/db/Sqlite.hx
+++ b/std/sys/db/Sqlite.hx
@@ -23,6 +23,14 @@
 package sys.db;
 
 class Sqlite {
+	/**
+		Opens a new SQLite connection on the specified path.
+
+		(cs) Note that you will need a SQLite ADO.NET Provider
+		(see http://www.mono-project.com/docs/database-access/providers/sqlite/).
+		Also note that this will try to open an assembly named `Mono.Data.Sqlite`
+		if it wasn't loaded yet.
+	**/
 	public static function open(file:String):Connection {
 		throw "Not implemented for this platform";
 		return null;

--- a/std/sys/io/Process.hx
+++ b/std/sys/io/Process.hx
@@ -49,7 +49,7 @@ extern class Process {
 		 2. When `args` is not given or is `null`, command arguments can be appended to `cmd`. No automatic quoting/escaping will be performed. `cmd` should be formatted exactly as it would be when typed at the command line.
 		It can run executables, as well as shell commands that are not executables (e.g. on Windows: `dir`, `cd`, `echo` etc).
 
-		`detached` allows the created process to be standalone. You cannot communicate with it but you can look at its exit code.
+		`detached` allows the created process to be standalone. You cannot communicate with it but you can look at its exit code. Not supported on php.
 
 		`close()` should be called when the `Process` is no longer used.
 	**/

--- a/std/sys/net/Socket.hx
+++ b/std/sys/net/Socket.hx
@@ -38,7 +38,7 @@ extern class Socket {
 	var output(default, null):haxe.io.Output;
 
 	/**
-			A custom value that can be associated with the socket. Can be used to retrieve your custom infos after a `select`.
+		A custom value that can be associated with the socket. Can be used to retrieve your custom infos after a `select`.
 	***/
 	var custom:Dynamic;
 
@@ -125,12 +125,14 @@ extern class Socket {
 	function setFastSend(b:Bool):Void;
 
 	/**
-		Wait until one of the sockets groups is ready for the given operation :
-		 - `read`contains sockets on which we want to wait for available data to be read,
+		Wait until one of the sockets group is ready for the given operation:
+
+		 - `read` contains sockets on which we want to wait for available data to be read,
 		 - `write` contains sockets on which we want to wait until we are allowed to write some data to their output buffers,
 		 - `others` contains sockets on which we want to wait for exceptional conditions.
 		 - `select` will block until one of the condition is met, in which case it will return the sockets for which the condition was true.
-		In case a `timeout` (in seconds) is specified, select might wait at worse until the timeout expires.
+
+		In case a `timeout` (in seconds) is specified, select might wait at worst until the timeout expires.
 	**/
 	static function select(read:Array<Socket>, write:Array<Socket>, others:Array<Socket>,
 		?timeout:Float):{read:Array<Socket>, write:Array<Socket>, others:Array<Socket>};

--- a/std/sys/thread/Tls.hx
+++ b/std/sys/thread/Tls.hx
@@ -28,7 +28,10 @@ package sys.thread;
 
 /**
 	Creates thread local storage.
- */
+
+	(hl) Warning: At the moment `Tls` does not protect the value from being
+	garbage collected. Keep the value reachable to avoid crashes.
+**/
 extern class Tls<T> {
 	public var value(get, set):T;
 


### PR DESCRIPTION
 - [x] Remove doc comments in target-specific `_std` directories. In most cases they were exact copies of the extern version. In some cases they were stale or slightly different. In other cases there were some target-specific comments, which were moved to the extern doc.

Stay tuned for the next PR:

 - [ ] Fix a whole bunch of grammatical and stylistic (Markdown-breaking) issues.
 - [ ] More descriptive argument names.