### PR TITLE
Allocation free `Map.iterator()` and `Map.keys()`

### DIFF
--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -337,7 +337,7 @@ let rec using_field ctx mode e i p =
 		loop ctx.m.module_using
 	with Not_found -> try
 		(* type using from `@:using(Path)` *)
-		let mt = module_type_of_type e.etype in
+		let mt = module_type_of_type (follow e.etype) in
 		loop (t_infos mt).mt_using
 	with Not_found | Exit -> try
 		(* global using *)

--- a/std/haxe/ds/Map.hx
+++ b/std/haxe/ds/Map.hx
@@ -110,7 +110,7 @@ abstract Map<K, V>(IMap<K, V>) {
 	public inline function remove(key:K)
 		return this.remove(key);
 
-#if doc_gen
+#if (doc_gen || as3)
 	/**
 		Returns an Iterator over the keys of `this` Map.
 

--- a/std/haxe/ds/Map.hx
+++ b/std/haxe/ds/Map.hx
@@ -46,6 +46,7 @@ import haxe.Constraints.IMap;
 
 	@see https://haxe.org/manual/std-Map.html
 **/
+@:using(haxe.iterators.MapIterator)
 @:multiType(@:followWithAbstracts K)
 abstract Map<K, V>(IMap<K, V>) {
 	/**
@@ -117,7 +118,7 @@ abstract Map<K, V>(IMap<K, V>) {
 	public inline function keys():Iterator<K> {
 		return this.keys();
 	}
-
+#if doc_gen
 	/**
 		Returns an Iterator over the values of `this` Map.
 
@@ -126,7 +127,7 @@ abstract Map<K, V>(IMap<K, V>) {
 	public inline function iterator():Iterator<V> {
 		return this.iterator();
 	}
-
+#end
 	/**
 		Returns an Iterator over the keys and values of `this` Map.
 

--- a/std/haxe/ds/Map.hx
+++ b/std/haxe/ds/Map.hx
@@ -110,6 +110,7 @@ abstract Map<K, V>(IMap<K, V>) {
 	public inline function remove(key:K)
 		return this.remove(key);
 
+#if doc_gen
 	/**
 		Returns an Iterator over the keys of `this` Map.
 
@@ -118,7 +119,6 @@ abstract Map<K, V>(IMap<K, V>) {
 	public inline function keys():Iterator<K> {
 		return this.keys();
 	}
-#if doc_gen
 	/**
 		Returns an Iterator over the values of `this` Map.
 

--- a/std/haxe/iterators/MapIterator.hx
+++ b/std/haxe/iterators/MapIterator.hx
@@ -6,14 +6,15 @@ import haxe.ds.IntMap;
 import haxe.ds.ObjectMap;
 import haxe.ds.StringMap;
 import haxe.ds.WeakMap;
+import haxe.Constraints.IMap;
 
 class MapGenericIterator {
 	static public inline function iterator<K, V>(m:Map<K, V>):Iterator<V> {
-		return (cast m).iterator();
+		return (cast m:IMap<K, V>).iterator();
 	}
 
 	static public inline function keys<K, V>(m:Map<K, V>):Iterator<K> {
-		return (cast m).keys();
+		return (cast m:IMap<K, V>).keys();
 	}
 }
 
@@ -43,7 +44,7 @@ class MapIntIterator {
 	}
 
 	static public inline function keys<K:Int, V>(m:Map<K, V>):Iterator<K> {
-		return cast (m:IntMap<V>).keys();
+		return cast ((m:IntMap<V>).keys());
 	}
 }
 
@@ -63,7 +64,7 @@ class MapStringIterator {
 	}
 
 	static public inline function keys<K:String, V>(m:Map<K, V>):Iterator<K> {
-		return cast (m:StringMap<V>).keys();
+		return cast ((m:StringMap<V>).keys());
 	}
 }
 

--- a/std/haxe/iterators/MapIterator.hx
+++ b/std/haxe/iterators/MapIterator.hx
@@ -7,6 +7,16 @@ import haxe.ds.ObjectMap;
 import haxe.ds.StringMap;
 import haxe.ds.WeakMap;
 
+class MapGenericIterator {
+	static public inline function iterator<K, V>(m:Map<K, V>):Iterator<V> {
+		return (cast m).iterator();
+	}
+
+	static public inline function keys<K, V>(m:Map<K, V>):Iterator<K> {
+		return (cast m).keys();
+	}
+}
+
 class MapEnumValueIterator {
 	static public inline function iterator<K:EnumValue, V>(m:EnumValueMap<K,V>) {
 		return m.iterator();
@@ -32,8 +42,8 @@ class MapIntIterator {
 		return m.iterator();
 	}
 
-	static public inline function keys<V>(m:IntMap<V>) {
-		return m.keys();
+	static public inline function keys<K:Int, V>(m:Map<K, V>):Iterator<K> {
+		return cast (m:IntMap<V>).keys();
 	}
 }
 
@@ -52,8 +62,8 @@ class MapStringIterator {
 		return m.iterator();
 	}
 
-	static public inline function keys<V>(m:StringMap<V>) {
-		return m.keys();
+	static public inline function keys<K:String, V>(m:Map<K, V>):Iterator<K> {
+		return cast (m:StringMap<V>).keys();
 	}
 }
 

--- a/std/haxe/iterators/MapIterator.hx
+++ b/std/haxe/iterators/MapIterator.hx
@@ -1,0 +1,68 @@
+package haxe.iterators;
+
+import haxe.ds.EnumValueMap;
+import haxe.ds.HashMap;
+import haxe.ds.IntMap;
+import haxe.ds.ObjectMap;
+import haxe.ds.StringMap;
+import haxe.ds.WeakMap;
+
+class MapEnumValueIterator {
+	static public inline function iterator<K:EnumValue, V>(m:EnumValueMap<K,V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:EnumValue, V>(m:EnumValueMap<K,V>) {
+		return m.keys();
+	}
+}
+
+class MapHashIterator {
+	static public inline function iterator<K:{function hashCode():Int;}, V>(m:HashMap<K,V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:{function hashCode():Int;}, V>(m:HashMap<K,V>) {
+		return m.keys();
+	}
+}
+
+class MapIntIterator {
+	static public inline function iterator<V>(m:IntMap<V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<V>(m:IntMap<V>) {
+		return m.keys();
+	}
+}
+
+class MapObjectIterator {
+	static public inline function iterator<K:{}, V>(m:ObjectMap<K,V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:{}, V>(m:ObjectMap<K,V>) {
+		return m.keys();
+	}
+}
+
+class MapStringIterator {
+	static public inline function iterator<V>(m:StringMap<V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<V>(m:StringMap<V>) {
+		return m.keys();
+	}
+}
+
+class MapWeakIterator {
+	static public inline function iterator<K:{}, V>(m:WeakMap<K, V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:{}, V>(m:WeakMap<K, V>) {
+		return m.keys();
+	}
+}

--- a/std/haxe/iterators/MapIterator.js.hx
+++ b/std/haxe/iterators/MapIterator.js.hx
@@ -9,11 +9,11 @@ import haxe.ds.WeakMap;
 
 class MapGenericIterator {
 	static public inline function iterator<K, V>(m:Map<K, V>):Iterator<V> {
-		return (cast m).iterator();
+		return (cast m:IMap<K, V>).iterator();
 	}
 
 	static public inline function keys<K, V>(m:Map<K, V>):Iterator<K> {
-		return (cast m).keys();
+		return (cast m:IMap<K, V>).keys();
 	}
 }
 

--- a/std/haxe/iterators/MapIterator.js.hx
+++ b/std/haxe/iterators/MapIterator.js.hx
@@ -7,6 +7,16 @@ import haxe.ds.ObjectMap;
 import haxe.ds.StringMap;
 import haxe.ds.WeakMap;
 
+class MapGenericIterator {
+	static public inline function iterator<K, V>(m:Map<K, V>):Iterator<V> {
+		return (cast m).iterator();
+	}
+
+	static public inline function keys<K, V>(m:Map<K, V>):Iterator<K> {
+		return (cast m).keys();
+	}
+}
+
 class MapEnumValueIterator {
 	static public inline function iterator<K:EnumValue, V>(m:EnumValueMap<K,V>) {
 		return m.iterator();
@@ -32,8 +42,8 @@ class MapIntIterator {
 		return @:privateAccess m.typedIterator();
 	}
 
-	static public inline function keys<V>(m:IntMap<V>) {
-		return new KeyIterator(@:privateAccess m.arrayKeys());
+	static public inline function keys<K:Int, V>(m:Map<K,V>) {
+		return new KeyIterator<K>(cast @:privateAccess (m:IntMap<V>).arrayKeys());
 	}
 }
 
@@ -52,8 +62,8 @@ class MapStringIterator {
 		return @:privateAccess m.typedIterator();
 	}
 
-	static public inline function keys<V>(m:StringMap<V>) {
-		return new KeyIterator(@:privateAccess m.arrayKeys());
+	static public inline function keys<K:String, V>(m:Map<K, V>) {
+		return new KeyIterator<K>(cast @:privateAccess (m:StringMap<V>).arrayKeys());
 	}
 }
 

--- a/std/haxe/iterators/MapIterator.js.hx
+++ b/std/haxe/iterators/MapIterator.js.hx
@@ -6,6 +6,7 @@ import haxe.ds.IntMap;
 import haxe.ds.ObjectMap;
 import haxe.ds.StringMap;
 import haxe.ds.WeakMap;
+import haxe.Constraints.IMap;
 
 class MapGenericIterator {
 	static public inline function iterator<K, V>(m:Map<K, V>):Iterator<V> {

--- a/std/haxe/iterators/MapIterator.js.hx
+++ b/std/haxe/iterators/MapIterator.js.hx
@@ -1,0 +1,85 @@
+package haxe.iterators;
+
+import haxe.ds.EnumValueMap;
+import haxe.ds.HashMap;
+import haxe.ds.IntMap;
+import haxe.ds.ObjectMap;
+import haxe.ds.StringMap;
+import haxe.ds.WeakMap;
+
+class MapEnumValueIterator {
+	static public inline function iterator<K:EnumValue, V>(m:EnumValueMap<K,V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:EnumValue, V>(m:EnumValueMap<K,V>) {
+		return m.keys();
+	}
+}
+
+class MapHashIterator {
+	static public inline function iterator<K:{function hashCode():Int;}, V>(m:HashMap<K,V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:{function hashCode():Int;}, V>(m:HashMap<K,V>) {
+		return m.keys();
+	}
+}
+
+class MapIntIterator {
+	static public inline function iterator<V>(m:IntMap<V>) {
+		return @:privateAccess m.typedIterator();
+	}
+
+	static public inline function keys<V>(m:IntMap<V>) {
+		return new KeyIterator(@:privateAccess m.arrayKeys());
+	}
+}
+
+class MapObjectIterator {
+	static public inline function iterator<K:{}, V>(m:ObjectMap<K,V>) {
+		return @:privateAccess m.typedIterator();
+	}
+
+	static public inline function keys<K:{}, V>(m:ObjectMap<K,V>) {
+		return new KeyIterator(@:privateAccess m.arrayKeys());
+	}
+}
+
+class MapStringIterator {
+	static public inline function iterator<V>(m:StringMap<V>) {
+		return @:privateAccess m.typedIterator();
+	}
+
+	static public inline function keys<V>(m:StringMap<V>) {
+		return new KeyIterator(@:privateAccess m.arrayKeys());
+	}
+}
+
+class MapWeakIterator {
+	static public inline function iterator<K:{}, V>(m:WeakMap<K, V>) {
+		return m.iterator();
+	}
+
+	static public inline function keys<K:{}, V>(m:WeakMap<K, V>) {
+		return m.keys();
+	}
+}
+
+private class KeyIterator<T> {
+	final keys:Array<T>;
+	var current:Int = 0;
+
+	public inline function new(keys:Array<T>) {
+		this.keys = keys;
+	}
+
+	public inline function hasNext():Bool {
+		return keys.length > current;
+	}
+
+	public inline function next():T {
+		return keys[current++];
+	}
+}

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -22,6 +22,28 @@
 
 package haxe.ds;
 
+private class IntMapIterator<T> {
+	var map:IntMap<T>;
+	var keys:Array<Int>;
+	var index:Int;
+	var count:Int;
+
+	public inline function new(map:IntMap<T>, keys:Array<Int>) {
+		this.map = map;
+		this.keys = keys;
+		this.index = 0;
+		this.count = keys.length;
+	}
+
+	public inline function hasNext() {
+		return index < count;
+	}
+
+	public inline function next() {
+		return map.get(keys[index++]);
+	}
+}
+
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	private var h:Dynamic;
 
@@ -49,23 +71,21 @@ package haxe.ds;
 	}
 
 	public function keys():Iterator<Int> {
+		return arrayKeys().iterator();
+	}
+
+	inline function arrayKeys():Array<Int> {
 		var a = [];
 		untyped __js__("for( var key in {0} ) {1}", h, if (h.hasOwnProperty(key)) a.push(key | 0));
-		return a.iterator();
+		return a;
 	}
 
 	public function iterator():Iterator<T> {
-		return untyped {
-			ref: h,
-			it: keys(),
-			hasNext: function() {
-				return __this__.it.hasNext();
-			},
-			next: function() {
-				var i = __this__.it.next();
-				return __this__.ref[i];
-			}
-		};
+		return typedIterator();
+	}
+
+	inline function typedIterator():IntMapIterator<T> {
+		return new IntMapIterator(this, arrayKeys());
 	}
 
 	@:runtime public inline function keyValueIterator():KeyValueIterator<Int, T> {

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -129,6 +129,10 @@ private class StringMapIterator<T> {
 	}
 
 	public inline function iterator():Iterator<T> {
+		return typedIterator();
+	}
+
+	inline function typedIterator():StringMapIterator<T> {
 		return new StringMapIterator(this, arrayKeys());
 	}
 


### PR DESCRIPTION
Ok, not completely free on all targets (e.g. we still need an array for keys on js), but close to that :)

Closes #3147

This branch contains only JS implementation for `Map.iterator` and `Map.key` to illustrate the idea. 
The idea is to move `iterator` and `key` to `@:using`.
The same approach could be applied to `Map.keyValueIterator()`.
```haxe
class Main {
	static function main() {
		var m = [1 => 2, 3 => 4];
		for(i in m) {
			trace(i);
		}
	}
}
```
<details>
  <summary>Generated JS with current development</summary>
  
```javascript
// Generated by Haxe 4.0.0-rc.5
(function ($global) { "use strict";
var HxOverrides = function() { };
HxOverrides.iter = function(a) {
	return { cur : 0, arr : a, hasNext : function() {
		return this.cur < this.arr.length;
	}, next : function() {
		return this.arr[this.cur++];
	}};
};
var Main = function() { };
Main.main = function() {
	var _g = new haxe_ds_IntMap();
	_g.h[1] = 2;
	_g.h[3] = 4;
	var i = _g.iterator();
	while(i.hasNext()) console.log("src/Main.hx:5:",i.next());
};
var haxe_ds_IntMap = function() {
	this.h = { };
};
haxe_ds_IntMap.prototype = {
	keys: function() {
		var a = [];
		for( var key in this.h ) this.h.hasOwnProperty(key) ? a.push(key | 0) : null;
		return HxOverrides.iter(a);
	}
	,iterator: function() {
		return { ref : this.h, it : this.keys(), hasNext : function() {
			return this.it.hasNext();
		}, next : function() {
			var i = this.it.next();
			return this.ref[i];
		}};
	}
};
Main.main();
})({});
```  
</details>
<details>
  <summary>Generated JS with this PR</summary>

```javascript
// Generated by Haxe 4.0.0-rc.5
(function ($global) { "use strict";
var Main = function() { };
Main.main = function() {
	var _g1_map_h = { };
	_g1_map_h[1] = 2;
	_g1_map_h[3] = 4;
	var a = [];
	for( var key in _g1_map_h ) _g1_map_h.hasOwnProperty(key) ? a.push(key | 0) : null;
	var keys = a;
	var _g1_keys = keys;
	var _g1_index = 0;
	var _g1_count = keys.length;
	while(_g1_index < _g1_count) console.log("src/Main.hx:5:",_g1_map_h[_g1_keys[_g1_index++]]);
};
Main.main();
})({});
```  
</details>