### PR TITLE
haxe.iterators.ArrayIterator

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -352,7 +352,7 @@ let is_dynamic_iterator ctx e =
 				loop (Abstract.get_underlying_type a tl)
 			| _ -> false
 		in
-		has_feature ctx "HxOverrides.iter" && loop x.etype
+		has_feature ctx "haxe.iterators.ArrayIterator.*" && loop x.etype
 	in
 	match e.eexpr with
 	| TField (x,f) when field_name f = "iterator" -> check x
@@ -1747,11 +1747,13 @@ let generate com =
 	List.iter (fun (_,_,e) -> chk_features e) ctx.statics;
 	if has_feature ctx "use.$iterator" then begin
 		add_feature ctx "use.$bind";
-		print ctx "function $iterator(o) { if( o instanceof Array ) return function() { return HxOverrides.iter(o); }; return typeof(o.iterator) == 'function' ? $bind(o,o.iterator) : o.iterator; }";
+		let array_iterator = s_path ctx (["haxe"; "iterators"], "ArrayIterator") in
+		print ctx "function $iterator(o) { if( o instanceof Array ) return function() { return new %s(o); }; return typeof(o.iterator) == 'function' ? $bind(o,o.iterator) : o.iterator; }" array_iterator;
 		newline ctx;
 	end;
 	if has_feature ctx "use.$getIterator" then begin
-		print ctx "function $getIterator(o) { if( o instanceof Array ) return HxOverrides.iter(o); else return o.iterator(); }";
+		let array_iterator = s_path ctx (["haxe"; "iterators"], "ArrayIterator") in
+		print ctx "function $getIterator(o) { if( o instanceof Array ) return new %s(o); else return o.iterator(); }" array_iterator;
 		newline ctx;
 	end;
 	if has_feature ctx "use.$bind" then begin

--- a/std/Array.hx
+++ b/std/Array.hx
@@ -265,7 +265,9 @@ extern class Array<T> {
 	/**
 		Returns an iterator of the Array values.
 	**/
-	function iterator():Iterator<T>;
+	@:runtime inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
+	}
 
 	/**
 		Creates a new Array by applying function `f` to all elements of `this`.

--- a/std/Array.hx
+++ b/std/Array.hx
@@ -265,13 +265,9 @@ extern class Array<T> {
 	/**
 		Returns an iterator of the Array values.
 	**/
-	#if hl
-	function iterator():haxe.iterators.ArrayIterator<T>;
-	#else
 	@:runtime inline function iterator():haxe.iterators.ArrayIterator<T> {
 		return new haxe.iterators.ArrayIterator(this);
 	}
-	#end
 
 	/**
 		Creates a new Array by applying function `f` to all elements of `this`.

--- a/std/Array.hx
+++ b/std/Array.hx
@@ -265,9 +265,13 @@ extern class Array<T> {
 	/**
 		Returns an iterator of the Array values.
 	**/
+	#if hl
+	function iterator():haxe.iterators.ArrayIterator<T>;
+	#else
 	@:runtime inline function iterator():haxe.iterators.ArrayIterator<T> {
 		return new haxe.iterators.ArrayIterator(this);
 	}
