### PR TITLE
Close every timer instead of skipping orphaned ones

### DIFF
--- a/src/core/timer.ml
+++ b/src/core/timer.ml
@@ -20,6 +20,7 @@
 type timer_infos = {
 	id : string list;
 	mutable start : float list;
+	mutable pauses : float list;
 	mutable total : float;
 	mutable calls : int;
 }
@@ -28,45 +29,57 @@ let get_time = Extc.time
 let htimers = Hashtbl.create 0
 
 let new_timer id =
+	let now = get_time() in
 	let key = String.concat "." id in
 	try
 		let t = Hashtbl.find htimers key in
-		t.start <- get_time() :: t.start;
+		t.start <- now :: t.start;
+		t.pauses <- 0. :: t.pauses;
 		t.calls <- t.calls + 1;
 		t
 	with Not_found ->
-		let t = { id = id; start = [get_time()]; total = 0.; calls = 1; } in
+		let t = { id = id; start = [now]; pauses = [0.]; total = 0.; calls = 1; } in
 		Hashtbl.add htimers key t;
 		t
 
 let curtime = ref []
 
-let close t =
-	let start = (match t.start with
-		| [] -> assert false
-		| s :: l -> t.start <- l; s
-	) in
-	let now = get_time() in
-	let dt = now -. start in
-	t.total <- t.total +. dt;
-	let rec loop() =
-		match !curtime with
-		| [] -> failwith ("Timer " ^ (String.concat "." t.id) ^ " closed while not active")
-		| tt :: l -> curtime := l; if t != tt then loop()
-	in
-	loop();
+let rec close now t =
+	match !curtime with
+	| [] ->
+		failwith ("Timer " ^ (String.concat "." t.id) ^ " closed while not active")
+	| tt :: rest ->
+		if t == tt then begin
+			let start = List.hd t.start in
+			let pauses = List.hd t.pauses in
+			let dt = now -. start in
+			t.total <- t.total +. dt -. pauses;
+			t.start <- List.tl t.start;
+			t.pauses <- List.tl t.pauses;
+			curtime := rest;
+			match !curtime with
+			| [] -> ()
+			| current :: _ ->
+				let pauses = dt +. List.hd current.pauses in
+				current.pauses <- pauses :: List.tl current.pauses
+				(* current.total <- *)
+		end else
+			close now tt
 	(* because of rounding errors while adding small times, we need to make sure that we don't have start > now *)
-	List.iter (fun ct -> ct.start <- List.map (fun t -> let s = t +. dt in if s > now then now else s) ct.start) !curtime
+	(* List.iter (fun ct -> ct.start <- List.map (fun t -> let s = t +. dt in if s > now then now else s) ct.start) !curtime *)
 
 let timer id =
 	let t = new_timer id in
 	curtime := t :: !curtime;
-	(function() -> close t)
+	(function() -> close (get_time()) t)
 
 let rec close_times() =
+	let now = get_time() in
 	match !curtime with
 	| [] -> ()
-	| t :: _ -> close t; close_times()
+	| t :: _ -> close now t; close_times()
+
+let close = close (get_time())
 
 (* Printing *)
 


### PR DESCRIPTION
Closes #6251. This time for real.

Comparison for `time haxe compile-macro.hxml --times -D eval-times` in our unit tests:

Current implementation:
```
<...>
-----------------------------------------------------------------
total                            |   3.052 | 100 | 100 | 466661 | 

real	0m3,209s
user	0m2,940s
sys	0m0,213s
```
This PR:
```
<...>
-----------------------------------------------------------------
total                            |   2.912 | 100 | 100 | 466661 | 

real	0m3,018s
user	0m2,813s
sys	0m0,192s
```
This PR shows real time value by 80-150ms less than current implementation.

<details>
  <summary>Full `--times` report for current implementation</summary>
  
```
name                             | time(s) |   % |  p% |      # | info
-----------------------------------------------------------------
macro                            |   1.064 |  35 |  35 | 383510 | 
  execution                      |   0.944 |  31 |  89 | 380991 | 
    ancestorHasInitializeUtest   |   0.152 |   5 |  16 |    898 | utest.utils.TestBuilder
    divMod                       |   0.075 |   2 |   8 |    453 | haxe._Int64.Int64_Impl_
    test                         |   0.046 |   2 |   5 |      1 | unit.spec.sys.io.TestFile
    localFunction1               |   0.043 |   1 |   5 |     61 | unit.UnitBuilder.read
    createFixture                |   0.033 |   1 |   3 |   1025 | utest.ui.common.PackageResult
    typeof                       |   0.029 |   1 |   3 |   4528 | haxe.macro.Context
    localFunction1               |   0.029 |   1 |   3 |   4103 | unit.UnitBuilder.mkEq
    build                        |   0.029 |   1 |   3 |    898 | utest.utils.TestBuilder
    add                          |   0.026 |   1 |   3 |  17555 | haxe.ds.List
    add                          |   0.022 |   1 |   2 |   8689 | utest.ui.common.FixtureResult
    new                          |   0.020 |   1 |   2 |  60711 | haxe._Int64.___Int64
    addSuccesses                 |   0.018 |   1 |   2 |  12590 | utest.ui.common.ResultStats
    ucompare                     |   0.014 |   0 |   2 |  42105 | haxe._Int32.Int32_Impl_
    getBuildFields               |   0.014 |   0 |   2 |    900 | haxe.macro.Context
    wire                         |   0.014 |   0 |   1 |   1851 | utest.ui.common.ResultStats
    sum                          |   0.013 |   0 |   1 |   1851 | utest.ui.common.ResultStats
    dispatch                     |   0.013 |   0 |   1 |  19967 | utest.Dispatcher
    defineModule                 |   0.011 |   0 |   1 |     61 | haxe.macro.Context
    addITest                     |   0.011 |   0 |   1 |    894 | utest.Runner
    new                          |   0.011 |   0 |   1 |   1852 | utest.ui.common.ResultStats
    toplevel                     |   0.010 |   0 |   1 |   1666 | 
    select                       |   0.010 |   0 |   1 |      5 | sys.net.Socket
    equals                       |   0.010 |   0 |   1 |   6566 | utest.Assert
    formatString                 |   0.009 |   0 |   1 |     52 | haxe.macro.MacroStringTools
    eq                           |   0.009 |   0 |   1 |   6566 | unit.Test
    mkEq                         |   0.008 |   0 |   1 |   2093 | unit.UnitBuilder
    new                          |   0.007 |   0 |   1 |  17559 | haxe.ds._List.ListNode
    load                         |   0.006 |   0 |   1 |  12696 | haxe.macro.Context
    localFunction2               |   0.006 |   0 |   1 |     61 | unit.UnitBuilder.read
    localFunction1               |   0.006 |   0 |   1 |    802 | unit.TestIssues.addIssueClasses
    new                          |   0.006 |   0 |   1 |   1025 | utest.TestHandler
    parse                        |   0.006 |   0 |   1 |     45 | haxe.xml.Parser
    processTest                  |   0.006 |   0 |   1 |   1025 | utest.utils.TestBuilder
    runFixture                   |   0.005 |   0 |   1 |   1025 | utest.Runner
    addResult                    |   0.005 |   0 |   1 |   1025 | utest.ui.common.PackageResult
    add                          |   0.005 |   0 |   1 |  11310 | utest.Dispatcher
    follow                       |   0.005 |   0 |   1 |   2297 | haxe.macro.Context
    testComplete                 |   0.005 |   0 |   0 |   1025 | utest.Runner
    new                          |   0.005 |   0 |   0 |  13368 | utest.Dispatcher
    has                          |   0.004 |   0 |   0 |   1482 | Lambda
    runTest                      |   0.004 |   0 |   0 |   1025 | utest.ITestHandler
    ofHandler                    |   0.004 |   0 |   0 |   1025 | utest.TestResult
    read                         |   0.004 |   0 |   0 |     61 | unit.UnitBuilder
    next                         |   0.004 |   0 |   0 |   8690 | haxe.ds._List.ListIterator
    makeExpr                     |   0.004 |   0 |   0 |   1682 | haxe.macro.Context
    hasNext                      |   0.004 |   0 |   0 |   9717 | haxe.ds._List.ListIterator
    getOrCreateClass             |   0.003 |   0 |   0 |   1025 | utest.ui.common.PackageResult
    runTeardown                  |   0.003 |   0 |   0 |   1025 | utest.ITestHandler
    completedFinally             |   0.003 |   0 |   0 |   1025 | utest.TestHandler
    checkTest                    |   0.003 |   0 |   0 |   1025 | utest.ITestHandler
    runSetup                     |   0.003 |   0 |   0 |   1025 | utest.ITestHandler
    ofData                       |   0.003 |   0 |   0 |   1025 | utest.TestFixture
    getOrCreatePackage           |   0.003 |   0 |   0 |   1025 | utest.ui.common.PackageResult
    runFixtures                  |   0.003 |   0 |   0 |    894 | utest._Runner.ITestRunner
    new                          |   0.003 |   0 |   0 |   1025 | utest.ui.common.FixtureResult
    progress                     |   0.003 |   0 |   0 |   1025 | utest.ui.common.ResultAggregator
    initialExpressions           |   0.003 |   0 |   0 |    898 | utest.utils.TestBuilder
    getIgnored                   |   0.003 |   0 |   0 |   1025 | utest.TestFixture
    localFunction1               |   0.003 |   0 |   0 |    809 | utest.ITestHandler.runTest
    new                          |   0.003 |   0 |   0 |   1025 | utest.ITestHandler
    addIssueClasses              |   0.002 |   0 |   0 |      2 | unit.TestIssues
    execute                      |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    isTrue                       |   0.002 |   0 |   0 |   1377 | utest.Assert
    printExpr                    |   0.002 |   0 |   0 |    436 | haxe.macro.Printer
    addCase                      |   0.002 |   0 |   0 |    894 | utest.Runner
    getResolved                  |   0.002 |   0 |   0 |   4861 | utest.Async
    getLocalClass                |   0.002 |   0 |   0 |    899 | haxe.macro.Context
    add                          |   0.002 |   0 |   0 |   1025 | utest.ui.common.ClassResult
    addClass                     |   0.002 |   0 |   0 |    811 | utest.ui.common.PackageResult
    typedAs                      |   0.002 |   0 |   0 |    110 | unit.HelperMacros
    defined                      |   0.002 |   0 |   0 |   1066 | haxe.macro.Context
    t                            |   0.002 |   0 |   0 |   1257 | unit.Test
    doParse                      |   0.002 |   0 |   0 |    357 | haxe.xml.Parser
    then                         |   0.002 |   0 |   0 |   3075 | utest.Async
    checkPossibleTypo            |   0.002 |   0 |   0 |    427 | utest.utils.TestBuilder
    iterator                     |   0.002 |   0 |   0 |   1027 | haxe.ds.List
    localFunction1               |   0.001 |   0 |   0 |     50 | unit.HelperMacros.pipeMarkupLiteral
    test                         |   0.001 |   0 |   0 |      1 | unit.spec.TestDate
    new                          |   0.001 |   0 |   0 |   1025 | utest.TestFixture
    new                          |   0.001 |   0 |   0 |    811 | utest.ui.common.ClassResult
    isTestFixtureName            |   0.001 |   0 |   0 |   1025 | utest.Runner
    checkTeardown                |   0.001 |   0 |   0 |   1025 | utest.ITestHandler
    getFields                    |   0.001 |   0 |   0 |   1030 | haxe.rtti.Meta
    checkSetup                   |   0.001 |   0 |   0 |   1025 | utest.ITestHandler
    xclassfield                  |   0.001 |   0 |   0 |     75 | haxe.rtti.XmlParser
    parse                        |   0.001 |   0 |   0 |    169 | haxe.macro.Context
    typeExpr                     |   0.001 |   0 |   0 |     31 | haxe.macro.Context
    isTestName                   |   0.001 |   0 |   0 |   1179 | utest.utils.TestBuilder
    new                          |   0.001 |   0 |   0 |   3190 | haxe.ds.List
    test                         |   0.001 |   0 |   0 |      1 | unit.spec.TestLambda
    parseString                  |   0.001 |   0 |   0 |     18 | haxe.Int64Helper
  jit                            |   0.015 |   0 |   1 |    859 | 
  add_types                      |   0.015 |   0 |   1 |     71 | 
typing                           |   0.663 |  22 |  22 |   4806 | 
analyzer                         |   0.520 |  17 |  17 |  71512 | 
parsing                          |   0.336 |  11 |  11 |   1284 | 
filters                          |   0.305 |  10 |  10 |     11 | 
interp                           |   0.135 |   4 |   4 |   5534 | 
  jit                            |   0.107 |   4 |  80 |   5531 | 
  add_types                      |   0.028 |   1 |  20 |      1 | 
haxelib                          |   0.025 |   1 |   1 |      1 | 
null safety                      |   0.003 |   0 |   0 |      1 | 
-----------------------------------------------------------------
total                            |   3.052 | 100 | 100 | 466661 | 

real	0m3,209s
user	0m2,940s
sys	0m0,213s
```
</details>
<details>
  <summary>Full `--times` report for this PR</summary>
  
```
name                             | time(s) |   % |  p% |      # | info
-----------------------------------------------------------------
macro                            |   0.915 |  31 |  31 | 383510 | 
  execution                      |   0.764 |  26 |  84 | 380991 | 
    ancestorHasInitializeUtest   |   0.150 |   5 |  20 |    898 | utest.utils.TestBuilder
    localFunction1               |   0.049 |   2 |   6 |     61 | unit.UnitBuilder.read
    divMod                       |   0.047 |   2 |   6 |    453 | haxe._Int64.Int64_Impl_
    localFunction1               |   0.028 |   1 |   4 |   4103 | unit.UnitBuilder.mkEq
    new                          |   0.026 |   1 |   3 |  60711 | haxe._Int64.___Int64
    build                        |   0.023 |   1 |   3 |    898 | utest.utils.TestBuilder
    typeof                       |   0.021 |   1 |   3 |   4528 | haxe.macro.Context
    add                          |   0.019 |   1 |   3 |  17555 | haxe.ds.List
    ucompare                     |   0.018 |   1 |   2 |  42105 | haxe._Int32.Int32_Impl_
    dispatch                     |   0.017 |   1 |   2 |  19967 | utest.Dispatcher
    createFixture                |   0.016 |   1 |   2 |   1025 | utest.ui.common.PackageResult
    defineModule                 |   0.013 |   0 |   2 |     61 | haxe.macro.Context
    getBuildFields               |   0.013 |   0 |   2 |    900 | haxe.macro.Context
    add                          |   0.013 |   0 |   2 |   8689 | utest.ui.common.FixtureResult
    addSuccesses                 |   0.012 |   0 |   2 |  12590 | utest.ui.common.ResultStats
    select                       |   0.011 |   0 |   1 |      5 | sys.net.Socket
    addITest                     |   0.010 |   0 |   1 |    894 | utest.Runner
    load                         |   0.009 |   0 |   1 |  12696 | haxe.macro.Context
    wire                         |   0.009 |   0 |   1 |   1851 | utest.ui.common.ResultStats
    new                          |   0.008 |   0 |   1 |  17559 | haxe.ds._List.ListNode
    test                         |   0.008 |   0 |   1 |      1 | unit.spec.sys.io.TestFile
    doParse                      |   0.007 |   0 |   1 |    357 | haxe.xml.Parser
    add                          |   0.007 |   0 |   1 |  11310 | utest.Dispatcher
    mkEq                         |   0.006 |   0 |   1 |   2093 | unit.UnitBuilder
    equals                       |   0.006 |   0 |   1 |   6566 | utest.Assert
    new                          |   0.006 |   0 |   1 |   1852 | utest.ui.common.ResultStats
    eq                           |   0.006 |   0 |   1 |   6566 | unit.Test
    new                          |   0.006 |   0 |   1 |  13368 | utest.Dispatcher
    sum                          |   0.006 |   0 |   1 |   1851 | utest.ui.common.ResultStats
    localFunction2               |   0.006 |   0 |   1 |     61 | unit.UnitBuilder.read
    processTest                  |   0.006 |   0 |   1 |   1025 | utest.utils.TestBuilder
    localFunction1               |   0.005 |   0 |   1 |    802 | unit.TestIssues.addIssueClasses
    hasNext                      |   0.004 |   0 |   1 |   9717 | haxe.ds._List.ListIterator
    then                         |   0.004 |   0 |   1 |   3075 | utest.Async
    follow                       |   0.004 |   0 |   1 |   2297 | haxe.macro.Context
    next                         |   0.004 |   0 |   1 |   8690 | haxe.ds._List.ListIterator
    ofHandler                    |   0.004 |   0 |   0 |   1025 | utest.TestResult
    runFixture                   |   0.004 |   0 |   0 |   1025 | utest.Runner
    new                          |   0.004 |   0 |   0 |   1025 | utest.TestHandler
    addResult                    |   0.003 |   0 |   0 |   1025 | utest.ui.common.PackageResult
    makeExpr                     |   0.003 |   0 |   0 |   1682 | haxe.macro.Context
    has                          |   0.003 |   0 |   0 |   1482 | Lambda
    addIssueClasses              |   0.003 |   0 |   0 |      2 | unit.TestIssues
    getResolved                  |   0.003 |   0 |   0 |   4861 | utest.Async
    testComplete                 |   0.002 |   0 |   0 |   1025 | utest.Runner
    runTest                      |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    getLocalClass                |   0.002 |   0 |   0 |    899 | haxe.macro.Context
    new                          |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    toplevel                     |   0.002 |   0 |   0 |   1666 | 
    read                         |   0.002 |   0 |   0 |     61 | unit.UnitBuilder
    getIgnored                   |   0.002 |   0 |   0 |   1025 | utest.TestFixture
    runSetup                     |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    initialExpressions           |   0.002 |   0 |   0 |    898 | utest.utils.TestBuilder
    runTeardown                  |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    ofData                       |   0.002 |   0 |   0 |   1025 | utest.TestFixture
    checkTest                    |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    runFixtures                  |   0.002 |   0 |   0 |    894 | utest._Runner.ITestRunner
    getOrCreateClass             |   0.002 |   0 |   0 |   1025 | utest.ui.common.PackageResult
    defined                      |   0.002 |   0 |   0 |   1066 | haxe.macro.Context
    isTestName                   |   0.002 |   0 |   0 |   1179 | utest.utils.TestBuilder
    execute                      |   0.002 |   0 |   0 |   1025 | utest.ITestHandler
    completedFinally             |   0.002 |   0 |   0 |   1025 | utest.TestHandler
    localFunction1               |   0.002 |   0 |   0 |    809 | utest.ITestHandler.runTest
    getOrCreatePackage           |   0.002 |   0 |   0 |   1025 | utest.ui.common.PackageResult
    addCase                      |   0.002 |   0 |   0 |    894 | utest.Runner
    printExpr                    |   0.002 |   0 |   0 |    436 | haxe.macro.Printer
    new                          |   0.002 |   0 |   0 |   3190 | haxe.ds.List
    checkPossibleTypo            |   0.002 |   0 |   0 |    427 | utest.utils.TestBuilder
    new                          |   0.001 |   0 |   0 |   1025 | utest.ui.common.FixtureResult
    progress                     |   0.001 |   0 |   0 |   1025 | utest.ui.common.ResultAggregator
    addClass                     |   0.001 |   0 |   0 |    811 | utest.ui.common.PackageResult
    isTrue                       |   0.001 |   0 |   0 |   1377 | utest.Assert
    add                          |   0.001 |   0 |   0 |   1025 | utest.ui.common.ClassResult
    isTestFixtureName            |   0.001 |   0 |   0 |   1025 | utest.Runner
    checkSetup                   |   0.001 |   0 |   0 |   1025 | utest.ITestHandler
    new                          |   0.001 |   0 |   0 |    811 | utest.ui.common.ClassResult
    currentPos                   |   0.001 |   0 |   0 |    718 | haxe.macro.Context
    iterator                     |   0.001 |   0 |   0 |   1027 | haxe.ds.List
    t                            |   0.001 |   0 |   0 |   1257 | unit.Test
    new                          |   0.001 |   0 |   0 |   1025 | utest.TestFixture
    addIgnores                   |   0.001 |   0 |   0 |   1851 | utest.ui.common.ResultStats
    checkTeardown                |   0.001 |   0 |   0 |   1025 | utest.ITestHandler
    typedAs                      |   0.001 |   0 |   0 |    110 | unit.HelperMacros
    getFields                    |   0.001 |   0 |   0 |   1030 | haxe.rtti.Meta
    addWarnings                  |   0.001 |   0 |   0 |   1851 | utest.ui.common.ResultStats
    addFailures                  |   0.001 |   0 |   0 |   1851 | utest.ui.common.ResultStats
    new                          |   0.001 |   0 |   0 |      1 | unit.issues._Issue6801.Child
    unbindHandler                |   0.001 |   0 |   0 |   1025 | utest.TestHandler
    typeExpr                     |   0.001 |   0 |   0 |     31 | haxe.macro.Context
  jit                            |   0.015 |   1 |   2 |    859 | 
  add_types                      |   0.014 |   0 |   2 |     71 | 
typing                           |   0.690 |  24 |  24 |   4806 | 
analyzer                         |   0.516 |  18 |  18 |  71512 | 
parsing                          |   0.332 |  11 |  11 |   1284 | 
filters                          |   0.315 |  11 |  11 |     11 | 
interp                           |   0.122 |   4 |   4 |   5534 | 
  jit                            |   0.103 |   4 |  84 |   5531 | 
  add_types                      |   0.019 |   1 |  16 |      1 | 
haxelib                          |   0.020 |   1 |   1 |      1 | 
null safety                      |   0.002 |   0 |   0 |      1 | 
-----------------------------------------------------------------
total                            |   2.912 | 100 | 100 | 466661 | 

real	0m3,018s
user	0m2,813s
sys	0m0,192s
```
</details>