### PR TITLE
Change `NoData` internal type.

### DIFF
--- a/std/haxe/NoData.hx
+++ b/std/haxe/NoData.hx
@@ -4,7 +4,6 @@ package haxe;
 	Data type used to indicate the absence of a value, especially in types with
 	type parameters.
 **/
-abstract NoData(Int) {
-	public inline function new()
-		this = 0;
+enum abstract NoData(Null<Dynamic>) from Dynamic {
+	var NoData = null;
 }


### PR DESCRIPTION
Currently NoData is defined as `abstract NoData(Int)`, which may cause an allocation on static targets when used as type parameters.
This PR changes it to 
```haxe
enum abstract NoData(Null<Dynamic>) from Dynamic {
	var NoData = null;
}
```
this will allow to use functions returning any values in any place where `NoData` return type is specified (pretty much like `->Void`).
```haxe
var ifn:()->Int = () -> 123;
var fn:()->NoData = ifn;
```
