### PR TITLE
[python] make _hx_AnonObject subscriptable, closes #9109

### DIFF
--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -2434,6 +2434,10 @@ module Generator = struct
 				spr ctx "        self.__dict__ = fields\n";
 				spr ctx "    def __repr__(self):\n";
 				spr ctx "        return repr(self.__dict__)\n";
+				spr ctx "    def __contains__(self, item):\n";
+				spr ctx "        return item in self.__dict__\n";
+				spr ctx "    def __getitem__(self, item):\n";
+				spr ctx "        return self.__dict__[item]\n";
 				spr ctx "    def __getattr__(self, name):\n";
 				spr ctx "        if (self._hx_disable_getattr):\n";
 				spr ctx "            raise AttributeError('field does not exist')\n";


### PR DESCRIPTION
This PR adds `__contains__` and `__getitem__` to the _hx_AnonObject class in generated python; `__contains__` enables `key in object` statements, and `__getitem__` makes anonymous objects subscriptable.  Consistent with python semantics, `obj[missing]` will throw a `KeyError` if missing is not a key on obj.

The motivation behind this change is that the syntax for creating an anonymous object in Haxe is the same as python's dictionary literal, and dicts are commonly used for structural types in python (same as anonymous objects in Haxe).  Because of this, it would be convenient if they worked the same in the generated python code.

This closes #9109