### PR TITLE
[js] Deprecate js.Browser.supported, rename to js.Browser.hasWindow

### DIFF
--- a/std/haxe/http/HttpJs.hx
+++ b/std/haxe/http/HttpJs.hx
@@ -58,7 +58,7 @@ class HttpJs extends haxe.http.HttpBase {
 			if (r.readyState != 4)
 				return;
 			var s = try r.status catch (e:Dynamic) null;
-			if (s == 0 && js.Browser.supported && js.Browser.location != null) {
+			if (s == 0 && js.Browser.window != null && js.Browser.location != null) {
 				// If the request is local and we have data: assume a success (jQuery approach):
 				var protocol = js.Browser.location.protocol.toLowerCase();
 				var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;

--- a/std/haxe/http/HttpJs.hx
+++ b/std/haxe/http/HttpJs.hx
@@ -58,7 +58,7 @@ class HttpJs extends haxe.http.HttpBase {
 			if (r.readyState != 4)
 				return;
 			var s = try r.status catch (e:Dynamic) null;
-			if (s == 0 && js.Browser.window != null && js.Browser.location != null) {
+			if (s == 0 && js.Browser.hasWindow && js.Browser.location != null) {
 				// If the request is local and we have data: assume a success (jQuery approach):
 				var protocol = js.Browser.location.protocol.toLowerCase();
 				var rlocalProtocol = ~/^(?:about|app|app-storage|.+-extension|file|res|widget):$/;

--- a/std/js/Browser.hx
+++ b/std/js/Browser.hx
@@ -58,15 +58,23 @@ class Browser {
 
 	/**
 	 * True if a window object exists, false otherwise.
-	 *
-	 * This can be used to check if the code is being executed in a non-browser
-	 * environment such as node.js.
 	 */
-	@:deprecated('Use js.Browser.window != null or feature detection instead')
+	public static var hasWindow(get, never):Bool;
+
+	extern inline static function get_hasWindow()
+		return js.Syntax.typeof(window) != "undefined";
+
+	/**
+	* True if a window object exists, false otherwise.
+	*
+	* This can be used to check if the code is being executed in a non-browser
+	* environment such as node.js.
+	*/
+	@:deprecated('Use js.Browser.hasWindow or feature detection instead')
 	public static var supported(get, never):Bool;
 
 	extern inline static function get_supported()
-		return js.Syntax.typeof(window) != "undefined";
+		return hasWindow;
 
 	/**
 	 * Safely gets the browser's local storage, or returns null if localStorage is unsupported or

--- a/std/js/Browser.hx
+++ b/std/js/Browser.hx
@@ -62,6 +62,7 @@ class Browser {
 	 * This can be used to check if the code is being executed in a non-browser
 	 * environment such as node.js.
 	 */
+	@:deprecated('Use js.Browser.window != null or feature detection instead')
 	public static var supported(get, never):Bool;
 
 	extern inline static function get_supported()

--- a/tests/unit/src/unit/TestDCE.hx
+++ b/tests/unit/src/unit/TestDCE.hx
@@ -179,7 +179,7 @@ class TestDCE extends Test {
 			throw c;
 		} catch (_:Dynamic) { }
 		#if js
-		if (!js.Browser.supported || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1)
+		if (js.Browser.window == null || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1)
 		#end
 		hf(ThrownWithToString, "toString");
 	}

--- a/tests/unit/src/unit/TestDCE.hx
+++ b/tests/unit/src/unit/TestDCE.hx
@@ -179,7 +179,7 @@ class TestDCE extends Test {
 			throw c;
 		} catch (_:Dynamic) { }
 		#if js
-		if (js.Browser.window == null || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1)
+		if (!js.Browser.hasWindow || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1)
 		#end
 		hf(ThrownWithToString, "toString");
 	}

--- a/tests/unit/src/unit/TestEReg.hx
+++ b/tests/unit/src/unit/TestEReg.hx
@@ -20,7 +20,7 @@ class TestEReg extends Test {
 		eq( r.matched(0), "aaa" );
 		eq( r.matchedLeft(), "" );
 		eq( r.matchedRight(), "" );
-		t(r.matched(1) == null #if js || (js.Browser.supported && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
+		t(r.matched(1) == null #if js || (js.Browser.window != null && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
 		eq( r.matched(2), "" );
 		unspec(function() r.matched(3));
 		unspec(function() r.matched(-1));
@@ -28,7 +28,7 @@ class TestEReg extends Test {
 		var r = ~/^(b)?$/;
 		t( r.match("") );
 		eq( r.matched(0), "" );
-		t(r.matched(1) == null #if js || (js.Browser.supported && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
+		t(r.matched(1) == null #if js || (js.Browser.window != null && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
 
 		t( ~/\//.match("/") );
 

--- a/tests/unit/src/unit/TestEReg.hx
+++ b/tests/unit/src/unit/TestEReg.hx
@@ -20,7 +20,7 @@ class TestEReg extends Test {
 		eq( r.matched(0), "aaa" );
 		eq( r.matchedLeft(), "" );
 		eq( r.matchedRight(), "" );
-		t(r.matched(1) == null #if js || (js.Browser.window != null && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
+		t(r.matched(1) == null #if js || (js.Browser.hasWindow && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
 		eq( r.matched(2), "" );
 		unspec(function() r.matched(3));
 		unspec(function() r.matched(-1));
@@ -28,7 +28,7 @@ class TestEReg extends Test {
 		var r = ~/^(b)?$/;
 		t( r.match("") );
 		eq( r.matched(0), "" );
-		t(r.matched(1) == null #if js || (js.Browser.window != null && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
+		t(r.matched(1) == null #if js || (js.Browser.hasWindow && js.Browser.navigator.userAgent.indexOf('MSIE 8') > -1) #end); // JS/IE7-8 bug
 
 		t( ~/\//.match("/") );
 

--- a/tests/unit/src/unit/TestHttp.hx
+++ b/tests/unit/src/unit/TestHttp.hx
@@ -21,7 +21,7 @@ class TestHttp extends Test {
 		// }
 
 		#if (js && !nodejs)
-		if(js.Browser.window == null)) {
+		if(js.Browser.window == null) {
 			noAssert();
 			async.done();
 			return;

--- a/tests/unit/src/unit/TestHttp.hx
+++ b/tests/unit/src/unit/TestHttp.hx
@@ -21,7 +21,7 @@ class TestHttp extends Test {
 		// }
 
 		#if (js && !nodejs)
-		if(js.Browser.window == null) {
+		if(!js.Browser.hasWindow) {
 			noAssert();
 			async.done();
 			return;

--- a/tests/unit/src/unit/TestHttp.hx
+++ b/tests/unit/src/unit/TestHttp.hx
@@ -21,7 +21,7 @@ class TestHttp extends Test {
 		// }
 
 		#if (js && !nodejs)
-		if(!js.Browser.supported) {
+		if(js.Browser.window == null)) {
 			noAssert();
 			async.done();
 			return;

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -15,7 +15,7 @@ class TestMain {
 
 	static function main() {
 		#if js
-		if (js.Browser.window != null) {
+		if (js.Browser.hasWindow) {
 			var oTrace = haxe.Log.trace;
 			var traceElement = js.Browser.document.getElementById("haxe:trace");
 			haxe.Log.trace = function(v, ?infos) {
@@ -137,7 +137,7 @@ class TestMain {
 				}
 			}
 			#if js
-			if (js.Browser.window != null && e.totals == e.done) {
+			if (js.Browser.hasWindow && e.totals == e.done) {
 				untyped js.Browser.window.success = success;
 			};
 			#end

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -15,7 +15,7 @@ class TestMain {
 
 	static function main() {
 		#if js
-		if (js.Browser.supported) {
+		if (js.Browser.window != null) {
 			var oTrace = haxe.Log.trace;
 			var traceElement = js.Browser.document.getElementById("haxe:trace");
 			haxe.Log.trace = function(v, ?infos) {
@@ -137,7 +137,7 @@ class TestMain {
 				}
 			}
 			#if js
-			if (js.Browser.supported && e.totals == e.done) {
+			if (js.Browser.window != null && e.totals == e.done) {
 				untyped js.Browser.window.success = success;
 			};
 			#end

--- a/tests/unit/src/unit/issues/Issue2857.hx.disabled
+++ b/tests/unit/src/unit/issues/Issue2857.hx.disabled
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue2857 extends unit.Test {
 #if js
 	function testElement() {
-		if (js.Browser.supported) {
+		if (js.Browser.window != null) {
 			var vid = js.Browser.document.createVideoElement();
 			t(Std.is(vid, js.html.VideoElement));
 			t(Std.is(vid, js.html.Element));

--- a/tests/unit/src/unit/issues/Issue2857.hx.disabled
+++ b/tests/unit/src/unit/issues/Issue2857.hx.disabled
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue2857 extends unit.Test {
 #if js
 	function testElement() {
-		if (js.Browser.window != null) {
+		if (js.Browser.hasWindow) {
 			var vid = js.Browser.document.createVideoElement();
 			t(Std.is(vid, js.html.VideoElement));
 			t(Std.is(vid, js.html.Element));

--- a/tests/unit/src/unit/issues/Issue3480.hx
+++ b/tests/unit/src/unit/issues/Issue3480.hx
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue3480 extends Test {
 	function test() {
 		#if js
-		if (js.Browser.window == null || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1) // IE8 doesn't like toString fields at all
+		if (!js.Browser.hasWindow || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1) // IE8 doesn't like toString fields at all
 			eq("{\n\ttoString : 1\n}", Std.string({toString: 1}));
 		#end
 		noAssert();

--- a/tests/unit/src/unit/issues/Issue3480.hx
+++ b/tests/unit/src/unit/issues/Issue3480.hx
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue3480 extends Test {
 	function test() {
 		#if js
-		if (!js.Browser.supported || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1) // IE8 doesn't like toString fields at all
+		if (js.Browser.window == null || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1) // IE8 doesn't like toString fields at all
 			eq("{\n\ttoString : 1\n}", Std.string({toString: 1}));
 		#end
 		noAssert();


### PR DESCRIPTION
`js.Browser.supported` tries to verify if the runtime is a browser by checking if `window` is defined

Unfortunately this doesn't work in all scenarios because non-browser contexts might define window for other reasons – see https://github.com/HaxeFoundation/haxe/issues/9118

There isn't a general simple approach to testing the runtime context so `js.Browser.supported` can provide a false sense of security for checking other browser features are also available (which happened in [HttpJs.hx](https://github.com/HaxeFoundation/haxe/commit/de092baa808897f68fb152a8c4eec368f79c5b03))

A more robust approach is to check for the existence of individual features as required


`js.Browser.supported` is only used once in the standard library in HttpJs.hx, the rest of the occurrences are in tests. 

Replaced with a clearer name `Browser.hasWindow`