### PR TITLE
Soft deprecation of "Std.is" (#2976)

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -464,7 +464,7 @@ let default_cast ?(vtmp="$t") com e texpr t p =
 	let std = (try List.find (fun t -> t_path t = ([],"Std")) com.types with Not_found -> assert false) in
 	let fis = (try
 			let c = (match std with TClassDecl c -> c | _ -> assert false) in
-			FStatic (c, PMap.find "is" c.cl_statics)
+			FStatic (c, PMap.find "isOfType" c.cl_statics)
 		with Not_found ->
 			assert false
 	) in

--- a/src/filters/jsExceptions.ml
+++ b/src/filters/jsExceptions.ml
@@ -147,7 +147,7 @@ let init ctx =
 					let etype = make_typeexpr (module_type_of_type t) e.epos in
 					let args = [eunwrapped;etype] in
 					let echeck =
-						match Inline.api_inline ctx cStd "is" args e.epos with
+						match Inline.api_inline ctx cStd "isOfType" args e.epos with
 						| Some e -> e
 						| None ->
 							let eBoot = make_static_this cBoot e.epos in

--- a/src/filters/tryCatchWrapper.ml
+++ b/src/filters/tryCatchWrapper.ml
@@ -150,7 +150,7 @@ let configure_cs com =
 	let gen_typecheck e t pos =
 		let std = make_static_this std_cl pos in
 		let e_type = make_typeexpr (module_type_of_type t) pos in
-		fcall std "is" [e; e_type] com.basic.tbool pos
+		fcall std "isOfType" [e; e_type] com.basic.tbool pos
 	in
 	init com should_wrap wrap_throw unwrap_expr rethrow_expr base_exception_t hx_exception_t catch_map gen_typecheck
 

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -243,12 +243,12 @@ struct
 			match e.eexpr with
 				(* Std.is() *)
 				| TCall(
-						{ eexpr = TField( _, FStatic({ cl_path = ([], "Std") }, { cf_name = "is" })) },
+						{ eexpr = TField( _, FStatic({ cl_path = ([], "Std") }, { cf_name = ("is" | "isOfType") })) },
 						[ obj; { eexpr = TTypeExpr(TClassDecl { cl_path = [], "Dynamic" } | TAbstractDecl { a_path = [], "Dynamic" }) }]
 					) ->
 						Type.map_expr run e
 				| TCall(
-						{ eexpr = TField( _, FStatic({ cl_path = ([], "Std") }, { cf_name = "is"}) ) },
+						{ eexpr = TField( _, FStatic({ cl_path = ([], "Std") }, { cf_name = ("is" | "isOfType") }) ) },
 						[ obj; { eexpr = TTypeExpr(md) }]
 					) ->
 					let md = change_md md in
@@ -272,7 +272,7 @@ struct
 						match obj.eexpr with
 							| TLocal(v) -> f obj
 							| _ ->
-								let var = mk_temp "is" obj.etype in
+								let var = mk_temp "isOfType" obj.etype in
 								let added = { obj with eexpr = TVar(var, Some(obj)); etype = basic.tvoid } in
 								let local = mk_local var obj.epos in
 								{

--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -254,7 +254,7 @@ struct
 
 				(* Std.is() *)
 				| TCall(
-						{ eexpr = TField( _, FStatic({ cl_path = ([], "Std") }, { cf_name = "is" })) },
+						{ eexpr = TField( _, FStatic({ cl_path = ([], "Std") }, { cf_name = ("is" | "isOfType") })) },
 						[ obj; { eexpr = TTypeExpr(md) } ]
 					) ->
 					let mk_is is_basic obj md =

--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -799,7 +799,7 @@ let field_name field =
 *)
 let is_std_is expr =
 	match expr.eexpr with
-		| TField (_, FStatic ({ cl_path = path }, { cf_name = "is" })) -> path = boot_type_path || path = std_type_path
+		| TField (_, FStatic ({ cl_path = path }, { cf_name = ("is" | "isOfType") })) -> path = boot_type_path || path = std_type_path
 		| _ -> false
 
 (**

--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -1405,7 +1405,7 @@ and gen_call ctx retval e el r =
 		gen_expr ctx true e;
 		gen_expr ctx true t;
 		write ctx (HOp A3OIs)
-	| TField (_,FStatic ({ cl_path = [],"Std" },{ cf_name = "is" })),[e;{ eexpr = TTypeExpr (TClassDecl _) } as t] ->
+	| TField (_,FStatic ({ cl_path = [],"Std" },{ cf_name = ("is" | "isOfType") })),[e;{ eexpr = TTypeExpr (TClassDecl _) } as t] ->
 		(* fast inlining of Std.is with known values *)
 		gen_expr ctx true e;
 		gen_expr ctx true t;

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2145,11 +2145,13 @@ module StdSocket = struct
 end
 
 module StdStd = struct
-	let is' = vfun2 (fun v t -> match t with
+	let isOfType = vfun2 (fun v t -> match t with
 		| VNull -> vfalse
 		| VPrototype proto -> vbool (is v proto.ppath)
 		| _ -> vfalse
 	)
+
+	let is' = isOfType
 
 	let downcast = vfun2 (fun v t -> match t with
 		| VPrototype proto ->
@@ -3548,6 +3550,7 @@ let init_standard_library builtins =
 		"instance",StdStd.instance;
 		"int",StdStd.int;
 		"is",StdStd.is';
+		"isOfType",StdStd.isOfType;
 		"parseFloat",StdStd.parseFloat;
 		"parseInt",StdStd.parseInt;
 		"string",StdStd.string;

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -124,7 +124,7 @@ let api_inline ctx c field params p =
 	let tint = ctx.com.basic.tint in
 
 	match c.cl_path, field, params with
-	| ([],"Std"),"is",[o;t] | (["js"],"Boot"),"__instanceof",[o;t] when ctx.com.platform = Js ->
+	| ([],"Std"),("is" | "isOfType"),[o;t] | (["js"],"Boot"),"__instanceof",[o;t] when ctx.com.platform = Js ->
 		let is_trivial e =
 			match e.eexpr with
 			| TConst _ | TLocal _ -> true

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -270,7 +270,7 @@ let rec make_meta name params ((v,p2) as e) p1 =
 	| _ -> EMeta((name,params,p1),e),punion p1 p2
 
 let make_is e (t,p_t) p p_is =
-	let e_is = EField((EConst(Ident "Std"),null_pos),"is"),p_is in
+	let e_is = EField((EConst(Ident "Std"),null_pos),"isOfType"),p_is in
 	let e2 = expr_of_type_path (t.tpackage,t.tname) p_t in
 	ECall(e_is,[e;e2]),p
 

--- a/std/Std.hx
+++ b/std/Std.hx
@@ -31,8 +31,17 @@ extern class Std {
 		Tells if a value `v` is of the type `t`. Returns `false` if `v` or `t` are null.
 
 		If `t` is a class or interface with `@:generic` meta, the result is `false`.
+
+		DEPRECATED. Use `Std.isOfType(v, t)` instead.
 	**/
 	public static function is(v:Dynamic, t:Dynamic):Bool;
+
+	/**
+		Tells if a value `v` is of the type `t`. Returns `false` if `v` or `t` are null.
+
+		If `t` is a class or interface with `@:generic` meta, the result is `false`.
+	**/
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool;
 
 	/**
 		Checks if object `value` is an instance of class or interface `c`.

--- a/std/cpp/_std/Std.hx
+++ b/std/cpp/_std/Std.hx
@@ -22,11 +22,15 @@
 @:headerClassCode("\t\tstatic inline String string(String &s) { return s; }")
 @:coreApi class Std {
 	@:keep public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		return untyped __global__.__instanceof(v, t);
 	}
 
 	@:keep public static function downcast<T:{}, S:T>(value:T, c:Class<S>):S {
-		return Std.is(value, c) ? cast value : null;
+		return Std.isOfType(value, c) ? cast value : null;
 	}
 
 	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')

--- a/std/cpp/_std/Std.hx
+++ b/std/cpp/_std/Std.hx
@@ -21,8 +21,8 @@
  */
 @:headerClassCode("\t\tstatic inline String string(String &s) { return s; }")
 @:coreApi class Std {
-	@:keep public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	@:keep public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/cpp/_std/haxe/Int64.hx
+++ b/std/cpp/_std/haxe/Int64.hx
@@ -37,7 +37,7 @@ private extern class ___Int64 {
 	public static function ofInt(value:Int):__Int64;
 
 	@:native(" ::cpp::Int64Struct::is")
-	public static function is(d:Dynamic):Bool;
+	public static function isInt64(d:Dynamic):Bool;
 
 	@:native("_hx_int64_is_neg")
 	public static function isNeg(a:__Int64):Bool;
@@ -156,8 +156,13 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return x.low;
 	}
 
-	public static #if !cppia inline #end function is(val:Dynamic):Bool
-		return __Int64.is(val);
+	@:deprecated('haxe.Int64.is() is deprecated. Use haxe.Int64.isInt64() instead')
+	inline public static function is(val:Dynamic):Bool {
+		return isInt64(val);
+	}
+
+	public static #if !cppia inline #end function isInt64(val:Dynamic):Bool
+		return __Int64.isInt64(val);
 
 	@:deprecated("Use high instead")
 	public static #if !cppia inline #end function getHigh(x:Int64):Int32

--- a/std/cpp/_std/sys/db/Mysql.hx
+++ b/std/cpp/_std/sys/db/Mysql.hx
@@ -158,7 +158,7 @@ private class MysqlConnection implements sys.db.Connection {
 	public function addValue(s:StringBuf, v:Dynamic) {
 		if (v == null) {
 			s.add(v);
-		} else if (Std.is(v, Bool)) {
+		} else if (Std.isOfType(v, Bool)) {
 			s.add(v ? 1 : 0);
 		} else {
 			var t:Int = untyped v.__GetType();

--- a/std/cpp/_std/sys/db/Sqlite.hx
+++ b/std/cpp/_std/sys/db/Sqlite.hx
@@ -58,7 +58,7 @@ private class SqliteConnection implements Connection {
 	public function addValue(s:StringBuf, v:Dynamic) {
 		if (v == null) {
 			s.add(v);
-		} else if (Std.is(v, Bool)) {
+		} else if (Std.isOfType(v, Bool)) {
 			s.add(v ? 1 : 0);
 		} else {
 			var t:Int = untyped v.__GetType();

--- a/std/cpp/net/ThreadServer.hx
+++ b/std/cpp/net/ThreadServer.hx
@@ -160,7 +160,7 @@ class ThreadServer<Client, Message> {
 					readClientData(infos);
 				} catch (e:Dynamic) {
 					t.socks.remove(s);
-					if (!Std.is(e, haxe.io.Eof) && !Std.is(e, haxe.io.Error))
+					if (!Std.isOfType(e, haxe.io.Eof) && !Std.isOfType(e, haxe.io.Error))
 						logError(e);
 					work(doClientDisconnected.bind(s, infos.client));
 				}

--- a/std/cs/_std/Reflect.hx
+++ b/std/cs/_std/Reflect.hx
@@ -90,7 +90,7 @@ import cs.system.reflection.*;
 			var ret = [];
 			untyped ihx.__hx_getFields(ret);
 			return ret;
-		} else if (Std.is(o, cs.system.Type)) {
+		} else if (Std.isOfType(o, cs.system.Type)) {
 			return Type.getClassFields(o);
 		} else {
 			return instanceFields(untyped o.GetType());
@@ -109,7 +109,7 @@ import cs.system.reflection.*;
 	}
 
 	inline public static function isFunction(f:Dynamic):Bool {
-		return Std.is(f, Function);
+		return Std.isOfType(f, Function);
 	}
 
 	public static function compare<T>(a:T, b:T):Int {
@@ -121,7 +121,7 @@ import cs.system.reflection.*;
 		if (f1 == f2)
 			return true;
 
-		if (Std.is(f1, Closure) && Std.is(f2, Closure)) {
+		if (Std.isOfType(f1, Closure) && Std.isOfType(f2, Closure)) {
 			var f1c:Closure = cast f1;
 			var f2c:Closure = cast f2;
 
@@ -132,11 +132,11 @@ import cs.system.reflection.*;
 	}
 
 	public static function isObject(v:Dynamic):Bool {
-		return v != null && !(Std.is(v, HxEnum) || Std.is(v, Function) || Std.is(v, cs.system.ValueType));
+		return v != null && !(Std.isOfType(v, HxEnum) || Std.isOfType(v, Function) || Std.isOfType(v, cs.system.ValueType));
 	}
 
 	public static function isEnumValue(v:Dynamic):Bool {
-		return v != null && (Std.is(v, HxEnum) || Std.is(v, cs.system.Enum));
+		return v != null && (Std.isOfType(v, HxEnum) || Std.isOfType(v, cs.system.Enum));
 	}
 
 	public static function deleteField(o:Dynamic, field:String):Bool {

--- a/std/cs/_std/Std.hx
+++ b/std/cs/_std/Std.hx
@@ -26,6 +26,10 @@ import cs.internal.Exceptions;
 
 @:coreApi @:nativeGen class Std {
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		if (v == null)
 			return false;
 		if (t == null)
@@ -65,7 +69,7 @@ import cs.internal.Exceptions;
 	public static function string(s:Dynamic):String {
 		if (s == null)
 			return "null";
-		if (Std.is(s, Bool))
+		if (Std.isOfType(s, Bool))
 			return cast(s, Bool) ? "true" : "false";
 
 		return s.ToString();

--- a/std/cs/_std/Std.hx
+++ b/std/cs/_std/Std.hx
@@ -25,8 +25,8 @@ import cs.Lib;
 import cs.internal.Exceptions;
 
 @:coreApi @:nativeGen class Std {
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/cs/_std/Type.hx
+++ b/std/cs/_std/Type.hx
@@ -44,16 +44,16 @@ enum ValueType {
 
 @:coreApi class Type {
 	public static function getClass<T>(o:T):Class<T> {
-		if (Object.ReferenceEquals(o, null) || Std.is(o, DynamicObject) || Std.is(o, cs.system.Type))
+		if (Object.ReferenceEquals(o, null) || Std.isOfType(o, DynamicObject) || Std.isOfType(o, cs.system.Type))
 			return null;
 
 		return cast cs.Lib.getNativeType(o);
 	}
 
 	public static function getEnum(o:EnumValue):Enum<Dynamic> {
-		if (Std.is(o, HxEnum))
+		if (Std.isOfType(o, HxEnum))
 			return cast cs.Lib.getNativeType(o).BaseType; // enum constructors are subclasses of an enum type
-		else if (Std.is(o, cs.system.Enum))
+		else if (Std.isOfType(o, cs.system.Enum))
 			return cast cs.Lib.getNativeType(o);
 		return null;
 	}
@@ -211,7 +211,7 @@ enum ValueType {
 		var mis = c.GetMembers(new cs.Flags(BindingFlags.Public) | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
 		for (i in 0...mis.Length) {
 			var i = mis[i];
-			if (Std.is(i, PropertyInfo))
+			if (Std.isOfType(i, PropertyInfo))
 				continue;
 			var n = i.Name;
 			if (!n.startsWith('__hx_') && n.fastCodeAt(0) != '.'.code) {
@@ -266,7 +266,7 @@ enum ValueType {
 		t = v.GetType();
 		if (t.IsEnum)
 			return ValueType.TEnum(cast t);
-		if (Std.is(v, HxEnum))
+		if (Std.isOfType(v, HxEnum))
 			return ValueType.TEnum(cast t.BaseType); // enum constructors are subclasses of an enum type
 		if (t.IsValueType) {
 			var vc = Std.downcast(v, cs.system.IConvertible);
@@ -290,11 +290,11 @@ enum ValueType {
 			}
 		}
 
-		if (Std.is(v, IHxObject)) {
-			if (Std.is(v, DynamicObject))
+		if (Std.isOfType(v, IHxObject)) {
+			if (Std.isOfType(v, DynamicObject))
 				return ValueType.TObject;
 			return ValueType.TClass(cast t);
-		} else if (Std.is(v, Function)) {
+		} else if (Std.isOfType(v, Function)) {
 			return ValueType.TFunction;
 		} else {
 			return ValueType.TClass(cast t);
@@ -312,17 +312,17 @@ enum ValueType {
 	}
 
 	public static function enumConstructor(e:EnumValue):String {
-		return Std.is(e, cs.system.Enum) ? cast(e, cs.system.Enum).ToString() : cast(e, HxEnum).getTag();
+		return Std.isOfType(e, cs.system.Enum) ? cast(e, cs.system.Enum).ToString() : cast(e, HxEnum).getTag();
 	}
 
 	public static function enumParameters(e:EnumValue):Array<Dynamic> {
-		return Std.is(e, cs.system.Enum) ? [] : cast(e, HxEnum).getParams();
+		return Std.isOfType(e, cs.system.Enum) ? [] : cast(e, HxEnum).getParams();
 	}
 
 	@:ifFeature("has_enum")
 	@:pure
 	public static function enumIndex(e:EnumValue):Int {
-		if (Std.is(e, cs.system.Enum)) {
+		if (Std.isOfType(e, cs.system.Enum)) {
 			var values = cs.system.Enum.GetValues(Lib.getNativeType(e));
 			return cs.system.Array.IndexOf(values, e);
 		} else {
@@ -335,7 +335,7 @@ enum ValueType {
 		var ret = [];
 		for (ctor in ctors) {
 			var v = Reflect.field(e, ctor);
-			if (Std.is(v, e))
+			if (Std.isOfType(v, e))
 				ret.push(v);
 		}
 

--- a/std/cs/_std/haxe/Int64.hx
+++ b/std/cs/_std/haxe/Int64.hx
@@ -66,7 +66,11 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return cast x.val;
 	}
 
+	@:deprecated('haxe.Int64.is() is deprecated. Use haxe.Int64.isInt64() instead')
 	inline public static function is(val:Dynamic):Bool
+		return Std.isOfType(val, cs.system.Int64);
+
+	inline public static function isInt64(val:Dynamic):Bool
 		return Std.isOfType(val, cs.system.Int64);
 
 	public static inline function getHigh(x:Int64):Int32

--- a/std/cs/_std/haxe/Int64.hx
+++ b/std/cs/_std/haxe/Int64.hx
@@ -67,7 +67,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	}
 
 	inline public static function is(val:Dynamic):Bool
-		return Std.is(val, cs.system.Int64);
+		return Std.isOfType(val, cs.system.Int64);
 
 	public static inline function getHigh(x:Int64):Int32
 		return cast(x.val >> 32);

--- a/std/cs/db/AdoNet.hx
+++ b/std/cs/db/AdoNet.hx
@@ -74,9 +74,9 @@ private class AdoConnection implements Connection {
 	}
 
 	public function addValue(s:StringBuf, v:Dynamic) {
-		if (Std.is(v, Date)) {
+		if (Std.isOfType(v, Date)) {
 			v = Std.string(v);
-		} else if (Std.is(v, haxe.io.Bytes)) {
+		} else if (Std.isOfType(v, haxe.io.Bytes)) {
 			var bt:haxe.io.Bytes = v;
 			v = bt.getData();
 		}
@@ -284,7 +284,7 @@ private class AdoResultSet implements ResultSet {
 			} else {
 				val = reader.GetValue(i);
 			}
-			if (Std.is(val, cs.system.DBNull))
+			if (Std.isOfType(val, cs.system.DBNull))
 				val = null;
 			Reflect.setField(ret, name, val);
 		}

--- a/std/cs/internal/Exceptions.hx
+++ b/std/cs/internal/Exceptions.hx
@@ -39,7 +39,7 @@ import cs.system.Exception;
 	public function new(obj:Dynamic) {
 		super();
 
-		if (Std.is(obj, HaxeException)) {
+		if (Std.isOfType(obj, HaxeException)) {
 			var _obj:HaxeException = cast obj;
 			obj = _obj.getObject();
 		}
@@ -55,7 +55,7 @@ import cs.system.Exception;
 	}
 
 	public static function wrap(obj:Dynamic):Exception {
-		if (Std.is(obj, Exception))
+		if (Std.isOfType(obj, Exception))
 			return obj;
 
 		return new HaxeException(obj);

--- a/std/cs/internal/HxObject.hx
+++ b/std/cs/internal/HxObject.hx
@@ -127,7 +127,7 @@ class DynamicObject extends HxObject {
 		} else {
 			var res = FieldLookup.findHash(hash, this.__hx_hashes_f, this.__hx_length_f);
 			if (res >= 0) {
-				if (Std.is(value, Float)) {
+				if (Std.isOfType(value, Float)) {
 					return this.__hx_dynamics_f[res] = value;
 				}
 

--- a/std/cs/internal/Runtime.hx
+++ b/std/cs/internal/Runtime.hx
@@ -132,23 +132,23 @@ import cs.system.Object;
 
 	public static function refEq(v1:{}, v2:{}):Bool {
 		#if !erase_generics
-		if (Std.is(v1, Type))
+		if (Std.isOfType(v1, Type))
 			return typeEq(Lib.as(v1, Type), Lib.as(v2, Type));
 		#end
 		return Object.ReferenceEquals(v1, v2);
 	}
 
 	public static function toDouble(obj:Dynamic):Float {
-		return (obj == null) ? .0 : Std.is(obj, Float) ? cast obj : Lib.as(obj, IConvertible).ToDouble(null);
+		return (obj == null) ? .0 : Std.isOfType(obj, Float) ? cast obj : Lib.as(obj, IConvertible).ToDouble(null);
 	}
 
 	public static function toInt(obj:Dynamic):Int {
-		return (obj == null) ? 0 : Std.is(obj, Int) ? cast obj : Lib.as(obj, IConvertible).ToInt32(null);
+		return (obj == null) ? 0 : Std.isOfType(obj, Int) ? cast obj : Lib.as(obj, IConvertible).ToInt32(null);
 	}
 
 	#if erase_generics
 	public static function toLong(obj:Dynamic):Int64 {
-		return (obj == null) ? 0 : Std.is(obj, Int64) ? cast obj : Lib.as(obj, IConvertible).ToInt64(null);
+		return (obj == null) ? 0 : Std.isOfType(obj, Int64) ? cast obj : Lib.as(obj, IConvertible).ToInt64(null);
 	}
 	#end
 
@@ -228,7 +228,7 @@ import cs.system.Object;
 	}
 
 	public static function plus(v1:Dynamic, v2:Dynamic):Dynamic {
-		if (Std.is(v1, String) || Std.is(v2, String))
+		if (Std.isOfType(v1, String) || Std.isOfType(v2, String))
 			return Std.string(v1) + Std.string(v2);
 
 		if (v1 == null) {
@@ -411,7 +411,7 @@ import cs.system.Object;
 							// if it is directly assignable, we'll give it top rate
 							continue;
 						} else if (untyped strParam.StartsWith("haxe.lang.Null")
-							|| ((oargs[i] == null || Std.is(oargs[i], IConvertible))
+							|| ((oargs[i] == null || Std.isOfType(oargs[i], IConvertible))
 								&& cast(untyped __typeof__(IConvertible), Type).IsAssignableFrom(param))) {
 							// if it needs conversion, give a penalty. TODO rate penalty
 							crate++;
@@ -468,7 +468,7 @@ import cs.system.Object;
 			}
 		}
 
-		if (methods[0].ContainsGenericParameters && Std.is(methods[0], cs.system.reflection.MethodInfo)) {
+		if (methods[0].ContainsGenericParameters && Std.isOfType(methods[0], cs.system.reflection.MethodInfo)) {
 			var m:MethodInfo = cast methods[0];
 			var tgs = m.GetGenericArguments();
 			for (i in 0...tgs.Length) {
@@ -480,7 +480,7 @@ import cs.system.Object;
 		}
 
 		var m = methods[0];
-		if (obj == null && Std.is(m, cs.system.reflection.ConstructorInfo)) {
+		if (obj == null && Std.isOfType(m, cs.system.reflection.ConstructorInfo)) {
 			var ret = cast(m, cs.system.reflection.ConstructorInfo).Invoke(oargs);
 			return unbox(ret);
 		}
@@ -604,7 +604,7 @@ import cs.system.Object;
 	public static function toString(obj:Dynamic):String {
 		if (obj == null)
 			return null;
-		if (Std.is(obj, Bool))
+		if (Std.isOfType(obj, Bool))
 			if (obj)
 				return "true";
 			else
@@ -643,7 +643,7 @@ import cs.system.Object;
 	#if !erase_generics
 	public static function getGenericAttr(t:cs.system.Type):cs.internal.HxObject.GenericInterface {
 		for (attr in t.GetCustomAttributes(true))
-			if (Std.is(attr, cs.internal.HxObject.GenericInterface))
+			if (Std.isOfType(attr, cs.internal.HxObject.GenericInterface))
 				return cast attr;
 		return null;
 	}

--- a/std/flash/Boot.hx
+++ b/std/flash/Boot.hx
@@ -232,7 +232,7 @@ class Boot extends flash.display.MovieClip {
 	}
 
 	static public function mapDynamic(d:Dynamic, f:Dynamic) {
-		if (Std.is(d, Array)) {
+		if (Std.isOfType(d, Array)) {
 			return untyped d["mapHX"](f);
 		} else {
 			return untyped d["map"](f);
@@ -240,7 +240,7 @@ class Boot extends flash.display.MovieClip {
 	}
 
 	static public function filterDynamic(d:Dynamic, f:Dynamic) {
-		if (Std.is(d, Array)) {
+		if (Std.isOfType(d, Array)) {
 			return untyped d["filterHX"](f);
 		} else {
 			return untyped d["filter"](f);

--- a/std/flash/Vector.hx
+++ b/std/flash/Vector.hx
@@ -68,7 +68,7 @@ package flash;
 		so there is no way to check if a value is of a type with specific type parameters.
 
 		However, on the Flash target, the `flash.Vector<T>` values carry type parameter
-		information at run-time all the type-checks (such as `Std.is` and `Std.downcast`) on them
+		information at run-time all the type-checks (such as `Std.isOfType` and `Std.downcast`) on them
 		must be done using a `Class<T>` value that also carries the type parameters. However,
 		Haxe syntax does not allow creating such values and this function exists to mitigate
 		this limitation.
@@ -76,11 +76,11 @@ package flash;
 		It should be used as such:
 		```haxe
 		var specificVectorType:Class<Vector<Int>> = Vector.typeReference();
-		trace(Std.is(vec, specificVectorType));
+		trace(Std.isOfType(vec, specificVectorType));
 		```
 		or using the type-check syntax:
 		```haxe
-		trace(Std.is(vec, (Vector.typeReference() : Class<Vector<Int>>)));
+		trace(Std.isOfType(vec, (Vector.typeReference() : Class<Vector<Int>>)));
 		```
 
 		It's also helpful when working with native Flash libraries, that receive Class instances:

--- a/std/flash/_std/Std.hx
+++ b/std/flash/_std/Std.hx
@@ -24,6 +24,10 @@ import flash.Boot;
 
 @:coreApi class Std {
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		return flash.Boot.__instanceof(v, t);
 	}
 

--- a/std/flash/_std/Std.hx
+++ b/std/flash/_std/Std.hx
@@ -23,8 +23,8 @@
 import flash.Boot;
 
 @:coreApi class Std {
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -65,11 +65,16 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return x.low;
 	}
 
+	@:deprecated('haxe.Int64.is() is deprecated. Use haxe.Int64.isInt64() instead')
+	inline public static function is(val:Dynamic):Bool {
+		return isInt64(val);
+	}
+
 	/**
 		Returns whether the value `val` is of type `haxe.Int64`
 	**/
-	inline public static function is(val:Dynamic):Bool
-		return Std.is(val, __Int64);
+	inline public static function isInt64(val:Dynamic):Bool
+		return Std.isOfType(val, __Int64);
 
 	/**
 		Returns the high 32-bit word of `x`.

--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -410,7 +410,7 @@ class Serializer {
 						}
 				}
 			case TObject:
-				if (Std.is(v, Class)) {
+				if (Std.isOfType(v, Class)) {
 					var className = Type.getClassName(v);
 					#if (flash || cpp)
 					// Currently, Enum and Class are the same for flash and cpp.
@@ -421,7 +421,7 @@ class Serializer {
 					#end
 					buf.add("A");
 					serializeString(className);
-				} else if (Std.is(v, Enum)) {
+				} else if (Std.isOfType(v, Enum)) {
 					buf.add("B");
 					serializeString(Type.getEnumName(v));
 				} else {

--- a/std/haxe/Unserializer.hx
+++ b/std/haxe/Unserializer.hx
@@ -188,7 +188,7 @@ class Unserializer {
 			if (get(pos) == "g".code)
 				break;
 			var k:Dynamic = unserialize();
-			if (!Std.is(k, String))
+			if (!Std.isOfType(k, String))
 				throw "Invalid object key";
 			var v = unserialize();
 			Reflect.setField(o, k, v);

--- a/std/haxe/ds/EnumValueMap.hx
+++ b/std/haxe/ds/EnumValueMap.hx
@@ -55,7 +55,7 @@ class EnumValueMap<K:EnumValue, V> extends haxe.ds.BalancedTree<K, V> implements
 	function compareArg(v1:Dynamic, v2:Dynamic):Int {
 		return if (Reflect.isEnumValue(v1) && Reflect.isEnumValue(v2)) {
 			compare(v1, v2);
-		} else if (Std.is(v1, Array) && Std.is(v2, Array)) {
+		} else if (Std.isOfType(v1, Array) && Std.isOfType(v2, Array)) {
 			compareArgs(v1, v2);
 		} else {
 			Reflect.compare(v1, v2);

--- a/std/haxe/rtti/Meta.hx
+++ b/std/haxe/rtti/Meta.hx
@@ -58,7 +58,7 @@ class Meta {
 		return php.Boot.getMeta(t.phpClassName);
 		#elseif (java || cs)
 		var ret = Reflect.field(t, "__meta__");
-		if (ret == null && Std.is(t, Class)) {
+		if (ret == null && Std.isOfType(t, Class)) {
 			if (isInterface(t)) {
 				var name = Type.getClassName(t),
 					cls = Type.resolveClass(name + '_HxMeta');

--- a/std/hl/_std/Std.hx
+++ b/std/hl/_std/Std.hx
@@ -50,6 +50,10 @@ class Std {
 	}
 
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		var t:hl.BaseType = t;
 		if (t == null)
 			return false;

--- a/std/hl/_std/Std.hx
+++ b/std/hl/_std/Std.hx
@@ -49,8 +49,8 @@ class Std {
 		return x <= 0 ? 0 : (rnd_int(rnd) & 0x3FFFFFFF) % x;
 	}
 
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/hl/_std/Type.hx
+++ b/std/hl/_std/Type.hx
@@ -109,14 +109,14 @@ class Type {
 
 	public static function resolveClass(name:String):Class<Dynamic> {
 		var t:hl.BaseType = allTypes.get(@:privateAccess name.bytes);
-		if (t == null || !Std.is(t, hl.BaseType.Class))
+		if (t == null || !Std.isOfType(t, hl.BaseType.Class))
 			return null;
 		return cast t;
 	}
 
 	public static function resolveEnum(name:String):Enum<Dynamic> {
 		var t:hl.BaseType = allTypes.get(@:privateAccess name.bytes);
-		if (t == null || !Std.is(t, hl.BaseType.Enum))
+		if (t == null || !Std.isOfType(t, hl.BaseType.Enum))
 			return null;
 		return cast t;
 	}

--- a/std/java/_std/Reflect.hx
+++ b/std/java/_std/Reflect.hx
@@ -27,7 +27,7 @@ import java.Boot;
 
 @:coreApi class Reflect {
 	public static function hasField(o:Dynamic, field:String):Bool {
-		if (Std.is(o, IHxObject)) {
+		if (Std.isOfType(o, IHxObject)) {
 			return untyped (o : IHxObject).__hx_getField(field, false, true, false) != Runtime.undefined;
 		}
 		return Runtime.slowHasField(o, field);
@@ -35,7 +35,7 @@ import java.Boot;
 
 	@:keep
 	public static function field(o:Dynamic, field:String):Dynamic {
-		if (Std.is(o, IHxObject)) {
+		if (Std.isOfType(o, IHxObject)) {
 			return untyped (o : IHxObject).__hx_getField(field, false, false, false);
 		}
 		return Runtime.slowGetField(o, field, false);
@@ -43,7 +43,7 @@ import java.Boot;
 
 	@:keep
 	public static function setField(o:Dynamic, field:String, value:Dynamic):Void {
-		if (Std.is(o, IHxObject)) {
+		if (Std.isOfType(o, IHxObject)) {
 			untyped (o : IHxObject).__hx_setField(field, value, false);
 		} else {
 			Runtime.slowSetField(o, field, value);
@@ -54,7 +54,7 @@ import java.Boot;
 		if (o == null || field == null) {
 			return null;
 		}
-		if (Std.is(o, IHxObject)) {
+		if (Std.isOfType(o, IHxObject)) {
 			return untyped (o : IHxObject).__hx_getField(field, false, false, true);
 		}
 		if (Runtime.slowHasField(o, "get_" + field)) {
@@ -64,7 +64,7 @@ import java.Boot;
 	}
 
 	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void {
-		if (Std.is(o, IHxObject)) {
+		if (Std.isOfType(o, IHxObject)) {
 			untyped (o : IHxObject).__hx_setField(field, value, true);
 		} else if (Runtime.slowHasField(o, "set_" + field)) {
 			Runtime.slowCallField(o, "set_" + field, java.NativeArray.make(value));
@@ -80,11 +80,11 @@ import java.Boot;
 
 	@:keep
 	public static function fields(o:Dynamic):Array<String> {
-		if (Std.is(o, IHxObject)) {
+		if (Std.isOfType(o, IHxObject)) {
 			var ret:Array<String> = [];
 			untyped (o : IHxObject).__hx_getFields(ret);
 			return ret;
-		} else if (Std.is(o, java.lang.Class)) {
+		} else if (Std.isOfType(o, java.lang.Class)) {
 			return Type.getClassFields(cast o);
 		} else {
 			return [];
@@ -92,7 +92,7 @@ import java.Boot;
 	}
 
 	public static function isFunction(f:Dynamic):Bool {
-		return Std.is(f, Function);
+		return Std.isOfType(f, Function);
 	}
 
 	public static function compare<T>(a:T, b:T):Int {
@@ -104,7 +104,7 @@ import java.Boot;
 		if (f1 == f2) {
 			return true;
 		}
-		if (Std.is(f1, Closure) && Std.is(f2, Closure)) {
+		if (Std.isOfType(f1, Closure) && Std.isOfType(f2, Closure)) {
 			var f1c:Closure = cast f1;
 			var f2c:Closure = cast f2;
 			return Runtime.refEq(f1c.obj, f2c.obj) && f1c.field == f2c.field;
@@ -114,19 +114,19 @@ import java.Boot;
 
 	public static function isObject(v:Dynamic):Bool {
 		return v != null
-			&& !(Std.is(v, HxEnum)
-				|| Std.is(v, Function)
-				|| Std.is(v, java.lang.Enum)
-				|| Std.is(v, java.lang.Number)
-				|| Std.is(v, java.lang.Boolean.BooleanClass));
+			&& !(Std.isOfType(v, HxEnum)
+				|| Std.isOfType(v, Function)
+				|| Std.isOfType(v, java.lang.Enum)
+				|| Std.isOfType(v, java.lang.Number)
+				|| Std.isOfType(v, java.lang.Boolean.BooleanClass));
 	}
 
 	public static function isEnumValue(v:Dynamic):Bool {
-		return v != null && (Std.is(v, HxEnum) || Std.is(v, java.lang.Enum));
+		return v != null && (Std.isOfType(v, HxEnum) || Std.isOfType(v, java.lang.Enum));
 	}
 
 	public static function deleteField(o:Dynamic, field:String):Bool {
-		return (Std.is(o, DynamicObject) && (o : DynamicObject).__hx_deleteField(field));
+		return (Std.isOfType(o, DynamicObject) && (o : DynamicObject).__hx_deleteField(field));
 	}
 
 	public static function copy<T>(o:Null<T>):Null<T> {

--- a/std/java/_std/Std.hx
+++ b/std/java/_std/Std.hx
@@ -25,8 +25,8 @@ import java.Lib;
 import java.internal.Exceptions;
 
 @:coreApi @:nativeGen class Std {
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/java/_std/Std.hx
+++ b/std/java/_std/Std.hx
@@ -26,6 +26,10 @@ import java.internal.Exceptions;
 
 @:coreApi @:nativeGen class Std {
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		if (v == null)
 			return false;
 		if (t == null)
@@ -157,7 +161,7 @@ import java.internal.Exceptions;
 	}
 
 	inline public static function downcast<T:{}, S:T>(value:T, c:Class<S>):S {
-		return Std.is(value, c) ? cast value : null;
+		return Std.isOfType(value, c) ? cast value : null;
 	}
 
 	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')

--- a/std/java/_std/StringBuf.hx
+++ b/std/java/_std/StringBuf.hx
@@ -43,7 +43,7 @@ class StringBuf {
 	}
 	#else
 	public function add<T>(x:T):Void {
-		if (Std.is(x, Int)) {
+		if (Std.isOfType(x, Int)) {
 			var x:Int = cast x;
 			var xd:Dynamic = x;
 			b.append(xd);

--- a/std/java/_std/Type.hx
+++ b/std/java/_std/Type.hx
@@ -38,14 +38,14 @@ enum ValueType {
 
 @:coreApi class Type {
 	public static function getClass<T>(o:T):Class<T> {
-		if (o == null || Std.is(o, DynamicObject) || Std.is(o, java.lang.Class)) {
+		if (o == null || Std.isOfType(o, DynamicObject) || Std.isOfType(o, java.lang.Class)) {
 			return null;
 		}
 		return cast java.Lib.getNativeType(o);
 	}
 
 	public static function getEnum(o:EnumValue):Enum<Dynamic> {
-		if (Std.is(o, java.lang.Enum) || Std.is(o, HxEnum)) {
+		if (Std.isOfType(o, java.lang.Enum) || Std.isOfType(o, HxEnum)) {
 			return untyped o.getClass();
 		}
 		return null;
@@ -137,12 +137,12 @@ enum ValueType {
 			for (arg in args) {
 				argNum++;
 				var expectedType = argNum < ptypes.length ? ptypes[argNum] : ptypes[ptypes.length - 1]; // varags
-				var isDynamic = Std.is(arg, DynamicObject) && expectedType.isAssignableFrom(java.Lib.getNativeType(arg));
+				var isDynamic = Std.isOfType(arg, DynamicObject) && expectedType.isAssignableFrom(java.Lib.getNativeType(arg));
 				var argType = Type.getClass(arg);
 
 				if (arg == null || isDynamic || (argType != null && expectedType.isAssignableFrom(java.Lib.toNativeType(argType)))) {
 					callArguments[argNum] = arg;
-				} else if (Std.is(arg, java.lang.Number)) {
+				} else if (Std.isOfType(arg, java.lang.Number)) {
 					var name = expectedType.getName();
 					switch (name) {
 						case 'double' | 'java.lang.Double':
@@ -193,7 +193,7 @@ enum ValueType {
 	public static function createEnum<T>(e:Enum<T>, constr:String, ?params:Array<Dynamic>):T {
 		if (params == null || params.length == 0) {
 			var ret:Dynamic = java.internal.Runtime.slowGetField(e, constr, true);
-			if (Std.is(ret, java.internal.Function)) {
+			if (Std.isOfType(ret, java.internal.Function)) {
 				throw "Constructor " + constr + " needs parameters";
 			}
 			return ret;
@@ -359,7 +359,7 @@ enum ValueType {
 		var ret = [];
 		for (ctor in ctors) {
 			var v = Reflect.field(e, ctor);
-			if (Std.is(v, e))
+			if (Std.isOfType(v, e))
 				ret.push(v);
 		}
 

--- a/std/java/_std/haxe/Int64.hx
+++ b/std/java/_std/haxe/Int64.hx
@@ -64,7 +64,11 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	@:from public static inline function ofInt(x:Int):Int64
 		return cast x;
 
+	@:deprecated('haxe.Int64.is() is deprecated. Use haxe.Int64.isInt64() instead')
 	inline public static function is(val:Dynamic):Bool
+		return Std.isOfType(val, java.lang.Long.LongClass);
+
+	inline public static function isInt64(val:Dynamic):Bool
 		return Std.isOfType(val, java.lang.Long.LongClass);
 
 	public static inline function toInt(x:Int64):Int {

--- a/std/java/_std/haxe/Int64.hx
+++ b/std/java/_std/haxe/Int64.hx
@@ -65,7 +65,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return cast x;
 
 	inline public static function is(val:Dynamic):Bool
-		return Std.is(val, java.lang.Long.LongClass);
+		return Std.isOfType(val, java.lang.Long.LongClass);
 
 	public static inline function toInt(x:Int64):Int {
 		if (x.val < 0x80000000 || x.val > 0x7FFFFFFF)

--- a/std/java/_std/sys/thread/Thread.hx
+++ b/std/java/_std/sys/thread/Thread.hx
@@ -63,7 +63,7 @@ abstract Thread(NativeThread) {
 	};
 
 	public static function getThread(jt:java.lang.Thread):NativeThread {
-		if (Std.is(jt, HaxeThread)) {
+		if (Std.isOfType(jt, HaxeThread)) {
 			var t:HaxeThread = cast jt;
 			return t.threadObject;
 		} else if (jt == mainJavaThread) {

--- a/std/java/db/Jdbc.hx
+++ b/std/java/db/Jdbc.hx
@@ -68,9 +68,9 @@ private class JdbcConnection implements sys.db.Connection {
 	}
 
 	public function addValue(s:StringBuf, v:Dynamic) {
-		if (Std.is(v, Date)) {
+		if (Std.isOfType(v, Date)) {
 			v = Std.string(v);
-		} else if (Std.is(v, Bytes)) {
+		} else if (Std.isOfType(v, Bytes)) {
 			var bt:Bytes = v;
 			v = bt.getData();
 		}

--- a/std/java/internal/Exceptions.hx
+++ b/std/java/internal/Exceptions.hx
@@ -46,7 +46,7 @@ class Exceptions {
 	public function new(obj:Dynamic, msg:String, cause:Throwable) {
 		super(msg, cause);
 
-		if (Std.is(obj, HaxeException)) {
+		if (Std.isOfType(obj, HaxeException)) {
 			var _obj:HaxeException = cast obj;
 			obj = _obj.getObject();
 		}
@@ -77,11 +77,11 @@ class Exceptions {
 
 	public static function wrap(obj:Dynamic):RuntimeException {
 		var ret:RuntimeException = null;
-		if (Std.is(obj, RuntimeException))
+		if (Std.isOfType(obj, RuntimeException))
 			ret = obj;
-		else if (Std.is(obj, String))
+		else if (Std.isOfType(obj, String))
 			ret = new HaxeException(obj, obj, null);
-		else if (Std.is(obj, Throwable))
+		else if (Std.isOfType(obj, Throwable))
 			ret = new HaxeException(obj, Std.string(obj), obj);
 		else
 			ret = new HaxeException(obj, Std.string(obj), null);

--- a/std/java/internal/HxObject.hx
+++ b/std/java/internal/HxObject.hx
@@ -103,7 +103,7 @@ class DynamicObject extends HxObject {
 		} else {
 			var res = FieldLookup.findHash(field, this.__hx_fields_f, this.__hx_length_f);
 			if (res >= 0) {
-				if (Std.is(value, Float)) {
+				if (Std.isOfType(value, Float)) {
 					return this.__hx_dynamics_f[res] = value;
 				}
 
@@ -267,8 +267,8 @@ private class ParamEnum extends HxEnum {
 	public function equals(obj:Dynamic) {
 		if (obj == this) // we cannot use == as .Equals !
 			return true;
-		var obj:ParamEnum = Std.is(obj, ParamEnum) ? cast obj : null;
-		var ret = obj != null && Std.is(obj, StdType.getEnum(cast this)) && obj.index == this.index;
+		var obj:ParamEnum = Std.isOfType(obj, ParamEnum) ? cast obj : null;
+		var ret = obj != null && Std.isOfType(obj, StdType.getEnum(cast this)) && obj.index == this.index;
 		if (!ret)
 			return false;
 		if (obj.params == this.params)

--- a/std/java/internal/Runtime.hx
+++ b/std/java/internal/Runtime.hx
@@ -149,7 +149,7 @@ package java.internal;
 	}
 
 	@:overload public static function isInt(obj:Dynamic):Bool {
-		if (Std.is(obj, java.lang.Number)) {
+		if (Std.isOfType(obj, java.lang.Number)) {
 			var n:java.lang.Number = obj;
 			return n.doubleValue() == n.intValue();
 		} else {
@@ -547,7 +547,7 @@ package java.internal;
 		if (obj == null)
 			return null;
 
-		if (Std.is(obj, java.lang.Number) && !Std.is(obj, java.lang.Integer.IntegerClass) && isInt((obj : java.lang.Number)))
+		if (Std.isOfType(obj, java.lang.Number) && !Std.isOfType(obj, java.lang.Integer.IntegerClass) && isInt((obj : java.lang.Number)))
 			return java.lang.Integer._toString(toInt(obj));
 		return untyped obj.toString();
 	}
@@ -569,27 +569,27 @@ package java.internal;
 	}
 
 	public static function numToInteger(num:java.lang.Number):java.lang.Integer {
-		return num == null ? null : (Std.is(num, java.lang.Integer.IntegerClass) ? cast num : java.lang.Integer.valueOf(num.intValue()));
+		return num == null ? null : (Std.isOfType(num, java.lang.Integer.IntegerClass) ? cast num : java.lang.Integer.valueOf(num.intValue()));
 	}
 
 	public static function numToDouble(num:java.lang.Number):java.lang.Double {
-		return num == null ? null : (Std.is(num, java.lang.Double.DoubleClass) ? cast num : java.lang.Double.valueOf(num.doubleValue()));
+		return num == null ? null : (Std.isOfType(num, java.lang.Double.DoubleClass) ? cast num : java.lang.Double.valueOf(num.doubleValue()));
 	}
 
 	public static function numToFloat(num:java.lang.Number):java.lang.Float {
-		return num == null ? null : (Std.is(num, java.lang.Float.FloatClass) ? cast num : java.lang.Float.valueOf(num.floatValue()));
+		return num == null ? null : (Std.isOfType(num, java.lang.Float.FloatClass) ? cast num : java.lang.Float.valueOf(num.floatValue()));
 	}
 
 	public static function numToByte(num:java.lang.Number):java.lang.Byte {
-		return num == null ? null : (Std.is(num, java.lang.Byte.ByteClass) ? cast num : java.lang.Byte.valueOf(num.byteValue()));
+		return num == null ? null : (Std.isOfType(num, java.lang.Byte.ByteClass) ? cast num : java.lang.Byte.valueOf(num.byteValue()));
 	}
 
 	public static function numToLong(num:java.lang.Number):java.lang.Long {
-		return num == null ? null : (Std.is(num, java.lang.Long.LongClass) ? cast num : java.lang.Long.valueOf(num.longValue()));
+		return num == null ? null : (Std.isOfType(num, java.lang.Long.LongClass) ? cast num : java.lang.Long.valueOf(num.longValue()));
 	}
 
 	public static function numToShort(num:java.lang.Number):java.lang.Short {
-		return num == null ? null : (Std.is(num, java.lang.Short.ShortClass) ? cast num : java.lang.Short.valueOf(num.shortValue()));
+		return num == null ? null : (Std.isOfType(num, java.lang.Short.ShortClass) ? cast num : java.lang.Short.valueOf(num.shortValue()));
 	}
 }
 

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -61,7 +61,7 @@ class Boot {
 	@:pure static function getClass(o:Null<Dynamic>):Null<Dynamic> {
 		if (o == null) {
 			return null;
-		} else if (Std.is(o, Array)) {
+		} else if (Std.isOfType(o, Array)) {
 			return Array;
 		} else {
 			var cl = untyped __define_feature__("js.Boot.getClass", o.__class__);

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -26,6 +26,10 @@ import js.Syntax;
 @:keepInit
 @:coreApi class Std {
 	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
+	}
+
+	public static inline function isOfType(v:Dynamic, t:Dynamic):Bool {
 		return @:privateAccess js.Boot.__instanceof(v, t);
 	}
 

--- a/std/jvm/_std/Std.hx
+++ b/std/jvm/_std/Std.hx
@@ -24,8 +24,8 @@ import jvm.Jvm;
 
 @:coreApi
 class Std {
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/jvm/_std/Std.hx
+++ b/std/jvm/_std/Std.hx
@@ -25,6 +25,10 @@ import jvm.Jvm;
 @:coreApi
 class Std {
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		if (v == null || t == null) {
 			return false;
 		}
@@ -98,7 +102,7 @@ class Std {
 	}
 
 	inline public static function downcast<T:{}, S:T>(value:T, c:Class<S>):S {
-		return Std.is(value, c) ? cast value : null;
+		return Std.isOfType(value, c) ? cast value : null;
 	}
 
 	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')

--- a/std/jvm/_std/Type.hx
+++ b/std/jvm/_std/Type.hx
@@ -185,7 +185,7 @@ class Type {
 	public static function createEnum<T>(e:Enum<T>, constr:String, ?params:Array<Dynamic>):T {
 		if (params == null || params.length == 0) {
 			var v:Dynamic = Jvm.readField(e, constr);
-			if (!Std.is(v, e)) {
+			if (!Std.isOfType(v, e)) {
 				throw 'Could not create enum value ${getEnumName(e)}.$constr: Unexpected value $v';
 			}
 			return v;

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -70,9 +70,9 @@ class Boot {
 		for the given class.
 	**/
 	static inline public function getClass(o:Dynamic):Class<Dynamic> {
-		if (Std.is(o, Array))
+		if (Std.isOfType(o, Array))
 			return Array;
-		else if (Std.is(o, String))
+		else if (Std.isOfType(o, String))
 			return String;
 		else {
 			var cl = untyped __define_feature__("lua.Boot.getClass", o.__class__);

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -78,9 +78,9 @@ class EReg {
 		else if (n == 0) {
 			var k = sub(s, m[1], m[2]).match;
 			return k;
-		} else if (Std.is(m[3], lua.Table)) {
+		} else if (Std.isOfType(m[3], lua.Table)) {
 			var mn = 2 * (n - 1);
-			if (Std.is(untyped m[3][mn + 1], Bool))
+			if (Std.isOfType(untyped m[3][mn + 1], Bool))
 				return null;
 			return sub(s, untyped m[3][mn + 1], untyped m[3][mn + 2]).match;
 		} else {

--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -122,7 +122,7 @@ import lua.Boot;
 		}
 
 	public static function isEnumValue(v:Dynamic):Bool {
-		return v != null && Std.is(v, lua.Table) && v.__enum__ != null;
+		return v != null && Std.isOfType(v, lua.Table) && v.__enum__ != null;
 	}
 
 	public static function deleteField(o:Dynamic, field:String):Bool

--- a/std/lua/_std/Std.hx
+++ b/std/lua/_std/Std.hx
@@ -26,6 +26,10 @@ import lua.NativeStringTools;
 @:keepInit
 @:coreApi class Std {
 	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
+	}
+
+	public static inline function isOfType(v:Dynamic, t:Dynamic):Bool {
 		return untyped lua.Boot.__instanceof(v, t);
 	}
 

--- a/std/neko/_std/Std.hx
+++ b/std/neko/_std/Std.hx
@@ -22,11 +22,15 @@
 @:coreApi class Std {
 	@:ifFeature("typed_cast")
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		return untyped neko.Boot.__instanceof(v, t);
 	}
 
 	public static function downcast<T:{}, S:T>(value:T, c:Class<S>):S {
-		return Std.is(value, c) ? cast value : null;
+		return Std.isOfType(value, c) ? cast value : null;
 	}
 
 	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')

--- a/std/neko/_std/Std.hx
+++ b/std/neko/_std/Std.hx
@@ -21,8 +21,8 @@
  */
 @:coreApi class Std {
 	@:ifFeature("typed_cast")
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	public static function isOfType(v:Dynamic, t:Dynamic):Bool {

--- a/std/php/Boot.hx
+++ b/std/php/Boot.hx
@@ -201,7 +201,7 @@ class Boot {
 		Check if provided value is an anonymous object
 	**/
 	public static inline function isAnon(v:Any):Bool {
-		return Std.is(v, HxAnon);
+		return Std.isOfType(v, HxAnon);
 	}
 
 	/**
@@ -342,7 +342,7 @@ class Boot {
 					return value;
 				}
 			case _:
-				if (value.is_object() && Std.is(value, cast hxClass)) {
+				if (value.is_object() && Std.isOfType(value, cast hxClass)) {
 					return value;
 				}
 		}
@@ -376,10 +376,10 @@ class Boot {
 			return '[' + Global.implode(', ', strings) + ']';
 		}
 		if (value.is_object()) {
-			if (Std.is(value, Array)) {
+			if (Std.isOfType(value, Array)) {
 				return inline stringifyNativeIndexedArray(value.arr, maxRecursion - 1);
 			}
-			if (Std.is(value, HxEnum)) {
+			if (Std.isOfType(value, HxEnum)) {
 				var e:HxEnum = value;
 				var result = e.tag;
 				if (Global.count(e.params) > 0) {
@@ -394,7 +394,7 @@ class Boot {
 			if (value.method_exists('__toString')) {
 				return value.__toString();
 			}
-			if (Std.is(value, StdClass)) {
+			if (Std.isOfType(value, StdClass)) {
 				if (Global.isset(Syntax.field(value, 'toString')) && value.toString.is_callable()) {
 					return value.toString();
 				}
@@ -408,7 +408,7 @@ class Boot {
 			if (isFunction(value)) {
 				return '<function>';
 			}
-			if (Std.is(value, HxClass)) {
+			if (Std.isOfType(value, HxClass)) {
 				return '[class ' + getClassName((value : HxClass).phpClassName) + ']';
 			} else {
 				return '[object ' + getClassName(Global.get_class(value)) + ']';
@@ -436,7 +436,7 @@ class Boot {
 		if (isNumber(left) && isNumber(right)) {
 			return Syntax.equal(left, right);
 		}
-		if (Std.is(left, HxClosure) && Std.is(right, HxClosure)) {
+		if (Std.isOfType(left, HxClosure) && Std.isOfType(right, HxClosure)) {
 			return (left : HxClosure).equals(right);
 		}
 		return Syntax.strictEqual(left, right);
@@ -453,10 +453,15 @@ class Boot {
 		return Syntax.add(left, right);
 	}
 
+	@:deprecated('php.Boot.is() is deprecated. Use php.Boot.isOfType() instead')
+	public static inline function is(value:Dynamic, type:HxClass):Bool {
+		return isOfType(value, type);
+	}
+
 	/**
-		`Std.is()` implementation
+		`Std.isOfType()` implementation
 	**/
-	public static function is(value:Dynamic, type:HxClass):Bool {
+	public static function isOfType(value:Dynamic, type:HxClass):Bool {
 		if (type == null)
 			return false;
 
@@ -483,7 +488,7 @@ class Boot {
 			case 'php\\NativeArray', 'php\\_NativeArray\\NativeArray_Impl_':
 				return value.is_array();
 			case 'Enum' | 'Class':
-				if (Std.is(value, HxClass)) {
+				if (Std.isOfType(value, HxClass)) {
 					var valuePhpClass = (cast value : HxClass).phpClassName;
 					var enumPhpClass = (cast HxEnum : HxClass).phpClassName;
 					var isEnumType = Global.is_subclass_of(valuePhpClass, enumPhpClass);
@@ -502,28 +507,28 @@ class Boot {
 		Check if `value` is a `Class<T>`
 	**/
 	public static inline function isClass(value:Dynamic):Bool {
-		return Std.is(value, HxClass);
+		return Std.isOfType(value, HxClass);
 	}
 
 	/**
 		Check if `value` is an enum constructor instance
 	**/
 	public static inline function isEnumValue(value:Dynamic):Bool {
-		return Std.is(value, HxEnum);
+		return Std.isOfType(value, HxEnum);
 	}
 
 	/**
 		Check if `value` is a function
 	**/
 	public static inline function isFunction(value:Dynamic):Bool {
-		return Std.is(value, Closure) || Std.is(value, HxClosure);
+		return Std.isOfType(value, Closure) || Std.isOfType(value, HxClosure);
 	}
 
 	/**
 		Check if `value` is an instance of `HxClosure`
 	**/
 	public static inline function isHxClosure(value:Dynamic):Bool {
-		return Std.is(value, HxClosure);
+		return Std.isOfType(value, HxClosure);
 	}
 
 	/**
@@ -972,7 +977,7 @@ private class HxClosure {
 		if (target.is_null()) {
 			throw "Unable to create closure on `null`";
 		}
-		callable = Std.is(target, HxAnon) ? Syntax.field(target, func) : Syntax.arrayDecl(target, func);
+		callable = Std.isOfType(target, HxAnon) ? Syntax.field(target, func) : Syntax.arrayDecl(target, func);
 	}
 
 	/**
@@ -990,7 +995,7 @@ private class HxClosure {
 		if (eThis == null) {
 			eThis = target;
 		}
-		if (Std.is(eThis, HxAnon)) {
+		if (Std.isOfType(eThis, HxAnon)) {
 			return Syntax.field(eThis, func);
 		}
 		return Syntax.arrayDecl(eThis, func);

--- a/std/php/Syntax.hx
+++ b/std/php/Syntax.hx
@@ -186,7 +186,7 @@ extern class Syntax {
 
 	/**
 		Generates `$value instanceof $phpClassName`.
-		Haxe generates `Std.is(value, Type)` calls as `$value instanceof Type` automatically where possible.
+		Haxe generates `Std.isOfType(value, Type)` calls as `$value instanceof Type` automatically where possible.
 		So you may need this only if you have a `Class` stored in a variable.
 	**/
 	@:overload(function(value:AsVar<Dynamic>, phpClassName:AsVar<String>):Bool {})

--- a/std/php/_std/Std.hx
+++ b/std/php/_std/Std.hx
@@ -26,16 +26,20 @@ import php.Syntax;
 
 @:coreApi class Std {
 	public static inline function is(v:Dynamic, t:Dynamic):Bool {
-		return Boot.is(v, t);
+		return isOfType(v, t);
+	}
+
+	public static inline function isOfType(v:Dynamic, t:Dynamic):Bool {
+		return Boot.isOfType(v, t);
 	}
 
 	public static inline function downcast<T:{}, S:T>(value:T, c:Class<S>):S {
-		return Boot.is(value, cast c) ? cast value : null;
+		return Boot.isOfType(value, cast c) ? cast value : null;
 	}
 
 	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')
 	public static inline function instance<T:{}, S:T>(value:T, c:Class<S>):S {
-		return Boot.is(value, cast c) ? cast value : null;
+		return Boot.isOfType(value, cast c) ? cast value : null;
 	}
 
 	public static function string(s:Dynamic):String {

--- a/std/php/_std/Type.hx
+++ b/std/php/_std/Type.hx
@@ -266,7 +266,7 @@ enum ValueType {
 		if (v.is_object()) {
 			if (Reflect.isFunction(v))
 				return TFunction;
-			if (Std.is(v, StdClass))
+			if (Std.isOfType(v, StdClass))
 				return TObject;
 			if (Boot.isClass(v))
 				return TObject;

--- a/std/php/_std/haxe/Json.hx
+++ b/std/php/_std/haxe/Json.hx
@@ -87,7 +87,7 @@ class Json {
 	}
 
 	static function convertBeforeEncode(value:Dynamic):Dynamic {
-		if (Std.is(value, Array)) {
+		if (Std.isOfType(value, Array)) {
 			var result = new NativeIndexedArray();
 			Syntax.foreach(value.arr, function(index:Int, item:Dynamic) {
 				result[index] = convertBeforeEncode(item);

--- a/std/python/VarArgs.hx
+++ b/std/python/VarArgs.hx
@@ -46,7 +46,7 @@ abstract VarArgs<T>(Dynamic) {
 	}
 
 	@:to public inline function toArray():Array<T> {
-		return if (!Std.is(raw(), Array)) list(raw()) else (raw() : Array<T>);
+		return if (!Std.isOfType(raw(), Array)) list(raw()) else (raw() : Array<T>);
 	}
 
 	@:from static inline function fromArray<T>(d:Array<T>):VarArgs<T> {

--- a/std/python/_std/Std.hx
+++ b/std/python/_std/Std.hx
@@ -52,6 +52,12 @@ import python.Syntax;
 	@:access(python.Boot)
 	@:ifFeature("typed_cast")
 	public static function is(v:Dynamic, t:Dynamic):Bool {
+		return inline isOfType(v, t);
+	}
+
+	@:access(python.Boot)
+	@:ifFeature("typed_cast")
+	public static function isOfType(v:Dynamic, t:Dynamic):Bool {
 		if (v == null && t == null) {
 			return false;
 		}

--- a/std/python/_std/Std.hx
+++ b/std/python/_std/Std.hx
@@ -49,10 +49,9 @@ import python.Syntax;
 		return Boot.isMetaType(v, t);
 	}
 
-	@:access(python.Boot)
 	@:ifFeature("typed_cast")
-	public static function is(v:Dynamic, t:Dynamic):Bool {
-		return inline isOfType(v, t);
+	public static inline function is(v:Dynamic, t:Dynamic):Bool {
+		return isOfType(v, t);
 	}
 
 	@:access(python.Boot)

--- a/std/python/_std/Type.hx
+++ b/std/python/_std/Type.hx
@@ -248,7 +248,7 @@ enum ValueType {
 		var ret = [];
 		for (ctor in ctors) {
 			var v = Reflect.field(e, ctor);
-			if (Std.is(v, e))
+			if (Std.isOfType(v, e))
 				ret.push(v);
 		}
 

--- a/tests/optimization/src/TestJs.hx
+++ b/tests/optimization/src/TestJs.hx
@@ -560,7 +560,7 @@ class TestJs {
 	}
 
 	static inline function as<T>(v:Dynamic, c:Class<T>):Null<T> {
-		return if (Std.is(v, c)) v else null;
+		return if (Std.isOfType(v, c)) v else null;
 	}
 
 }

--- a/tests/unit/src/unit/TestBasetypes.hx
+++ b/tests/unit/src/unit/TestBasetypes.hx
@@ -305,7 +305,7 @@ class TestBasetypes extends Test {
 
 	function testAbstract() {
 		var a = new MyAbstract(33);
-		t( Std.is(a, Int) );
+		t( Std.isOfType(a, Int) );
 		eq( a.toInt(), 33 );
 		var b = a;
 		a.incr();
@@ -317,26 +317,26 @@ class TestBasetypes extends Test {
 		var s = "Abstract casting ::t::";
 		// var from
 		var tpl:unit.MyAbstract.TemplateWrap = s;
-		t(Std.is(tpl, haxe.Template));
-		t(Std.is(tpl.get(), haxe.Template));
+		t(Std.isOfType(tpl, haxe.Template));
+		t(Std.isOfType(tpl.get(), haxe.Template));
 		eq(tpl.get().execute( { t:"works!" } ), "Abstract casting works!");
 
 		//var to
 		var str:String = tpl;
-		t(Std.is(str, String));
+		t(Std.isOfType(str, String));
 		eq(str, "Abstract casting really works!");
 
 		// assign from
 		var tpl:unit.MyAbstract.TemplateWrap;
 		tpl = s;
-		t(Std.is(tpl, haxe.Template));
-		t(Std.is(tpl.get(), haxe.Template));
+		t(Std.isOfType(tpl, haxe.Template));
+		t(Std.isOfType(tpl.get(), haxe.Template));
 		eq(tpl.get().execute( { t:"works!" } ), "Abstract casting works!");
 
 		//assign to
 		var str:String;
 		str = tpl;
-		t(Std.is(str, String));
+		t(Std.isOfType(str, String));
 		eq(str, "Abstract casting really works!");
 
 		// call arg from

--- a/tests/unit/src/unit/TestInterface.hx
+++ b/tests/unit/src/unit/TestInterface.hx
@@ -63,11 +63,11 @@ class TestInterface extends Test {
 		var p = new Point(1.3,5);
 		var px : IX = p;
 		var py : IY = p;
-		t( Std.is(p, Point) );
-		t( Std.is(p, IX) );
-		t( Std.is(p, IY) );
-		f( Std.is(p, IEmpty) );
-		f( Std.is(p, IX2) );
+		t( Std.isOfType(p, Point) );
+		t( Std.isOfType(p, IX) );
+		t( Std.isOfType(p, IY) );
+		f( Std.isOfType(p, IEmpty) );
+		f( Std.isOfType(p, IX2) );
 
 		t( px == p );
 		t( py == p );

--- a/tests/unit/src/unit/TestMatch.hx
+++ b/tests/unit/src/unit/TestMatch.hx
@@ -534,7 +534,7 @@ class TestMatch extends Test {
 		eq(3, check(3));
 		eq(4, check(4));
 
-		function is<T>(pred : T -> Bool) return function (x : T) {
+		function isTrue<T>(pred : T -> Bool) return function (x : T) {
 			return pred(x)?Some(x):None;
 		}
 
@@ -549,7 +549,7 @@ class TestMatch extends Test {
 			return switch(i) {
 				case [x]: 1;
 				case isPair(_) => Some({ a : a, b : b }) if (a < 0): 42;
-				case isPair(_) => Some({ a : is(even)(_) => Some(a), b : b }) : a+b;
+				case isPair(_) => Some({ a : isTrue(even)(_) => Some(a), b : b }) : a+b;
 				case isPair(_) => Some({ a : isNot(even)(_) => Some(a), b : b }) : a*b;
 				case testArgs(1, "foo", _) => "[99,98,97]": 99;
 				case var arr: 3;

--- a/tests/unit/src/unit/TestReflect.hx
+++ b/tests/unit/src/unit/TestReflect.hx
@@ -106,41 +106,41 @@ class TestReflect extends Test {
 	}
 
 	public function testIs() {
-		is(0,Int,Float);
-		is(1,Int,Float);
-		is(-1,Int,Float);
-		is(2.0,Int,Float);
-		is(1.2,Float);
-		is(1e10,Float);
-		is(-1e10,Float);
-		is(Math.NaN,Float);
-		is(Math.POSITIVE_INFINITY,Float);
-		is(Math.NEGATIVE_INFINITY,Float);
-		is(true,Bool);
-		is(false,Bool);
-		is("Hello",String);
-		is("123",String);
-		is("false",String);
-		is("",String);
-		is([],Array);
-		is([1, 2], Array);
-		is([1.1, 2.2], Array);
-		is(["a", "b"], Array);
-		is((["a",2]:Array<Dynamic>),Array);
-		is(new List(),List);
-		is(new haxe.ds.StringMap(),haxe.ds.StringMap);
-		is(new MyClass(0),MyClass);
-		is(new MySubClass(0),MyClass,MySubClass);
-		is(MyEnum.A,MyEnum);
-		is(MyEnum.C(0,""),MyEnum);
-		is(Date.now(),Date);
-		is({ x : 0 },null);
-		is(function() { },null);
-		is(MyClass,Class);
-		is(MyEnum,Enum);
+		isTrue(0,Int,Float);
+		isTrue(1,Int,Float);
+		isTrue(-1,Int,Float);
+		isTrue(2.0,Int,Float);
+		isTrue(1.2,Float);
+		isTrue(1e10,Float);
+		isTrue(-1e10,Float);
+		isTrue(Math.NaN,Float);
+		isTrue(Math.POSITIVE_INFINITY,Float);
+		isTrue(Math.NEGATIVE_INFINITY,Float);
+		isTrue(true,Bool);
+		isTrue(false,Bool);
+		isTrue("Hello",String);
+		isTrue("123",String);
+		isTrue("false",String);
+		isTrue("",String);
+		isTrue([],Array);
+		isTrue([1, 2], Array);
+		isTrue([1.1, 2.2], Array);
+		isTrue(["a", "b"], Array);
+		isTrue((["a",2]:Array<Dynamic>),Array);
+		isTrue(new List(),List);
+		isTrue(new haxe.ds.StringMap(),haxe.ds.StringMap);
+		isTrue(new MyClass(0),MyClass);
+		isTrue(new MySubClass(0),MyClass,MySubClass);
+		isTrue(MyEnum.A,MyEnum);
+		isTrue(MyEnum.C(0,""),MyEnum);
+		isTrue(Date.now(),Date);
+		isTrue({ x : 0 },null);
+		isTrue(function() { },null);
+		isTrue(MyClass,Class);
+		isTrue(MyEnum,Enum);
 	}
 
-	function is( v : Dynamic, t1 : Dynamic, ?t2 : Dynamic, ?pos : haxe.PosInfos ){
+	function isTrue( v : Dynamic, t1 : Dynamic, ?t2 : Dynamic, ?pos : haxe.PosInfos ){
 		for( i in 0...TYPES.length ) {
 			var c : Dynamic = TYPES[i];
 			eq( Std.isOfType(v,c), c != null && (c == t1 || c == t2) || (c == Dynamic), pos );

--- a/tests/unit/src/unit/TestReflect.hx
+++ b/tests/unit/src/unit/TestReflect.hx
@@ -143,7 +143,7 @@ class TestReflect extends Test {
 	function is( v : Dynamic, t1 : Dynamic, ?t2 : Dynamic, ?pos : haxe.PosInfos ){
 		for( i in 0...TYPES.length ) {
 			var c : Dynamic = TYPES[i];
-			eq( Std.is(v,c), c != null && (c == t1 || c == t2) || (c == Dynamic), pos );
+			eq( Std.isOfType(v,c), c != null && (c == t1 || c == t2) || (c == Dynamic), pos );
 		}
 		t( (v is Dynamic), pos );
 	}

--- a/tests/unit/src/unit/TestSyntaxModule.hx
+++ b/tests/unit/src/unit/TestSyntaxModule.hx
@@ -39,11 +39,11 @@ class TestSyntaxModule extends Test {
 			#elseif python "unit__TestSyntaxModule_Construct";
 			#end
 		var a:Construct = Syntax.construct(className, 10);
-		t(Std.is(a, Construct));
+		t(Std.isOfType(a, Construct));
 		eq(10, a.value);
 
 		var b = Syntax.construct(Construct, 10);
-		t(Std.is(b, Construct));
+		t(Std.isOfType(b, Construct));
 		eq(10, b.value);
 	}
 	#end

--- a/tests/unit/src/unit/TestType.hx
+++ b/tests/unit/src/unit/TestType.hx
@@ -298,8 +298,8 @@ class TestType extends Test {
 
 		var c = new Cov2();
 		typedAs(c.covariant(), c1);
-		t(Std.is(c.covariant(), Child1));
-		t(Std.is(cast(c, Cov1).covariant(), Child1));
+		t(Std.isOfType(c.covariant(), Child1));
+		t(Std.isOfType(cast(c, Cov1).covariant(), Child1));
 
 		// base class reference
 		var br:Cov1 = c;

--- a/tests/unit/src/unit/issues/Issue4014.hx
+++ b/tests/unit/src/unit/issues/Issue4014.hx
@@ -1,4 +1,5 @@
 package unit.issues;
+
 import haxe.Int64;
 
 class Issue4014 extends Test
@@ -7,11 +8,11 @@ class Issue4014 extends Test
 	{
 		var d = Int64.make(1,1);
 		var dyn:Dynamic = d;
-		t(Int64.is(dyn));
+		t(Int64.isInt64(dyn));
 		d = dyn;
 		eq(d.high,1);
 		eq(d.low,1);
 		dyn = {};
-		f(Int64.is(dyn));
+		f(Int64.isInt64(dyn));
 	}
 }

--- a/tests/unit/src/unit/issues/Issue4285.hx
+++ b/tests/unit/src/unit/issues/Issue4285.hx
@@ -7,6 +7,6 @@ class Issue4285 extends Test {
 	}
 
 	static function myIs(d:Dynamic, t:Dynamic) {
-		return Std.is(d, t);
+		return Std.isOfType(d, t);
 	}
 }

--- a/tests/unit/src/unit/issues/Issue4962.hx
+++ b/tests/unit/src/unit/issues/Issue4962.hx
@@ -8,8 +8,8 @@ private class C {
 class Issue4962 extends Test {
 	function test() {
 		var int:Dynamic = Int;
-		f(Std.is(new C(), int));
+		f(Std.isOfType(new C(), int));
 
-		f(Std.is(new C(), Int));
+		f(Std.isOfType(new C(), Int));
 	}
 }

--- a/tests/unit/src/unit/issues/Issue4973.hx
+++ b/tests/unit/src/unit/issues/Issue4973.hx
@@ -8,8 +8,8 @@ class Issue4973 extends Test {
 	#if php
 	function test() {
 		try sys.io.File.getContent("not-existant")
-		catch(exc:Exception) t(Std.is(exc, Exception))
-		catch(exc:Dynamic) t(Std.is(exc, Exception));
+		catch(exc:Exception) t(Std.isOfType(exc, Exception))
+		catch(exc:Dynamic) t(Std.isOfType(exc, Exception));
 	}
 	#end
 }

--- a/tests/unit/src/unit/issues/Issue5039.hx
+++ b/tests/unit/src/unit/issues/Issue5039.hx
@@ -42,7 +42,7 @@ class Issue5039 extends Test {
 		f(getterCalled);
 		f(setterCalled);
 
-		t(Std.is(@:bypassAccessor c, C));
+		t(Std.isOfType(@:bypassAccessor c, C));
 		eq(42, @:bypassAccessor (@:bypassAccessor c).prop);
 		eq(42, @:bypassAccessor @:bypassAccessor c.prop);
 	}

--- a/tests/unit/src/unit/issues/Issue5168.hx
+++ b/tests/unit/src/unit/issues/Issue5168.hx
@@ -2,7 +2,7 @@ package unit.issues;
 
 class Issue5168 extends unit.Test {
 	function test() {
-		f(Std.is("hello", Issue5168));
-		f(Std.is(1, String));
+		f(Std.isOfType("hello", Issue5168));
+		f(Std.isOfType(1, String));
 	}
 }

--- a/tests/unit/src/unit/issues/Issue5466.hx
+++ b/tests/unit/src/unit/issues/Issue5466.hx
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue5466 extends Test {
   function test() {
     var test:Base = (Math.random() > 0.5) ? new A() : new B();
-    t(Std.is(test, A) || Std.is(test, B));
+    t(Std.isOfType(test, A) || Std.isOfType(test, B));
   }
 }
 

--- a/tests/unit/src/unit/issues/Issue5486.hx
+++ b/tests/unit/src/unit/issues/Issue5486.hx
@@ -23,7 +23,7 @@ class Issue5486 extends unit.Test {
 	}
 
 	static function broken(?input:Dynamic):Option<Int>{
-		if(Std.is(input, Int)){
+		if(Std.isOfType(input, Int)){
 			return Some(input);
 		} else {
 			return None;

--- a/tests/unit/src/unit/issues/Issue5565.hx
+++ b/tests/unit/src/unit/issues/Issue5565.hx
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue5565 extends Test {
 	#if php
 	function test() {
-		t(Std.is(php.Syntax.arrayDecl(), php.NativeArray));
+		t(Std.isOfType(php.Syntax.arrayDecl(), php.NativeArray));
 	}
 	#end
 }

--- a/tests/unit/src/unit/issues/Issue5973.hx
+++ b/tests/unit/src/unit/issues/Issue5973.hx
@@ -4,12 +4,12 @@ class Issue5973 extends Test{
 		var foo    = new Issue5973Foo();
 		var bar    = new Issue5973Bar();
 		var foobar = new Issue5973FooBar();
-		t(Std.is(foo    , Issue5973IFoo));
-		f(Std.is(foo    , Issue5973IBar));
-		f(Std.is(bar    , Issue5973IFoo));
-		t(Std.is(bar    , Issue5973IBar));
-		t(Std.is(foobar , Issue5973IFoo));
-		t(Std.is(foobar , Issue5973IBar));
+		t(Std.isOfType(foo    , Issue5973IFoo));
+		f(Std.isOfType(foo    , Issue5973IBar));
+		f(Std.isOfType(bar    , Issue5973IFoo));
+		t(Std.isOfType(bar    , Issue5973IBar));
+		t(Std.isOfType(foobar , Issue5973IFoo));
+		t(Std.isOfType(foobar , Issue5973IBar));
 	}
 }
 

--- a/tests/unit/src/unit/issues/Issue6208.hx
+++ b/tests/unit/src/unit/issues/Issue6208.hx
@@ -4,8 +4,8 @@ package unit.issues;
 class Issue6208 extends unit.Test implements IBase implements IChild {
 
     function test() {
-        t(Std.is(this, IChild));
-        t(Std.is(this, IBase));
+        t(Std.isOfType(this, IChild));
+        t(Std.isOfType(this, IBase));
     }
 
     public function base() {}

--- a/tests/unit/src/unit/issues/Issue6290.hx
+++ b/tests/unit/src/unit/issues/Issue6290.hx
@@ -13,7 +13,7 @@ private class TakeParent {
 private class TakeChild extends TakeParent {
 	public function new(child:Child) {
 		super(child);
-		if (!Std.is(child, Child)) throw 'wtf?';
+		if (!Std.isOfType(child, Child)) throw 'wtf?';
 	}
 }
 

--- a/tests/unit/src/unit/issues/Issue6848.hx
+++ b/tests/unit/src/unit/issues/Issue6848.hx
@@ -4,7 +4,7 @@ class Issue6848 extends unit.Test {
 #if php
 	function test() {
 		var e = Type.createInstance(php.Exception, ['hello']);
-		t(Std.is(e, php.Exception));
+		t(Std.isOfType(e, php.Exception));
 		eq('hello', e.getMessage());
 	}
 #end

--- a/tests/unit/src/unit/issues/Issue7115.hx
+++ b/tests/unit/src/unit/issues/Issue7115.hx
@@ -4,15 +4,15 @@ private interface Interface { }
 
 class Issue7115 extends unit.Test {
 	function testIs() {
-		f(Std.is(getNull(), Int));
-		f(Std.is(getNull(), Float));
-		f(Std.is(getNull(), Bool));
-		f(Std.is(getNull(), String));
-		f(Std.is(getNull(), Issue7115));
-		f(Std.is(getNull(), haxe.ds.Option));
-		f(Std.is(getNull(), Dynamic));
-		f(Std.is(getNull(), null));
-		f(Std.is(getNull(), Interface));
+		f(Std.isOfType(getNull(), Int));
+		f(Std.isOfType(getNull(), Float));
+		f(Std.isOfType(getNull(), Bool));
+		f(Std.isOfType(getNull(), String));
+		f(Std.isOfType(getNull(), Issue7115));
+		f(Std.isOfType(getNull(), haxe.ds.Option));
+		f(Std.isOfType(getNull(), Dynamic));
+		f(Std.isOfType(getNull(), null));
+		f(Std.isOfType(getNull(), Interface));
 	}
 
 	function testCast() {

--- a/tests/unit/src/unit/issues/Issue8493.hx
+++ b/tests/unit/src/unit/issues/Issue8493.hx
@@ -10,11 +10,11 @@ class Issue8493 extends unit.Test {
 	static var typeRef = (Vector.typeReference() : Class<Vector<Vector<Array<Int>>>>);
 
 	function test() {
-		t(Std.is(v, (Vector.typeReference() : Class<Vector<Vector<Array<Int>>>>)));
+		t(Std.isOfType(v, (Vector.typeReference() : Class<Vector<Vector<Array<Int>>>>)));
 		t(Std.downcast(v, (Vector.typeReference() : Class<Vector<Vector<Array<Int>>>>)) == v);
 		t(flash.Lib.as(v, (Vector.typeReference() : Class<Vector<Vector<Array<Int>>>>)) == v);
 
-		t(Std.is(v, typeRef));
+		t(Std.isOfType(v, typeRef));
 		t(Std.downcast(v, typeRef) == v);
 		t(flash.Lib.as(v, typeRef) == v);
 	}

--- a/tests/unit/src/unit/issues/Issue8549.hx
+++ b/tests/unit/src/unit/issues/Issue8549.hx
@@ -5,7 +5,7 @@ class Issue8549 extends unit.Test {
 	function test() {
 		// can be used as a Vector type param, for type checking :-/
 		var v = new flash.Vector<String>();
-		t(Std.is(v, (flash.Vector.typeReference() : Class<flash.Vector<flash.AnyType>>)));
+		t(Std.isOfType(v, (flash.Vector.typeReference() : Class<flash.Vector<flash.AnyType>>)));
 
 		// also assignable from/to stuff, similar to Any, just in case...
 		var v:flash.AnyType = 10;

--- a/tests/unit/src/unitstd/Std.unit.hx
+++ b/tests/unit/src/unitstd/Std.unit.hx
@@ -15,6 +15,23 @@ var unknown = null;
 ([] is Array) == true;
 (cast unit.MyEnum.A is Array) == false;
 
+// isOfType
+var known:String = null;
+Std.isOfType(known, String) == false;
+
+var unknown = null;
+Std.isOfType(unknown, String) == false;
+Std.isOfType(null, String) == false;
+//Std.isOfType("foo", null) == false;
+
+Std.isOfType("", String) == true;
+Std.isOfType(false, Bool) == true;
+Std.isOfType(1, Int) == true;
+Std.isOfType(1.5, Int) == false;
+Std.isOfType(1.5, Float) == true;
+Std.isOfType([], Array) == true;
+Std.isOfType(cast unit.MyEnum.A, Array) == false;
+
 // instance
 #if !js
 Std.downcast("", String) == "";


### PR DESCRIPTION
Waiting for CI.
See #2976 

No deprecation warning for now. 
Also deprecates `haxe.Int64.is()` in favor of `haxe.Int64.isInt64()` - this one with a warning.