### PR TITLE
[cli] disallow changing the true/false/null defines

### DIFF
--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -81,7 +81,7 @@ let error ctx msg p =
 	ctx.has_error <- true
 
 let reserved_flags = [
-	"true";"false";"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
+	"true";"false";"null";"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
 	"as3";"swc";"macro";"sys";"static";"utf16";"haxe";"haxe_ver"
 	]
 

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -81,7 +81,7 @@ let error ctx msg p =
 	ctx.has_error <- true
 
 let reserved_flags = [
-	"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
+	"true";"false";"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
 	"as3";"swc";"macro";"sys";"static";"utf16";"haxe";"haxe_ver"
 	]
 


### PR DESCRIPTION
This should be pretty non-controversial - at the moment you can do things like this:

```hxml
-D false
-D true=foo
```

...which should probably not be allowed. :)