### PR TITLE
Map.clear

### DIFF
--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -1545,6 +1545,11 @@ module StdIntMap = struct
 		let s = join rempty [rbropen;s;rbrclose] in
 		vstring s
 	)
+
+	let clear = vifun0 (fun vthis ->
+		IntHashtbl.clear (this vthis);
+		vnull
+	)
 end
 
 module StdStringMap = struct
@@ -1599,6 +1604,11 @@ module StdStringMap = struct
 		let s = join rempty [rbropen;s;rbrclose] in
 		vstring s
 	)
+
+	let clear = vifun0 (fun vthis ->
+		StringHashtbl.clear (this vthis);
+		vnull
+	)
 end
 
 module StdObjectMap = struct
@@ -1651,6 +1661,11 @@ module StdObjectMap = struct
 		let s = join rcomma l in
 		let s = join rempty [rbropen;s;rbrclose] in
 		vstring s
+	)
+
+	let clear = vifun0 (fun vthis ->
+		ValueHashtbl.reset (this vthis);
+		vnull
 	)
 end
 
@@ -3067,6 +3082,7 @@ let init_maps builtins =
 		"remove",StdIntMap.remove;
 		"set",StdIntMap.set;
 		"toString",StdIntMap.toString;
+		"clear",StdIntMap.clear;
 	];
 	init_fields builtins (["haxe";"ds"],"ObjectMap") [] [
 		"copy",StdObjectMap.copy;
@@ -3078,6 +3094,7 @@ let init_maps builtins =
 		"remove",StdObjectMap.remove;
 		"set",StdObjectMap.set;
 		"toString",StdObjectMap.toString;
+		"clear",StdObjectMap.clear;
 	];
 	init_fields builtins (["haxe";"ds"],"StringMap") [] [
 		"copy",StdStringMap.copy;
@@ -3089,6 +3106,7 @@ let init_maps builtins =
 		"remove",StdStringMap.remove;
 		"set",StdStringMap.set;
 		"toString",StdStringMap.toString;
+		"clear",StdStringMap.clear;
 	]
 
 let init_constructors builtins =

--- a/src/macro/eval/evalValue.ml
+++ b/src/macro/eval/evalValue.ml
@@ -56,6 +56,7 @@ module StringHashtbl = struct
 	let iter f this = StringMap.iter f !this
 	let mem this key = StringMap.mem key.sstring !this
 	let remove this key = this := StringMap.remove key.sstring !this
+	let clear this = this := StringMap.empty
 end
 
 module IntHashtbl = struct
@@ -70,6 +71,7 @@ module IntHashtbl = struct
 	let iter f this = IntMap.iter f !this
 	let mem this key = IntMap.mem key !this
 	let remove this key = this := IntMap.remove key !this
+	let clear this = this := IntMap.empty
 end
 
 type vregex = {

--- a/std/cpp/_std/haxe/ds/IntMap.hx
+++ b/std/cpp/_std/haxe/ds/IntMap.hx
@@ -98,6 +98,10 @@ package haxe.ds;
 		return untyped __global__.__int_hash_to_string(h);
 	}
 
+	public function clear():Void {
+		return untyped __global__.__int_hash_clear(h);
+	}
+
 	#if (scriptable)
 	private function setString(key:Int, val:String):Void {
 		untyped __int_hash_set_string(__cpp__("HX_MAP_THIS"), key, val);

--- a/std/cpp/_std/haxe/ds/IntMap.hx
+++ b/std/cpp/_std/haxe/ds/IntMap.hx
@@ -99,7 +99,11 @@ package haxe.ds;
 	}
 
 	public function clear():Void {
+		#if (hxcpp_api_level >= 400)
 		return untyped __global__.__int_hash_clear(h);
+		#else
+		h = null;
+		#end
 	}
 
 	#if (scriptable)

--- a/std/cpp/_std/haxe/ds/ObjectMap.hx
+++ b/std/cpp/_std/haxe/ds/ObjectMap.hx
@@ -98,6 +98,10 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		return untyped __global__.__object_hash_to_string(h);
 	}
 