+	#end
 
 	/**
 		Creates a new Array by applying function `f` to all elements of `this`.

--- a/std/cs/_std/Array.hx
+++ b/std/cs/_std/Array.hx
@@ -415,8 +415,8 @@ final class Array<T> implements ArrayAccess<T> {
 		return ofNative(newarr);
 	}
 
-	public inline function iterator():Iterator<T> {
-		return new ArrayIterator<T>(this);
+	public inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	public function resize(len:Int):Void {
@@ -459,22 +459,4 @@ final class Array<T> implements ArrayAccess<T> {
 	private inline function __unsafe_set(idx:Int, val:T):T {
 		return __a[idx] = val;
 	}
-}
-
-private final class ArrayIterator<T> {
-	var arr:Array<T>;
-	var len:Int;
-	var i:Int;
-
-	public inline function new(a:Array<T>) {
-		arr = a;
-		len = a.length;
-		i = 0;
-	}
-
-	public inline function hasNext():Bool
-		return i < len;
-
-	public inline function next():T
-		return arr[i++];
 }

--- a/std/haxe/iterators/ArrayIterator.hx
+++ b/std/haxe/iterators/ArrayIterator.hx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C)2005-2018 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package haxe.iterators;
+
+/**
+	This iterator is used only when `Array<T>` is passed to `Iterable<T>`
+**/
+class ArrayIterator<T> {
+	final array:Array<T>;
+	var current:Int = 0;
+
+	/**
+		Create a new `ArrayIterator`.
+	**/
+	public inline function new(array:Array<T>) {
+		this.array = array;
+	}
+
+	/**
+		See `Iterator.hasNext`
+	**/
+	public inline function hasNext() {
+		return current < array.length;
+	}
+
+	/**
+		See `Iterator.next`
+	**/
+	public inline function next() {
+		return array[current++];
+	}
+}

--- a/std/haxe/iterators/ArrayIterator.hx
+++ b/std/haxe/iterators/ArrayIterator.hx
@@ -25,6 +25,9 @@ package haxe.iterators;
 /**
 	This iterator is used only when `Array<T>` is passed to `Iterable<T>`
 **/
+#if hl
+typedef ArrayIterator<T> = Iterator<T>;
+#else
 class ArrayIterator<T> {
 	final array:Array<T>;
 	var current:Int = 0;
@@ -50,3 +53,4 @@ class ArrayIterator<T> {
 		return array[current++];
 	}
 }
+#end

--- a/std/haxe/iterators/ArrayIterator.hx
+++ b/std/haxe/iterators/ArrayIterator.hx
@@ -25,9 +25,6 @@ package haxe.iterators;
 /**
 	This iterator is used only when `Array<T>` is passed to `Iterable<T>`
 **/
-#if hl
-typedef ArrayIterator<T> = Iterator<T>;
-#else
 class ArrayIterator<T> {
 	final array:Array<T>;
 	var current:Int = 0;
@@ -53,4 +50,3 @@ class ArrayIterator<T> {
 		return array[current++];
 	}
 }
-#end

