### PR TITLE
[js] Add @:deprecated typedef for js.lib.Map.MapEntry

### DIFF
--- a/std/js/lib/Map.hx
+++ b/std/js/lib/Map.hx
@@ -108,3 +108,5 @@ extern class Map<K, V> {
 		return new HaxeIterator(this.entries());
 	}
 }
+
+@:deprecated typedef MapEntry<K, V> = KeyValue<K, V>;


### PR DESCRIPTION
Add `@:deprecated typedef` for `js.lib.Map.MapEntry` since it was removed in be528d9 so that it isn't a breaking change

Not sure if I should be targeting development or 4.0_bugfix for this change

See https://github.com/HaxeFoundation/haxe/pull/8747#issuecomment-532218597