+	public function clear():Void {
+		return untyped __global__.__object_hash_clear(h);
+	}
+
 	#if (scriptable)
 	private function setString(key:Dynamic, val:String):Void {
 		untyped __object_hash_set_string(__cpp__("HX_MAP_THIS"), key, val);

--- a/std/cpp/_std/haxe/ds/ObjectMap.hx
+++ b/std/cpp/_std/haxe/ds/ObjectMap.hx
@@ -99,7 +99,11 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	}
 
 	public function clear():Void {
+		#if (hxcpp_api_level >= 400)
 		return untyped __global__.__object_hash_clear(h);
+		#else
+		h = null;
+		#end
 	}
 
 	#if (scriptable)

--- a/std/cpp/_std/haxe/ds/StringMap.hx
+++ b/std/cpp/_std/haxe/ds/StringMap.hx
@@ -99,7 +99,11 @@ package haxe.ds;
 	}
 
 	public function clear():Void {
+		#if (hxcpp_api_level >= 400)
 		return untyped __global__.__string_hash_clear(h);
+		#else
+		h = null;
+		#end
 	}
 
 	#if (scriptable)

--- a/std/cpp/_std/haxe/ds/StringMap.hx
+++ b/std/cpp/_std/haxe/ds/StringMap.hx
@@ -98,6 +98,10 @@ package haxe.ds;
 		return untyped __global__.__string_hash_to_string(h);
 	}
 
+	public function clear():Void {
+		return untyped __global__.__string_hash_clear(h);
+	}
+
 	#if (scriptable)
 	private function setString(key:String, val:String):Void {
 		untyped __string_hash_set_string(__cpp__("HX_MAP_THIS"), key, val);

--- a/std/cpp/_std/haxe/ds/WeakMap.hx
+++ b/std/cpp/_std/haxe/ds/WeakMap.hx
@@ -92,6 +92,10 @@ class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	}
 
 	public function clear():Void {
+		#if (hxcpp_api_level >= 400)
 		return untyped __global__.__object_hash_clear(h);
+		#else
+		h = null;
+		#end
 	}
 }

--- a/std/cpp/_std/haxe/ds/WeakMap.hx
+++ b/std/cpp/_std/haxe/ds/WeakMap.hx
@@ -90,4 +90,8 @@ class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	public function toString():String {
 		return untyped __global__.__object_hash_to_string(h);
 	}
+
+	public function clear():Void {
+		return untyped __global__.__object_hash_clear(h);
+	}
 }

--- a/std/cs/_std/haxe/ds/IntMap.hx
+++ b/std/cs/_std/haxe/ds/IntMap.hx
@@ -377,6 +377,20 @@ import cs.NativeArray;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		flags = null;
+		_keys = null;
+		vals = null;
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedKey = 0;
+		cachedIndex = -1;
+		#end
+	}
+
 	private static inline function assert(x:Bool):Void {
 		#if debug
 		if (!x)

--- a/std/cs/_std/haxe/ds/ObjectMap.hx
+++ b/std/cs/_std/haxe/ds/ObjectMap.hx
@@ -391,6 +391,26 @@ import cs.NativeArray;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		hashes = null;
+		_keys = null;
+		vals = null;
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedKey = null;
+		cachedIndex = -1;
+		#end
+		#if DEBUG_HASHTBL
+		totalProbes = 0;
+		probeTimes = 0;
+		sameHash = 0;
+		maxProbe = 0;
+		#end
+	}
+
 	extern private static inline function roundUp(x:Int):Int {
 		--x;
 		x |= (x) >>> 1;

--- a/std/cs/_std/haxe/ds/StringMap.hx
+++ b/std/cs/_std/haxe/ds/StringMap.hx
@@ -390,6 +390,26 @@ import cs.NativeArray;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		hashes = null;
+		_keys = null;
+		vals = null;
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedKey = null;
+		cachedIndex = -1;
+		#end
+		#if DEBUG_HASHTBL
+		totalProbes = 0;
+		probeTimes = 0;
+		sameHash = 0;
+		maxProbe = 0;
+		#end
+	}
+
 	extern private static inline function roundUp(x:Int):Int {
 		--x;
 		x |= (x) >>> 1;

--- a/std/flash/_std/haxe/ds/IntMap.hx
+++ b/std/flash/_std/haxe/ds/IntMap.hx
@@ -103,6 +103,10 @@ package haxe.ds;
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = new flash.utils.Dictionary();
+	}
 }
 
 #if !as3