--- a/std/haxe/iterators/ArrayIterator.hx
+++ b/std/haxe/iterators/ArrayIterator.hx
@@ -32,21 +32,24 @@ class ArrayIterator<T> {
 	/**
 		Create a new `ArrayIterator`.
 	**/
-	public inline function new(array:Array<T>) {
+	#if !hl inline #end
+	public function new(array:Array<T>) {
 		this.array = array;
 	}
 
 	/**
 		See `Iterator.hasNext`
 	**/
-	public inline function hasNext() {
+	#if !hl inline #end
+	public function hasNext() {
 		return current < array.length;
 	}
 
 	/**
 		See `Iterator.next`
 	**/
-	public inline function next() {
+	#if !hl inline #end
+	public function next() {
 		return array[current++];
 	}
 }

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -22,22 +22,24 @@
 
 package hl.types;
 
+import haxe.iterators.ArrayIterator;
+
 @:keep
 @:generic
-class BytesIterator<T> {
-	var pos:Int;
+class BytesIterator<T> extends ArrayIterator<T> {
 	var a:ArrayBytes<T>;
 
 	public function new(a) {
+		super((null:Dynamic));
 		this.a = a;
 	}
 
-	public function hasNext() {
-		return pos < a.length;
+	override public function hasNext() {
+		return current < a.length;
 	}
 
-	public function next():T {
-		return @:privateAccess a.bytes.get(pos++);
+	override public function next():T {
+		return @:privateAccess a.bytes.get(current++);
 	}
 }
 
@@ -253,7 +255,7 @@ class BytesIterator<T> {
 		return a;
 	}
 
-	public function iterator():Iterator<T> {
+	public function iterator():ArrayIterator<T> {
 		return new BytesIterator(this);
 	}
 

--- a/std/hl/types/ArrayDyn.hx
+++ b/std/hl/types/ArrayDyn.hx
@@ -23,24 +23,22 @@
 package hl.types;
 
 import hl.types.ArrayBase;
+import haxe.iterators.ArrayIterator;
 
-class ArrayDynIterator {
+class ArrayDynIterator extends ArrayIterator<Dynamic> {
 	var a:ArrayBase;
-	var len:Int;
-	var pos:Int;
 
 	public function new(a) {
+		super((null:Dynamic));
 		this.a = a;
-		this.len = a.length;
-		this.pos = 0;
 	}
 
-	public function hasNext() {
-		return pos < len;
+	override public function hasNext() {
+		return current < a.length;
 	}
 
-	public function next() {
-		return a.getDyn(pos++);
+	override public function next() {
+		return a.getDyn(current++);
 	}
 }
 
@@ -169,7 +167,7 @@ class ArrayDyn extends ArrayAccess {
 		return alloc(ArrayObj.alloc(a), true);
 	}
 
-	public function iterator():Iterator<Dynamic> {
+	public function iterator():ArrayIterator<Dynamic> {
 		return new ArrayDynIterator(array);
 	}
 

--- a/std/hl/types/ArrayObj.hx
+++ b/std/hl/types/ArrayObj.hx
@@ -24,7 +24,7 @@ package hl.types;
 
 import haxe.iterators.ArrayIterator;
 
-@:generic class ArrayObjIterator<T> extends ArrayIterator<T> {
+class ArrayObjIterator<T> extends ArrayIterator<T> {
 	var arr:ArrayObj<T>;
 
 	public inline function new(arr:ArrayObj<T>) {

--- a/std/hl/types/ArrayObj.hx
+++ b/std/hl/types/ArrayObj.hx
@@ -22,6 +22,25 @@
 
 package hl.types;
 
+import haxe.iterators.ArrayIterator;
+
+@:generic class ArrayObjIterator<T> extends ArrayIterator<T> {
+	var arr:ArrayObj<T>;
+
+	public inline function new(arr:ArrayObj<T>) {
+		super((null:Dynamic));
+		this.arr = arr;
+	}
+
+	override public function hasNext() {
+		return current < arr.length;
+	}
+
+	override public function next() {
+		return @:privateAccess arr.array[current++];
+	}
+}
+
 @:keep
 class ArrayObj<T> extends ArrayBase {
 	var array:hl.NativeArray<Dynamic>;
@@ -244,10 +263,8 @@ class ArrayObj<T> extends ArrayBase {
 		return alloc(n);
 	}
 
-	public function iterator():Iterator<T> {
-		var n = new NativeArray.NativeArrayIterator<T>(cast array);
-		@:privateAccess n.length = length;
-		return n;
+	public function iterator():ArrayIterator<T> {
+		return new ArrayObjIterator(this);
 	}
 
 	public function map<S>(f:T->S):ArrayDyn {

--- a/std/java/_std/Array.hx
+++ b/std/java/_std/Array.hx
@@ -414,8 +414,8 @@ import java.NativeArray;
 		return ofNative(newarr);
 	}
 
-	public inline function iterator():Iterator<T> {
-		return new ArrayIterator<T>(this);
+	public inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	public function resize(len:Int):Void {
@@ -483,22 +483,4 @@ import java.NativeArray;
 	private inline function __unsafe_set(idx:Int, val:T):T {
 		return __a[idx] = val;
 	}
-}
-
-private final class ArrayIterator<T> {
-	var arr:Array<T>;
-	var len:Int;
-	var i:Int;
-
-	public inline function new(a:Array<T>) {
-		arr = a;
-		len = a.length;
-		i = 0;
-	}
-
-	public inline function hasNext():Bool
-		return i < len;
-
-	public inline function next():T
-		return arr[i++];
 }

--- a/std/js/_std/Array.hx
+++ b/std/js/_std/Array.hx
@@ -74,8 +74,8 @@ extern class Array<T> {
 		return [for (v in this) if (f(v)) v];
 	}
 
-	@:runtime inline function iterator():Iterator<T> {
-		return @:privateAccess HxOverrides.iter(this);
+	@:runtime inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	inline function resize(len:Int):Void {

--- a/std/lua/_std/Array.hx
+++ b/std/lua/_std/Array.hx
@@ -235,12 +235,8 @@ class Array<T> {
 		return [for (i in this) if (f(i)) i];
 	}
 
-	public inline function iterator():Iterator<T> {
-		var cur_length = 0;
-		return {
-			hasNext: function() return cur_length < length,
-			next: function() return this[cur_length++]
-		}
+	public inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	public function resize(len:Int):Void {

--- a/std/neko/_std/Array.hx
+++ b/std/neko/_std/Array.hx
@@ -51,19 +51,8 @@
 		return new1(neko.NativeArray.sub(this.__a, 0, this.length), this.length);
 	}
 
-	public function iterator():Iterator<T> {
-		return untyped {
-			a: this,
-			p: 0,
-			hasNext: function() {
-				return __this__.p < __this__.a.length;
-			},
-			next: function() {
-				var i = __this__.a.__a[__this__.p];
-				__this__.p += 1;
-				return i;
-			}
-		};
+	public inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	public function insert(pos:Int, x:T):Void {

--- a/std/php/_std/Array.hx
+++ b/std/php/_std/Array.hx
@@ -85,8 +85,8 @@ final class Array<T> implements ArrayAccess<Int, T> implements IteratorAggregate
 	}
 
 	@:ifFeature("dynamic_read.iterator", "anon_optional_read.iterator", "anon_read.iterator")
-	public inline function iterator():Iterator<T> {
-		return new ArrayIterator(this);
+	public inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	public function join(sep:String):String {
@@ -244,33 +244,6 @@ final class Array<T> implements ArrayAccess<Int, T> implements IteratorAggregate
 		a.arr = arr;
 		a.length = Global.count(arr);
 		return a;
-	}
-}
-
-private class ArrayIterator<T> {
-	var idx:Int;
-	var arr:Array<T>;
-
-	public inline function new(arr:Array<T>) {
-		this.arr = arr;
-		idx = 0;
-	}
-
-	public inline function hasNext():Bool {
-		return idx < arr.length;
-	}
-
-	public inline function next():T {
-		return arr[idx++];
-	}
-
-	@:keep
-	@:phpMagic
-	function __get(method:String) {
-		return switch (method) {
-			case 'hasNext', 'next': Boot.closure(this, method);
-			case _: null;
-		}
 	}
 }
 

--- a/std/python/_std/Array.hx
+++ b/std/python/_std/Array.hx
@@ -40,8 +40,8 @@ extern class Array<T> implements ArrayAccess<T> {
 		return ArrayImpl.copy(this);
 	}
 
-	@:runtime public inline function iterator():Iterator<T> {
-		return ArrayImpl.iterator(this);
+	@:runtime public inline function iterator():haxe.iterators.ArrayIterator<T> {
+		return new haxe.iterators.ArrayIterator(this);
 	}
 
 	public inline function insert(pos:Int, x:T):Void {


### PR DESCRIPTION
This allows some optimizations to be applied to `Array.iterator` 
E.g. this
```haxe
static function main() {
	var a = [1, 2, 3];
	var r = find(a, i -> i == 2);
	trace(r);
}

public static inline function find<T>(it:Iterable<T>, f:(item:T) -> Bool):Null<T> {
	var result = null;
	for (v in it) {
		if (f(v)) {
			result = v;
			break;
		}
	}
	return result;
}
```
is compiled to this js:
```js
var a = [1,2,3];
var result = null;
var _g_current = 0;
while(_g_current < a.length) {
	var v = a[_g_current++];
	if(v == 2) {
		result = v;
		break;
	}
}
console.log("src/Main.hx:5:",result);
```
notice the absence of `Iterator` allocation.
