### PR TITLE
add js.lib.BigInt

### DIFF
--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -90,19 +90,19 @@ abstract BigInt {
 	@:op(-A) static function neg(a:BigInt):BigInt;
 
 	@:op(++A) static inline function incPre(a:BigInt):BigInt {
-		return untyped __js__("(++{0})", a);
+		return untyped __js__("++{0}", a);
 	}
 
 	@:op(A++) static inline function incPost(a:BigInt):BigInt {
-		return untyped __js__("({0}++)", a);
+		return untyped __js__("{0}++", a);
 	}
 
 	@:op(--A) static inline function decPre(a:BigInt):BigInt {
-		return untyped __js__("(--{0})", a);
+		return untyped __js__("--{0}", a);
 	}
 
 	@:op(A--) static inline function decPost(a:BigInt):BigInt {
-		return untyped __js__("({0}--)", a);
+		return untyped __js__("{0}--", a);
 	}
 
 	@:op(A + B) static function add(a:BigInt, b:BigInt):BigInt;

--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
 package js.lib;
 
 import js.Syntax;

--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -35,9 +35,10 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 
 	@see <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt>
 **/
-abstract BigInt(_BigInt) from _BigInt to _BigInt {
+@:coreType
+abstract BigInt {
 	public inline function new(value:EitherType<String, Int>) {
-		this = new _BigInt(value);
+		this = Syntax.code("BigInt({0})", value);
 	}
 
 	/**
@@ -47,15 +48,15 @@ abstract BigInt(_BigInt) from _BigInt to _BigInt {
 	public inline function toLocaleString(?locales:EitherType<String, Array<String>>, ?options:NumberFormatOptions):String {
 		return if (locales == null) {
 			if (options == null) {
-				this.toLocaleString();
+				Syntax.code("({0}).toLocaleString()", this);
 			} else {
-				this.toLocaleString(js.Lib.undefined, options);
+				Syntax.code("({0}).toLocaleString({1}, {2})", this, js.Lib.undefined, options);
 			}
 		} else {
 			if (options == null) {
-				this.toLocaleString(locales);
+				Syntax.code("({0}).toLocaleString({1})", this, locales);
 			} else {
-				this.toLocaleString(locales, options);
+				Syntax.code("({0}).toLocaleString({1}, {2})", this, locales, options);
 			}
 		}
 	}
@@ -66,158 +67,83 @@ abstract BigInt(_BigInt) from _BigInt to _BigInt {
 	**/
 	public inline function toString(?radix:Int):String {
 		return if (radix == null) {
-			this.toString();
+			return Syntax.code("({0}).toString()", this);
 		} else {
-			this.toString(radix);
+			return Syntax.code("({0}).toString({1})", this, radix);
 		}
-	}
-
-	/**
-		Returns the primitive value of the specified object.
-		Overrides the `Object.prototype.valueOf()` method.
-	**/
-	public inline function valueOf():BigInt {
-		return this.valueOf();
 	}
 
 	/**
 		Wraps a BigInt value to a signed integer between `-2^(width-1)` and `2^(width-1)-1`.
 	**/
 	public static inline function asIntN(width:Int, bigint:BigInt):BigInt {
-		return _BigInt.asIntN(width, bigint);
+		return Syntax.code("BigInt.asIntN({0}, {1})", width, bigint);
 	}
 
 	/**
 		Wraps a BigInt value to an unsigned integer between `0` and `2^width-1`.
 	**/
 	public static inline function asUintN(width:Int, bigint:BigInt):BigInt {
-		return _BigInt.asUintN(width, bigint);
+		return Syntax.code("BigInt.asUintN({0}, {1})", width, bigint);
 	}
 
-	@:op(-A) static inline function neg(a:BigInt):BigInt {
-		return (Syntax.code("(-{0})", a));
-	}
+	@:op(-A) static function neg(a:BigInt):BigInt;
 
 	@:op(++A) static inline function incPre(a:BigInt):BigInt {
-		return Syntax.code("(++{0})", a);
+		return untyped __js__("(++{0})", a);
 	}
 
 	@:op(A++) static inline function incPost(a:BigInt):BigInt {
-		return Syntax.code("({0}++)", a);
+		return untyped __js__("({0}++)", a);
 	}
 
 	@:op(--A) static inline function decPre(a:BigInt):BigInt {
-		return Syntax.code("(--{0})", a);
+		return untyped __js__("(--{0})", a);
 	}
 
 	@:op(A--) static inline function decPost(a:BigInt):BigInt {
-		return Syntax.code("({0}--)", a);
+		return untyped __js__("({0}--)", a);
 	}
 
-	@:op(A + B) static inline function add(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} + {1})", a, b);
-	}
+	@:op(A + B) static function add(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A - B) static inline function sub(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} - {1})", a, b);
-	}
+	@:op(A - B) static function sub(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A * B) static inline function mul(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} * {1})", a, b);
-	}
+	@:op(A * B) static function mul(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A / B) static inline function div(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} / {1})", a, b);
-	}
+	@:op(A / B) static function div(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A % B) static inline function mod(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} % {1})", a, b);
-	}
+	@:op(A % B) static function mod(a:BigInt, b:BigInt):BigInt;
 
