### PR TITLE
Timers. Remake.

### DIFF
--- a/src/codegen/gencommon/gencommon.ml
+++ b/src/codegen/gencommon/gencommon.ml
@@ -136,7 +136,7 @@ let debug_expr = s_expr debug_type
 
 let debug_mode = ref false
 let trace s = if !debug_mode then print_endline s else ()
-let timer name = if !debug_mode then Timer.timer name else fun () -> ()
+let timer name = if !debug_mode then Timer.timer_fn name else fun () -> ()
 
 let is_string t =
 	match follow t with
@@ -302,7 +302,7 @@ class ['tp, 'ret] rule_dispatcher name =
 				if key < priority then begin
 					let q = Hashtbl.find tbl key in
 					Stack.iter (fun (n, rule) ->
-						let t = if !debug_mode then Timer.timer [("rule dispatcher rule: " ^ n)] else fun () -> () in
+						let t = timer [("rule dispatcher rule: " ^ n)] in
 						let r = rule(tp) in
 						t();
 						if is_some r then begin ret := r; raise Exit end
@@ -362,7 +362,7 @@ class ['tp] rule_map_dispatcher name = object(self)
 				let q = Hashtbl.find tbl key in
 				Stack.iter (fun (n, rule) ->
 					trace ("running rule " ^ n);
-					let t = if !debug_mode then Timer.timer [("rule map dispatcher rule: " ^ n)] else fun () -> () in
+					let t = timer [("rule map dispatcher rule: " ^ n)] in
 					cur := rule !cur;
 					t();
 				) q
@@ -809,7 +809,7 @@ let run_filters gen =
 	List.iter (fun fn -> fn()) gen.gafter_filters_ended;
 
 	reorder_modules gen;
-	t();
+	Timer.close t;
 	if !has_errors then raise (Abort("Compilation aborted with errors",null_pos))
 
 (* ******************************************* *)

--- a/src/codegen/genxml.ml
+++ b/src/codegen/genxml.ml
@@ -286,13 +286,13 @@ let rec write_xml ch tabs x =
 let generate com file =
 	let t = Timer.timer ["generate";"xml"] in
 	let x = node "haxe" [] (List.map (gen_type_decl com true) (List.filter (fun t -> not (Meta.has Meta.NoDoc (t_infos t).mt_meta)) com.types)) in
-	t();
+	Timer.close t;
 	let t = Timer.timer ["write";"xml"] in
 	let ch = IO.output_channel (open_out_bin file) in
 	IO.printf ch "<!-- This file can be parsed by haxe.rtti.XmlParser -->\n";
 	write_xml ch "" x;
 	IO.close_out ch;
-	t()
+	Timer.close t
 
 let gen_type_string ctx t =
 	let x = gen_type_decl ctx false t in

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -466,7 +466,7 @@ let extract_data (_,tags) =
 			List.iter (fun i -> Array.iter loop_field i.hls_fields) (As3hlparse.parse as3)
 		| _ -> ()
 	) tags;
-	t();
+	Timer.close t;
 	h
 
 let remove_debug_infos as3 =
@@ -569,7 +569,7 @@ let parse_swf com file =
 			t.tdata <- TActionScript3 (id,remove_debug_infos as3)
 		| _ -> ()
 	) tags;
-	t();
+	Timer.close t;
 	(h,tags)
 
 class swf_library com name file_path = object(self)

--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -29,12 +29,12 @@ let htmlescape s =
 
 let get_timer_fields start_time =
 	let tot = ref 0. in
-	Hashtbl.iter (fun _ t -> tot := !tot +. t.total) Timer.htimers;
+	Timer.iter_times (fun id total -> tot := !tot +. total);
 	let fields = [("@TOTAL", Printf.sprintf "%.3fs" (get_time() -. start_time))] in
 	if !tot > 0. then
-		Hashtbl.fold (fun _ t acc ->
-			((String.concat "." t.id),(Printf.sprintf "%.3fs (%.0f%%)" t.total (t.total *. 100. /. !tot))) :: acc
-		) Timer.htimers fields
+		Timer.fold_times (fun id total acc ->
+			((String.concat "." id),(Printf.sprintf "%.3fs (%.0f%%)" total (total *. 100. /. !tot))) :: acc
+		) fields
 	else
 		fields
 

