### PR TITLE
Local var renaming improvements

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -100,7 +100,7 @@ type nested_function_scoping =
 	(** TFunction nodes are nested in the output **)
 	| Nested
 	(** TFunction nodes are nested in the output and there is var hoisting **)
-	| JsLike
+	| Hoisted
 
 type platform_config = {
 	(** has a static type system, with not-nullable basic types (Int/Float/Bool) *)
@@ -378,7 +378,7 @@ let get_config com =
 				ec_wildcard_catch = ([],"Dynamic");
 				ec_base_throw = ([],"Dynamic");
 			};
-			pf_nested_function_scoping = JsLike;
+			pf_nested_function_scoping = Hoisted;
 		}
 	| Lua ->
 		{
@@ -432,7 +432,8 @@ let get_config com =
 				];
 				ec_wildcard_catch = (["php"],"Throwable");
 				ec_base_throw = (["php"],"Throwable");
-			}
+			};
+			pf_nested_function_scoping = Nested;
 		}
 	| Cpp ->
 		{

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -94,6 +94,14 @@ type exceptions_config = {
 	ec_base_throw : path;
 }
 
+type nested_function_scoping =
+	(** each TFunction has its own scope in the output **)
+	| Independent
+	(** TFunction nodes are nested in the output **)
+	| Nested
+	(** TFunction nodes are nested in the output and there is var hoisting **)
+	| JsLike
+
 type platform_config = {
 	(** has a static type system, with not-nullable basic types (Int/Float/Bool) *)
 	pf_static : bool;
@@ -123,6 +131,8 @@ type platform_config = {
 	pf_supports_unicode : bool;
 	(** exceptions handling config **)
 	pf_exceptions : exceptions_config;
+	(** the scoping behavior of nested functions **)
+	pf_nested_function_scoping : nested_function_scoping;
 }
 
 class compiler_callbacks = object(self)
@@ -342,7 +352,8 @@ let default_config =
 			ec_native_catches = [];
 			ec_wildcard_catch = ([],"Dynamic");
 			ec_base_throw = ([],"Dynamic");
-		}
+		};
+		pf_nested_function_scoping = Independent;
 	}
 
 let get_config com =
@@ -366,7 +377,8 @@ let get_config com =
 				ec_native_catches = [];
 				ec_wildcard_catch = ([],"Dynamic");
 				ec_base_throw = ([],"Dynamic");
-			}
+			};
+			pf_nested_function_scoping = JsLike;
 		}
 	| Lua ->
 		{
@@ -487,7 +499,8 @@ let get_config com =
 				];
 				ec_wildcard_catch = ["python";"Exceptions"],"BaseException";
 				ec_base_throw = ["python";"Exceptions"],"BaseException";
-			}
+			};
+			pf_nested_function_scoping = Nested;
 		}
 	| Hl ->
 		{

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -256,7 +256,13 @@ let rec rename_local_vars_aux ctx reserved e =
 				collect e
 			) catches
 		| TFunction tf ->
-			funcs := tf :: !funcs;
+			begin match ctx.com.config.pf_nested_function_scoping with
+			| JsLike ->
+				funcs := tf :: !funcs;
+			| Nested | Independent ->
+				List.iter (fun (v,_) -> declare v) tf.tf_args;
+				collect tf.tf_expr
+			end
 		| TTypeExpr t ->
 			check t
 		| TNew (c,_,_) ->

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -257,7 +257,7 @@ let rec rename_local_vars_aux ctx reserved e =
 			) catches
 		| TFunction tf ->
 			begin match ctx.com.config.pf_nested_function_scoping with
-			| JsLike ->
+			| Hoisted ->
 				funcs := tf :: !funcs;
 			| Nested | Independent ->
 				List.iter (fun (v,_) -> declare v) tf.tf_args;

--- a/tests/optimization/src/issues/Issue6715.hx
+++ b/tests/optimization/src/issues/Issue6715.hx
@@ -9,12 +9,12 @@ class Issue6715 {
 		issues_Issue6715.x = f;
 		issues_Issue6715.x = f;
 		issues_Issue6715.x = f;
+		var x = 1;
+		x = 2;
 		var x1 = 1;
 		x1 = 2;
 		var x2 = 1;
 		x2 = 2;
-		var x3 = 1;
-		x3 = 2;
 	')
 	@:analyzer(no_local_dce)
 	static public function test1() {


### PR DESCRIPTION
For #9035 

Requires some fiddling to find the optimal approach for each target. We add a `pf_nested_function_scoping` configuration to control the behavior here, which will allow us to express the naming constraints that targets have locally.