-	@:op(~A) static inline function not(a:BigInt):BigInt {
-		return Syntax.code("~{0}", a);
-	}
+	@:op(~A) static function not(a:BigInt):BigInt;
 
-	@:op(A & B) static inline function and(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} & {1})", a, b);
-	}
+	@:op(A & B) static function and(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A | B) static inline function or(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} | {1})", a, b);
-	}
+	@:op(A | B) static function or(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A ^ B) static inline function xor(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} ^ {1})", a, b);
-	}
+	@:op(A ^ B) static function xor(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A << B) static inline function lshift(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} << {1})", a, b);
-	}
+	@:op(A << B) static function lshift(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A >> B) static inline function rshift(a:BigInt, b:BigInt):BigInt {
-		return Syntax.code("({0} >> {1})", a, b);
-	}
+	@:op(A >> B) static function rshift(a:BigInt, b:BigInt):BigInt;
 
-	@:op(A == B) @:commutative static inline function eq(a:BigInt, b:EitherType<Int, BigInt>):Bool {
-		return Syntax.code("({0} == {1})", a, b);
-	}
+	@:op(A == B) @:commutative static function eq<T:Float>(a:BigInt, b:EitherType<BigInt, T>):Bool;
 
-	@:op(A != B) @:commutative static inline function neq(a:BigInt, b:EitherType<Int, BigInt>):Bool {
-		return Syntax.code("({0} != {1})", a, b);
-	}
+	@:op(A != B) @:commutative static function neq<T:Float>(a:BigInt, b:EitherType<BigInt, T>):Bool;
 
-	@:op(A < B) static inline function ltPre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
-		return Syntax.code("({0} < {1})", a, b);
-	}
+	@:op(A < B) static function lt<T:Float>(a:EitherType<BigInt, T>, b:BigInt):Bool;
 
-	@:op(A < B) static inline function ltPost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
-		return Syntax.code("({0} < {1})", a, b);
-	}
+	@:op(A < B) static function lt2<T:Float>(a:BigInt, b:EitherType<BigInt, T>):Bool;
 
-	@:op(A <= B) static inline function lePre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
-		return Syntax.code("({0} <= {1})", a, b);
-	}
+	@:op(A <= B) static function le<T:Float>(a:EitherType<BigInt, T>, b:BigInt):Bool;
 
-	@:op(A <= B) static inline function lePost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
-		return Syntax.code("({0} <= {1})", a, b);
-	}
+	@:op(A <= B) static function le2<T:Float>(a:BigInt, b:EitherType<BigInt, T>):Bool;
 
-	@:op(A > B) static inline function gtPre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
-		return Syntax.code("({0} > {1})", a, b);
-	}
+	@:op(A > B) static function gt<T:Float>(a:EitherType<Int, BigInt>, b:BigInt):Bool;
 
-	@:op(A > B) static inline function gtPost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
-		return Syntax.code("({0} > {1})", a, b);
-	}
+	@:op(A > B) static function gt2<T:Float>(a:BigInt, b:EitherType<Int, BigInt>):Bool;
 
-	@:op(A >= B) static inline function gePre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
-		return Syntax.code("({0} >= {1})", a, b);
-	}
+	@:op(A >= B) static function ge<T:Float>(a:EitherType<Int, BigInt>, b:BigInt):Bool;
 
-	@:op(A >= B) static inline function gePost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
-		return Syntax.code("({0} >= {1})", a, b);
-	}
-
-	@:op(A + B) static inline function joinPre(a:String, b:BigInt):String {
-		return Syntax.code("({0} + {1})", a, b);
-	}
-
-	@:op(A + B) static inline function joinPost(a:BigInt, b:String):String {
-		return Syntax.code("({0} + {1})", a, b);
-	}
-}
-
-@:native("BigInt")
-private extern class _BigInt {
-	@:selfCall @:pure function new(value:EitherType<String, Int>);
-
-	@:pure function toLocaleString(?locales:EitherType<String, Array<String>>, ?options:NumberFormatOptions):String;
-
-	@:pure function toString(?radix:Int):String;
-
-	@:pure function valueOf():_BigInt;
-
-	@:pure static function asIntN(width:Int, bigint:_BigInt):_BigInt;
-
-	@:pure static function asUintN(width:Int, bigint:_BigInt):_BigInt;
+	@:op(A >= B) static function ge2<T:Float>(a:BigInt, b:EitherType<Int, BigInt>):Bool;
 }