--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -69,7 +69,7 @@ let explore_class_paths com timer class_paths recusive f_pack f_module =
 	in
 	let t = Timer.timer (timer @ ["class path exploration"]) in
 	List.iter (fun dir -> loop dir []) class_paths;
-	t()
+	Timer.close t
 
 let read_class_paths com timer =
 	explore_class_paths com timer (List.filter ((<>) "") com.class_path) true (fun _ -> ()) (fun file path ->
@@ -436,7 +436,7 @@ let collect ctx tk with_type =
 	(* sorting *)
 	let l = DynArray.to_list cctx.items in
 	let l = Display.sort_fields l with_type tk in
-	t();
+	Timer.close t;
 	l
 
 let collect_and_raise ctx tk with_type cr (name,pname) pinsert =

--- a/src/context/display/findReferences.ml
+++ b/src/context/display/findReferences.ml
@@ -166,14 +166,14 @@ let find_possible_references tctx cs =
 				()
 			end
 	) files;
-	t();
+	Timer.close t;
 	()
 
 let find_references tctx com with_definition =
 	let name,pos,kind = Display.ReferencePosition.get () in
 	let t = Timer.timer ["display";"references";"collect"] in
 	let symbols,relations = Statistics.collect_statistics tctx (SFPos pos) in
-	t();
+	Timer.close t;
 	let rec loop acc relations = match relations with
 		| (Statistics.Referenced,p) :: relations -> loop (p :: acc) relations
 		| _ :: relations -> loop acc relations
@@ -189,6 +189,6 @@ let find_references tctx com with_definition =
 		let c = compare p1.pfile p2.pfile in
 		if c <> 0 then c else compare p1.pmin p2.pmin
 	) usages in
-	t();
+	Timer.close t;
 	Display.ReferencePosition.set ("",null_pos,KVar);
 	DisplayException.raise_positions usages

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -702,9 +702,9 @@ let generate types file =
 	let t = Timer.timer ["generate";"json";"construct"] in
 	let ctx = create_context GMFull in
 	let json = jarray (List.map (generate_module_type ctx) types) in
-	t();
+	Timer.close t;
 	let t = Timer.timer ["generate";"json";"write"] in
 	let ch = open_out_bin file in
 	Json.write_json (output_string ch) json;
 	close_out ch;
-	t()
+	Timer.close t

--- a/src/core/timer.ml
+++ b/src/core/timer.ml
@@ -17,58 +17,7 @@
 	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *)
 
-type timer_infos = {
-	id : string list;
-	mutable start : float list;
-	mutable total : float;
-	mutable calls : int;
-}
-
 let get_time = Extc.time
