### PR TITLE
[php] Improve json representation of haxe arrays

### DIFF
--- a/std/php/JsonSerializable.hx
+++ b/std/php/JsonSerializable.hx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package php;
+
+/**
+	@see https://www.php.net/manual/en/class.jsonserializable.php
+**/
+@:native('JsonSerializable')
+extern interface JsonSerializable<T> {
+	private function jsonSerialize():T;
+}

--- a/std/php/_std/Array.hx
+++ b/std/php/_std/Array.hx
@@ -26,7 +26,7 @@ import php.ArrayIterator as NativeArrayIterator;
 using php.Global;
 
 @:coreApi
-final class Array<T> implements ArrayAccess<Int, T> implements IteratorAggregate<T> {
+final class Array<T> implements ArrayAccess<Int, T> implements IteratorAggregate<T> implements JsonSerializable<NativeIndexedArray<T>> {
 	public var length(default, null):Int;
 
 	var arr:NativeIndexedArray<T>;
@@ -232,6 +232,11 @@ final class Array<T> implements ArrayAccess<Int, T> implements IteratorAggregate
 	@:noCompletion @:keep
 	private function getIterator():Traversable {
 		return new NativeArrayIterator(arr);
+	}
+
+	@:noCompletion @:keep
+	function jsonSerialize():NativeIndexedArray<T> {
+		return arr;
 	}
 
 	static function wrap<T>(arr:NativeIndexedArray<T>):Array<T> {


### PR DESCRIPTION
One more to improve passing off haxe arrays to php side.
````php
// currently:
json_encode($haxeArray); // {"arr": [...], "length": ...}
// after:
json_encode($haxeArray); // [...]
````