### PR TITLE
Track working memory and adapt overhead

### DIFF
--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -644,7 +644,7 @@ let wait_loop process_params verbose accept =
 		let words_allocated = (fst heap_stats_now) -. (fst !heap_stats_start) in
 		let heap_size = float_of_int (snd heap_stats_now) in
 		Ring.push ring words_allocated;
-		print_endline (Printf.sprintf "words_allocated: %s" (fmt_word words_allocated));
+		(* print_endline (Printf.sprintf "words_allocated: %s" (fmt_word words_allocated)); *)
 		if Ring.is_filled ring then begin
 			Ring.reset_filled ring;
 			let stats = Gc.stat() in
@@ -657,7 +657,7 @@ let wait_loop process_params verbose accept =
 			let percent_needed = (1. -. live_words /. needed_max) in
 			(* Effective cache size percentage = what's live / heap size. *)
 			let percent_used = live_words /. heap_size in
-			print_endline (Printf.sprintf "live: %s, max: %s, needed_max: %s, needed: %i%%, used: %i%%" (fmt_word live_words) (fmt_word max) (fmt_word needed_max) (fmt_percent percent_needed) (fmt_percent percent_used));
+			(* print_endline (Printf.sprintf "live: %s, max: %s, needed_max: %s, needed: %i%%, used: %i%%" (fmt_word live_words) (fmt_word max) (fmt_word needed_max) (fmt_percent percent_needed) (fmt_percent percent_used)); *)
 			(* Set allowed space_overhead to the maximum of what we needed during the last X compilations. *)
 			Gc.set { (Gc.get()) with Gc.space_overhead = int_of_float ((percent_needed +. 0.05) *. 100.); };
 			(* Compact if less than 80% of our heap words consist of the cache and there's less than 50% overhead. *)

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -659,10 +659,12 @@ let wait_loop process_params verbose accept =
 			let percent_used = live_words /. heap_size in
 			(* print_endline (Printf.sprintf "live: %s, max: %s, needed_max: %s, needed: %i%%, used: %i%%" (fmt_word live_words) (fmt_word max) (fmt_word needed_max) (fmt_percent percent_needed) (fmt_percent percent_used)); *)
 			(* Set allowed space_overhead to the maximum of what we needed during the last X compilations. *)
+			let new_space_overhead = int_of_float ((percent_needed +. 0.05) *. 100.) in
 			let old_gc = Gc.get() in
-			Gc.set { old_gc with Gc.space_overhead = int_of_float ((percent_needed +. 0.05) *. 100.); };
+			Gc.set { old_gc with Gc.space_overhead = new_space_overhead; };
 			(* Compact if less than 80% of our heap words consist of the cache and there's less than 50% overhead. *)
-			begin if percent_used < 80. && percent_needed < 50. then
+			let do_compact = percent_used < 0.8 && percent_needed < 0.5 in
+			begin if do_compact then
 				Gc.compact()
 			else
 				Gc.full_major();

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -635,7 +635,6 @@ let wait_loop process_params verbose accept =
 	TypeloadModule.type_module_hook := type_module sctx;
 	MacroContext.macro_enable_cache := true;
 	TypeloadParse.parse_hook := parse_file cs;
-	let run_count = ref 0 in
 	let ring = Ring.create 10 0. in
 	let heap_stats_start = ref (gc_heap_stats()) in
 	let update_heap () =
@@ -723,14 +722,6 @@ let wait_loop process_params verbose accept =
 		current_stdin := None;
 		cleanup();
 		update_heap();
-		(* prevent too much fragmentation by doing some compactions every X run *)
-		if sctx.was_compilation then incr run_count;
-		if !run_count mod 10 = 0 then begin
-			run_count := 1;
-			let t0 = get_time() in
-			Gc.compact();
-			ServerMessage.gc_stats (get_time() -. t0);
-		end else Gc.minor();
 	done
 
 (* The accept-function to wait for a stdio connection. *)

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -659,12 +659,15 @@ let wait_loop process_params verbose accept =
 			let percent_used = live_words /. heap_size in
 			(* print_endline (Printf.sprintf "live: %s, max: %s, needed_max: %s, needed: %i%%, used: %i%%" (fmt_word live_words) (fmt_word max) (fmt_word needed_max) (fmt_percent percent_needed) (fmt_percent percent_used)); *)
 			(* Set allowed space_overhead to the maximum of what we needed during the last X compilations. *)
-			Gc.set { (Gc.get()) with Gc.space_overhead = int_of_float ((percent_needed +. 0.05) *. 100.); };
+			let old_gc = Gc.get() in
+			Gc.set { old_gc with Gc.space_overhead = int_of_float ((percent_needed +. 0.05) *. 100.); };
 			(* Compact if less than 80% of our heap words consist of the cache and there's less than 50% overhead. *)
-			if percent_used < 80. && percent_needed < 50. then
+			begin if percent_used < 80. && percent_needed < 50. then
 				Gc.compact()
 			else
 				Gc.full_major();
+			end;
+			Gc.set old_gc;
 		end;
 		heap_stats_start := heap_stats_now;
 	in

--- a/src/compiler/serverMessage.ml
+++ b/src/compiler/serverMessage.ml
@@ -124,11 +124,16 @@ let stats stats time =
 let message s =
 	if config.print_message then print_endline ("> " ^ s)
 
-let gc_stats time =
+let gc_stats time stats_before did_compact space_overhead =
 	if config.print_stats then begin
-		let stat = Gc.quick_stat() in
-		let size = (float_of_int stat.Gc.heap_words) *. (float_of_int (Sys.word_size / 8)) in
-		print_endline (Printf.sprintf "Compacted memory %.3fs %.1fMB" time (size /. (1024. *. 1024.)));
+		let stats = Gc.quick_stat() in
+		print_endline (Printf.sprintf "GC %s done in %.2fs with space_overhead = %i\n\tbefore: %s\n\tafter: %s"
+			(if did_compact then "compaction" else "collection")
+			time
+			space_overhead
+			(Memory.fmt_word (float_of_int stats_before.Gc.heap_words))
+			(Memory.fmt_word (float_of_int stats.heap_words))
+		)
 	end
 
 let socket_message s =

--- a/src/context/memory.ml
+++ b/src/context/memory.ml
@@ -87,6 +87,9 @@ let fmt_size sz =
 	else
 		Printf.sprintf "%.1f MB" ((float_of_int sz) /. (1024.*.1024.))
 
+let fmt_word f =
+	fmt_size (int_of_float f * (Sys.word_size / 8))
+
 let size v =
 	fmt_size (mem_size v)
 


### PR DESCRIPTION
Here's my suggestion for how to improve memory handling when the server is running. I'm not a GC expert so please assume that I'm doing everything wrong here when reviewing this.

The idea is to track the working memory needed for each request. This is the difference between the `major_words` at the start of the request and when the request has completed. This value is available from `Gc.quick_stat()`, so it's fair to query it for each request.

We keep track of the last X (currently 10) working memory values in a ring structure. Once that ring is full (10 pushes made), we call a `Gc.stat()` because we want to do some calculations based on the number of live words. I have documented that part in the code, so there's little point in repeating everything here.

The main part is this line: `Gc.set { (Gc.get()) with Gc.space_overhead = int_of_float ((percent_needed +. 0.05) *. 100.); }`. It sets the acceptable space overhead to the maximum we had + 5%. What we want to avoid is shrinking the heap to the point where the next compilation immediately has to grow it again.

## Example

This is how process memory behaves for our unit tests (JVM target):

* After vshaxe initialization (cache building + class path reading): 781 MB
* Doing some hover requests has no impact.
* Once we reach 10 requests: `live: 541.9 MB, max: 709.0 MB, needed_max: 1250.9 MB, needed: 56%, used: 73%`. This sets the `space_overhead` to 61% (56 + 5) and triggers a GC collection (not a compaction). Memory is at 589 MB.
* Doing some hover requests again has no impact.
* Once we reach another 10 requests: `live: 308.8 MB, max: 695 KB, needed_max: 309.4 MB, needed: 0%, used: 55%`. Sets `space_overhead` to 5% and triggers a GC compaction. Memory is at 346 MB.
* Making further completion requests leaves memory at around 346 MB (some variance due to working memory changes). Triggering a proper compilation brings memory back to 589 MB.
* Filling up the ring again we get `live: 485.4 MB, max: 176.2 MB, needed_max: 661.6 MB, needed: 26%, used: 87%`. This triggers another collection, but not a compaction because our `used` value is good. Memory is at 450 MB.
* It stays somewhere in the 346 to 589 MB range, depending on whether or not we make proper compilation requests. 

----

Note that all the GC action happens after a request has been fulfilled. The worst case should be that we trigger a GC compaction on a request while another request is waiting, which could lead to a small delay. We could actually avoid the GC operations in that case, but that requires dealing with https://github.com/vshaxe/vshaxe/issues/217 as I don't think we can check for "are there further requests?" on stdin without blocking.

I'm setting this to 4.0 because I consider it important to do something about our memory behavior.