### PR TITLE
[js] Enable haxe for-in iteration of js.lib Map and Set

### DIFF
--- a/std/js/lib/HaxeIterator.hx
+++ b/std/js/lib/HaxeIterator.hx
@@ -45,4 +45,8 @@ class HaxeIterator<T> {
 		return v;
 	}
 
+	public static inline function iterator<T>(jsIterator: js.lib.Iterator<T>) {
+		return new HaxeIterator(jsIterator);
+	}
+
 }

--- a/std/js/lib/HaxeIterator.hx
+++ b/std/js/lib/HaxeIterator.hx
@@ -22,11 +22,27 @@
 
 package js.lib;
 
-typedef Iterator<T> = {
-	function next():IteratorStep<T>;
-}
+/**
+	HaxeIterator wraps a JavaScript iterator object in a class that haxe can iterate over
+**/
+class HaxeIterator<T> {
 
-typedef IteratorStep<T> = {
-	done:Bool,
-	?value:T
+	final jsIterator: js.lib.Iterator<T>;
+	var lastStep: js.lib.Iterator.IteratorStep<T>;
+
+	public inline function new(jsIterator: js.lib.Iterator<T>) {
+		this.jsIterator = jsIterator;
+		lastStep = jsIterator.next();
+	}
+
+	public inline function hasNext(): Bool {
+		return !lastStep.done;
+	}
+
+	public inline function next(): T {
+		var v = lastStep.value;
+		lastStep = jsIterator.next();
+		return v;
+	}
+
 }

--- a/std/js/lib/HaxeIterator.hx
+++ b/std/js/lib/HaxeIterator.hx
@@ -23,7 +23,8 @@
 package js.lib;
 
 /**
-	HaxeIterator wraps a JavaScript iterator object in a class that haxe can iterate over
+	`HaxeIterator` wraps a JavaScript native iterator object to enable for-in iteration in haxe.
+	It can be used directly: `new HaxeIterator(jsIterator)` or via using: `using HaxeIterator`.
 **/
 class HaxeIterator<T> {
 

--- a/std/js/lib/Iterator.hx
+++ b/std/js/lib/Iterator.hx
@@ -22,7 +22,19 @@
 
 package js.lib;
 
-typedef Iterator<T> = {
+/**
+	abstract over JavaScript iterator objects that enables supports haxe for-in iteration
+**/
+@:forward
+abstract Iterator<T>(IteratorStructure<T>) from IteratorStructure<T> {
+
+	public inline function iterator(): JSIterator<T> {
+		return new JSIterator<T>(this);
+	}
+
+}
+
+typedef IteratorStructure<T> = {
 	function next():IteratorStep<T>;
 }
 
@@ -30,3 +42,28 @@ typedef IteratorStep<T> = {
 	done:Bool,
 	?value:T
 }
+
+/**
+	JSIterator wraps a JavaScript iterator object in a class that haxe can iterate over
+**/
+class JSIterator<T> {
+
+	final jsIterator: js.lib.IteratorStructure<T>;
+	var lastStep: js.lib.Iterator.IteratorStep<T>;
+
+	public inline function new(jsIterator: js.lib.IteratorStructure<T>) {
+		this.jsIterator = jsIterator;
+		lastStep = jsIterator.next();
+	}
+
+	public inline function hasNext(): Bool {
+		return !lastStep.done;
+	}
+
+	public inline function next(): T {
+		var v = lastStep.value;
+		lastStep = jsIterator.next();
+		return v;
+	}
+
+} 

--- a/std/js/lib/Iterator.hx
+++ b/std/js/lib/Iterator.hx
@@ -23,7 +23,7 @@
 package js.lib;
 
 /**
-	abstract over JavaScript iterator objects that enables supports haxe for-in iteration
+	abstract over JavaScript iterator objects that enables haxe for-in iteration
 **/
 @:forward
 abstract Iterator<T>(IteratorStructure<T>) from IteratorStructure<T> to IteratorStructure<T> {

--- a/std/js/lib/Iterator.hx
+++ b/std/js/lib/Iterator.hx
@@ -26,7 +26,7 @@ package js.lib;
 	abstract over JavaScript iterator objects that enables supports haxe for-in iteration
 **/
 @:forward
-abstract Iterator<T>(IteratorStructure<T>) from IteratorStructure<T> {
+abstract Iterator<T>(IteratorStructure<T>) from IteratorStructure<T> to IteratorStructure<T> {
 
 	public inline function iterator(): JSIterator<T> {
 		return new JSIterator<T>(this);

--- a/std/js/lib/Iterator.hx
+++ b/std/js/lib/Iterator.hx
@@ -22,6 +22,11 @@
 
 package js.lib;
 
+/**
+	Native JavaScript iterator structure. To enable haxe for-in iteration, use `js.lib.HaxeIterator`, for example `for (v in new js.lib.HaxeIterator(jsIterator))` or add `using js.lib.HaxeIterator;` to your module
+
+	See [Iteration Protocols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
+**/
 typedef Iterator<T> = {
 	function next():IteratorStep<T>;
 }

--- a/std/js/lib/Map.hx
+++ b/std/js/lib/Map.hx
@@ -104,8 +104,8 @@ extern class Map<K, V> {
 		return new HaxeIterator(this.values());
 	}
 
-	inline function keyValueIterator(): MapKVIterator<K, V> {
-		return new MapKVIterator(this);
+	inline function keyValueIterator(): HaxeIterator<MapEntry<K,V>> {
+		return new HaxeIterator(this.entries());
 	}
 
 }
@@ -123,27 +123,3 @@ abstract MapEntry<K, V>(Array<Any>) {
 	inline function get_value():V
 		return this[1];
 }
-
-class MapKVIterator<K, V> {
-
-	final map: js.lib.Map<K, V>;
-	final entries: HaxeIterator<MapEntry<K, V>>;
-
-	public inline function new(map: js.lib.Map<K, V>) {
-		this.map = map;
-		this.entries = new HaxeIterator(map.entries());
-	}
-
-	public inline function hasNext() : Bool {
-		return entries.hasNext();
-	}
-
-	public inline function next() : {key: K, value: V} {
-		var entry = entries.next();
-		return {
-			key: entry.key,
-			value: entry.value,
-		};
-	}
-
-} 

--- a/std/js/lib/Map.hx
+++ b/std/js/lib/Map.hx
@@ -100,8 +100,8 @@ extern class Map<K, V> {
 	**/
 	function entries():js.lib.Iterator<MapEntry<K, V>>;
 
-	inline function iterator(): js.lib.Iterator.JSIterator<V> {
-		return this.values().iterator();
+	inline function iterator(): js.lib.HaxeIterator<V> {
+		return new HaxeIterator(this.values());
 	}
 
 	inline function keyValueIterator(): MapKVIterator<K, V> {
@@ -127,11 +127,11 @@ abstract MapEntry<K, V>(Array<Any>) {
 class MapKVIterator<K, V> {
 
 	final map: js.lib.Map<K, V>;
-	final entries: js.lib.Iterator.JSIterator<MapEntry<K, V>>;
+	final entries: HaxeIterator<MapEntry<K, V>>;
 
 	public inline function new(map: js.lib.Map<K, V>) {
 		this.map = map;
-		this.entries = map.entries().iterator();
+		this.entries = new HaxeIterator(map.entries());
 	}
 
 	public inline function hasNext() : Bool {

--- a/std/js/lib/Map.hx
+++ b/std/js/lib/Map.hx
@@ -22,8 +22,6 @@
 
 package js.lib;
 
-import js.lib.Iterator;
-
 /**
 	The (native) JavaScript Map object holds key-value pairs.
 	Any value (both objects and primitive values) may be used as either a key
@@ -88,19 +86,28 @@ extern class Map<K, V> {
 		Returns a new `Iterator` object that contains the keys for each element
 		in the `js.Map` object in insertion order.
 	**/
-	function keys():Iterator<K>;
+	function keys():js.lib.Iterator<K>;
 
 	/**
 		Returns a new `Iterator` object that contains the values for each
 		element in the `js.Map` object in insertion order.
 	**/
-	function values():Iterator<V>;
+	function values():js.lib.Iterator<V>;
 
 	/**
 		Returns a new `Iterator` object that contains an array of `MapEntry`
 		for each element in the `js.Map` object in insertion order.
 	**/
-	function entries():Iterator<MapEntry<K, V>>;
+	function entries():js.lib.Iterator<MapEntry<K, V>>;
+
+	inline function iterator(): js.lib.Iterator.JSIterator<V> {
+		return this.values().iterator();
+	}
+
+	inline function keyValueIterator(): MapKVIterator<K, V> {
+		return new MapKVIterator(this);
+	}
+
 }
 
 /**
@@ -116,3 +123,27 @@ abstract MapEntry<K, V>(Array<Any>) {
 	inline function get_value():V
 		return this[1];
 }
+
+class MapKVIterator<K, V> {
+
+	final map: js.lib.Map<K, V>;
+	final entries: js.lib.Iterator.JSIterator<MapEntry<K, V>>;
+
+	public inline function new(map: js.lib.Map<K, V>) {
+		this.map = map;
+		this.entries = map.entries().iterator();
+	}
+
+	public inline function hasNext() : Bool {
+		return entries.hasNext();
+	}
+
+	public inline function next() : {key: K, value: V} {
+		var entry = entries.next();
+		return {
+			key: entry.key,
+			value: entry.value,
+		};
+	}
+
+} 

--- a/std/js/lib/Set.hx
+++ b/std/js/lib/Set.hx
@@ -97,8 +97,8 @@ extern class Set<T> {
 	**/
 	function entries():js.lib.Iterator<MapEntry<T, T>>;
 
-	inline function iterator(): js.lib.Iterator.JSIterator<T> {
-		return this.values().iterator();
+	inline function iterator(): HaxeIterator<T> {
+		return new HaxeIterator(this.values());
 	}
 
 	inline function keyValueIterator(): SetKVIterator<T> {
@@ -113,12 +113,12 @@ extern class Set<T> {
 class SetKVIterator<T> {
 
 	final set: js.lib.Set<T>;
-	final values: js.lib.Iterator.JSIterator<T>;
+	final values: HaxeIterator<T>;
 	var index = 0;
 
 	public inline function new(set: js.lib.Set<T>) {
 		this.set = set;
-		this.values = set.values().iterator();
+		this.values = new HaxeIterator(set.values());
 	}
 
 	public inline function hasNext() : Bool {

--- a/std/js/lib/Set.hx
+++ b/std/js/lib/Set.hx
@@ -23,7 +23,6 @@
 package js.lib;
 
 import js.lib.Map.MapEntry;
-import js.lib.Iterator;
 
 /**
 	The `js.Set` object lets you store unique values of any type, whether
@@ -81,13 +80,13 @@ extern class Set<T> {
 		Returns a new `js.lib.Iterator` object that contains the keys for each element
 		in the `js.Set` object in insertion order.
 	**/
-	function keys():Iterator<T>;
+	function keys():js.lib.Iterator<T>;
 
 	/**
 		Returns a new `js.lib.Iterator` object that contains the values for each
 		element in the `js.Set` object in insertion order.
 	**/
-	function values():Iterator<T>;
+	function values():js.lib.Iterator<T>;
 
 	/**
 		Returns a new `js.lib.Iterator` object that contains an array of
@@ -96,5 +95,41 @@ extern class Set<T> {
 		This is kept similar to the `js.Map` object, so that each entry has the
 		same value for its key and value here.
 	**/
-	function entries():Iterator<MapEntry<T, T>>;
+	function entries():js.lib.Iterator<MapEntry<T, T>>;
+
+	inline function iterator(): js.lib.Iterator.JSIterator<T> {
+		return this.values().iterator();
+	}
+
+	inline function keyValueIterator(): SetKVIterator<T> {
+		return new SetKVIterator(this);
+	}
+
 }
+
+/**
+	key => value iterator for js.lib.Set, tracking the entry index for the key to match the behavior of haxe.ds.List
+**/
+class SetKVIterator<T> {
+
+	final set: js.lib.Set<T>;
+	final values: js.lib.Iterator.JSIterator<T>;
+	var index = 0;
+
+	public inline function new(set: js.lib.Set<T>) {
+		this.set = set;
+		this.values = set.values().iterator();
+	}
+
+	public inline function hasNext() : Bool {
+		return values.hasNext();
+	}
+
+	public inline function next() : {key: Int, value: T} {
+		return {
+			key: index++,
+			value: values.next(),
+		};
+	}
+
+} 

--- a/std/js/lib/Set.hx
+++ b/std/js/lib/Set.hx
@@ -101,8 +101,8 @@ extern class Set<T> {
 		return new HaxeIterator(this.values());
 	}
 
-	inline function keyValueIterator(): SetKvIterator<T> {
-		return new SetKvIterator(this);
+	inline function keyValueIterator(): SetKeyValueIterator<T> {
+		return new SetKeyValueIterator(this);
 	}
 
 }
@@ -110,7 +110,7 @@ extern class Set<T> {
 /**
 	key => value iterator for js.lib.Set, tracking the entry index for the key to match the behavior of haxe.ds.List
 **/
-class SetKvIterator<T> {
+class SetKeyValueIterator<T> {
 
 	final set: js.lib.Set<T>;
 	final values: HaxeIterator<T>;

--- a/std/js/lib/Set.hx
+++ b/std/js/lib/Set.hx
@@ -101,8 +101,8 @@ extern class Set<T> {
 		return new HaxeIterator(this.values());
 	}
 
-	inline function keyValueIterator(): SetKVIterator<T> {
-		return new SetKVIterator(this);
+	inline function keyValueIterator(): SetKvIterator<T> {
+		return new SetKvIterator(this);
 	}
 
 }
@@ -110,7 +110,7 @@ extern class Set<T> {
 /**
 	key => value iterator for js.lib.Set, tracking the entry index for the key to match the behavior of haxe.ds.List
 **/
-class SetKVIterator<T> {
+class SetKvIterator<T> {
 
 	final set: js.lib.Set<T>;
 	final values: HaxeIterator<T>;


### PR DESCRIPTION
This enables using `for-in` on `js.lib.Set`, `js.lib.Map` and `js.lib.Iterator`;

**Impact on Existing Code**
None expected

For example, the following will now compile:
```haxe
var set = new js.lib.Set();
set.add('A');
set.add('B');
set.add('C');

for (value in set) {
    trace(value);
}
```

```haxe
var map = new js.lib.Map();
map.set('a', 1);
map.set('b', 2);
map.set('c', 3);

for (key => value in map) {
    trace('$key => $value');
}
```

For key-value iteration over a Set I've matched the behavior of `haxe.ds.List`
```haxe
for (key => value in set) {
    trace('$key => $value');
}
// 0 => A
// 1 => B
// 2 => C
```

To iterate over a `js.lib.Iterator` requires using the `HaxeIterator` class:
```haxe
using js.lib.HaxeIterator;
...

for (value in set.values()) {
    trace(value);
}
```

or alternatively
```haxe
for (value in new js.lib.HaxeIterator(set.values())) {
    trace(value);
}
```
The generated code gets nicely inlined, for key-value iteration on map it looks something like
```js
var jsIterator = map.entries();
var _this_lastStep = jsIterator.next();
while(!_this_lastStep.done) {
    var v2 = _this_lastStep.value;
    _this_lastStep = jsIterator.next();
    console.log("Main.hx", v2[0] + " => " + v2[1]);
}
```