--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -30,6 +30,10 @@ import js.lib.intl.NumberFormat.NumberFormatOptions;
 	`BigInt` is a built-in object that provides a way to represent whole numbers larger than `2^53 - 1`,
 	which is the largest number JavaScript can reliably represent with the `Number` primitive.
 	`BigInt` can be used for arbitrarily large integers.
+
+	Documentation [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
+
+	@see <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt>
 **/
 abstract BigInt(_BigInt) from _BigInt to _BigInt {
 	public inline function new(value:EitherType<String, Int>) {

--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -23,6 +23,7 @@
 package js.lib;
 
 import js.Syntax;
+import js.Lib.undefined;
 import haxe.extern.EitherType;
 import js.lib.intl.NumberFormat.NumberFormatOptions;
 
@@ -46,19 +47,12 @@ abstract BigInt {
 		Overrides the `Object.prototype.toLocaleString()` method.
 	**/
 	public inline function toLocaleString(?locales:EitherType<String, Array<String>>, ?options:NumberFormatOptions):String {
-		return if (locales == null) {
-			if (options == null) {
-				Syntax.code("({0}).toLocaleString()", this);
-			} else {
-				Syntax.code("({0}).toLocaleString({1}, {2})", this, js.Lib.undefined, options);
-			}
-		} else {
-			if (options == null) {
-				Syntax.code("({0}).toLocaleString({1})", this, locales);
-			} else {
-				Syntax.code("({0}).toLocaleString({1}, {2})", this, locales, options);
-			}
-		}
+		return Syntax.code(
+			"({0}).toLocaleString({1}, {2})",
+			this,
+			(locales != null) ? locales : undefined,
+			(options != null) ? options : undefined
+		);
 	}
 
 	/**
@@ -66,11 +60,11 @@ abstract BigInt {
 		Overrides the `Object.prototype.toString()` method.
 	**/
 	public inline function toString(?radix:Int):String {
-		return if (radix == null) {
-			return Syntax.code("({0}).toString()", this);
-		} else {
-			return Syntax.code("({0}).toString({1})", this, radix);
-		}
+		return Syntax.code(
+			"({0}).toString({1})",
+			this,
+			(radix != null) ? radix : undefined
+		);
 	}
 
 	/**

--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -81,7 +81,7 @@ abstract BigInt(_BigInt) from _BigInt to _BigInt {
 	}
 
 	/**
-		Wraps a BigInt value to a signed integer between `-2^(width-1)` and `2^(width-1-1)`.
+		Wraps a BigInt value to a signed integer between `-2^(width-1)` and `2^(width-1)-1`.
 	**/
 	public static inline function asIntN(width:Int, bigint:BigInt):BigInt {
 		return _BigInt.asIntN(width, bigint);

--- a/std/js/lib/BigInt.hx
+++ b/std/js/lib/BigInt.hx
@@ -1,0 +1,197 @@
+package js.lib;
+
+import js.Syntax;
+import haxe.extern.EitherType;
+import js.lib.intl.NumberFormat.NumberFormatOptions;
+
+/**
+	`BigInt` is a built-in object that provides a way to represent whole numbers larger than `2^53 - 1`,
+	which is the largest number JavaScript can reliably represent with the `Number` primitive.
+	`BigInt` can be used for arbitrarily large integers.
+**/
+abstract BigInt(_BigInt) from _BigInt to _BigInt {
+	public inline function new(value:EitherType<String, Int>) {
+		this = new _BigInt(value);
+	}
+
+	/**
+		Returns a string with a language-sensitive representation of this number.
+		Overrides the `Object.prototype.toLocaleString()` method.
+	**/
+	public inline function toLocaleString(?locales:EitherType<String, Array<String>>, ?options:NumberFormatOptions):String {
+		return if (locales == null) {
+			if (options == null) {
+				this.toLocaleString();
+			} else {
+				this.toLocaleString(js.Lib.undefined, options);
+			}
+		} else {
+			if (options == null) {
+				this.toLocaleString(locales);
+			} else {
+				this.toLocaleString(locales, options);
+			}
+		}
+	}
+
+	/**
+		Returns a string representing the specified object in the specified radix (base).
+		Overrides the `Object.prototype.toString()` method.
+	**/
+	public inline function toString(?radix:Int):String {
+		return if (radix == null) {
+			this.toString();
+		} else {
+			this.toString(radix);
+		}
+	}
+
+	/**
+		Returns the primitive value of the specified object.
+		Overrides the `Object.prototype.valueOf()` method.
+	**/
+	public inline function valueOf():BigInt {
+		return this.valueOf();
+	}
+
+	/**
+		Wraps a BigInt value to a signed integer between `-2^(width-1)` and `2^(width-1-1)`.
+	**/
+	public static inline function asIntN(width:Int, bigint:BigInt):BigInt {
+		return _BigInt.asIntN(width, bigint);
+	}
+
+	/**
+		Wraps a BigInt value to an unsigned integer between `0` and `2^width-1`.
+	**/
+	public static inline function asUintN(width:Int, bigint:BigInt):BigInt {
+		return _BigInt.asUintN(width, bigint);
+	}
+
+	@:op(-A) static inline function neg(a:BigInt):BigInt {
+		return (Syntax.code("(-{0})", a));
+	}
+
+	@:op(++A) static inline function incPre(a:BigInt):BigInt {
+		return Syntax.code("(++{0})", a);
+	}
+
+	@:op(A++) static inline function incPost(a:BigInt):BigInt {
+		return Syntax.code("({0}++)", a);
+	}
+
+	@:op(--A) static inline function decPre(a:BigInt):BigInt {
+		return Syntax.code("(--{0})", a);
+	}
+
+	@:op(A--) static inline function decPost(a:BigInt):BigInt {
+		return Syntax.code("({0}--)", a);
+	}
+
+	@:op(A + B) static inline function add(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} + {1})", a, b);
+	}
+
+	@:op(A - B) static inline function sub(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} - {1})", a, b);
+	}
+
+	@:op(A * B) static inline function mul(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} * {1})", a, b);
+	}
+
+	@:op(A / B) static inline function div(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} / {1})", a, b);
+	}
+
+	@:op(A % B) static inline function mod(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} % {1})", a, b);
+	}
+
+	@:op(~A) static inline function not(a:BigInt):BigInt {
+		return Syntax.code("~{0}", a);
+	}
+
+	@:op(A & B) static inline function and(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} & {1})", a, b);
+	}
+
+	@:op(A | B) static inline function or(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} | {1})", a, b);
+	}
+
+	@:op(A ^ B) static inline function xor(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} ^ {1})", a, b);
+	}
+
+	@:op(A << B) static inline function lshift(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} << {1})", a, b);
+	}
+
+	@:op(A >> B) static inline function rshift(a:BigInt, b:BigInt):BigInt {
+		return Syntax.code("({0} >> {1})", a, b);
+	}
+
+	@:op(A == B) @:commutative static inline function eq(a:BigInt, b:EitherType<Int, BigInt>):Bool {
+		return Syntax.code("({0} == {1})", a, b);
+	}
+
+	@:op(A != B) @:commutative static inline function neq(a:BigInt, b:EitherType<Int, BigInt>):Bool {
+		return Syntax.code("({0} != {1})", a, b);
+	}
+
+	@:op(A < B) static inline function ltPre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
+		return Syntax.code("({0} < {1})", a, b);
+	}
+
+	@:op(A < B) static inline function ltPost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
+		return Syntax.code("({0} < {1})", a, b);
+	}
+
+	@:op(A <= B) static inline function lePre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
+		return Syntax.code("({0} <= {1})", a, b);
+	}
+
+	@:op(A <= B) static inline function lePost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
+		return Syntax.code("({0} <= {1})", a, b);
+	}
+
+	@:op(A > B) static inline function gtPre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
+		return Syntax.code("({0} > {1})", a, b);
+	}
+
+	@:op(A > B) static inline function gtPost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
+		return Syntax.code("({0} > {1})", a, b);
+	}
+
+	@:op(A >= B) static inline function gePre(a:EitherType<Int, BigInt>, b:BigInt):Bool {
+		return Syntax.code("({0} >= {1})", a, b);
+	}
+
+	@:op(A >= B) static inline function gePost(a:BigInt, b:EitherType<Int, BigInt>):Bool {
+		return Syntax.code("({0} >= {1})", a, b);
+	}
+
+	@:op(A + B) static inline function joinPre(a:String, b:BigInt):String {
+		return Syntax.code("({0} + {1})", a, b);
+	}
+
+	@:op(A + B) static inline function joinPost(a:BigInt, b:String):String {
+		return Syntax.code("({0} + {1})", a, b);
+	}
+}
+
+@:native("BigInt")
+private extern class _BigInt {
+	@:selfCall @:pure function new(value:EitherType<String, Int>);
+
+	@:pure function toLocaleString(?locales:EitherType<String, Array<String>>, ?options:NumberFormatOptions):String;
+
+	@:pure function toString(?radix:Int):String;
+
+	@:pure function valueOf():_BigInt;
+
+	@:pure static function asIntN(width:Int, bigint:_BigInt):_BigInt;
+
+	@:pure static function asUintN(width:Int, bigint:_BigInt):_BigInt;
+}


### PR DESCRIPTION
`BigInt` is supported by Chrome, Firefox and Node.js.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt

Node.js v12 was added some BigInt API.
https://nodejs.org/dist/latest-v12.x/docs/api/buffer.html#buffer_buf_readbigint64be_offset