### PR TITLE
[js] Add js.Lib.isUndefined(value)

### DIFF
--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -72,6 +72,17 @@ class Lib {
 	}
 
 	/**
+		Checks a value against JavaScript `undefined` value.
+
+		Note that this is only needed in very rare cases when working with external JavaScript code.
+
+		In Haxe, `null` is used to represent the absence of a value.
+	**/
+	public static inline function isUndefined<T>(value:T):Bool {
+		return untyped __js__("{0} === undefined", value);
+	}
+
+	/**
 		`nativeThis` is the JavaScript `this`, which is semantically different
 		from the Haxe `this`. Use `nativeThis` only when working with external
 		JavaScript code.


### PR DESCRIPTION
When working with externs, we occasionally want to check something strictly against `undefined`.

Having this piece of code in `js.Lib` would allow us to avoid these otherwise unavoidable `untyped` in user/lib code and fits pretty well alongside `js.Lib.undefined` imo.