### PR TITLE
[js] Use higher precision timestamp when available

### DIFF
--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -175,7 +175,12 @@ class Timer {
 		#elseif (neko || php)
 		return Sys.time();
 		#elseif js
-		return js.lib.Date.now() / 1000;
+			#if nodejs
+			var hrtime = js.Syntax.code('process.hrtime()'); // [seconds, remaining nanoseconds]
+			return hrtime[0] + hrtime[1] / 1e9;
+			#else
+			return @:privateAccess HxOverrides.now() / 1000;
+			#end
 		#elseif cpp
 		return untyped __global__.__time_stamp();
 		#elseif python

--- a/std/js/_std/HxOverrides.hx
+++ b/std/js/_std/HxOverrides.hx
@@ -138,6 +138,9 @@ class HxOverrides {
 			};
 		}
 
+	@:pure
+	static function now(): Float return js.lib.Date.now();
+
 	static function __init__()
 		untyped {
 			#if (js_es < 5)
@@ -146,5 +149,11 @@ class HxOverrides {
 			__feature__('HxOverrides.lastIndexOf',
 				if (Array.prototype.lastIndexOf) __js__("HxOverrides").lastIndexOf = function(a, o, i) return Array.prototype.lastIndexOf.call(a, o, i));
 			#end
+
+			__feature__('HxOverrides.now',
+				if (js.Syntax.typeof(performance) != 'undefined' && js.Syntax.typeof(performance.now) == 'function') {
+					HxOverrides.now = performance.now.bind(performance);
+				}
+			);
 		}
 }


### PR DESCRIPTION
Updating #8168 

Improves precision of `haxe.Timer.stamp()` by using:
- `process.hrtime()` (nanosecond precision returned) if `-D nodejs`
- `performance.now()` if it exists. Precision depends on browser, ranges from [5µs to 1ms](https://github.com/w3c/hr-time/issues/56#issuecomment-485583476)
- otherwise, `Date.now()`