### PR TITLE
Don't allow to define reserved flags via Compiler.define

### DIFF
--- a/extra/ImportAll.hx
+++ b/extra/ImportAll.hx
@@ -34,9 +34,6 @@ class ImportAll {
 			pack = "";
 			haxe.macro.Compiler.define("doc_gen");
 		}
-		if (Context.defined("interp")) {
-			haxe.macro.Compiler.define("macro");
-		}
 		switch( pack ) {
 		case "php":
 			if( !Context.defined("php") ) return;

--- a/src/compiler/main.ml
+++ b/src/compiler/main.ml
@@ -80,13 +80,6 @@ let error ctx msg p =
 	message ctx (CMError(msg,p));
 	ctx.has_error <- true
 
-let reserved_flags = [
-	"true";"false";"null";"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
-	"as3";"swc";"macro";"sys";"static";"utf16";"haxe";"haxe_ver"
-	]
-
-let reserved_flag_namespaces = ["target"]
-
 let delete_file f = try Sys.remove f with _ -> ()
 
 let expand_env ?(h=None) path  =
@@ -772,14 +765,7 @@ try
 			Common.raw_define com l;
 		),"<name[:ver]>","use a haxelib library");
 		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
-			let raise_reserved description =
-				raise (Arg.Bad (description ^ " and cannot be defined from the command line"))
-			in
-			if List.mem var reserved_flags then raise_reserved (Printf.sprintf "`%s` is a reserved compiler flag" var);
-			List.iter (fun ns ->
-				if ExtString.String.starts_with var (ns ^ ".") then raise_reserved (Printf.sprintf "`%s` uses the reserved compiler flag namespace `%s.*`" var ns)
-			) reserved_flag_namespaces;
-			Common.raw_define com var;
+			Common.user_raw_define com var;
 		),"<var[=value]>","define a conditional compilation flag");
 		("Debug",["-v";"--verbose"],[],Arg.Unit (fun () ->
 			com.verbose <- true

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -262,6 +262,25 @@ let define_value com k v =
 let raw_defined_value com k =
 	Define.raw_defined_value com.defines k
 
+let reserved_flags = [
+	"true";"false";"null";"cross";"js";"lua";"neko";"flash";"php";"cpp";"cs";"java";"python";
+	"as3";"swc";"macro";"sys";"static";"utf16";"haxe";"haxe_ver"
+	]
+
+let reserved_flag_namespaces = ["target"]
+
+let user_raw_define com k =
+	let flag,_ = try ExtString.String.split k "=" with _ -> k,"1" in
+	let raise_reserved description =
+		raise (Arg.Bad (description ^ " and cannot be defined manually"))
+	in
+	if List.mem flag reserved_flags then raise_reserved (Printf.sprintf "`%s` is a reserved compiler flag" flag);
+	List.iter (fun ns ->
+		if ExtString.String.starts_with flag (ns ^ ".") then
+			raise_reserved (Printf.sprintf "`%s` uses the reserved compiler flag namespace `%s.*`" flag ns)
+	) reserved_flag_namespaces;
+	raw_define com k
+
 let get_es_version com =
 	try int_of_string (defined_value com Define.JsEs) with _ -> 0
 

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1563,7 +1563,7 @@ let macro_api ccom get_api =
 		);
 		"define", vfun2 (fun s v ->
 			let v = if v = vnull then "" else "=" ^ (decode_string v) in
-			Common.raw_define (ccom()) ((decode_string s) ^ v);
+			Common.user_raw_define (ccom()) ((decode_string s) ^ v);
 			vnull
 		);
 		"defined", vfun1 (fun s ->

--- a/std/haxe/macro/CompilationServer.hx
+++ b/std/haxe/macro/CompilationServer.hx
@@ -76,7 +76,7 @@ enum abstract ContextOptions(Int) {
 	`--macro server.field(args)`.
 **/
 class CompilationServer {
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	/**
 		Sets the `ModuleCheckPolicy` of all files whose dot-path matches an
 		element of `pathFilters`.

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -52,7 +52,7 @@ class Compiler {
 		return macro $v{haxe.macro.Context.definedValue(key)};
 	}
 
-	#if (neko || (macro && hl) || (macro && eval))
+	#if (neko || (macro && hl) || (macro && eval) || doc_gen)
 	static var ident = ~/^[A-Za-z_][A-Za-z0-9_]*$/;
 	static var path = ~/^[A-Za-z_][A-Za-z0-9_.]*$/;
 
@@ -464,7 +464,7 @@ class Compiler {
 
 	#end
 
-	#if (js || lua || macro)
+	#if (js || lua || macro || doc_gen)
 	/**
 		Embed a JavaScript or Lua file at compile time (can be called by `--macro` or within an `__init__` method).
 	**/

--- a/std/haxe/macro/ComplexTypeTools.hx
+++ b/std/haxe/macro/ComplexTypeTools.hx
@@ -39,7 +39,7 @@ class ComplexTypeTools {
 	static public function toString(c:ComplexType):String
 		return new Printer().printComplexType(c);
 
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	/**
 		Returns a type corresponding to `c`.
 

--- a/std/haxe/macro/ExampleJSGenerator.hx
+++ b/std/haxe/macro/ExampleJSGenerator.hx
@@ -250,7 +250,7 @@ class ExampleJSGenerator {
 		sys.io.File.saveContent(api.outputFile, buf.toString());
 	}
 
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	public static function use() {
 		Compiler.setCustomJSGenerator(function(api) new ExampleJSGenerator(api).generate());
 	}

--- a/std/haxe/macro/Format.hx
+++ b/std/haxe/macro/Format.hx
@@ -29,7 +29,7 @@ import haxe.macro.Context;
 	The actual macro implemented for Std.format
 **/
 class Format {
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	public static function format(estr:Expr) {
 		var str = switch (estr.expr) {
 			case EConst(c): switch (c) {

--- a/std/haxe/macro/MacroStringTools.hx
+++ b/std/haxe/macro/MacroStringTools.hx
@@ -32,7 +32,7 @@ import haxe.macro.Expr;
 @:hlNative("macro")
 #end
 class MacroStringTools {
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	/**
 		Formats `String` `s` using the usual interpolation rules.
 

--- a/std/haxe/macro/PositionTools.hx
+++ b/std/haxe/macro/PositionTools.hx
@@ -60,7 +60,7 @@ class PositionTools {
 		#end
 	}
 
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	/**
 		Converts a `haxe.macro.Position` to a `haxe.display.Position.Location`.
 

--- a/std/haxe/macro/TypeTools.hx
+++ b/std/haxe/macro/TypeTools.hx
@@ -162,7 +162,7 @@ class TypeTools {
 			}
 		}
 
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	/**
 		Follows all typedefs of `t` to reach the actual type.
 

--- a/std/haxe/macro/TypedExprTools.hx
+++ b/std/haxe/macro/TypedExprTools.hx
@@ -167,7 +167,7 @@ class TypedExprTools {
 		}
 	}
 
-	#if (macro || display)
+	#if (macro || display || doc_gen)
 	static public function toString(t:TypedExpr, ?pretty = false):String {
 		return @:privateAccess haxe.macro.Context.sExpr(t, pretty);
 	}

--- a/tests/misc/projects/Issue8689/compile-fail.hxml
+++ b/tests/misc/projects/Issue8689/compile-fail.hxml
@@ -1,0 +1,1 @@
+-D js=value

--- a/tests/misc/projects/Issue8689/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8689/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Error: : `js` is a reserved compiler flag and cannot be defined manually.

--- a/tests/misc/projects/Issue8689/compile2-fail.hxml
+++ b/tests/misc/projects/Issue8689/compile2-fail.hxml
@@ -1,0 +1,1 @@
+--macro define("js", "value")

--- a/tests/misc/projects/Issue8689/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8689/compile2-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Error: `js` is a reserved compiler flag and cannot be defined manually


### PR DESCRIPTION
Fixes #8689 
Shouldn't be merged yet because it will break `hxnodejs`, which defines its flags via `Compiler.define()`:
https://github.com/HaxeFoundation/hxnodejs/blob/2587ccbffa3cc032d7ecca28d299e7357993f536/extraParams.hxml#L1-L3