--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -88,6 +88,11 @@ class ObjectMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constrai
 		}
 		return s + "}";
 	}
+
+	public function clear():Void {
+		for (i in keys())
+			untyped __delete__(this, key);
+	}
 }
 
 #if !as3

--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -91,7 +91,7 @@ class ObjectMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constrai
 
 	public function clear():Void {
 		for (i in keys())
-			untyped __delete__(this, key);
+			untyped __delete__(this, i);
 	}
 }
 

--- a/std/flash/_std/haxe/ds/StringMap.hx
+++ b/std/flash/_std/haxe/ds/StringMap.hx
@@ -142,6 +142,11 @@ package haxe.ds;
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = {};
+		rh = null;
+	}
 }
 
 #if !as3

--- a/std/flash/_std/haxe/ds/UnsafeStringMap.hx
+++ b/std/flash/_std/haxe/ds/UnsafeStringMap.hx
@@ -108,6 +108,10 @@ class UnsafeStringMap<T> implements haxe.Constraints.IMap<String, T> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = new flash.utils.Dictionary();
+	}
 }
 
 #if !as3

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -88,6 +88,11 @@ class WeakMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraint
 		}
 		return s + "}";
 	}
+
+	public function clear():Void {
+		for (i in keys())
+			untyped __delete__(this, key);
+	}
 }
 
 #if !as3

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -91,7 +91,7 @@ class WeakMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraint
 
 	public function clear():Void {
 		for (i in keys())
-			untyped __delete__(this, key);
+			untyped __delete__(this, i);
 	}
 }
 

--- a/std/haxe/Constraints.hx
+++ b/std/haxe/Constraints.hx
@@ -66,4 +66,5 @@ interface IMap<K, V> {
 	public function keyValueIterator():KeyValueIterator<K, V>;
 	public function copy():IMap<K, V>;
 	public function toString():String;
+	public function clear():Void;
 }

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -229,6 +229,10 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 	public function toString() {
 		return root == null ? '{}' : '{${root.toString()}}';
 	}
+
+	public function clear():Void {
+		root = null;
+	}
 }
 
 /**

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -230,6 +230,9 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		return root == null ? '{}' : '{${root.toString()}}';
 	}
 
+	/**
+		Removes all keys from `this` BalancedTree.
+	**/
 	public function clear():Void {
 		root = null;
 	}

--- a/std/haxe/ds/HashMap.hx
+++ b/std/haxe/ds/HashMap.hx
@@ -90,6 +90,14 @@ abstract HashMap<K:{function hashCode():Int;}, V>(HashMapData<K, V>) {
 	public inline function iterator() {
 		return this.values.iterator();
 	}
+
+	/**
+		See `Map.clear`
+	**/
+	public inline function clear():Void {
+		this.keys.clear();
+		this.values.clear();
+	}
 }
 
 private class HashMapData<K:{function hashCode():Int;}, V> {

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -91,4 +91,9 @@ extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		See `Map.toString`
 	**/
 	public function toString():String;
+
+	/**
+		See `Map.clear`
+	**/
+	public function clear():Void;
 }

--- a/std/haxe/ds/Map.hx
+++ b/std/haxe/ds/Map.hx
@@ -154,6 +154,13 @@ abstract Map<K, V>(IMap<K, V>) {
 		return this.toString();
 	}
 
+	/**
+		Removes all keys from `this` Map.
+	**/
+	public inline function clear():Void {
+		this.clear();
+	}
+
 	@:arrayAccess @:noCompletion public inline function arrayWrite(k:K, v:V):V {
 		this.set(k, v);
 		return v;

--- a/std/haxe/ds/ObjectMap.hx
+++ b/std/haxe/ds/ObjectMap.hx
@@ -94,4 +94,9 @@ extern class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		See `Map.toString`
 	**/
 	public function toString():String;
+
+	/**
+		See `Map.clear`
+	**/
+	public function clear():Void;
 }

