### PR TITLE
HttpJs handle http request with r.status == 0

### DIFF
--- a/std/haxe/http/HttpJs.hx
+++ b/std/haxe/http/HttpJs.hx
@@ -74,7 +74,7 @@ class HttpJs extends haxe.http.HttpBase {
 			if (s != null && s >= 200 && s < 400) {
 				req = null;
 				success(Bytes.ofData(r.response));
-			} else if (s == null || s == 0) {
+			} else if (s == null || (s == 0 && r.response == null)) {
 				req = null;
 				onError("Failed to connect or resolve host");
 			} else

--- a/std/haxe/http/HttpJs.hx
+++ b/std/haxe/http/HttpJs.hx
@@ -74,7 +74,7 @@ class HttpJs extends haxe.http.HttpBase {
 			if (s != null && s >= 200 && s < 400) {
 				req = null;
 				success(Bytes.ofData(r.response));
-			} else if (s == null) {
+			} else if (s == null || s == 0) {
 				req = null;
 				onError("Failed to connect or resolve host");
 			} else
@@ -87,7 +87,7 @@ class HttpJs extends haxe.http.HttpBase {
 						onError("Unknown host");
 					default:
 						req = null;
-						responseBytes = Bytes.ofData(r.response);
+						responseBytes = r.response != null ? Bytes.ofData(r.response) : null;
 						onError("Http Error #" + r.status);
 				}
 		};


### PR DESCRIPTION
or `r.response == null`.
this will fix #8749 
Additional it will handle any case when `r.response == null`. The later would fix the case for a http request which could not be resolved too, But handling the particular case when `r.status == 0` will give the right error message.