### PR TITLE
hashlink: remove useless path conversion at sqlite

### DIFF
--- a/std/hl/_std/sys/db/Sqlite.hx
+++ b/std/hl/_std/sys/db/Sqlite.hx
@@ -78,7 +78,7 @@ private class SqliteConnection implements Connection {
 	var c:SqliteConnectionHandle;
 
 	public function new(file:String) {
-		c = SqliteLib.connect(Sys.getPath(file));
+		c = SqliteLib.connect(file.bytes);
 	}
 
 	public function close():Void {


### PR DESCRIPTION
HaxeFoundation/hashlink/issues/310