### PR TITLE
Make lowercase / uppercase errors more consistent

### DIFF
--- a/src/core/path.ml
+++ b/src/core/path.ml
@@ -29,7 +29,7 @@ let check_package_name x =
 	if String.length x = 0 then
 		failwith "Package name must not be empty"
 	else if (x.[0] < 'a' || x.[0] > 'z') && x.[0] <> '_' then
-		failwith "Package name must start with a lower case character";
+		failwith "Package name must start with a lowercase letter";
 	check_invalid_char x
 
 let parse_path f =

--- a/src/core/stringHelper.ml
+++ b/src/core/stringHelper.ml
@@ -25,7 +25,7 @@ let check_uppercase x =
 	if String.length x = 0 then
 		failwith "empty part"
 	else if not (starts_uppercase_identifier x) then
-		failwith "Class name must start with uppercase letter"
+		failwith "Class name must start with an uppercase letter"
 
 let s_escape ?(hex=true) s =
 	let b = Buffer.create (String.length s) in

--- a/src/core/stringHelper.ml
+++ b/src/core/stringHelper.ml
@@ -25,7 +25,7 @@ let check_uppercase x =
 	if String.length x = 0 then
 		failwith "empty part"
 	else if not (starts_uppercase_identifier x) then
-		failwith "Class name must start with uppercase character"
+		failwith "Class name must start with uppercase letter"
 
 let s_escape ?(hex=true) s =
 	let b = Buffer.create (String.length s) in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -669,7 +669,7 @@ let field_to_type_path ctx e =
 					if Char.uppercase fchar = fchar then
 						pack, f, None
 					else begin
-						display_error ctx "A class name must start with an uppercase character" (snd e);
+						display_error ctx "A class name must start with an uppercase letter" (snd e);
 						raise Exit
 					end
 				| [name] ->

--- a/tests/misc/projects/Issue8019/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8019/compile-fail.hxml.stderr
@@ -1,18 +1,18 @@
 Macro.hx:8: characters 17-18 : "" is not a valid package name:
 Macro.hx:8: characters 17-18 : Package name must not be empty
 Macro.hx:8: characters 17-18 : "\n" is not a valid package name:
-Macro.hx:8: characters 17-18 : Package name must start with a lower case character
+Macro.hx:8: characters 17-18 : Package name must start with a lowercase letter
 Macro.hx:8: characters 17-18 : "pack\n" is not a valid package name:
 Macro.hx:8: characters 17-18 : Invalid character: \n
 Macro.hx:8: characters 17-18 : "pack~" is not a valid package name:
 Macro.hx:8: characters 17-18 : Invalid character: ~
 Macro.hx:8: characters 17-18 : "Foo" is not a valid package name:
-Macro.hx:8: characters 17-18 : Package name must start with a lower case character
+Macro.hx:8: characters 17-18 : Package name must start with a lowercase letter
 Macro.hx:8: characters 17-18 : "0_class" is not a valid package name:
-Macro.hx:8: characters 17-18 : Package name must start with a lower case character
+Macro.hx:8: characters 17-18 : Package name must start with a lowercase letter
 Macro.hx:8: characters 17-18 : "0_enum" is not a valid package name:
-Macro.hx:8: characters 17-18 : Package name must start with a lower case character
+Macro.hx:8: characters 17-18 : Package name must start with a lowercase letter
 Macro.hx:8: characters 17-18 : "0_structure" is not a valid package name:
-Macro.hx:8: characters 17-18 : Package name must start with a lower case character
+Macro.hx:8: characters 17-18 : Package name must start with a lowercase letter
 Macro.hx:8: characters 17-18 : "0_abstract" is not a valid package name:
-Macro.hx:8: characters 17-18 : Package name must start with a lower case character
+Macro.hx:8: characters 17-18 : Package name must start with a lowercase letter


### PR DESCRIPTION
During my previous two PRs I noticed that there was quite a bit of inconsistency in the phrasing here: lower case vs uppercase, character vs letter...

Technically it might be more correct to add an "or underscore" at the end of all these errors too? But I'm not sure if that should necessarily be "encouraged".