--- a/std/haxe/ds/StringMap.hx
+++ b/std/haxe/ds/StringMap.hx
@@ -91,4 +91,9 @@ extern class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		See `Map.toString`
 	**/
 	public function toString():String;
+
+	/**
+		See `Map.clear`
+	**/
+	public function clear():Void;
 }

--- a/std/haxe/ds/WeakMap.hx
+++ b/std/haxe/ds/WeakMap.hx
@@ -99,4 +99,9 @@ class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	public function toString():String {
 		return null;
 	}
+
+	/**
+		See `Map.clear`
+	**/
+	public function clear():Void {}
 }

--- a/std/hl/_std/haxe/ds/IntMap.hx
+++ b/std/hl/_std/haxe/ds/IntMap.hx
@@ -82,6 +82,10 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	}
 
 	public function clear():Void {
+		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
+		#else
+		h = new hl.types.IntMap();
+		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/IntMap.hx
+++ b/std/hl/_std/haxe/ds/IntMap.hx
@@ -80,4 +80,8 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		s.addChar('}'.code);
 		return s.toString();
 	}
+
+	public function clear():Void {
+		@:privateAccess h.clear();
+	}
 }

--- a/std/hl/_std/haxe/ds/ObjectMap.hx
+++ b/std/hl/_std/haxe/ds/ObjectMap.hx
@@ -82,6 +82,10 @@ class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
 	}
 
 	public function clear():Void {
+		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
+		#else
+		h = new hl.types.IntMap();
+		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/ObjectMap.hx
+++ b/std/hl/_std/haxe/ds/ObjectMap.hx
@@ -80,4 +80,8 @@ class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
 		s.addChar('}'.code);
 		return s.toString();
 	}
+
+	public function clear():Void {
+		@:privateAccess h.clear();
+	}
 }

--- a/std/hl/_std/haxe/ds/ObjectMap.hx
+++ b/std/hl/_std/haxe/ds/ObjectMap.hx
@@ -85,7 +85,7 @@ class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
 		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
 		#else
-		h = new hl.types.IntMap();
+		h = new hl.types.ObjectMap();
 		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -110,6 +110,10 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 	}
 
 	public function clear():Void {
+		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
+		#else
+		h = new hl.types.IntMap();
+		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -113,7 +113,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
 		#else
-		h = new hl.types.IntMap();
+		h = new hl.types.StringMap();
 		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -108,4 +108,8 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		s.addChar('}'.code);
 		return s.toString();
 	}
+
+	public function clear():Void {
+		@:privateAccess h.clear();
+	}
 }

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -113,7 +113,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
 		#else
-		h = new hl.types.StringMap();
+		h = new hl.types.BytesMap();
 		#end
 	}
 }

--- a/std/hl/types/BytesMap.hx
+++ b/std/hl/types/BytesMap.hx
@@ -61,8 +61,10 @@ abstract BytesMap(BytesMapData) {
 		return null;
 	}
 
+	#if (hl_ver >= version("1.11.0"))
 	@:hlNative("std", "hbclear")
 	public function clear():Void {}
+	#end
 
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());

--- a/std/hl/types/BytesMap.hx
+++ b/std/hl/types/BytesMap.hx
@@ -61,6 +61,9 @@ abstract BytesMap(BytesMapData) {
 		return null;
 	}
 
+	@:hlNative("std", "hbclear")
+	public function clear():Void {}
+
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());
 	}

--- a/std/hl/types/IntMap.hx
+++ b/std/hl/types/IntMap.hx
@@ -61,8 +61,10 @@ abstract IntMap(IntMapData) {
 		return null;
 	}
 
+	#if (hl_ver >= version("1.11.0"))
 	@:hlNative("std", "hiclear")
 	public function clear():Void {}
+	#end
 
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());

--- a/std/hl/types/IntMap.hx
+++ b/std/hl/types/IntMap.hx
@@ -61,6 +61,9 @@ abstract IntMap(IntMapData) {
 		return null;
 	}
 
