### PR TITLE
[parser] Eval empty flag value as true

### DIFF
--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -32,7 +32,7 @@ type small_type =
 	| TVersion of (version * version * version) * (version list option)
 
 let is_true = function
-	| TBool false | TNull | TFloat 0. | TString "" -> false
+	| TBool false | TNull | TFloat 0. -> false
 	| _ -> true
 
 let s_small_type v =

--- a/tests/misc/projects/Issue8946/Main.hx
+++ b/tests/misc/projects/Issue8946/Main.hx
@@ -1,0 +1,7 @@
+class Main {
+	static function main() {
+		#if !EMPTY_FLAG
+		throw "Missing branch matching -D EMPTY_FLAG=";
+		#end
+	}
+}

--- a/tests/misc/projects/Issue8946/compile.hxml
+++ b/tests/misc/projects/Issue8946/compile.hxml
@@ -1,0 +1,2 @@
+-D EMPTY_FLAG=
+--run Main


### PR DESCRIPTION
This is a trivial attempt to fix #8946, based on the fact that `is_true` will generally only deal with strings or nulls.

However, I'm not confident that there aren't more complex cases that I've missed.

---

Related: #8946 ("Empty flag values evaluate to false for conditional compilation")