### PR TITLE
Do not check field name on extern classes

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1322,7 +1322,7 @@ let init_field (ctx,cctx,fctx) f =
 	let name = fst f.cff_name in
 	TypeloadCheck.check_global_metadata ctx f.cff_meta (fun m -> f.cff_meta <- m :: f.cff_meta) c.cl_module.m_path c.cl_path (Some name);
 	let p = f.cff_pos in
-	Typecore.check_field_name ctx name p;
+	if not c.cl_extern then Typecore.check_field_name ctx name p;
 	List.iter (fun acc ->
 		match (fst acc, f.cff_kind) with
 		| APublic, _ | APrivate, _ | AStatic, _ | AFinal, _ | AExtern, _ -> ()


### PR DESCRIPTION
In #8721 @Gama11 added a fix for extern types but it was actually missing the fix for fields of extern classes too.

I don't have a minimal test (using netlibs like my original issue in a real world project) to submit though