### PR TITLE
[std] make haxe.ds.ReadOnlyArray unify with Iterable

### DIFF
--- a/std/haxe/ds/ReadOnlyArray.hx
+++ b/std/haxe/ds/ReadOnlyArray.hx
@@ -31,7 +31,7 @@ package haxe.ds;
 	and the reference can be obtained with a `cast`.
 **/
 @:forward(concat, copy, filter, indexOf, iterator, join, lastIndexOf, map, slice, toString)
-abstract ReadOnlyArray<T>(Array<T>) from Array<T> {
+abstract ReadOnlyArray<T>(Array<T>) from Array<T> to Iterable<T> {
 	/**
 		The length of `this` Array.
 	**/

--- a/tests/unit/src/unit/issues/Issue9102.hx
+++ b/tests/unit/src/unit/issues/Issue9102.hx
@@ -1,0 +1,12 @@
+package unit.issues;
+
+import haxe.ds.ReadOnlyArray;
+
+using Lambda;
+
+class Issue9102 extends unit.Test {
+	function test() {
+		var a:ReadOnlyArray<Int> = [1, 2, 3];
+		t(a.exists(i -> i == 1));
+	}
+}


### PR DESCRIPTION
#9066 is stuck on some cppia problem, but let's see if this works better for `haxe.ds.ReadOnlyArray`...