### PR TITLE
Better inlining of for-loops with anonymous iterators.

### DIFF
--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -837,7 +837,7 @@ let run com tctx main =
 	NullSafety.run com new_types;
 	(* PASS 1: general expression filters *)
 	let filters = [
-		(* ForRemap.apply tctx; *)
+		ForRemap.apply tctx;
 		VarLazifier.apply com;
 		AbstractCast.handle_abstract_casts tctx;
 	] in

--- a/tests/optimization/src/Test.hx
+++ b/tests/optimization/src/Test.hx
@@ -8,10 +8,19 @@ class InlineCtor {
 	}
 }
 
-class Set {
-	var amount:Int;
-	public inline function new(a:Int) amount = a;
+class Collection<V> {
+	public var amount:Int;
+	public inline function new(amount:Int) this.amount = amount;
 	public inline function count() return amount;
+	public inline function iterator() return new CollectionIterator(this);
+}
+
+class CollectionIterator<V> {
+	final set:Collection<V>;
+	var current:Int = 0;
+	public inline function new(set:Collection<V>) this.set = set;
+	public inline function hasNext() return current++ < set.amount;
+	public inline function next() return (null:V);
 }
 
 typedef Countable = {
@@ -100,10 +109,38 @@ class Test {
 		var a = 10;
 	')
 	static function testInlineCtor_passedToInlineMethodAsAnonConstraint() {
-		var a = count(new Set(10));
+		var a = count(new Collection(10));
 	}
 	static inline function count<T:Countable>(v:T) {
 		return v.count();
+	}
+
+	@:js('
+		var _g_set_amount = 10;
+		var _g_current = 0;
+		while(_g_current++ < 10) {
+			var i = null;
+		}
+	')
+	static function testIterator_passedToInlineMethodAsAnonConstraint() {
+		iterIterator(new Collection(10).iterator());
+	}
+	static inline function iterIterator<V,T:Iterator<V>>(it:T) {
+		for(i in it) {}
+	}
+
+	@:js('
+		var _g_set_amount = 10;
+		var _g_current = 0;
+		while(_g_current++ < 10) {
+			var i = null;
+		}
+	')
+	static function testIterable_passedToInlineMethodAsAnonConstraint() {
+		iterIterable(new Collection(10));
+	}
+	static inline function iterIterable<V,T:Iterable<V>>(it:T) {
+		for(i in it) {}
 	}
 
 	@:js('

--- a/tests/optimization/src/Test.hx
+++ b/tests/optimization/src/Test.hx
@@ -144,20 +144,6 @@ class Test {
 	}
 
 	@:js('
-		var _g_min = 0;
-		var _g_max = 10;
-		while(_g_min < 10) {
-			var i = _g_min++;
-		}
-	')
-	static function testInlineIteratorConstraint() {
-		iter(0...10);
-	}
-	static inline function iter<V,T:Iterator<V>>(v:T) {
-		for(i in v) {}
-	}
-
-	@:js('
 		var x_foo = 1;
 		var x_bar = 2;
 		var y = 1;

--- a/tests/optimization/src/Test.hx
+++ b/tests/optimization/src/Test.hx
@@ -107,6 +107,20 @@ class Test {
 	}
 
 	@:js('
+		var _g_min = 0;
+		var _g_max = 10;
+		while(_g_min < 10) {
+			var i = _g_min++;
+		}
+	')
+	static function testInlineIteratorConstraint() {
+		iter(0...10);
+	}
+	static inline function iter<V,T:Iterator<V>>(v:T) {
+		for(i in v) {}
+	}
+
+	@:js('
 		var x_foo = 1;
 		var x_bar = 2;
 		var y = 1;


### PR DESCRIPTION
This PR allows to inline `for` loops with `Iterator` or `Iterable` provided as type parameter without allocating an iterator.
Here is an example:
<details>
  <summary>Main.hx</summary>
  
  ```haxe
class Main {
    public static function main() {
        iter(new Collection(10));
    }

    static public inline function iter<A,T:Iterable<A>>(v:T) {
        for(i in v) {
            trace(i);
        }
    }
}

class Collection<V> {
    public var amount:Int;
    public inline function new(amount:Int) this.amount = amount;
    public inline function iterator() return new CollectionIterator(this);
}

class CollectionIterator<V> {
    var collection:Collection<V>;
    var current:Int = 0;
    public inline function new(collection:Collection<V>) this.collection = collection;
    public inline function hasNext() return current++ < collection.amount;
    public inline function next() return (null:V);

}
  ```
  
</details>
<details> 
<summary>JS compiled _with_ this PR</summary>

```javascript
// Generated by Haxe 4.0.0-rc.5
(function ($global) { "use strict";
var Main = function() { };
Main.main = function() {
    var _g_collection_amount = 10;
    var _g_current = 0;
    while(_g_current++ < _g_collection_amount) {
        var i = null;
        console.log("src/Main.hx:8:",i);
    }
};
Main.main();
})({});
```

</details>
<details> 
<summary>JS compiled _without_ this PR</summary>

```javascript
// Generated by Haxe 4.0.0-rc.5
(function ($global) { "use strict";
var Main = function() { };
Main.main = function() {
    var i = new CollectionIterator(new Collection(10));
    while(i.hasNext()) {
        var i1 = i.next();
        console.log("src/Main.hx:8:",i1);
    }
};
var Collection = function(amount) {
    this.amount = amount;
};
Collection.prototype = {
    iterator: function() {
        return new CollectionIterator(this);
    }
};
var CollectionIterator = function(collection) {
    this.current = 0;
    this.collection = collection;
};
CollectionIterator.prototype = {
    hasNext: function() {
        return this.current++ < this.collection.amount;
    }
    ,next: function() {
        return null;
    }
};
Main.main();
})({});
```

</details>

If this PR is accepted I'll make another one which will make `Lambda` methods allocation-free