### PR TITLE
Eliminate unused vars on inlining

### DIFF
--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -545,19 +545,6 @@ class inline_state ctx ethis params cf f p = object(self)
 				| _ -> unify_func())
 			| _ -> unify_func());
 		end;
-		let rec drop_unused_vars e =
-			match e.eexpr with
-			| TVar (v, Some { eexpr = TConst _ }) ->
-				(try
-					let data = Hashtbl.find locals v.v_id in
-					if data.i_read = 0 && not data.i_write then mk (TBlock []) e.etype e.epos
-					else Type.map_expr drop_unused_vars e
-				with Not_found ->
-					Type.map_expr drop_unused_vars e
-				)
-			| _ -> Type.map_expr drop_unused_vars e
-		in
-		let e = drop_unused_vars e in
 		let vars = Hashtbl.create 0 in
 		let rec map_var map_type v =
 			if not (Hashtbl.mem vars v.v_id) then begin
@@ -583,7 +570,20 @@ class inline_state ctx ethis params cf f p = object(self)
 			in
 			Type.map_expr_type (map_expr_type map_type) map_type (map_var map_type) e
 		in
-		map_expr_type map_type e
+		let e = map_expr_type map_type e in
+		let rec drop_unused_vars e =
+			match e.eexpr with
+			| TVar (v, Some { eexpr = TConst _ }) ->
+				(try
+					let data = Hashtbl.find locals v.v_id in
+					if data.i_read = 0 && not data.i_write then mk (TBlock []) e.etype e.epos
+					else Type.map_expr drop_unused_vars e
+				with Not_found ->
+					Type.map_expr drop_unused_vars e
+				)
+			| _ -> Type.map_expr drop_unused_vars e
+		in
+		drop_unused_vars e
 end
 
 let rec type_inline ctx cf f ethis params tret config p ?(self_calling_closure=false) force =

--- a/tests/misc/projects/Issue8654/Check.hx
+++ b/tests/misc/projects/Issue8654/Check.hx
@@ -31,7 +31,7 @@ class Check {
 														//success;
 														return;
 													case _:
-														Context.error('Invalid invalid type of "f(get())" in Arr.map: $t', exprs[0].pos);
+														Context.error('Invalid type of "f(get())" in Arr.map: $t', exprs[0].pos);
 												}
 											case _:
 												Context.error('Invalid expression of Arr.map block', exprs[0].pos);

--- a/tests/optimization/src/issues/Issue6715.hx
+++ b/tests/optimization/src/issues/Issue6715.hx
@@ -4,27 +4,34 @@ class Issue6715 {
 	@:js('
 		var f = function() {
 			var x = 1;
+			x = 2;
 		};
 		issues_Issue6715.x = f;
 		issues_Issue6715.x = f;
 		issues_Issue6715.x = f;
 		var x1 = 1;
+		x1 = 2;
 		var x2 = 1;
+		x2 = 2;
 		var x3 = 1;
+		x3 = 2;
 	')
 	@:analyzer(no_local_dce)
 	static public function test1() {
-		insanity(function() var x = 1);
+		insanity(function() { var x = 1; x = 2; });
 	}
 
 	@:js('
 		var x = 1;
+		x = 2;
 		var x1 = 1;
+		x1 = 2;
 		var x2 = 1;
+		x2 = 2;
 	')
 	@:analyzer(no_local_dce)
 	static public function test2() {
-		insanity2(function() var x = 1);
+		insanity2(function() { var x = 1; x = 2; });
 	}
 
 	@:js('

--- a/tests/optimization/src/issues/Issue8770.hx
+++ b/tests/optimization/src/issues/Issue8770.hx
@@ -1,0 +1,20 @@
+package issues;
+
+class Issue8770 {
+	@:pure(false) static var testStatic:String;
+	static var pureStatic:String;
+
+	@:pure(false) var testInstance:String;
+	var pureInstance:String;
+
+	@:js('
+		var m_h;
+		m_h = { };
+	')
+	@:analyzer(ignore)
+	static function test() {
+		var m = new Map<Int,Bool>();
+	}
+
+	public function new() {}
+}


### PR DESCRIPTION
Closes #8770

I'm not sure if we really need this, because `-D analyzer-optimize` already does the job.
OTOH since it's not a default setting and `Map` is a frequently used type, it sucks to have `var t = null` all over the generated code for no reason.