### PR TITLE
[printer] don't print `var` with `final` accessor. Closes #8859

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -165,7 +165,7 @@ class Printer {
 			+ (field.meta != null && field.meta.length > 0 ? field.meta.map(printMetadata).join('\n$tabs') + '\n$tabs' : "")
 			+ (field.access != null && field.access.length > 0 ? field.access.map(printAccess).join(" ") + " " : "")
 			+ switch (field.kind) {
-				case FVar(t, eo): 'var ${field.name}' + opt(t, printComplexType, " : ") + opt(eo, printExpr, " = ");
+				case FVar(t, eo): ((field.access != null && field.access.has(AFinal)) ? '' : 'var ') + '${field.name}' + opt(t, printComplexType, " : ") + opt(eo, printExpr, " = ");
 				case FProp(get, set, t, eo): 'var ${field.name}($get, $set)' + opt(t, printComplexType, " : ") + opt(eo, printExpr, " = ");
 				case FFun(func): 'function ${field.name}' + printFunction(func);
 			}

--- a/tests/unit/src/unit/issues/Issue8859.hx
+++ b/tests/unit/src/unit/issues/Issue8859.hx
@@ -1,0 +1,16 @@
+package unit.issues;
+
+class Issue8859 extends Test {
+	function test() {
+		var td = macro class X {
+			final x: Int = 0;
+			var y: Int = 0;
+			private final z: Int = 0;
+			private var w: Int = 0;
+		}
+		var printer = new haxe.macro.Printer();
+		var s = printer.printTypeDefinition(td);
+		s = ~/[\t\n\r]/g.replace(s, "");
+		eq("class X {final x : Int = 0;var y : Int = 0;private final z : Int = 0;private var w : Int = 0;}", s);
+	}
+}


### PR DESCRIPTION
- When printing `var` check that the `final` accessor hasn't been set