### PR TITLE
[js] Correct time units in setTimeout, closes #9121

### DIFF
--- a/std/haxe/EntryPoint.hx
+++ b/std/haxe/EntryPoint.hx
@@ -110,7 +110,7 @@ class EntryPoint {
 		var nextTick = processEvents();
 		inline function setTimeoutNextTick() {
 			if (nextTick >= 0) {
-				(untyped setTimeout)(run, nextTick);
+				(untyped setTimeout)(run, nextTick * 1000);
 			}
 		}
 		#if nodejs


### PR DESCRIPTION
(I've verified the fix produces the correct behavior)

Test failure unrelated