### PR TITLE
[cs] Allow generating native properties with implicit getter/setter

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -928,7 +928,7 @@
 	{
 		"name": "Property",
 		"metadata": ":property",
-		"doc": "Marks a property field to be compiled as a native C# property.",
+		"doc": "Marks a field to be compiled as a native C# property.",
 		"platforms": ["cs"],
 		"targets": ["TClassField"]
 	},

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -2188,9 +2188,12 @@ let generate con =
 							| Some e ->
 								write w " = ";
 								expr_s true w e;
-							| None -> ()
+								write w ";"
+							| None when (Meta.has Meta.Property cf.cf_meta) ->
+								write w " { get; set; }";
+							| None ->
+								write w ";"
 						);
-						write w ";"
 					end (* TODO see how (get,set) variable handle when they are interfaces *)
 				| Method _ when not (Type.is_physical_field cf) || (match cl.cl_kind, cf.cf_expr with | KAbstractImpl _, None -> true | _ -> false) ->
 					List.iter (fun cf -> if cl.cl_interface || cf.cf_expr <> None then


### PR DESCRIPTION
Currently, `@:property` only works for fields that have non-default field access. With this, one can generate

```c#
public static string test { get; set; }
```

From

```haxe
@:property
public static var test(default, default):String;
```