### PR TITLE
haxe.macro.Compiler.ignoreFiles(path)

### DIFF
--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1828,6 +1828,12 @@ let macro_api ccom get_api =
 			Hashtbl.clear com.readdir_cache;
 			vnull
 		);
+		"ignore_files", vfun1 (fun path ->
+			let path = decode_string path in
+			let com = ccom() in
+			com.ignore_files <- path :: com.ignore_files;
+			vnull
+		);
 		"add_native_lib", vfun1 (fun file ->
 			let file = decode_string file in
 			let com = ccom() in

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -140,6 +140,29 @@ class Compiler {
 		#end
 	}
 
+	/**
+		Ignore any existing files starting with `path`.
+		`path` should be specified relative to the class path directory.
+
+		E.g.
+		```
+		-cp src1
+		-cp src2
+		--macro ignorePath("my/pack")
+		```
+		would ignore all files located in `src1/my/pack`, `src2/my/pack`.
+
+		NOTICE:
+		To cancel the effect of this function the compilation server may need to be restarted.
+
+		Usage of this function outside of initialization macros is not recommended and may cause compilation server issues.
+	**/
+	public static function ignoreFiles(path:String) {
+		#if (neko || eval)
+		load("ignore_files", 1)(path);
+		#end
+	}
+
 	public static function getOutput():String {
 		#if (neko || eval)
 		return load("get_output", 0)();

--- a/tests/misc/projects/Issue8999/Main.hx
+++ b/tests/misc/projects/Issue8999/Main.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main() {
+		pack.Some.test();
+	}
+}

--- a/tests/misc/projects/Issue8999/compile-fail.hxml
+++ b/tests/misc/projects/Issue8999/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--macro ignoreFiles('pack')

--- a/tests/misc/projects/Issue8999/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8999/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:3: characters 3-7 : Type not found : pack.Some

--- a/tests/misc/projects/Issue8999/pack/Some.hx
+++ b/tests/misc/projects/Issue8999/pack/Some.hx
@@ -1,0 +1,5 @@
+package pack;
+
+class Some {
+	static public function test() {}
+}


### PR DESCRIPTION
Closes #8999 

This allows to ignore any files located in `std/java` (for example) and to load the same types from dll  instead (see #8999)