### PR TITLE
[js] change the way we check for inherited __interfaces__ (closes #9172)

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -165,8 +165,11 @@ class Boot {
 			return false;
 		if (cc == cl)
 			return true;
-		if (js.lib.Object.prototype.hasOwnProperty.call(cc, "__interfaces__")) {
-			var intf:Dynamic = cc.__interfaces__;
+		var intf:Dynamic = cc.__interfaces__;
+		if (intf != null
+			// ES6 classes inherit statics, so we want to avoid accessing inherited `__interfaces__`
+			#if (js_es >= 6) && (cc.__super__ == null || cc.__super__.__interfaces__ != intf) #end
+		) {
 			for (i in 0...intf.length) {
 				var i:Dynamic = intf[i];
 				if (i == cl || __interfLoop(i, cl))


### PR DESCRIPTION
Basically do what @back2dos suggests in https://github.com/HaxeFoundation/haxe/issues/9172#issuecomment-589932831.

I am still puzzled because I don't remember #7834 being ES6-specific, but I tested it again on a haxe version before 3e46bfaa450ce745ef5a524e2976a00592670581 and it seems to indeed reproduce only with `-D js-es=6`, and this version is better than `hasOwnProperty` anyway, so let's go with it.