### PR TITLE
[php] Implement native iterator on arrays

### DIFF
--- a/std/php/ArrayIterator.hx
+++ b/std/php/ArrayIterator.hx
@@ -23,14 +23,35 @@
 package php;
 
 /**
-	Native PHP interface.
-	@see https://www.php.net/manual/en/class.iterator.php
+	@see https://www.php.net/manual/en/class.arrayiterator.php
 **/
-@:native('Iterator')
-extern interface NativeIterator<K, V> extends Traversable {
+@:native('ArrayIterator')
+extern class ArrayIterator<K, V> implements php.ArrayAccess<K, V> implements SeekableIterator<K, V> implements Countable implements Serializable {
+	static final STD_PROP_LIST:Int;
+	static final ARRAY_AS_PROPS:Int;
+
+	function new(?array:NativeArray, ?flags:Int);
+	function append(value:V):Void;
+	function asort():Void;
+	function count():Int;
 	function current():V;
+	function getArrayCopy():NativeArray;
+	function getFlags():Int;
 	function key():K;
+	function ksort():Void;
+	function natcasesort():Void;
+	function natsort():Void;
 	function next():Void;
+	function offsetExists(offset:K):Bool;
+	function offsetGet(offset:K):V;
+	function offsetSet(offset:K, value:V):Void;
+	function offsetUnset(offset:K):Void;
 	function rewind():Void;
+	function seek(position:Int):Void;
+	function serialize():String;
+	function setFlags(flags:Int):Void;
+	function uasort(cmp_function:(a:V, b:V) -> Int):Void;
+	function uksort(cmp_function:(a:K, b:K) -> Int):Void;
+	function unserialize(serialized:String):Void;
 	function valid():Bool;
 }

--- a/std/php/ArrayIterator.hx
+++ b/std/php/ArrayIterator.hx
@@ -27,8 +27,8 @@ package php;
 **/
 @:native('ArrayIterator')
 extern class ArrayIterator<K, V> implements php.ArrayAccess<K, V> implements SeekableIterator<K, V> implements Countable implements Serializable {
-	static final STD_PROP_LIST:Int;
-	static final ARRAY_AS_PROPS:Int;
+	@:phpClassConst static final STD_PROP_LIST:Int;
+	@:phpClassConst static final ARRAY_AS_PROPS:Int;
 
 	function new(?array:NativeArray, ?flags:Int);
 	function append(value:V):Void;

--- a/std/php/Countable.hx
+++ b/std/php/Countable.hx
@@ -19,18 +19,13 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
+ 
 package php;
 
 /**
-	Native PHP interface.
-	@see https://www.php.net/manual/en/class.iterator.php
+	@see https://www.php.net/manual/en/class.countable.php
 **/
-@:native('Iterator')
-extern interface NativeIterator<K, V> extends Traversable {
-	function current():V;
-	function key():K;
-	function next():Void;
-	function rewind():Void;
-	function valid():Bool;
+@:native('Countable')
+extern interface Countable {
+	function count():Int;
 }

--- a/std/php/NativeIterator.hx
+++ b/std/php/NativeIterator.hx
@@ -23,14 +23,14 @@
 package php;
 
 /**
-	@see https://www.php.net/manual/en/class.iteratoraggregate.php
+	Native PHP interface.
+	@see https://www.php.net/manual/en/class.iterator.php
 **/
-@:native('IteratorAggregate')
-extern interface IteratorAggregate<T> extends Traversable {
-	/**
-		This method is not public to not induce Haxe users to use it ;)
-		Use iterator() instead.
-	**/
-	private function getIterator():Traversable;
-
+@:native('Iterator')
+private extern interface NativeIterator<K, V> extends Traversable {
+	function current():V;
+	function key():K;
+	function next():Void;
+	function rewind():Void;
+	function valid():Bool;
 }

--- a/std/php/SeekableIterator.hx
+++ b/std/php/SeekableIterator.hx
@@ -19,18 +19,13 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
+ 
 package php;
 
 /**
-	Native PHP interface.
-	@see https://www.php.net/manual/en/class.iterator.php
+	@see https://www.php.net/manual/en/class.seekableiterator.php
 **/
-@:native('Iterator')
-extern interface NativeIterator<K, V> extends Traversable {
-	function current():V;
-	function key():K;
-	function next():Void;
-	function rewind():Void;
-	function valid():Bool;
+@:native('SeekableIterator')
+extern interface SeekableIterator<K, V> extends NativeIterator<K, V> {
+	function seek(position:Int):Void;
 }

--- a/std/php/Serializable.hx
+++ b/std/php/Serializable.hx
@@ -23,14 +23,10 @@
 package php;
 
 /**
-	Native PHP interface.
-	@see https://www.php.net/manual/en/class.iterator.php
+	@see https://www.php.net/manual/en/class.serializable.php
 **/
-@:native('Iterator')
-extern interface NativeIterator<K, V> extends Traversable {
-	function current():V;
-	function key():K;
-	function next():Void;
-	function rewind():Void;
-	function valid():Bool;
+@:native('Serializable')
+extern interface Serializable {
+    function serialize():String;
+    function unserialize(serialized:String):Void;
 }

--- a/std/php/_std/Array.hx
+++ b/std/php/_std/Array.hx
@@ -21,6 +21,7 @@
  */
 
 import php.*;
+import php.ArrayIterator as NativeArrayIterator;
 
 using php.Global;
 
@@ -277,9 +278,4 @@ private extern interface ArrayAccess<K, V> {
 	private function offsetGet(offset:K):V;
 	private function offsetSet(offset:K, value:V):Void;
 	private function offsetUnset(offset:K):Void;
-}
-
-@:native('ArrayIterator')
-private extern class NativeArrayIterator<T> implements Traversable {
-	function new(?array:NativeIndexedArray<T>, ?flags:Int);
 }

--- a/std/php/_std/Array.hx
+++ b/std/php/_std/Array.hx
@@ -25,7 +25,7 @@ import php.*;
 using php.Global;
 
 @:coreApi
-final class Array<T> implements ArrayAccess<Int, T> implements NativeIterator<Int, T> {
+final class Array<T> implements ArrayAccess<Int, T> implements IteratorAggregate<T> {
 	public var length(default, null):Int;
 
 	var arr:NativeIndexedArray<T>;
@@ -229,28 +229,8 @@ final class Array<T> implements ArrayAccess<Int, T> implements NativeIterator<In
 	}
 
 	@:noCompletion @:keep
-	function current():T {
-		return Global.current(arr);
-	}
-
-	@:noCompletion @:keep
-	function key():Int {
-		return Global.key(arr);
-	}
-
-	@:noCompletion @:keep
-	function next():Void {
-		Global.next(arr);
-	}
-
-	@:noCompletion @:keep
-	function rewind():Void {
-		Global.reset(arr);
-	}
-
-	@:noCompletion @:keep
-	function valid():Bool {
-		return Global.key(arr) != null;
+	private function getIterator():Traversable {
+		return new NativeArrayIterator(arr);
 	}
 
 	static function wrap<T>(arr:NativeIndexedArray<T>):Array<T> {
@@ -299,11 +279,7 @@ private extern interface ArrayAccess<K, V> {
 	private function offsetUnset(offset:K):Void;
 }
 
-@:native('Iterator')
-private extern interface NativeIterator<K, V> {
-	private function current():V;
-	private function key():K;
-	private function next():Void;
-	private function rewind():Void;
-	private function valid():Bool;
+@:native('ArrayIterator')
+private extern class NativeArrayIterator<T> implements Traversable {
+	function new(?array:NativeIndexedArray<T>, ?flags:Int);
 }

--- a/std/php/_std/Array.hx
+++ b/std/php/_std/Array.hx
@@ -25,7 +25,7 @@ import php.*;
 using php.Global;
 
 @:coreApi
-final class Array<T> implements ArrayAccess<Int, T> {
+final class Array<T> implements ArrayAccess<Int, T> implements NativeIterator<Int, T> {
 	public var length(default, null):Int;
 
 	var arr:NativeIndexedArray<T>;
@@ -228,6 +228,31 @@ final class Array<T> implements ArrayAccess<Int, T> {
 		}
 	}
 
+	@:noCompletion @:keep
+	function current():T {
+		return Global.current(arr);
+	}
+
+	@:noCompletion @:keep
+	function key():Int {
+		return Global.key(arr);
+	}
+
+	@:noCompletion @:keep
+	function next():Void {
+		Global.next(arr);
+	}
+
+	@:noCompletion @:keep
+	function rewind():Void {
+		Global.reset(arr);
+	}
+
+	@:noCompletion @:keep
+	function valid():Bool {
+		return Global.key(arr) != null;
+	}
+
 	static function wrap<T>(arr:NativeIndexedArray<T>):Array<T> {
 		var a = new Array();
 		a.arr = arr;
@@ -272,4 +297,13 @@ private extern interface ArrayAccess<K, V> {
 	private function offsetGet(offset:K):V;
 	private function offsetSet(offset:K, value:V):Void;
 	private function offsetUnset(offset:K):Void;
+}
+
+@:native('Iterator')
+private extern interface NativeIterator<K, V> {
+	private function current():V;
+	private function key():K;
+	private function next():Void;
+	private function rewind():Void;
+	private function valid():Bool;
 }


### PR DESCRIPTION
This one implements php's [`Iterator`](https://www.php.net/manual/en/class.iterator.php) on arrays using the internal array position. It eases interfacing with generated haxe code from the php side. (Eg. allows us to `foreach ($anyHaxeArray as $key => $item)`).