+	@:hlNative("std", "hiclear")
+	public function clear():Void {}
+
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());
 	}

--- a/std/hl/types/ObjectMap.hx
+++ b/std/hl/types/ObjectMap.hx
@@ -61,6 +61,9 @@ abstract ObjectMap(ObjectMapData) {
 		return null;
 	}
 
+	@:hlNative("std", "hoclear")
+	public function clear():Void {}
+
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());
 	}

--- a/std/hl/types/ObjectMap.hx
+++ b/std/hl/types/ObjectMap.hx
@@ -61,8 +61,10 @@ abstract ObjectMap(ObjectMapData) {
 		return null;
 	}
 
+	#if (hl_ver >= version("1.11.0"))
 	@:hlNative("std", "hoclear")
 	public function clear():Void {}
+	#end
 
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());

--- a/std/java/_std/haxe/ds/IntMap.hx
+++ b/std/java/_std/haxe/ds/IntMap.hx
@@ -377,6 +377,20 @@ import java.NativeArray;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		flags = null;
+		_keys = null;
+		vals = null;
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedKey = 0;
+		cachedIndex = -1;
+		#end
+	}
+
 	private static inline function assert(x:Bool):Void {
 		#if debug
 		if (!x)

--- a/std/java/_std/haxe/ds/ObjectMap.hx
+++ b/std/java/_std/haxe/ds/ObjectMap.hx
@@ -391,6 +391,26 @@ import java.NativeArray;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		hashes = null;
+		_keys = null;
+		vals = null;
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedKey = null;
+		cachedIndex = -1;
+		#end
+		#if DEBUG_HASHTBL
+		totalProbes = 0;
+		probeTimes = 0;
+		sameHash = 0;
+		maxProbe = 0;
+		#end
+	}
+
 	extern private static inline function roundUp(x:Int):Int {
 		--x;
 		x |= (x) >>> 1;

--- a/std/java/_std/haxe/ds/StringMap.hx
+++ b/std/java/_std/haxe/ds/StringMap.hx
@@ -390,6 +390,26 @@ import java.NativeArray;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		hashes = null;
+		_keys = null;
+		vals = null;
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedKey = null;
+		cachedIndex = -1;
+		#end
+		#if DEBUG_HASHTBL
+		totalProbes = 0;
+		probeTimes = 0;
+		sameHash = 0;
+		maxProbe = 0;
+		#end
+	}
+
 	extern private static inline function roundUp(x:Int):Int {
 		--x;
 		x |= (x) >>> 1;

--- a/std/java/_std/haxe/ds/WeakMap.hx
+++ b/std/java/_std/haxe/ds/WeakMap.hx
@@ -417,6 +417,26 @@ import java.lang.ref.ReferenceQueue;
 		return s.toString();
 	}
 
+	public function clear():Void {
+		hashes = null;
+		entries = null;
+		queue = new ReferenceQueue();
+		nBuckets = 0;
+		size = 0;
+		nOccupied = 0;
+		upperBound = 0;
+		#if !no_map_cache
+		cachedEntry = null;
+		cachedIndex = -1;
+		#end
+		#if DEBUG_HASHTBL
+		totalProbes = 0;
+		probeTimes = 0;
+		sameHash = 0;
+		maxProbe = 0;
+		#end
+	}
+
 	extern private static inline function roundUp(x:Int):Int {
 		--x;
 		x |= (x) >>> 1;

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -93,4 +93,8 @@ package haxe.ds;
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = {};
+	}
 }

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -123,4 +123,8 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = {__keys__: {}};
+	}
 }

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -159,6 +159,11 @@ private class StringMapIterator<T> {
 		return s.toString();
 	}
 
+	public inline function clear():Void {
+		h = {};
+		rh = null;
+	}
+
 	static function __init__():Void {
 		untyped __js__("var __map_reserved = {};");
 	}

--- a/std/lua/_std/haxe/ds/IntMap.hx
+++ b/std/lua/_std/haxe/ds/IntMap.hx
@@ -108,4 +108,8 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = lua.Table.create();
+	}
 }

