### PR TITLE
Split signal into Signal & Emitter

### DIFF
--- a/std/asys/CurrentProcess.hx
+++ b/std/asys/CurrentProcess.hx
@@ -1,5 +1,7 @@
 package asys;
 
+import haxe.signals.Signal;
+import haxe.signals.ArraySignal;
 import haxe.async.*;
 import asys.net.Socket;
 import asys.io.*;
@@ -13,7 +15,11 @@ class CurrentProcess {
 		Emitted when a message is received over IPC. `initIpc` must be called first
 		to initialise the IPC channel.
 	**/
-	public static final messageSignal:Signal<IpcMessage> = new ArraySignal();
+	public static var messageSignal(get,never):Signal<IpcMessage>;
+	static final _messageSignal = new ArraySignal<IpcMessage>();
+	static inline function get_messageSignal():Signal<IpcMessage>
+		return _message_signal;
+
 
 	static var ipc:Socket;
 	static var ipcOut:IpcSerializer;

--- a/std/asys/CurrentProcess.hx
+++ b/std/asys/CurrentProcess.hx
@@ -18,7 +18,7 @@ class CurrentProcess {
 	public static var messageSignal(get,never):Signal<IpcMessage>;
 	static final _messageSignal = new ArraySignal<IpcMessage>();
 	static inline function get_messageSignal():Signal<IpcMessage>
-		return _message_signal;
+		return _messageSignal;
 
 
 	static var ipc:Socket;

--- a/std/asys/FileWatcher.hx
+++ b/std/asys/FileWatcher.hx
@@ -1,5 +1,7 @@
 package asys;
 
+import haxe.signals.Signal;
+import haxe.signals.ArraySignal;
 import asys.uv.UVError;
 import haxe.NoData;
 import haxe.async.*;
@@ -14,18 +16,27 @@ class FileWatcher {
 	/**
 		Emitted when a watched file is modified.
 	**/
-	public final changeSignal:Signal<FileWatcherEvent> = new ArraySignal();
+	public var changeSignal(get,never):Signal<FileWatcherEvent>;
+	final _changeSignal = new ArraySignal<FileWatcherEvent>();
+	inline function get_changeSignal():Signal<FileWatcherEvent>
+		return _changeSignal;
 
 	/**
 		Emitted when `this` watcher is fully closed. No further signals will be
 		emitted.
 	**/
-	public final closeSignal:Signal<NoData> = new ArraySignal();
+	public var closeSignal(get,never):Signal<NoData>;
+	final _closeSignal = new ArraySignal<NoData>();
+	inline function get_closeSignal():Signal<NoData>
+		return _closeSignal;
 
 	/**
 		Emitted when an error occurs.
 	**/
-	public final errorSignal:Signal<UVError> = new ArraySignal();
+	public var errorSignal(get,never):Signal<UVError>;
+	final _errorSignal= new ArraySignal<UVError>();
+	inline function get_errorSignal():Signal<UVError>
+		return _errorSignal;
 
 	private var native:FileWatcherNative;
 

--- a/std/asys/Process.hx
+++ b/std/asys/Process.hx
@@ -2,7 +2,7 @@ package asys;
 
 import asys.uv.UVError;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.*;
 import haxe.io.*;
 import asys.net.Socket;
 import asys.io.*;
@@ -89,25 +89,37 @@ class Process {
 	/**
 		Emitted when `this` process and all of its pipes are closed.
 	**/
-	public final closeSignal:Signal<NoData> = new ArraySignal();
+	public var closeSignal:Signal<NoData>;
+	final _closeSignal = new ArraySignal();
+	inline function get_closeSignal():Signal<NoData>
+		return _closeSignal;
 
 	// public final disconnectSignal:Signal<NoData> = new ArraySignal(); // IPC
 
 	/**
 		Emitted when an error occurs during communication with `this` process.
 	**/
-	public final errorSignal:Signal<UVError> = new ArraySignal();
+	public var errorSignal:Signal<UVError>;
+	final _errorSignal = new ArraySignal();
+	inline function get_errorSignal():Signal<UVError>
+		return _errorSignal;
 
 	/**
 		Emitted when `this` process exits, potentially due to a signal.
 	**/
-	public final exitSignal:Signal<ProcessExit> = new ArraySignal();
+	public var exitSignal:Signal<ProcessExit>;
+	final _exitSignal = new ArraySignal();
+	inline function get_exitSignal():Signal<Process>
+		return _exitSignal;
 
 	/**
 		Emitted when a message is received over IPC. The process must be created
 		with an `Ipc` entry in `options.stdio`; see `Process.spawn`.
 	**/
-	public var messageSignal(default, null):Signal<IpcMessage>;
+	public var messageSignal(get, never):Signal<IpcMessage>;
+	var _messageSignal:SignalEmitter<IpcMessage>;
+	inline function get_messageSignal():Signal<IpcMessage>
+		return _messageSignal;
 
 	public var connected(default, null):Bool = false;
 	public var killed:Bool;

--- a/std/asys/io/FileReadStream.hx
+++ b/std/asys/io/FileReadStream.hx
@@ -1,7 +1,7 @@
 package asys.io;
 
 import haxe.NoData;
-import haxe.async.Signal;
+import haxe.signals.Signal;
 
 typedef FileReadStreamOptions = {
 	?autoClose:Bool,
@@ -10,9 +10,10 @@ typedef FileReadStreamOptions = {
 	?highWaterMark:Int
 };
 
+//TODO: why does extern class extends non-extern one?
 extern class FileReadStream extends haxe.io.Readable {
-	final openSignal:Signal<File>;
-	final readySignal:Signal<NoData>;
+	var openSignal(get,never):Signal<File>;
+	var readySignal(get,never):Signal<NoData>;
 
 	var bytesRead:Int;
 	var path:String;

--- a/std/asys/io/FileWriteStream.hx
+++ b/std/asys/io/FileWriteStream.hx
@@ -1,11 +1,12 @@
 package asys.io;
 
 import haxe.NoData;
-import haxe.async.Signal;
+import haxe.signals.Signal;
 
+//TODO: why does extern class extends non-extern one?
 extern class FileWriteStream extends haxe.io.Writable {
-	final openSignal:Signal<File>;
-	final readySignal:Signal<NoData>;
+	var openSignal(get,never):Signal<File>;
+	var readySignal(get,never):Signal<NoData>;
 
 	var bytesWritten:Int;
 	var path:String;

--- a/std/asys/io/IpcUnserializer.hx
+++ b/std/asys/io/IpcUnserializer.hx
@@ -1,7 +1,8 @@
 package asys.io;
 
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.Signal;
+import haxe.signals.ArraySignal;
 import haxe.io.*;
 import asys.net.Socket;
 
@@ -12,8 +13,15 @@ import asys.net.Socket;
 class IpcUnserializer {
 	static var activeUnserializer:IpcUnserializer = null;
 
-	public final messageSignal:Signal<IpcMessage> = new ArraySignal();
-	public final errorSignal:Signal<Dynamic> = new ArraySignal();
+	public var messageSignal(get,never):Signal<IpcMessage>;
+	final _messageSignal = new ArraySignal<IpcMessage>();
+	inline function get_messageSignal():Signal<IpcMessage>
+		return _messageSignal;
+
+	public var errorSignal(get,never):Signal<Any>;
+	final _errorSignal = new ArraySignal<Any>();
+	inline function get_errorSignal():Signal<Any>
+		return _errorSignal;
 
 	final pipe:Socket;
 	// var chunkSockets:Array<Socket> = [];
@@ -69,7 +77,7 @@ class IpcUnserializer {
 							chunkSockets.push(pipe.readHandle());
 						activeUnserializer = this;
 						var message = haxe.Unserializer.run(serial);
-						messageSignal.emit({message: message, sockets: chunkSockets});
+						_messageSignal.emit({message: message, sockets: chunkSockets});
 						chunkSize = 0;
 						chunkSocketCount = 0;
 						// chunkSockets.resize(0);
@@ -78,7 +86,7 @@ class IpcUnserializer {
 				}
 			}
 		} catch (e:Dynamic) {
-			errorSignal.emit(e);
+			_errorSignal.emit(e);
 		}
 	}
 }

--- a/std/asys/net/Server.hx
+++ b/std/asys/net/Server.hx
@@ -2,7 +2,8 @@ package asys.net;
 
 import asys.uv.UVError;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.Signal;
+import haxe.signals.ArraySignal;
 
 typedef ServerOptions = {
 	?allowHalfOpen:Bool,
@@ -27,10 +28,26 @@ typedef ServerListenIpcOptions = {
 };
 
 class Server {
-	public final closeSignal:Signal<NoData> = new ArraySignal<NoData>();
-	public final connectionSignal:Signal<Socket> = new ArraySignal<Socket>();
-	public final errorSignal:Signal<UVError> = new ArraySignal<UVError>();
-	public final listeningSignal:Signal<NoData> = new ArraySignal<NoData>();
+	public var closeSignal(get,never):Signal<NoData>;
+	final _closeSignal = new ArraySignal<NoData>();
+	inline function get_closeSignal():Signal<NoData>
+		return _closeSignal;
+
+	public var connectionSignal(get,never):Signal<Socket>;
+	final _connectionSignal = new ArraySignal<Socket>();
+	inline function get_connectionSignal():Signal<Socket>
+		return _connectionSignal;
+
+	public var errorSignal(get,never):Signal<UVError>;
+	final _errorSignal = new ArraySignal<UVError>();
+	inline function get_errorSignal():Signal<UVError>
+		return _errorSignal;
+
+	public var listeningSignal(get,never):Signal<NoData>;
+	final _listeningSignal = new ArraySignal<NoData>();
+	inline function get_listeningSignal():Signal<NoData>
+		return _listeningSignal;
+
 
 	public var listening(default, null):Bool;
 	public var maxConnections:Int; // TODO

--- a/std/asys/net/Socket.hx
+++ b/std/asys/net/Socket.hx
@@ -2,7 +2,8 @@ package asys.net;
 
 import asys.uv.UVError;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.Signal;
+import haxe.signals.ArraySignal;
 import haxe.io.*;
 import haxe.io.Readable.ReadResult;
 import asys.io.*;
@@ -36,9 +37,15 @@ class Socket extends Duplex {
 	/**
 		Emitted when the socket connects to a remote endpoint.
 	**/
-	public final closeSignal:Signal<NoData> = new ArraySignal();
+	public var closeSignal(get,never):Signal<NoData>;
+	final _closeSignal = new ArraySignal();
+	inline function get_closeSignal():Signal<NoData>
+		return _closeSignal;
 
-	public final connectSignal:Signal<NoData> = new ArraySignal();
+	public var connectSignal(get,never):Signal<NoData>;
+	final _connectSignal = new ArraySignal();
+	inline function get_connectSignal():Signal<NoData>
+		return _connectSignal;
 
 	// endSignal
 
@@ -46,12 +53,18 @@ class Socket extends Duplex {
 		(TCP only.) Emitted after the IP address of the hostname given in
 		`connectTcp` is resolved, but before the socket connects.
 	**/
-	public final lookupSignal:Signal<Address> = new ArraySignal();
+	public var lookupSignal(get,never):Signal<Address>;
+	final _lookupSignal = new ArraySignal();
+	inline function get_lookupSignal():Signal<Address>
+		return _lookupSignal;
 
 	/**
 		Emitted when a timeout occurs. See `setTimeout`.
 	**/
-	public final timeoutSignal:Signal<NoData> = new ArraySignal();
+	public var timeoutSignal(get,never):Signal<NoData>;
+	final _timeoutSignal = new ArraySignal();
+	inline function get_timeoutSignal():Signal<NoData>
+		return _timeoutSignal;
 
 	extern private function get_localAddress():Null<SocketAddress>;
 
@@ -199,13 +212,13 @@ class Socket extends Duplex {
 	function writeDone(err:UVError, nd:NoData):Void {
 		timeoutReset();
 		if (err != null)
-			errorSignal.emit(err);
+			_errorSignal.emit(err);
 		// TODO: destroy stream and socket
 	}
 
 	function timeoutTrigger():Void {
 		timeoutTimer = null;
-		timeoutSignal.emit(new NoData());
+		_timeoutSignal.emit(new NoData());
 	}
 
 	function timeoutReset():Void {

--- a/std/asys/net/UdpSocket.hx
+++ b/std/asys/net/UdpSocket.hx
@@ -2,7 +2,8 @@ package asys.net;
 
 import asys.uv.UVError;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.Signal;
+import haxe.signals.ArraySignal;
 import haxe.io.Bytes;
 import asys.net.SocketOptions.UdpSocketOptions;
 
@@ -49,12 +50,18 @@ class UdpSocket {
 	// final connectSignal:Signal<NoData>;
 	// final listeningSignal:Signal<NoData>;
 
-	public final errorSignal:Signal<UVError> = new ArraySignal();
+	public var errorSignal(get,never):Signal<UVError>;
+	final _errorSignal = new ArraySignal();
+	inline function get_errorSignal():Signal<UVError>
+		return _errorSignal;
 
 	/**
 		Emitted when a message is received by `this` socket. See `UdpMessage`.
 	**/
-	public final messageSignal:Signal<UdpMessage> = new ArraySignal();
+	public var messageSignal(get,never):Signal<UdpMessage>;
+	final _messageSignal = new ArraySignal();
+	inline function get_messageSignal():Signal<UdpMessage>
+		return _messageSignal;
 
 	/**
 		Joins the given multicast group.

--- a/std/haxe/io/Duplex.hx
+++ b/std/haxe/io/Duplex.hx
@@ -2,7 +2,7 @@ package haxe.io;
 
 import haxe.Error;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.Signal;
 import haxe.ds.List;
 import haxe.io.Readable.ReadResult;
 
@@ -16,16 +16,42 @@ import haxe.io.Readable.ReadResult;
 @:access(haxe.io.Readable)
 @:access(haxe.io.Writable)
 class Duplex implements IReadable implements IWritable {
-	public final dataSignal:Signal<Bytes>;
-	public final endSignal:Signal<NoData>;
-	public final errorSignal:Signal<Error>;
-	public final pauseSignal:Signal<NoData>;
-	public final resumeSignal:Signal<NoData>;
+	public var dataSignal(get,never):Signal<Bytes>;
+	function get_dataSignal():Signal<Bytes>
+		return output.dataSignal;
 
-	public final drainSignal:Signal<NoData>;
-	public final finishSignal:Signal<NoData>;
-	public final pipeSignal:Signal<IReadable>;
-	public final unpipeSignal:Signal<IReadable>;
+	public var endSignal(get,never):Signal<NoData>;
+	function get_endSignal():Signal<NoData>
+		return output.endSignal;
+
+	public var errorSignal(get,never):Signal<Error>;
+	function get_errorSignal():Signal<Error>
+		return output.errorSignal;
+
+	public var pauseSignal(get,never):Signal<NoData>;
+	function get_pauseSignal():Signal<NoData>
+		return output.pauseSignal;
+
+	public var resumeSignal(get,never):Signal<NoData>;
+	function get_resumeSignal():Signal<NoData>
+		return output.resumeSignal;
+
+	public var drainSignal(get,never):Signal<NoData>;
+	function get_drainSignal():Signal<NoData>
+		return input.drainSignal;
+
+	public var finishSignal(get,never):Signal<NoData>;
+	function get_finishSignal():Signal<NoData>
+		return input.finishSignal;
+
+	public var pipeSignal(get,never):Signal<IReadable>;
+	function get_pipeSignal():Signal<IReadable>
+		return input.pipeSignal;
+
+	public var unpipeSignal(get,never):Signal<IReadable>;
+	function get_unpipeSignal():Signal<IReadable>
+		return input.unpipeSignal;
+
 
 	final input:Writable;
 	final output:Readable;
@@ -45,15 +71,6 @@ class Duplex implements IReadable implements IWritable {
 	function new() {
 		input = new DuplexWritable(this);
 		output = new DuplexReadable(this);
-		dataSignal = output.dataSignal;
-		endSignal = output.endSignal;
-		errorSignal = output.errorSignal;
-		pauseSignal = output.pauseSignal;
-		resumeSignal = output.resumeSignal;
-		drainSignal = input.drainSignal;
-		finishSignal = input.finishSignal;
-		pipeSignal = input.pipeSignal;
-		unpipeSignal = input.unpipeSignal;
 		inputBuffer = input.buffer;
 		outputBuffer = output.buffer;
 	}

--- a/std/haxe/io/IReadable.hx
+++ b/std/haxe/io/IReadable.hx
@@ -2,7 +2,7 @@ package haxe.io;
 
 import haxe.Error;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.Signal;
 
 /**
 	A readable stream.
@@ -15,28 +15,28 @@ interface IReadable {
 	/**
 		Emitted whenever a chunk of data is available.
 	**/
-	final dataSignal:Signal<Bytes>;
+	var dataSignal(get,never):Signal<Bytes>;
 
 	/**
 		Emitted when the stream is finished. No further signals will be emitted by
 		`this` instance after `endSignal` is emitted.
 	**/
-	final endSignal:Signal<NoData>;
+	var endSignal(get,never):Signal<NoData>;
 
 	/**
 		Emitted for any error that occurs during reading.
 	**/
-	final errorSignal:Signal<Error>;
+	var errorSignal(get,never):Signal<Error>;
 
 	/**
 		Emitted when `this` stream is paused.
 	**/
-	final pauseSignal:Signal<NoData>;
+	var pauseSignal(get,never):Signal<NoData>;
 
 	/**
 		Emitted when `this` stream is resumed.
 	**/
-	final resumeSignal:Signal<NoData>;
+	var resumeSignal(get,never):Signal<NoData>;
 
 	/**
 		Resumes flow of data. Note that this method is called automatically

--- a/std/haxe/io/IWritable.hx
+++ b/std/haxe/io/IWritable.hx
@@ -1,13 +1,13 @@
 package haxe.io;
 
 import haxe.NoData;
-import haxe.async.Signal;
+import haxe.signals.Signal;
 
 interface IWritable {
-	final drainSignal:Signal<NoData>;
-	final finishSignal:Signal<NoData>;
-	final pipeSignal:Signal<IReadable>;
-	final unpipeSignal:Signal<IReadable>;
+	var drainSignal(get,never):Signal<NoData>;
+	var finishSignal(get,never):Signal<NoData>;
+	var pipeSignal(get,never):Signal<IReadable>;
+	var unpipeSignal(get,never):Signal<IReadable>;
 	function write(chunk:Bytes):Bool;
 	function end():Void;
 	function cork():Void;

--- a/std/haxe/io/Transform.hx
+++ b/std/haxe/io/Transform.hx
@@ -2,21 +2,37 @@ package haxe.io;
 
 import haxe.Error;
 import haxe.NoData;
-import haxe.async.*;
+import haxe.signals.*;
 
 @:access(haxe.io.Readable)
 @:access(haxe.io.Writable)
 class Transform implements IReadable implements IWritable {
-	public final dataSignal:Signal<Bytes>;
-	public final endSignal:Signal<NoData>;
-	public final errorSignal:Signal<Error>;
-	public final pauseSignal:Signal<NoData>;
-	public final resumeSignal:Signal<NoData>;
+	public var dataSignal(get,never):Signal<Bytes>;
+	function get_dataSignal() return output.dataSignal;
 
-	public final drainSignal:Signal<NoData>;
-	public final finishSignal:Signal<NoData>;
-	public final pipeSignal:Signal<IReadable>;
-	public final unpipeSignal:Signal<IReadable>;
+	public var endSignal(get,never):Signal<NoData>;
+	function get_endSignal() return output.endSignal;
+
+	public var errorSignal(get,never):Signal<Error>;
+	function get_errorSignal() return output.errorSignal;
+
+	public var pauseSignal(get,never):Signal<NoData>;
+	function get_pauseSignal() return output.pauseSignal;
+
+	public var resumeSignal(get,never):Signal<NoData>;
+	function get_resumeSignal() return output.resumeSignal;
+
+	public var drainSignal(get,never):Signal<NoData>;
+	function get_drainSignal() return input.drainSignal;
+
+	public var finishSignal(get,never):Signal<NoData>;
+	function get_finishSignal() return input.finishSignal;
+
+	public var pipeSignal(get,never):Signal<IReadable>;
+	function get_pipeSignal() return input.pipeSignal;
+
+	public var unpipeSignal(get,never):Signal<IReadable>;
+	function get_unpipeSignal() return input.unpipeSignal;
 
 	final input:Writable;
 	final output:Readable;
@@ -26,15 +42,6 @@ class Transform implements IReadable implements IWritable {
 	function new() {
 		input = new TransformWritable(this);
 		output = @:privateAccess new Readable(0);
-		dataSignal = output.dataSignal;
-		endSignal = output.endSignal;
-		errorSignal = output.errorSignal;
-		pauseSignal = output.pauseSignal;
-		resumeSignal = output.resumeSignal;
-		drainSignal = input.drainSignal;
-		finishSignal = input.finishSignal;
-		pipeSignal = input.pipeSignal;
-		unpipeSignal = input.unpipeSignal;
 	}
 
 	function internalTransform(chunk:Bytes):Void {

--- a/std/haxe/io/Writable.hx
+++ b/std/haxe/io/Writable.hx
@@ -2,6 +2,7 @@ package haxe.io;
 
 import haxe.NoData;
 import haxe.async.*;
+import haxe.signals.*;
 import haxe.ds.List;
 
 /**
@@ -11,10 +12,26 @@ import haxe.ds.List;
 	subclasses should override the `internalWrite` method.
 **/
 class Writable implements IWritable {
-	public final drainSignal:Signal<NoData> = new ArraySignal<NoData>();
-	public final finishSignal:Signal<NoData> = new ArraySignal<NoData>();
-	public final pipeSignal:Signal<IReadable> = new ArraySignal<IReadable>();
-	public final unpipeSignal:Signal<IReadable> = new ArraySignal<IReadable>();
+	public var drainSignal(get,never):Signal<NoData>;
+	final _drainSignal = new ArraySignal<NoData>();
+	function get_drainSignal():Signal<NoData>
+		return _drainSignal;
+
+	public var finishSignal(get,never):Signal<NoData>;
+	final _finishSignal = new ArraySignal<NoData>();
+	function get_finishSignal():Signal<NoData>
+		return _finishSignal;
+
+	public var pipeSignal(get,never):Signal<IReadable>;
+	final _pipeSignal = new ArraySignal<IReadable>();
+	function get_pipeSignal():Signal<IReadable>
+		return _pipeSignal;
+
+	public var unpipeSignal(get,never):Signal<IReadable>;
+	final _unpipeSignal = new ArraySignal<IReadable>();
+	function get_unpipeSignal():Signal<IReadable>
+		return _unpipeSignal;
+
 
 	public var highWaterMark = 8192;
 	public var bufferLength(default, null) = 0;
@@ -35,12 +52,12 @@ class Writable implements IWritable {
 			if (deferred == null)
 				deferred = Defer.nextTick(() -> {
 					deferred = null;
-					drainSignal.emit(new NoData());
+					_drainSignal.emit(new NoData());
 				});
 		}
 		if (willFinish && buffer.length == 0) {
 			willFinish = false;
-			Defer.nextTick(() -> finishSignal.emit(new NoData()));
+			Defer.nextTick(() -> _finishSignal.emit(new NoData()));
 		}
 		return chunk;
 	}
@@ -72,7 +89,7 @@ class Writable implements IWritable {
 		if (buffer.length > 0)
 			willFinish = true;
 		else
-			finishSignal.emit(new NoData());
+			_finishSignal.emit(new NoData());
 		done = true;
 	}
 

--- a/std/haxe/signals/ArraySignal.hx
+++ b/std/haxe/signals/ArraySignal.hx
@@ -1,10 +1,10 @@
-package haxe.async;
+package haxe.signals;
 
 /**
 	Basic implementation of a `haxe.async.Signal`. Uses an array for storing
 	listeners for the signal.
 **/
-class ArraySignal<T> implements Signal<T> {
+class ArraySignal<T> implements SignalEmitter<T> {
 	final listeners:Array<Listener<T>> = [];
 
 	function get_listenerCount():Int {

--- a/std/haxe/signals/Emitter.hx
+++ b/std/haxe/signals/Emitter.hx
@@ -1,0 +1,11 @@
+package haxe.signals;
+
+/**
+	Emitters allow to emit some data to whatever might be waiting for that data.
+
+	E.g. can be used in conjunction with `haxe.signals.Signal` to implement a class,
+	which can emit an event and notify listeners of that event.
+**/
+interface Emitter<T> {
+	function emit(data:T):Void;
+}

--- a/std/haxe/signals/Listener.hx
+++ b/std/haxe/signals/Listener.hx
@@ -1,6 +1,4 @@
-package haxe.async;
-
-import haxe.NoData;
+package haxe.signals;
 
 typedef ListenerData<T> = (data:T) -> Void;
 

--- a/std/haxe/signals/Signal.hx
+++ b/std/haxe/signals/Signal.hx
@@ -1,12 +1,15 @@
-package haxe.async;
+package haxe.signals;
 
 /**
-	Signals are a type-safe system to emit events. A signal will calls its
+	Signals are a type-safe system to listen for events. A signal will call its
 	listeners whenever _something_ (the event that the signal represents) happens,
 	passing along any relevant associated data.
 
 	Signals which have no associated data should use `haxe.NoData` as their type
 	parameter.
+
+	Signals should be used in conjunction with something like `haxe.Emitter`, which would
+	actually emit a signal.
 **/
 interface Signal<T> {
 	/**
@@ -30,9 +33,4 @@ interface Signal<T> {
 		Removes the given listener from `this` signal.
 	**/
 	function off(?listener:Listener<T>):Void;
-
-	/**
-		Emits `data` to all current listeners of `this` signal.
-	**/
-	function emit(data:T):Void;
 }

--- a/std/haxe/signals/SignalEmitter.hx
+++ b/std/haxe/signals/SignalEmitter.hx
@@ -1,0 +1,3 @@
+package haxe.signals;
+
+interface SignalEmitter<T> extends Signal<T> extends Emitter<T> {}


### PR DESCRIPTION
This is the first PR in a stream of signal-related PRs I'm going to propose.

This one splits the functionality of `Signal` into two interfaces:
* Signal - to listen for events
* Emitter - to emit events

With such a split only signal owner is allowed to emit it while providing a public API to signal users to listen for that signal.

Also this PR moves all signal-related types to `haxe.signals` package.