-let htimers = Hashtbl.create 0
-
-let new_timer id =
-	let key = String.concat "." id in
-	try
-		let t = Hashtbl.find htimers key in
-		t.start <- get_time() :: t.start;
-		t.calls <- t.calls + 1;
-		t
-	with Not_found ->
-		let t = { id = id; start = [get_time()]; total = 0.; calls = 1; } in
-		Hashtbl.add htimers key t;
-		t
-
-let curtime = ref []
-
-let close t =
-	let start = (match t.start with
-		| [] -> assert false
-		| s :: l -> t.start <- l; s
-	) in
-	let now = get_time() in
-	let dt = now -. start in
-	t.total <- t.total +. dt;
-	let rec loop() =
-		match !curtime with
-		| [] -> failwith ("Timer " ^ (String.concat "." t.id) ^ " closed while not active")
-		| tt :: l -> curtime := l; if t != tt then loop()
-	in
-	loop();
-	(* because of rounding errors while adding small times, we need to make sure that we don't have start > now *)
-	List.iter (fun ct -> ct.start <- List.map (fun t -> let s = t +. dt in if s > now then now else s) ct.start) !curtime
-
-let timer id =
-	let t = new_timer id in
-	curtime := t :: !curtime;
-	(function() -> close t)
-
-let rec close_times() =
-	match !curtime with
-	| [] -> ()
-	| t :: _ -> close t; close_times()
-
-(* Printing *)
 
 type timer_node = {
 	name : string;
@@ -80,76 +29,194 @@ type timer_node = {
 	mutable children : timer_node list;
 }
 
-let build_times_tree () =
-	let nodes = Hashtbl.create 0 in
-	let rec root = {
-		name = "";
-		path = "";
-		parent = root;
-		info = "";
-		time = 0.;
-		num_calls = 0;
-		children = [];
-	} in
-	Hashtbl.iter (fun _ timer ->
-		let rec loop parent sl = match sl with
-			| [] -> assert false
-			| s :: sl ->
-				let path = (match parent.path with "" -> "" | _ -> parent.path ^ ".") ^ s in
-				let node = try
-					let node = Hashtbl.find nodes path in
-					node.num_calls <- node.num_calls + timer.calls;
-					node.time <- node.time +. timer.total;
-					node
-				with Not_found ->
-					let name,info = try
-						let i = String.rindex s '.' in
-						String.sub s (i + 1) (String.length s - i - 1),String.sub s 0 i
-					with Not_found ->
-						s,""
-					in
-					let node = {
-						name = name;
-						path = path;
-						parent = parent;
-						info = info;
-						time = timer.total;
-						num_calls = timer.calls;
-						children = [];
-					} in
-					Hashtbl.add nodes path node;
-					node
-				in
-				begin match sl with
-					| [] -> ()
-					| _ ->
-						let child = loop node sl in
-						if not (List.memq child node.children) then
-							node.children <- child :: node.children;
-				end;
-				node
+module ActiveTimers : sig
+	type t
+	val timer : string list -> t
+	val close : float -> t -> unit
+	val close_times : unit -> unit
+	val clear_times : unit -> unit
+	(* Iterate closed timers only. Arguments: timer id and total duration *)
+	val iter_times : (string list -> float -> unit) -> unit
+	(* Iterate closed timers only. Arguments: timer id and total duration *)
+	val fold_times : (string list -> float -> 'a -> 'a) -> 'a -> 'a
+	val build_times_tree : unit -> (int * int * timer_node)
+end = struct
+	type t = {
+		id : string list;
+		mutable start : float;
+		mutable duration : float;
+		mutable previous : t;
+	}
+
+	type result = {
+		r_id : string list;
+		mutable r_total : float;
+		mutable r_count : int;
+	}
+
+	let rec nil = {
+		id = [];
+		start = get_time();
+		duration = 0.;
+		previous = nil;
+	}
+
+	let current = ref nil
+	let closed = ref nil
+	(* Calculated summary of closed timers *)
+	let results = Hashtbl.create 0
+
+	let stamp time tmr =
+		tmr.duration <- tmr.duration +. (time -. tmr.start);
+		tmr.start <- time
+
+	let timer id =
+		let now = get_time() in
+		let tmr = {
+			id = id;
+			start = now;
+			duration = 0.;
+			previous = !current;
+		} in
+		stamp now !current;
+		current := tmr;
+		tmr
+
+	let close time tmr =
+		stamp time tmr;
+		current := tmr.previous;
+		!current.start <- time;
+		tmr.previous <- !closed;
+		closed := tmr
+
+	let close_times() =
+		let now = get_time() in
+		let rec close_next() =
+			if !current == nil then ()
+			else begin
+				close now !current;
+				close_next()
+			end
 		in
-		let node = loop root timer.id in
-		if not (List.memq node root.children) then
-			root.children <- node :: root.children
-	) htimers;
-	let max_name = ref 0 in
-	let max_calls = ref 0 in
-	let rec loop depth node =
-		let l = (String.length node.name) + 2 * depth in
-		List.iter (fun child ->
-			if depth = 0 then begin
-				node.num_calls <- node.num_calls + child.num_calls;
-				node.time <- node.time +. child.time;
-			end;
-			loop (depth + 1) child;
-		) node.children;
-		node.children <- List.sort (fun node1 node2 -> compare node2.time node1.time) node.children;
-		if node.num_calls > !max_calls then max_calls := node.num_calls;
-		if node.time > 0.0009 && l > !max_name then max_name := l;
-	in
-	loop 0 root;
-	!max_name,!max_calls,root
+		close_next()
+
+	let clear_times() =
+		Hashtbl.clear results;
+		current := nil;
+		closed := nil
+
+	let consume_closed_timers() =
+		let rec loop tmr =
+			if tmr == nil then ()
+			else begin
+				let result =
+					try
+						Hashtbl.find results tmr.id
+					with Not_found ->
+						let result = { r_id = tmr.id; r_total = 0.; r_count = 0; } in
+						Hashtbl.add results tmr.id result;
+						result
+				in
+				result.r_total <- result.r_total +. tmr.duration;
+				result.r_count <- result.r_count + 1;
+				loop tmr.previous
+			end
+		in
+		loop !closed;
+		closed := nil
+
+	let iter_times callback =
+		consume_closed_timers();
+		Hashtbl.iter (fun _ result -> callback result.r_id result.r_total) results
+
+	let fold_times callback initial =
+		consume_closed_timers();
+		Hashtbl.fold (fun _ result acc -> callback result.r_id result.r_total acc) results initial
+
+	let build_times_tree () =
+		consume_closed_timers();
+		let nodes = Hashtbl.create 0 in
+		let rec root = {
+			name = "";
+			path = "";
+			parent = root;
+			info = "";
+			time = 0.;
+			num_calls = 0;
+			children = [];
+		} in
+		Hashtbl.iter (fun _ result ->
+			let rec loop parent sl = match sl with
+				| [] -> assert false
+				| s :: sl ->
+					let path = (match parent.path with "" -> "" | _ -> parent.path ^ ".") ^ s in
+					let node = try
+						let node = Hashtbl.find nodes path in
+						node.num_calls <- node.num_calls + result.r_count;
+						node.time <- node.time +. result.r_total;
+						node
+					with Not_found ->
+						let name,info = try
+							let i = String.rindex s '.' in
+							String.sub s (i + 1) (String.length s - i - 1),String.sub s 0 i
+						with Not_found ->
+							s,""
+						in
+						let node = {
+							name = name;
+							path = path;
+							parent = parent;
+							info = info;
+							time = result.r_total;
+							num_calls = result.r_count;
+							children = [];
+						} in
+						Hashtbl.add nodes path node;
+						node
+					in
+					begin match sl with
+						| [] -> ()
+						| _ ->
+							let child = loop node sl in
+							if not (List.memq child node.children) then
+								node.children <- child :: node.children;
+					end;
+					node
+			in
+			let node = loop root result.r_id in
+			if not (List.memq node root.children) then
+				root.children <- node :: root.children
+		) results;
+		let max_name = ref 0 in
+		let max_calls = ref 0 in
+		let rec loop depth node =
+			let l = (String.length node.name) + 2 * depth in
+			List.iter (fun child ->
+				if depth = 0 then begin
+					node.num_calls <- node.num_calls + child.num_calls;
+					node.time <- node.time +. child.time;
+				end;
+				loop (depth + 1) child;
+			) node.children;
+			node.children <- List.sort (fun node1 node2 -> compare node2.time node1.time) node.children;
+			if node.num_calls > !max_calls then max_calls := node.num_calls;
+			if node.time > 0.0009 && l > !max_name then max_name := l;
+		in
+		loop 0 root;
+		!max_name,!max_calls,root
+end
+
+let timer = ActiveTimers.timer
+let close tmr = ActiveTimers.close (get_time()) tmr
+let close_times = ActiveTimers.close_times
+let clear_times = ActiveTimers.clear_times
+let iter_times = ActiveTimers.iter_times
+let fold_times = ActiveTimers.fold_times
+let build_times_tree = ActiveTimers.build_times_tree
+
+let timer_fn id =
+	let tmr = timer id in
+	(fun() -> close tmr)
 
 let report_times print =
 	let max_name,max_calls,root = build_times_tree () in

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -843,7 +843,7 @@ let run com tctx main =
 	] in
 	let t = filter_timer detail_times ["expr 0"] in
 	List.iter (run_expression_filters tctx filters) new_types;
-	t();
+	Timer.close t;
 	let filters = [
 		fix_return_dynamic_from_void_function tctx true;
 		check_local_vars_init;
@@ -870,7 +870,7 @@ let run com tctx main =
 	in
 	let t = filter_timer detail_times ["expr 1"] in
 	List.iter (run_expression_filters tctx filters) new_types;
-	t();
+	Timer.close t;
 	(* PASS 1.5: pre-analyzer type filters *)
 	let filters =
 		match com.platform with
@@ -888,7 +888,7 @@ let run com tctx main =
 	in
 	let t = filter_timer detail_times ["type 1"] in
 	List.iter (fun f -> List.iter f new_types) filters;
-	t();
+	Timer.close t;
 	com.stage <- CAnalyzerStart;
 	if com.platform <> Cross then Analyzer.Run.run_on_types tctx new_types;
 	com.stage <- CAnalyzerDone;
@@ -903,19 +903,19 @@ let run com tctx main =
 	] in
 	let t = filter_timer detail_times ["expr 2"] in
 	List.iter (run_expression_filters tctx filters) new_types;
-	t();
+	Timer.close t;
 	next_compilation();
 	let t = filter_timer detail_times ["callbacks"] in
 	List.iter (fun f -> f()) (List.rev com.callbacks#get_before_save); (* macros onGenerate etc. *)
-	t();
+	Timer.close t;
 	com.stage <- CSaveStart;
 	let t = filter_timer detail_times ["save state"] in
 	List.iter (save_class_state tctx) new_types;
-	t();
+	Timer.close t;
 	com.stage <- CSaveDone;
 	let t = filter_timer detail_times ["callbacks"] in
 	List.iter (fun f -> f()) (List.rev com.callbacks#get_after_save); (* macros onGenerate etc. *)
-	t();
+	Timer.close t;
 	let t = filter_timer detail_times ["type 2"] in
 	(* PASS 2: type filters pre-DCE *)
 	List.iter (fun t ->
@@ -925,7 +925,7 @@ let run com tctx main =
 		(* check @:remove metadata before DCE so it is ignored there (issue #2923) *)
 		check_remove_metadata tctx t;
 	) com.types;
-	t();
+	Timer.close t;
 	com.stage <- CDceStart;
 	let t = filter_timer detail_times ["dce"] in
 	(* DCE *)
@@ -941,7 +941,7 @@ let run com tctx main =
 		| _ -> failwith ("Unknown DCE mode " ^ dce_mode)
 	in
 	Dce.run com main dce_mode;
-	t();
+	Timer.close t;
 	com.stage <- CDceDone;
 	(* PASS 3: type filters post-DCE *)
 	let type_filters = [
@@ -962,6 +962,6 @@ let run com tctx main =
 	in
 	let t = filter_timer detail_times ["type 3"] in
 	List.iter (fun t -> List.iter (fun f -> f tctx t) type_filters) com.types;
-	t();
+	Timer.close t;
 	List.iter (fun f -> f()) (List.rev com.callbacks#get_after_filters);
 	com.stage <- CFilteringDone

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -8444,7 +8444,7 @@ let generate_source ctx =
       common_ctx.print (!cmd ^ "\n");
       if common_ctx.run_command !cmd <> 0 then failwith "Build failed";
       Sys.chdir old_dir;
-      t()
+      Timer.close t
    end
    ;;
 

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -2289,7 +2289,7 @@ let generate con =
 											if unchecked then (begin_block w; write w "unchecked ");
 											let t = Timer.timer ["expression to string"] in
 											expr_s false w e;
-											t();
+											Timer.close t;
 											line_reset_directive w;
 											if unchecked then end_block w
 										| _ ->
@@ -2314,7 +2314,7 @@ let generate con =
 												let t = Timer.timer ["expression to string"] in
 												expr_s false w this_call;
 												write w " ";
-												t();
+												Timer.close t;
 												write w "{}"
 											| TBlock(bl) ->
 												let super_call, rest = get_super_call bl in
@@ -2325,7 +2325,7 @@ let generate con =
 														let t = Timer.timer ["expression to string"] in
 														expr_s false w sc;
 														write w " ";
-														t()
+														Timer.close t
 												);
 												write_method_expr { expr with eexpr = TBlock(rest) }
 											| _ -> assert false

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -3263,7 +3263,7 @@ and make_fun ?gen_content ctx name fidx f cthis cparent =
 	let f = if ctx.optimize && (gen_content = None || name <> ("","")) then begin
 		let t = Timer.timer ["generate";"hl";"opt"] in
 		let f = Hlopt.optimize ctx.dump_out (DynArray.get ctx.cstrings.arr) hlf f in
-		t();
+		Timer.close t;
 		f
 	end else
 		hlf
@@ -4068,7 +4068,7 @@ let generate com =
 		Hl2c.write_c com com.file code gnames;
 		let t = Timer.timer ["nativecompile";"hl"] in
 		if not (Common.defined com Define.NoCompilation) && com.run_command ("haxelib run hashlink build " ^ escape_command com.file) <> 0 then failwith "Build failed";
-		t();
+		Timer.close t;
 	end else begin
 		let ch = IO.output_string() in
 		write_code ch code (not (Common.raw_defined com "hl-no-debug"));
@@ -4078,7 +4078,7 @@ let generate com =
 		close_out ch;
 	end;
 	Hlopt.clean_cache();
-	t();
+	Timer.close t;
 	if Common.raw_defined com "run" then begin
 		if com.run_command ("haxelib run hashlink run " ^ escape_command com.file) <> 0 then failwith "Failed to run HL";
 	end;
@@ -4087,6 +4087,6 @@ let generate com =
 			let t = Timer.timer ["generate";"hl";"interp"] in
 			let ctx = Hlinterp.create true in
 			Hlinterp.add_code ctx code;
-			t();
+			Timer.close t;
 		with
 			Failure msg -> abort msg null_pos

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -375,7 +375,7 @@ let write_class jar path jc =
 	let ch = IO.output_bytes() in
 	JvmWriter.write_jvm_class ch jc;
 	Zip.add_entry (Bytes.unsafe_to_string (IO.close_out ch)) jar path;
-	t()
+	Timer.close t
 
 let is_const_int_pattern (el,_) =
 	List.for_all (fun e -> match e.eexpr with
@@ -3025,7 +3025,7 @@ let generate com =
 			export_debug = com.debug;
 		}
 	} in
-	Std.finally (Timer.timer ["generate";"java";"preprocess"]) Preprocessor.preprocess gctx;
+	Std.finally (Timer.timer_fn ["generate";"java";"preprocess"]) Preprocessor.preprocess gctx;
 	let class_paths = ExtList.List.filter_map (fun java_lib ->
 		if java_lib#has_flag NativeLibraries.FlagIsStd then None
 		else begin

--- a/src/generators/genswf.ml
+++ b/src/generators/genswf.ml
@@ -672,7 +672,7 @@ let generate swf_header com =
 		Swf.write ch swf;
 		IO.close_out ch;
 	);
-	t()
+	Timer.close t
 
 ;;
 SwfParser.init Extc.input_zip Extc.output_zip;

--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -418,7 +418,7 @@ let create_env_info static pfile kind capture_infos =
 let push_environment ctx info num_locals num_captures =
 	let eval = get_eval ctx in
 	let timer = if ctx.detail_times then
-		Timer.timer ["macro";"execution";kind_name eval info.kind]
+		Timer.timer_fn ["macro";"execution";kind_name eval info.kind]
 	else
 		no_timer
 	in

--- a/src/macro/eval/evalJit.ml
+++ b/src/macro/eval/evalJit.ml
@@ -700,7 +700,7 @@ let jit_tfunction ctx key_type key_field tf static pos =
 	let hasret = jit.has_nonfinal_return in
 	let eci = get_env_creation jit static tf.tf_expr.epos.pfile (EKMethod(key_type,key_field)) in
 	let f = if hasret then create_function ctx eci exec fl else create_function_noret ctx eci exec fl in
-	t();
+	Timer.close t;
 	f
 
 (* JITs expression [e] to a function. This is used for expressions that are not in a method. *)
@@ -708,5 +708,5 @@ let jit_expr ctx e =
 	let t = Timer.timer [(if ctx.is_macro then "macro" else "interp");"jit"] in
 	let jit = EvalJitContext.create ctx in
 	let f = jit_expr jit false (mk_block e) in
-	t();
+	Timer.close t;
 	jit,f

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -137,7 +137,7 @@ let create com api is_macro =
 		select ctx;
 		ignore(Event.sync(Event.receive eval.debug_channel));
 	end;
-	t();
+	Timer.close t;
 	ctx
 
 (* API for macroContext.ml *)

--- a/src/macro/eval/evalPrototype.ml
+++ b/src/macro/eval/evalPrototype.ml
@@ -359,4 +359,4 @@ let add_types ctx types ready =
 	) fl_static;
 	(* 4. Initialize static fields. *)
 	DynArray.iter (fun (proto,delays) -> List.iter (fun (_,f) -> f proto) delays) fl_static_init;
-	t()
+	Timer.close t

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -908,7 +908,7 @@ module Run = struct
 	let with_timer detailed s f =
 		let timer = Timer.timer (if detailed then "analyzer" :: s else ["analyzer"]) in
 		let r = f() in
-		timer();
+		Timer.close timer;
 		r
 
 	let create_analyzer_context com config e =

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1508,7 +1508,7 @@ let run (com:Common.context) (types:module_type list) =
 			| TClassDecl cls -> (new class_checker cls immediate_execution report)#check
 	in
 	List.iter traverse types;
-	timer();
+	Timer.close timer;
 	match com.callbacks#get_null_safety_report with
 		| [] ->
 			List.iter (fun err -> com.error err.sm_msg err.sm_pos) (List.rev report.sr_errors)

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -38,10 +38,10 @@ let parse_file_from_lexbuf com file p lexbuf =
 		ParserEntry.parse com.defines lexbuf file
 	with
 		| Sedlexing.MalFormed ->
-			t();
+			Timer.close t;
 			error "Malformed file. Source files must be encoded with UTF-8." {pfile = file; pmin = 0; pmax = 0}
 		| e ->
-			t();
+			Timer.close t;
 			raise e
 	in
 	begin match !Parser.display_mode,parse_result with
@@ -52,7 +52,7 @@ let parse_file_from_lexbuf com file p lexbuf =
 		| _ ->
 			()
 	end;
-	t();
+	Timer.close t;
 	Common.log com ("Parsed " ^ file);
 	parse_result
 

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -570,7 +570,7 @@ let handle_display ?resume_typing ctx e_ast dk with_type =
 				true
 			| _ -> false
 		) r.fitems in
-		timer();
+		Timer.close timer;
 		raise_fields l CRNew r.fsubject
 	in
 	let e = match e.eexpr with


### PR DESCRIPTION
Closes #6251

These are times using current dev on our unit tests:
```
haxe/tests/unit$ time haxe compile-php.hxml --times
name          | time(s) |   % |  p% |     # | info
---------------------------------------------
generate      |   0.997 |  26 |  26 |     1 | 
  php         |   0.997 |  26 | 100 |     1 | 
typing        |   0.769 |  20 |  20 |  4887 | 
analyzer      |   0.733 |  19 |  19 | 78804 | 
macro         |   0.452 |  12 |  12 |  2521 | 
  jit         |   0.017 |   0 |   4 |   859 | 
  add_types   |   0.014 |   0 |   3 |    71 | 
filters       |   0.391 |  10 |  10 |    11 | 
parsing       |   0.389 |  10 |  10 |  1323 | 
other         |   0.037 |   1 |   1 |     1 | 
haxelib       |   0.025 |   1 |   1 |     1 | 
null safety   |   0.003 |   0 |   0 |     1 | 
---------------------------------------------
total         |   3.796 | 100 | 100 | 87551 | 

real	0m3,816s
user	0m3,647s
sys	0m0,156s
```
These are times using this PR on our unit tests:
```
haxe/tests/unit$ time haxe compile-php.hxml --times
name          | time(s) |   % |  p% |     # | info
---------------------------------------------
generate      |   0.969 |  26 |  26 |     1 | 
  php         |   0.969 |  26 | 100 |     1 | 
typing        |   0.788 |  21 |  21 |  4887 | 
analyzer      |   0.740 |  20 |  20 | 78804 | 
macro         |   0.474 |  13 |  13 |  2521 | 
  jit         |   0.015 |   0 |   3 |   859 | 
  add_types   |   0.014 |   0 |   3 |    71 | 
filters       |   0.414 |  11 |  11 |    11 | 
parsing       |   0.374 |  10 |  10 |  1323 | 
haxelib       |   0.017 |   0 |   0 |     1 | 
null safety   |   0.002 |   0 |   0 |     1 | 
other         |   0.001 |   0 |   0 |     1 | 
---------------------------------------------
total         |   3.781 | 100 | 100 | 87551 | 

real	0m3,801s
user	0m3,639s
sys	0m0,165s
```