--- a/std/lua/_std/haxe/ds/ObjectMap.hx
+++ b/std/lua/_std/haxe/ds/ObjectMap.hx
@@ -112,4 +112,9 @@ class ObjectMap<A, B> implements haxe.Constraints.IMap<A, B> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = lua.Table.create();
+		k = lua.Table.create();
+	}
 }

--- a/std/lua/_std/haxe/ds/StringMap.hx
+++ b/std/lua/_std/haxe/ds/StringMap.hx
@@ -112,4 +112,8 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = lua.Table.create();
+	}
 }

--- a/std/neko/_std/haxe/ds/IntMap.hx
+++ b/std/neko/_std/haxe/ds/IntMap.hx
@@ -86,4 +86,8 @@ package haxe.ds;
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = untyped __dollar__hnew(0);
+	}
 }

--- a/std/neko/_std/haxe/ds/ObjectMap.hx
+++ b/std/neko/_std/haxe/ds/ObjectMap.hx
@@ -106,4 +106,9 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = untyped __dollar__hnew(0);
+		k = untyped __dollar__hnew(0);
+	}
 }

--- a/std/neko/_std/haxe/ds/StringMap.hx
+++ b/std/neko/_std/haxe/ds/StringMap.hx
@@ -86,4 +86,8 @@ package haxe.ds;
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h = untyped __dollar__hnew(0);
+	}
 }

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -79,4 +79,8 @@ import php.NativeIndexedArray;
 
 		return '{' + Global.implode(', ', parts) + '}';
 	}
+
+	public inline function clear():Void {
+		data = new NativeIndexedArray();
+	}
 }

--- a/std/php/_std/haxe/ds/ObjectMap.hx
+++ b/std/php/_std/haxe/ds/ObjectMap.hx
@@ -87,4 +87,9 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		}
 		return s + "}";
 	}
+
+	public inline function clear():Void {
+		_keys = new NativeAssocArray();
+		_values = new NativeAssocArray();
+	}
 }

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -80,4 +80,8 @@ import haxe.Constraints;
 
 		return '{' + Global.implode(', ', parts) + '}';
 	}
+
+	public inline function clear():Void {
+		data = new NativeAssocArray();
+	}
 }

--- a/std/python/_std/haxe/ds/IntMap.hx
+++ b/std/python/_std/haxe/ds/IntMap.hx
@@ -84,4 +84,8 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h.clear();
+	}
 }

--- a/std/python/_std/haxe/ds/ObjectMap.hx
+++ b/std/python/_std/haxe/ds/ObjectMap.hx
@@ -83,4 +83,8 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h.clear();
+	}
 }

--- a/std/python/_std/haxe/ds/StringMap.hx
+++ b/std/python/_std/haxe/ds/StringMap.hx
@@ -85,4 +85,8 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		s.add("}");
 		return s.toString();
 	}
+
+	public inline function clear():Void {
+		h.clear();
+	}
 }

--- a/tests/unit/src/unitstd/haxe/ds/BalancedTree.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/BalancedTree.unit.hx
@@ -82,3 +82,23 @@ for(i in 0 ... keys1.length) test2.set(keys1[i], values1[i]);
 [for(k=>v in test2) k] == [1,2,3];
 [for(k=>v in test2) v] == [2,4,6];
 [for(k=>v in test2) k*v] == [2,8,18];
+
+// clear
+var test3 = new haxe.ds.BalancedTree<Int, Int>();
+test3.set(0, 1);
+test3.set(2, 3);
+test3.set(4, 6);
+
+[for(k=>v in test3) k] == [0,2,4];
+
+test3.clear();
+
+[for(k=>v in test3) k] == [];
+test3.exists(0) == false;
+test3.exists(2) == false;
+test3.exists(4) == false;
+
+test3.set(0, 1);
+test3.exists(0) == true;
+test3.exists(2) == false;
+test3.exists(4) == false;

