### PR TITLE
Hide BaseString from the API docs

### DIFF
--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -25,9 +25,9 @@ import lua.Table;
 import lua.Boot;
 
 #if lua_vanilla
-typedef BaseString = lua.NativeStringTools;
+private typedef BaseString = lua.NativeStringTools;
 #else
-typedef BaseString = lua.lib.luautf8.Utf8;
+private typedef BaseString = lua.lib.luautf8.Utf8;
 #end
 
 @:coreApi


### PR DESCRIPTION
This should probably be merged to 4.0_bugfix if CI passes, since this currently shows up as a toplevel type in the 4.0.0 API docs:

![](https://i.imgur.com/TuvRXjX.png)