### PR TITLE
add overloads in js.lib.Date for converting to locale strings

### DIFF
--- a/std/js/lib/Date.hx
+++ b/std/js/lib/Date.hx
@@ -246,6 +246,7 @@ extern class Date {
 	/**
 		Returns a string with a locality sensitive representation of the date portion of this date based on system settings.
 	**/
+	@:overload(function(?locales:Array<String>, ?options:Dynamic<Dynamic>):String {})
 	function toLocaleDateString(?locales:String, ?options:Dynamic<Dynamic>):String;
 
 	/**
@@ -256,11 +257,13 @@ extern class Date {
 	/**
 		Returns a string with a locality sensitive representation of this date. Overrides the Object.prototype.toLocaleString() method.
 	**/
+	@:overload(function(?locales:Array<String>, ?options:Dynamic<Dynamic>):String {})
 	function toLocaleString(?locales:String, ?options:Dynamic<Dynamic>):String;
 
 	/**
 		Returns a string with a locality sensitive representation of the time portion of this date based on system settings.
 	**/
+	@:overload(function(?locales:Array<String>, ?options:Dynamic<Dynamic>):String {})
 	function toLocaleTimeString(?locales:String, ?options:Dynamic<Dynamic>):String;
 
 	/**


### PR DESCRIPTION
In Javascript, the `Date.toLocaleString()`  (and `Date.toLocaleDateString()` and `Date.toLocaleTimeString()`) can take either a string for the locales to use for conversion, or take an array of strings ([MDN—`locales` parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString)). Currently, the Haxe std only supports using a single string. This PR adds a simple overload to each of the `js.lib.Date` extern functions mentioned, allowing them to take an array of strings as well.