--- a/tests/unit/src/unitstd/haxe/ds/EnumValueMap.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/EnumValueMap.unit.hx
@@ -96,3 +96,9 @@ evm.exists(EVMF([EVMA, EVMB()])) == true;
 evm.exists(EVMF([EVMA, EVMB(null)])) == true;
 evm.get(EVMF([EVMA, EVMB()])) == 12;
 evm.get(EVMF([EVMA, EVMB(null)])) == 12;
+
+evm.clear();
+evm.exists(EVMF([EVMA, EVMB()])) == false;
+evm.exists(EVMF([EVMA, EVMB(null)])) == false;
+
+[for (k=>v in evm) k] == [];

--- a/tests/unit/src/unitstd/haxe/ds/IntMap.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/IntMap.unit.hx
@@ -56,6 +56,16 @@ var values2b = [for (k=>v in map2) v];
 values2b.sort(Reflect.compare); 
 values2b == ["2","4","6"];
 
+// clear
+map2.clear();
+map2.get(1) == null;
+map2.exists(1) == false;
+map2.exists(2) == false;
+map2.exists(3) == false;
+
+var keys3 = [for (k in map2.keys()) k];
+keys3 == [];
+
 
 // Test unification
 

--- a/tests/unit/src/unitstd/haxe/ds/ObjectMap.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/ObjectMap.unit.hx
@@ -83,3 +83,12 @@ a.length == 2;
 a[0] in ["9", "7"];
 a[1] in ["9", "7"];
 o.remove(k2) == false;
+
+// clear
+o.clear();
+o.get(k1) == null;
+o.exists(k1) == false;
+o.exists(k2) == false;
+o.exists(k3) == false;
+var a = [for (k in o.keys()) k];
+a == [];

--- a/tests/unit/src/unitstd/haxe/ds/StringMap.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/StringMap.unit.hx
@@ -52,6 +52,15 @@ var values2b = [for (k=>v in map2) v];
 values2b.sort(Reflect.compare); 
 values2b == ["2","4","6"];
 
+// clear
+map2.clear();
+map2.get("1a") == null;
+map2.exists("1a") == false;
+map2.exists("2a") == false;
+map2.exists("3a") == false;
+
+var keys3 = [for (k in map2.keys()) k];
+keys3 == [];
 
 // Test unification
 

--- a/tests/unit/src/unitstd/haxe/ds/WeakMap.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/WeakMap.unit.hx
@@ -84,6 +84,17 @@ a.length == 2;
 a[0] in ["9", "7"];
 a[1] in ["9", "7"];
 o.remove(k2) == false;
+
+// clear
+o.clear();
+o.get(k1) == null;
+o.exists(k1) == true;
+o.exists(k2) == false;
+o.exists(k3) == true;
+
+var a = [for (k in o.keys()) k];
+a == [];
+
 #else
 1 == 1;
 #end

--- a/tests/unit/src/unitstd/haxe/ds/WeakMap.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/WeakMap.unit.hx
@@ -88,9 +88,9 @@ o.remove(k2) == false;
 // clear
 o.clear();
 o.get(k1) == null;
-o.exists(k1) == true;
+o.exists(k1) == false;
 o.exists(k2) == false;
-o.exists(k3) == true;
+o.exists(k3) == false;
 
 var a = [for (k in o.keys()) k];
 a == [];


### PR DESCRIPTION
Closes #2550.

Synchronise with https://github.com/HaxeFoundation/hashlink/pull/288 and https://github.com/HaxeFoundation/hxcpp/pull/844.

 - [x] target-agnostic implementations
 - [x] js (reassigns to `{}`)
 - [x] python (`dict.clear`)
 - [x] php (reassigns to `[]`)
 - [x] flash (reassigns to `{}`; `ObjectMap` and `WeakMap` iterate and `delete`)
 - [x] lua (reassigns to new table)
 - [x] neko (reassigns to `$hnew`)
 - [x] java (resets all fields to how they were after initialisation)
 - [x] cs (resets all fields to how they were after initialisation)
 - [x] hl (`memset`s `t_map` to zeroes, like the initialiser)
 - [x] cpp (resizes to 0 buckets)
 - [x] eval (reassigns to `empty` or `reset`s)
 - [x] tests
