### PR TITLE
[jvm] implement typed functions

### DIFF
--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -2944,4 +2944,8 @@ let generate com =
 	) gctx.anon_identification#get_anons;
 	let jc_waneck = gctx.waneck#generate in
 	write_class gctx.jar jc_waneck#get_this_path (jc_waneck#export_class gctx.default_export_config);
+	let jc_varargs = gctx.waneck#generate_var_args in
+	write_class gctx.jar jc_varargs#get_this_path (jc_varargs#export_class gctx.default_export_config);
+	let jc_closure_dispatch = gctx.waneck#generate_closure_dispatch in
+	write_class gctx.jar jc_closure_dispatch#get_this_path (jc_closure_dispatch#export_class gctx.default_export_config);
 	Zip.close_out gctx.jar

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -2573,7 +2573,7 @@ class tclass_to_jvm gctx c = object(self)
 			self#handle_relation_type_params;
 		end;
 		self#generate_signature;
-		if not (Meta.has Meta.NativeGen c.cl_meta) then
+		if not (Meta.has Meta.NativeGen c.cl_meta) && not c.cl_interface then
 			generate_dynamic_access gctx jc (List.map (fun cf -> cf.cf_name,jsignature_of_type gctx cf.cf_type,cf.cf_kind) c.cl_ordered_fields) false;
 		self#generate_annotations;
 		jc#add_attribute (AttributeSourceFile (jc#get_pool#add_string c.cl_pos.pfile));

--- a/src/generators/jvm/jvmCode.ml
+++ b/src/generators/jvm/jvmCode.ml
@@ -133,7 +133,7 @@ class builder pool = object(self)
 			match js,js' with
 			| (TObject _ | TTypeParameter _),(TObject _ | TTypeParameter _ | TArray _) -> () (* TODO ??? *)
 			| TMethod _,TMethod _ -> ()
-			| TMethod _,TObject((["java";"lang";"invoke"],"MethodHandle"),[]) -> ()
+			| TMethod _,TObject(path,[]) when path = NativeSignatures.haxe_function_path -> ()
 			| TTypeParameter _,TMethod _ -> ()
 			| TObject _,TMethod _ -> ()
 			| TMethod _,TObject _ -> ()

--- a/src/generators/jvm/jvmFunctions.ml
+++ b/src/generators/jvm/jvmFunctions.ml
@@ -1,0 +1,277 @@
+open JvmSignature
+open NativeSignatures
+
+type signature_classification =
+	| CByte
+	| CChar
+	| CDouble
+	| CFloat
+	| CInt
+	| CLong
+	| CShort
+	| CBool
+	| CObject
+
+type method_signature = {
+	arity : int;
+	name : string;
+	has_nonobject : bool;
+	sort_string : string;
+	cargs : signature_classification list;
+	cret : signature_classification option;
+	dargs : jsignature list;
+	dret : jsignature option;
+	mutable next : method_signature option;
+}
+
+let string_of_classification = function
+	| CByte -> "Byte"
+	| CChar -> "Char"
+	| CDouble -> "Double"
+	| CFloat -> "Float"
+	| CInt -> "Int"
+	| CLong -> "Long"
+	| CShort -> "Short"
+	| CBool -> "Bool"
+	| CObject -> "Object"
+
+let classify = function
+	| TByte -> CByte
+	| TChar -> CChar
+	| TDouble -> CDouble
+	| TFloat -> CFloat
+	| TInt -> CInt
+	| TLong -> CLong
+	| TShort -> CShort
+	| TBool -> CBool
+	| TObject _
+	| TObjectInner _
+	| TArray _
+	| TMethod _
+	| TTypeParameter _
+	| TUninitialized _ -> CObject
+
+let declassify = function
+	| CByte -> TByte
+	| CChar -> TChar
+	| CDouble -> TDouble
+	| CFloat -> TFloat
+	| CInt -> TInt
+	| CLong -> TLong
+	| CShort -> TShort
+	| CBool -> TBool
+	| CObject -> object_path_sig object_path
+
+class waneck_functions = object(self)
+	val signatures = Hashtbl.create 0
+	val mutable max_arity = 0
+
+	method register_signature (tl : jsignature list) (tr : jsignature option) =
+		let cl = List.map classify tl in
+		let cr = Option.map classify tr in
+		self#get_signature cl cr
+
+	method objectify (meth : method_signature) =
+		let cl_objects = List.map (fun _ -> CObject) meth.cargs in
+		self#get_signature cl_objects meth.cret
+
+	method private get_signature
+		(cl : signature_classification list)
+		(cr : signature_classification option)
+	=
+		try
+			Hashtbl.find signatures (cl,cr)
+		with Not_found ->
+			self#do_register_signature cl cr
+
+	method private do_register_signature
+		(cl : signature_classification list)
+		(cr : signature_classification option)
+	=
+		let to_string (cl,cr) =
+			Printf.sprintf "[%s] %s"
+				(String.concat ", " (List.map string_of_classification cl))
+				(Option.map_default string_of_classification "CVoid" cr)
+		in
+		let suffix = Option.map_default string_of_classification "Void" cr in
+		let meth = {
+			arity = List.length cl;
+			name = Printf.sprintf "invoke%s" suffix;
+			has_nonobject = List.exists (function CObject -> false | _ -> true) cl;
+			sort_string = to_string (cl,cr);
+			cargs = cl;
+			cret = cr;
+			dargs = List.map declassify cl;
+			dret = Option.map declassify cr;
+			next = None;
+		} in
+		if meth.arity > max_arity then max_arity <- meth.arity;
+		Hashtbl.add signatures (meth.cargs,meth.cret) meth;
+		(* If the method has something that's not java.lang.Object, the next method is one where all arguments are
+		   of type java.lang.Object. *)
+		if meth.has_nonobject then begin
+			let meth_objects = self#objectify meth in
+			meth.next <- Some meth_objects;
+		(* Otherwise, if the method has a return type that's not java.lang.Object, the next method is one that returns
+		   java.lang.Object. *)
+		end else begin match cr with
+			| Some CObject ->
+				()
+			| _ ->
+				meth.next <- Some (self#get_signature meth.cargs (Some CObject))
+		end;
+		meth
+
+	method make_forward_method
+		(jc : JvmClass.builder)
+		(jm : JvmMethod.builder)
+		(meth_from : method_signature)
+		(meth_to : method_signature)
+	=
+		let args = List.mapi (fun i jsig ->
+			jm#add_local (Printf.sprintf "arg%i" i) jsig VarArgument
+		) meth_from.dargs in
+		jm#finalize_arguments;
+		jm#load_this;
+		let rec loop loads jsigs = match loads,jsigs with
+			| (_,load,_) :: loads,jsig :: jsigs ->
+				load();
+				jm#cast jsig;
+				loop loads jsigs
+			| [],jsig :: jsigs ->
+				jm#load_default_value jsig;
+				loop [] jsigs
+			| [],[] ->
+				()
+			| _,[] ->
+				assert false
+		in
+		loop args meth_to.dargs;
+		jm#invokevirtual jc#get_this_path meth_to.name (method_sig meth_to.dargs meth_to.dret);
+		Option.may jm#cast meth_from.dret;
+		jm#return;
+
+	method generate_invoke_dynamic (jc : JvmClass.builder) =
+		let array_sig = TArray(object_sig,None) in
+		let jm = jc#spawn_method "invokeDynamic" (method_sig [array_sig] (Some object_sig)) [MPublic] in
+		let _,load,_ = jm#add_local "args" array_sig VarArgument in
+		jm#finalize_arguments;
+		load();
+		jm#get_code#arraylength array_sig;
+		let cases = List.init max_arity (fun i ->
+			[Int32.of_int i],(fun () ->
+				jm#load_this;
+				let args = List.init i (fun index ->
+					load();
+					jm#get_code#iconst (Int32.of_int index);
+					jm#get_code#aaload array_sig object_sig;
+					object_sig
+				) in
+				jm#invokevirtual jc#get_this_path "invokeObject" (method_sig args (Some object_sig));
+				jm#return;
+			)
+		) in
+		let def = (fun () ->
+			jm#string "Invalid call";
+			jm#invokestatic (["haxe";"jvm"],"Exception") "wrap" (method_sig [object_sig] (Some exception_sig));
+			jm#get_code#athrow;
+			jm#set_terminated true;
+		) in
+		ignore(jm#int_switch true cases (Some def));
+
+	method generate =
+		let l = Hashtbl.fold (fun _ v acc -> v :: acc) signatures [] in
+		let l = List.sort (fun meth1 meth2 -> compare (meth1.arity,meth1.sort_string) (meth2.arity,meth2.sort_string)) l in
+		let jc = new JvmClass.builder haxe_function_path object_path in
+		jc#add_access_flag 1; (* public *)
+		List.iter (fun meth ->
+			let jm = jc#spawn_method meth.name (method_sig meth.dargs meth.dret) [MPublic] in
+			begin match meth.next with
+			| Some meth_next ->
+				self#make_forward_method jc jm meth meth_next;
+			| None when meth.arity < max_arity && not meth.has_nonobject ->
+				let meth_next = self#get_signature (CObject :: meth.cargs) meth.cret in
+				self#make_forward_method jc jm meth meth_next
+			| None ->
+				List.iteri (fun i jsig ->
+					ignore(jm#add_local (Printf.sprintf "arg%i" i) jsig VarArgument)
+				) meth.dargs;
+				jm#finalize_arguments;
+				begin match meth.dret with
+				| Some jsig -> jm#load_default_value jsig
+				| None -> ()
+				end;
+				jm#return;
+			end;
+		) l;
+		let jm_ctor = jc#spawn_method "<init>" (method_sig [] None) [MPublic] in
+		jm_ctor#load_this;
+		jm_ctor#call_super_ctor ConstructInit (method_sig [] None);
+		jm_ctor#return;
+		self#generate_invoke_dynamic jc;
+		jc
+end
+
+
+class waneck_function
+	(waneck : waneck_functions)
+	(host_class : JvmClass.builder)
+	(host_method : JvmMethod.builder)
+	(context : (string * jsignature) list)
+
+= object(self)
+
+	val jc_closure =
+		let jc = host_class#spawn_inner_class None haxe_function_path (Some host_class#get_next_closure_name) in
+		jc#add_access_flag 0x10; (* final *)
+		jc
+
+	method get_class = jc_closure
+
+	method generate_constructor (public : bool) =
+		let context_sigs = List.map snd context in
+		let jm_ctor = jc_closure#spawn_method "<init>" (method_sig context_sigs None) (if public then [MPublic] else []) in
+		List.iter (fun (name,jsig) ->
+			jm_ctor#add_argument_and_field name jsig;
+		) context;
+		jm_ctor#load_this;
+		jm_ctor#call_super_ctor ConstructInit (method_sig [] None);
+		jm_ctor#return;
+		jm_ctor
+
+	method generate_invoke (args : (string * jsignature) list) (ret : jsignature option)=
+		let arg_sigs = List.map snd args in
+		let meth = waneck#register_signature arg_sigs ret in
+		let jsig_invoke = method_sig arg_sigs ret in
+		let jm_invoke = jc_closure#spawn_method meth.name jsig_invoke [MPublic] in
+		let rec loop meth =
+			begin match meth.next with
+			| Some meth_next ->
+				begin match meth.dret,meth_next.dret with
+				| None,Some _ ->
+					()
+				| _ ->
+					let jm_invoke_next = jc_closure#spawn_method meth_next.name (method_sig meth_next.dargs meth_next.dret) [MPublic] in
+					waneck#make_forward_method jc_closure jm_invoke_next meth_next meth;
+					loop meth_next;
+				end
+			| None ->
+				()
+			end;
+		in
+		let return_differs = match meth.dret,ret with
+			| None,None -> false
+			| Some jsig1,Some jsig2 -> not (equals_at_runtime jsig1 jsig2)
+			| _ -> true
+		in
+		let meth = if not (List.for_all2 equals_at_runtime meth.dargs arg_sigs) || return_differs then begin
+			let meth_prev = meth in
+			let meth = {meth with dargs = arg_sigs; dret = ret} in
+			meth.next <- Some meth_prev;
+			meth
+		end else
+			meth
+		in
+		loop meth;
+		jm_invoke
+end

--- a/src/generators/jvm/jvmFunctions.ml
+++ b/src/generators/jvm/jvmFunctions.ml
@@ -62,7 +62,7 @@ let declassify = function
 	| CBool -> TBool
 	| CObject -> object_path_sig object_path
 
-class waneck_functions = object(self)
+class typed_functions = object(self)
 	val signatures = Hashtbl.create 0
 	val mutable max_arity = 0
 
@@ -271,8 +271,8 @@ class waneck_functions = object(self)
 end
 
 
-class waneck_function
-	(waneck : waneck_functions)
+class typed_function
+	(functions : typed_functions)
 	(host_class : JvmClass.builder)
 	(host_method : JvmMethod.builder)
 	(context : (string * jsignature) list)
@@ -299,14 +299,14 @@ class waneck_function
 
 	method generate_invoke (args : (string * jsignature) list) (ret : jsignature option)=
 		let arg_sigs = List.map snd args in
-		let meth = waneck#register_signature arg_sigs ret in
+		let meth = functions#register_signature arg_sigs ret in
 		let jsig_invoke = method_sig arg_sigs ret in
 		let jm_invoke = jc_closure#spawn_method meth.name jsig_invoke [MPublic] in
 		let rec loop meth =
 			begin match meth.next with
 			| Some meth_next ->
 				let jm_invoke_next = jc_closure#spawn_method meth_next.name (method_sig meth_next.dargs meth_next.dret) [MPublic] in
-				waneck#make_forward_method jc_closure jm_invoke_next meth_next meth;
+				functions#make_forward_method jc_closure jm_invoke_next meth_next meth;
 				loop meth_next;
 			| None ->
 				()

--- a/src/generators/jvm/jvmFunctions.ml
+++ b/src/generators/jvm/jvmFunctions.ml
@@ -167,10 +167,10 @@ class waneck_functions = object(self)
 		jm#finalize_arguments;
 		load();
 		jm#get_code#arraylength array_sig;
-		let cases = List.init max_arity (fun i ->
+		let cases = ExtList.List.init max_arity (fun i ->
 			[Int32.of_int i],(fun () ->
 				jm#load_this;
-				let args = List.init i (fun index ->
+				let args = ExtList.List.init i (fun index ->
 					load();
 					jm#get_code#iconst (Int32.of_int index);
 					jm#get_code#aaload array_sig object_sig;

--- a/src/generators/jvm/jvmMethod.ml
+++ b/src/generators/jvm/jvmMethod.ml
@@ -301,15 +301,6 @@ class builder jc name jsig = object(self)
 			NativeArray.write code jasig jsig
 		) fl
 
-	(** Adds a closure to method [name] ob [path] with signature [jsig_method] to the constant pool.
-
-	    Also emits an instruction to load the closure.
-	**)
-	method read_closure is_static path name jsig_method =
-		let offset = code#get_pool#add_field path name jsig_method FKMethod in
-		let offset = code#get_pool#add (ConstMethodHandle((if is_static then 6 else 5), offset)) in
-		code#ldc offset jsig_method
-
 	(**
 		Emits a return instruction.
 	**)

--- a/src/generators/jvm/jvmMethod.ml
+++ b/src/generators/jvm/jvmMethod.ml
@@ -78,7 +78,7 @@ module NativeArray = struct
 		| TInt -> primitive 10
 		| TLong -> primitive 11
 		| TObject(path,_) -> reference path
-		| TMethod _ -> reference NativeSignatures.method_handle_path
+		| TMethod _ -> reference NativeSignatures.haxe_function_path
 		| TTypeParameter _ -> reference NativeSignatures.object_path
 		| TArray _ ->
 			let offset = pool#add_type (generate_signature false je) in
@@ -320,7 +320,8 @@ class builder jc name jsig = object(self)
 				code#return_void
 			| Some jsig ->
 				code#return_value jsig
-			end
+			end;
+			self#set_terminated true;
 		| _ ->
 			assert false
 
@@ -375,20 +376,6 @@ class builder jc name jsig = object(self)
 			| TBool -> unwrap_null "Boolean" "toBoolean"
 			| _ -> ()
 		end
-
-	method adapt_method jsig =
-		()
-		(* let offset = code#get_pool#add_string (generate_method_signature false jsig) in
-		let offset = code#get_pool#add (ConstMethodType offset) in
-		self#get_code#dup;
-		self#if_then
-			(fun () -> self#get_code#if_null_ref jsig)
-			(fun () ->
-				code#ldc offset method_type_sig;
-				self#invokevirtual method_handle_path "asType" (method_sig [method_type_sig] (Some method_handle_sig))
-			);
-		ignore(code#get_stack#pop);
-		code#get_stack#push jsig; *)
 
 	(** Casts the top of the stack to [jsig]. If [allow_to_string] is true, Jvm.toString is called. **)
 	method cast ?(not_null=false) ?(allow_to_string=false) jsig =
@@ -570,14 +557,8 @@ class builder jc name jsig = object(self)
 				code#checkcast path1;
 		| TObject(path,_),TTypeParameter _ ->
 			code#checkcast path
-		| TMethod _,TMethod _ ->
-			if jsig <> jsig' then self#adapt_method jsig;
-		| TMethod _,TObject((["java";"lang";"invoke"],"MethodHandle"),_) ->
-			self#adapt_method jsig;
-		| TObject((["java";"lang";"invoke"],"MethodHandle"),_),TMethod _ ->
-			()
 		| TMethod _,_ ->
-			code#checkcast (["java";"lang";"invoke"],"MethodHandle");
+			code#checkcast NativeSignatures.haxe_function_path;
 		| TArray(jsig1,_),TArray(jsig2,_) when jsig1 = jsig2 ->
 			()
 		| TArray _,_ ->
@@ -666,12 +647,17 @@ class builder jc name jsig = object(self)
 
 		If [is_exhaustive] is true and [def] is None, the first case is used as the default case.
 	**)
-	method int_switch (is_exhaustive : bool) (cases : (Int32.t list * (unit -> unit)) list) (def : (unit -> unit) option) =
-		let def,cases = match def,cases with
-			| None,(_,ec) :: cases when is_exhaustive ->
-				Some ec,cases
+	method int_switch (need_val : bool) (cases : (Int32.t list * (unit -> unit)) list) (def : (unit -> unit) option) =
+		let def = match def with
+			| None when need_val ->
+				Some (fun () ->
+					self#string "Match failure";
+					self#invokestatic (["haxe";"jvm"],"Exception") "wrap" (method_sig [object_sig] (Some exception_sig));
+					self#get_code#athrow;
+					self#set_terminated true;
+				)
 			| _ ->
-				def,cases
+				def
 		in
 		let flat_cases = DynArray.create () in
 		let case_lut = ref Int32Map.empty in

--- a/src/generators/jvm/jvmSignature.ml
+++ b/src/generators/jvm/jvmSignature.ml
@@ -49,6 +49,160 @@ and jsignature =
 (* ( jsignature list ) ReturnDescriptor (| V | jsignature) *)
 and jmethod_signature = jsignature list * jsignature option
 
+module NativeSignatures = struct
+	let object_path = ["java";"lang"],"Object"
+	let object_sig = TObject(object_path,[])
+
+	let string_path = ["java";"lang"],"String"
+	let string_sig = TObject(string_path,[])
+
+	let boolean_path = ["java";"lang"],"Boolean"
+	let boolean_sig = TObject(boolean_path,[])
+
+	let character_path = ["java";"lang"],"Character"
+	let character_sig = TObject(character_path,[])
+
+	let method_type_path = (["java";"lang";"invoke"],"MethodType")
+	let method_type_sig = TObject(method_type_path,[])
+
+	let method_lookup_path = (["java";"lang";"invoke"],"MethodHandles$Lookup")
+	let method_lookup_sig = TObject(method_lookup_path,[])
+
+	let call_site_path = (["java";"lang";"invoke"],"CallSite")
+	let call_site_sig = TObject(call_site_path,[])
+
+	let java_class_path = ["java";"lang"],"Class"
+	let java_class_sig = TObject(java_class_path,[TType(WNone,object_sig)])
+
+	let haxe_jvm_path = ["haxe";"jvm"],"Jvm"
+
+	let haxe_dynamic_object_path = ["haxe";"jvm"],"DynamicObject"
+	let haxe_dynamic_object_sig = TObject(haxe_dynamic_object_path,[])
+
+	let haxe_exception_path = ["haxe";"jvm"],"Exception"
+	let haxe_exception_sig = TObject(haxe_exception_path,[])
+
+	let haxe_object_path = ["haxe";"jvm"],"Object"
+	let haxe_object_sig = TObject(haxe_object_path,[])
+
+	let throwable_path = (["java";"lang"],"Throwable")
+	let throwable_sig = TObject(throwable_path,[])
+
+	let exception_path = (["java";"lang"],"Exception")
+	let exception_sig = TObject(exception_path,[])
+
+	let retention_path = (["java";"lang";"annotation"],"Retention")
+	let retention_sig = TObject(retention_path,[])
+
+	let retention_policy_path = (["java";"lang";"annotation"],"RetentionPolicy")
+	let retention_policy_sig = TObject(retention_policy_path,[])
+
+	let java_enum_path = (["java";"lang"],"Enum")
+	let java_enum_sig jsig = TObject(java_enum_path,[TType(WNone,jsig)])
+
+	let haxe_enum_path = (["haxe";"jvm"],"Enum")
+	let haxe_enum_sig jsig = TObject(haxe_enum_path,[TType(WNone,jsig)])
+
+	let haxe_empty_constructor_path = (["haxe";"jvm"],"EmptyConstructor")
+	let haxe_empty_constructor_sig = TObject(haxe_empty_constructor_path,[])
+
+	let haxe_function_path = (["haxe";"jvm"],"Function")
+	let haxe_function_sig = TObject(haxe_function_path,[])
+
+	let void_path = ["java";"lang"],"Void"
+	let void_sig = TObject(void_path,[])
+
+	(* numeric *)
+
+	let number_path = ["java";"lang"],"Number"
+	let number_sig = TObject(number_path,[])
+
+	let byte_path = ["java";"lang"],"Byte"
+	let byte_sig = TObject(byte_path,[])
+
+	let short_path = ["java";"lang"],"Short"
+	let short_sig = TObject(short_path,[])
+
+	let integer_path = ["java";"lang"],"Integer"
+	let integer_sig = TObject(integer_path,[])
+
+	let long_path = ["java";"lang"],"Long"
+	let long_sig = TObject(long_path,[])
+
+	let float_path = ["java";"lang"],"Float"
+	let float_sig = TObject(float_path,[])
+
+	let double_path = ["java";"lang"],"Double"
+	let double_sig = TObject(double_path,[])
+
+	(* compound *)
+
+	let array_sig jsig = TArray(jsig,None)
+
+	let method_sig jsigs jsig = TMethod(jsigs,jsig)
+
+	let object_path_sig path = TObject(path,[])
+
+	let get_boxed_type jsig = match jsig with
+		| TBool -> boolean_sig
+		| TChar -> character_sig
+		| TByte -> byte_sig
+		| TShort -> short_sig
+		| TInt -> integer_sig
+		| TLong -> long_sig
+		| TFloat -> float_sig
+		| TDouble -> double_sig
+		| _ -> jsig
+
+	let get_unboxed_type jsig = match jsig with
+		| TObject((["java";"lang"],"Boolean"),_) -> TBool
+		| TObject((["java";"lang"],"Charcter"),_) -> TChar
+		| TObject((["java";"lang"],"Byte"),_) -> TByte
+		| TObject((["java";"lang"],"Short"),_) -> TShort
+		| TObject((["java";"lang"],"Integer"),_) -> TInt
+		| TObject((["java";"lang"],"Long"),_) -> TLong
+		| TObject((["java";"lang"],"Float"),_) -> TFloat
+		| TObject((["java";"lang"],"Double"),_) -> TDouble
+		| _ -> jsig
+
+	let is_unboxed jsig = match jsig with
+		| TBool | TChar
+		| TByte | TShort | TInt | TLong
+		| TFloat | TDouble ->
+			true
+		| _ ->
+			false
+
+	let is_dynamic_at_runtime = function
+		| TObject((["java";"lang"],"Object"),_)
+		| TTypeParameter _ ->
+			true
+		| _ ->
+			false
+end
+
+let equals_at_runtime jsig1 jsig2 = match jsig1,jsig2 with
+	| TByte,TByte
+	| TChar,TChar
+	| TDouble,TDouble
+	| TFloat,TFloat
+	| TInt,TInt
+	| TLong,TLong
+	| TShort,TShort
+	| TBool,TBool
+	| TObjectInner _,TObjectInner _
+	| TArray _,TArray _
+	| TMethod _,TMethod _
+	| TTypeParameter _,TTypeParameter _
+	| TUninitialized _,TUninitialized _ ->
+		true
+	| TObject(path1,_),TObject(path2,_) ->
+		path1 = path2
+	| TObject(path,_),TTypeParameter _
+	| TTypeParameter _,TObject(path,_) ->
+		path = NativeSignatures.object_path
+	| _ -> false
+
 let s_wildcard = function
 	| WExtends -> "WExtends"
 	| WSuper -> "WSuper"
@@ -131,7 +285,7 @@ and write_signature full ch jsig = match jsig with
 		end;
 		write_signature full ch s
 	| TMethod _ ->
-		write_signature full ch (TObject((["java";"lang";"invoke"],"MethodHandle"),[]))
+		write_signature full ch NativeSignatures.haxe_function_sig
 	| TTypeParameter name ->
 		if full then begin
 			write_byte ch (Char.code 'T');
@@ -169,135 +323,3 @@ let generate_method_signature full jsig =
 let signature_size = function
 	| TDouble | TLong -> 2
 	| _ -> 1
-
-module NativeSignatures = struct
-	let object_path = ["java";"lang"],"Object"
-	let object_sig = TObject(object_path,[])
-
-	let string_path = ["java";"lang"],"String"
-	let string_sig = TObject(string_path,[])
-
-	let boolean_path = ["java";"lang"],"Boolean"
-	let boolean_sig = TObject(boolean_path,[])
-
-	let character_path = ["java";"lang"],"Character"
-	let character_sig = TObject(character_path,[])
-
-	let method_handle_path = (["java";"lang";"invoke"],"MethodHandle")
-	let method_handle_sig = TObject(method_handle_path,[])
-
-	let method_type_path = (["java";"lang";"invoke"],"MethodType")
-	let method_type_sig = TObject(method_type_path,[])
-
-	let method_lookup_path = (["java";"lang";"invoke"],"MethodHandles$Lookup")
-	let method_lookup_sig = TObject(method_lookup_path,[])
-
-	let call_site_path = (["java";"lang";"invoke"],"CallSite")
-	let call_site_sig = TObject(call_site_path,[])
-
-	let java_class_path = ["java";"lang"],"Class"
-	let java_class_sig = TObject(java_class_path,[TType(WNone,object_sig)])
-
-	let haxe_jvm_path = ["haxe";"jvm"],"Jvm"
-
-	let haxe_dynamic_object_path = ["haxe";"jvm"],"DynamicObject"
-	let haxe_dynamic_object_sig = TObject(haxe_dynamic_object_path,[])
-
-	let haxe_exception_path = ["haxe";"jvm"],"Exception"
-	let haxe_exception_sig = TObject(haxe_exception_path,[])
-
-	let haxe_object_path = ["haxe";"jvm"],"Object"
-	let haxe_object_sig = TObject(haxe_object_path,[])
-
-	let throwable_path = (["java";"lang"],"Throwable")
-	let throwable_sig = TObject(throwable_path,[])
-
-	let exception_path = (["java";"lang"],"Exception")
-	let exception_sig = TObject(exception_path,[])
-
-	let retention_path = (["java";"lang";"annotation"],"Retention")
-	let retention_sig = TObject(retention_path,[])
-
-	let retention_policy_path = (["java";"lang";"annotation"],"RetentionPolicy")
-	let retention_policy_sig = TObject(retention_policy_path,[])
-
-	let java_enum_path = (["java";"lang"],"Enum")
-	let java_enum_sig jsig = TObject(java_enum_path,[TType(WNone,jsig)])
-
-	let haxe_enum_path = (["haxe";"jvm"],"Enum")
-	let haxe_enum_sig jsig = TObject(haxe_enum_path,[TType(WNone,jsig)])
-
-	let haxe_empty_constructor_path = (["haxe";"jvm"],"EmptyConstructor")
-	let haxe_empty_constructor_sig = TObject(haxe_empty_constructor_path,[])
-
-	let void_path = ["java";"lang"],"Void"
-	let void_sig = TObject(void_path,[])
-
-	(* numeric *)
-
-	let number_path = ["java";"lang"],"Number"
-	let number_sig = TObject(number_path,[])
-
-	let byte_path = ["java";"lang"],"Byte"
-	let byte_sig = TObject(byte_path,[])
-
-	let short_path = ["java";"lang"],"Short"
-	let short_sig = TObject(short_path,[])
-
-	let integer_path = ["java";"lang"],"Integer"
-	let integer_sig = TObject(integer_path,[])
-
-	let long_path = ["java";"lang"],"Long"
-	let long_sig = TObject(long_path,[])
-
-	let float_path = ["java";"lang"],"Float"
-	let float_sig = TObject(float_path,[])
-
-	let double_path = ["java";"lang"],"Double"
-	let double_sig = TObject(double_path,[])
-
-	(* compound *)
-
-	let array_sig jsig = TArray(jsig,None)
-
-	let method_sig jsigs jsig = TMethod(jsigs,jsig)
-
-	let object_path_sig path = TObject(path,[])
-
-	let get_boxed_type jsig = match jsig with
-		| TBool -> boolean_sig
-		| TChar -> character_sig
-		| TByte -> byte_sig
-		| TShort -> short_sig
-		| TInt -> integer_sig
-		| TLong -> long_sig
-		| TFloat -> float_sig
-		| TDouble -> double_sig
-		| _ -> jsig
-
-	let get_unboxed_type jsig = match jsig with
-		| TObject((["java";"lang"],"Boolean"),_) -> TBool
-		| TObject((["java";"lang"],"Charcter"),_) -> TChar
-		| TObject((["java";"lang"],"Byte"),_) -> TByte
-		| TObject((["java";"lang"],"Short"),_) -> TShort
-		| TObject((["java";"lang"],"Integer"),_) -> TInt
-		| TObject((["java";"lang"],"Long"),_) -> TLong
-		| TObject((["java";"lang"],"Float"),_) -> TFloat
-		| TObject((["java";"lang"],"Double"),_) -> TDouble
-		| _ -> jsig
-
-	let is_unboxed jsig = match jsig with
-		| TBool | TChar
-		| TByte | TShort | TInt | TLong
-		| TFloat | TDouble ->
-			true
-		| _ ->
-			false
-
-	let is_dynamic_at_runtime = function
-		| TObject((["java";"lang"],"Object"),_)
-		| TTypeParameter _ ->
-			true
-		| _ ->
-			false
-end

--- a/src/generators/jvm/jvmVerificationTypeInfo.ml
+++ b/src/generators/jvm/jvmVerificationTypeInfo.ml
@@ -37,7 +37,7 @@ let of_signature pool jsig = match jsig with
     | TLong -> VLong
     | TDouble -> VDouble
     | TObject(path,_) -> VObject (pool#add_path path)
-	| TMethod _ -> VObject (pool#add_path (["java";"lang";"invoke"],"MethodHandle"))
+	| TMethod _ -> VObject (pool#add_path NativeSignatures.haxe_function_path)
 	| TArray _ -> VObject (pool#add_path ([],generate_signature false jsig))
 	| TTypeParameter _ -> VObject (pool#add_path (["java";"lang"],"Object"))
 	| TUninitialized (Some i) -> VUninitialized i

--- a/std/jvm/Closure.hx
+++ b/std/jvm/Closure.hx
@@ -6,7 +6,7 @@ import java.lang.reflect.Method;
 @:native("haxe.jvm.Closure")
 @:nativeGen
 @:keep
-class Closure extends Function {
+class Closure extends ClosureDispatch {
 	public var context:Dynamic;
 	public var method:Method;
 
@@ -52,42 +52,14 @@ class Closure extends Function {
 			throw e.getCause();
 		}
 	}
-
-	@:overload public function invokeObject():Dynamic {
-		return invokeDynamic(new NativeArray(0));
-	}
-
-	@:overload public function invokeObject(arg1:Dynamic):Dynamic {
-		return invokeDynamic(NativeArray.make(arg1));
-	}
-
-	@:overload public function invokeObject(arg1:Dynamic, arg2:Dynamic):Dynamic {
-		return invokeDynamic(NativeArray.make(arg1, arg2));
-	}
 }
 
-@:keep
-class VarArgs extends Function {
+@:native("haxe.jvm.ClosureDispatch")
+extern class ClosureDispatch extends Function {}
+
+@:native("haxe.jvm.VarArgs")
+extern class VarArgs extends Function {
 	var func:Function;
 
-	public function new(func:Function) {
-		super();
-		this.func = func;
-	}
-
-	@:overload public function invokeObject():Dynamic {
-		return func.invokeObject(cast []);
-	}
-
-	@:overload public function invokeObject(arg1:Dynamic):Dynamic {
-		return func.invokeObject(cast [arg1]);
-	}
-
-	@:overload public function invokeObject(arg1:Dynamic, arg2:Dynamic):Dynamic {
-		return func.invokeObject(cast [arg1, arg2]);
-	}
-
-	@:overload public function invokeObject(arg1:Dynamic, arg2:Dynamic, arg3:Dynamic):Dynamic {
-		return func.invokeObject(cast [arg1, arg2, arg3]);
-	}
+	public function new(func:Function):Void;
 }

--- a/std/jvm/Closure.hx
+++ b/std/jvm/Closure.hx
@@ -65,3 +65,29 @@ class Closure extends Function {
 		return invokeDynamic(NativeArray.make(arg1, arg2));
 	}
 }
+
+@:keep
+class VarArgs extends Function {
+	var func:Function;
+
+	public function new(func:Function) {
+		super();
+		this.func = func;
+	}
+
+	@:overload public function invokeObject():Dynamic {
+		return func.invokeObject(cast []);
+	}
+
+	@:overload public function invokeObject(arg1:Dynamic):Dynamic {
+		return func.invokeObject(cast [arg1]);
+	}
+
+	@:overload public function invokeObject(arg1:Dynamic, arg2:Dynamic):Dynamic {
+		return func.invokeObject(cast [arg1, arg2]);
+	}
+
+	@:overload public function invokeObject(arg1:Dynamic, arg2:Dynamic, arg3:Dynamic):Dynamic {
+		return func.invokeObject(cast [arg1, arg2, arg3]);
+	}
+}

--- a/std/jvm/Closure.hx
+++ b/std/jvm/Closure.hx
@@ -1,0 +1,67 @@
+package jvm;
+
+import java.NativeArray;
+import java.lang.reflect.Method;
+
+@:native("haxe.jvm.Closure")
+@:nativeGen
+@:keep
+class Closure extends Function {
+	public var context:Dynamic;
+	public var method:Method;
+
+	var isStatic:Bool;
+	var params:NativeArray<java.lang.Class<Dynamic>>;
+
+	public function new(context:Null<Dynamic>, method:Method) {
+		super();
+		this.context = context;
+		this.method = method;
+		isStatic = method.getModifiers() & java.lang.reflect.Modifier.STATIC != 0;
+		params = method.getParameterTypes();
+	}
+
+	public function bindTo(context:Dynamic) {
+		return new Closure(context, method);
+	}
+
+	override public function equals(other:java.lang.Object) {
+		if (!Jvm.instanceof(other, Closure)) {
+			return false;
+		}
+		var other:Closure = cast other;
+		return context == other.context && method == other.method;
+	}
+
+	public override function invokeDynamic(args:NativeArray<Dynamic>):Dynamic {
+		if (isStatic && context != null) {
+			var newArgs = new NativeArray(args.length + 1);
+			haxe.ds.Vector.blit(cast args, 0, cast newArgs, 1, args.length);
+			newArgs[0] = context;
+			args = newArgs;
+		}
+		var args = switch (jvm.Jvm.unifyCallArguments(args, params, true)) {
+			case Some(args):
+				args;
+			case None:
+				args;
+		};
+		try {
+			return method.invoke(context, args);
+		} catch (e:java.lang.reflect.InvocationTargetException) {
+			throw e.getCause();
+		}
+	}
+
+	@:overload public function invokeObject():Dynamic {
+		return invokeDynamic(new NativeArray(0));
+	}
+
+	@:overload public function invokeObject(arg1:Dynamic):Dynamic {
+		return invokeDynamic(NativeArray.make(arg1));
+	}
+
+	@:overload public function invokeObject(arg1:Dynamic, arg2:Dynamic):Dynamic {
+		return invokeDynamic(NativeArray.make(arg1, arg2));
+	}
+}

--- a/std/jvm/Function.hx
+++ b/std/jvm/Function.hx
@@ -1,0 +1,11 @@
+package jvm;
+
+import java.NativeArray;
+
+@:native("haxe.jvm.Function")
+@:nativeGen
+extern class Function {
+	public function new():Void;
+	public function invokeDynamic(args:NativeArray<Dynamic>):Dynamic;
+	public function equals(other:java.lang.Object):Bool;
+}

--- a/std/jvm/Function.hx
+++ b/std/jvm/Function.hx
@@ -8,4 +8,5 @@ extern class Function {
 	public function new():Void;
 	public function invokeDynamic(args:NativeArray<Dynamic>):Dynamic;
 	public function equals(other:java.lang.Object):Bool;
+	public function invokeObject(arg1:java.lang.Object):java.lang.Object;
 }

--- a/std/jvm/Jvm.hx
+++ b/std/jvm/Jvm.hx
@@ -45,8 +45,6 @@ class Jvm {
 
 	extern static public function referenceEquals<T>(v1:T, v2:T):Bool;
 
-	extern static public function invokedynamic<T>(bootstrapMethod:Function, fieldName:String, staticArguments:Array<Dynamic>, rest:Rest<Dynamic>):T;
-
 	static public function stringCompare(v1:String, v2:String):Int {
 		if (v1 == null) {
 			return v2 == null ? 0 : 1;
@@ -145,12 +143,8 @@ class Jvm {
 		return Some(callArgs);
 	}
 
-	static public function call(mh:java.lang.invoke.MethodHandle, args:NativeArray<Dynamic>) {
-		var params = mh.type().parameterArray();
-		return switch (unifyCallArguments(args, params, true)) {
-			case Some(args): mh.invokeWithArguments(args);
-			case None: mh.invokeWithArguments(args);
-		}
+	static public function call(func:jvm.Function, args:NativeArray<Dynamic>) {
+		return func.invokeDynamic(args);
 	}
 
 	// casts
@@ -287,11 +281,6 @@ class Jvm {
 		throw 'Cannot array-write on $obj';
 	}
 
-	static public function bootstrap(caller:MethodHandles.MethodHandles_Lookup, name:String, type:MethodType):CallSite {
-		var handle = caller.findStatic(caller.lookupClass(), name, type);
-		return new ConstantCallSite(handle);
-	}
-
 	static public function readFieldNoObject(obj:Dynamic, name:String):Dynamic {
 		var isStatic = instanceof(obj, java.lang.Class);
 		var cl = isStatic ? obj : (obj : java.lang.Object).getClass();
@@ -304,11 +293,11 @@ class Jvm {
 				var methods = cl.getMethods();
 				for (m in methods) {
 					if (m.getName() == name) {
-						var method = java.lang.invoke.MethodHandles.lookup().unreflect(m);
+						var context = null;
 						if (!isStatic || cl == cast java.lang.Class) {
-							method = method.bindTo(obj);
+							context = obj;
 						}
-						return method;
+						return new jvm.Closure(context, m);
 					}
 				}
 				if (isStatic) {
@@ -336,27 +325,27 @@ class Jvm {
 				case "length":
 					return (obj : String).length;
 				case "charAt":
-					return (cast jvm.StringExt.charAt : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "charAt") : Closure).bindTo(obj);
 				case "charCodeAt":
-					return (cast jvm.StringExt.charCodeAt : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "charCodeAt") : Closure).bindTo(obj);
 				case "indexOf":
-					return (cast jvm.StringExt.indexOf : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "indexOf") : Closure).bindTo(obj);
 				case "iterator":
 					return function() return new haxe.iterators.StringIterator(obj);
 				case "keyValueIterator":
 					return function() return new haxe.iterators.StringKeyValueIterator(obj);
 				case "lastIndexOf":
-					return (cast jvm.StringExt.lastIndexOf : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "lastIndexOf") : Closure).bindTo(obj);
 				case "split":
-					return (cast jvm.StringExt.split : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "split") : Closure).bindTo(obj);
 				case "substr":
-					return (cast jvm.StringExt.substr : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "substr") : Closure).bindTo(obj);
 				case "substring":
-					return (cast jvm.StringExt.substring : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "substring") : Closure).bindTo(obj);
 				case "toLowerCase":
-					return (cast jvm.StringExt.toLowerCase : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "toLowerCase") : Closure).bindTo(obj);
 				case "toUpperCase":
-					return (cast jvm.StringExt.toUpperCase : java.lang.invoke.MethodHandle).bindTo(obj);
+					return (readFieldNoObject(jvm.StringExt, "toUpperCase") : Closure).bindTo(obj);
 			}
 		}
 		return readFieldNoObject(obj, name);

--- a/std/jvm/StringExt.hx
+++ b/std/jvm/StringExt.hx
@@ -25,6 +25,7 @@ package jvm;
 import java.NativeString;
 
 @:native("haxe.jvm.StringExt")
+@:keep
 class StringExt {
 	public static function fromCharCode(code:Int):String {
 		var a = new java.NativeArray(1);

--- a/std/jvm/_std/Reflect.hx
+++ b/std/jvm/_std/Reflect.hx
@@ -172,11 +172,6 @@ class Reflect {
 
 	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
 	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
-		return f;
-		// var fAdapt = function(args:java.NativeArray<Dynamic>) {
-		// 	return f(@:privateAccess Array.ofNative(args));
-		// }
-		// // return (cast fAdapt : java.lang.invoke.MethodHandle).asVarargsCollector(cast java.NativeArray);
-		// return fAdapt;
+		return new jvm.Closure.VarArgs((cast f : jvm.Function));
 	}
 }

--- a/std/jvm/_std/Reflect.hx
+++ b/std/jvm/_std/Reflect.hx
@@ -84,7 +84,7 @@ class Reflect {
 	}
 
 	public static function isFunction(f:Dynamic):Bool {
-		return Jvm.instanceof(f, java.lang.invoke.MethodHandle);
+		return Jvm.instanceof(f, jvm.Function);
 	}
 
 	public static function compare<T>(a:T, b:T):Int {
@@ -120,15 +120,13 @@ class Reflect {
 		if (c1 != (f2 : java.lang.Object).getClass()) {
 			return false;
 		}
-		try {
-			var arg0 = c1.getDeclaredField("argL0");
-			arg0.setAccessible(true);
-			var arg1 = c1.getDeclaredField("argL1");
-			arg1.setAccessible(true);
-			return arg0.get(f1) == arg0.get(f2) && arg1.get(f1) == arg1.get(f2);
-		} catch (_:Dynamic) {
-			return false;
+		if (Std.is(f1, jvm.Function)) {
+			if (!Std.is(f2, jvm.Function)) {
+				return false;
+			}
+			return (f1 : jvm.Function).equals(f2);
 		}
+		return false;
 	}
 
 	public static function isObject(v:Dynamic):Bool {
@@ -144,7 +142,7 @@ class Reflect {
 		if (Jvm.instanceof(v, java.lang.Boolean.BooleanClass)) {
 			return false;
 		}
-		if (Jvm.instanceof(v, java.lang.invoke.MethodHandle)) {
+		if (Jvm.instanceof(v, jvm.Function)) {
 			return false;
 		}
 		return true;
@@ -174,9 +172,11 @@ class Reflect {
 
 	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
 	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
-		var fAdapt = function(args:java.NativeArray<Dynamic>) {
-			return f(@:privateAccess Array.ofNative(args));
-		}
-		return (cast fAdapt : java.lang.invoke.MethodHandle).asVarargsCollector(cast java.NativeArray);
+		return f;
+		// var fAdapt = function(args:java.NativeArray<Dynamic>) {
+		// 	return f(@:privateAccess Array.ofNative(args));
+		// }
+		// // return (cast fAdapt : java.lang.invoke.MethodHandle).asVarargsCollector(cast java.NativeArray);
+		// return fAdapt;
 	}
 }

--- a/std/jvm/_std/Type.hx
+++ b/std/jvm/_std/Type.hx
@@ -260,7 +260,7 @@ class Type {
 		if (Jvm.instanceof(v, jvm.DynamicObject)) {
 			return TObject;
 		}
-		if (Jvm.instanceof(v, java.lang.invoke.MethodHandle)) {
+		if (Jvm.instanceof(v, jvm.Function)) {
 			return TFunction;
 		}
 		var c = (cast v : java.lang.Object).getClass();


### PR DESCRIPTION
Instead of using `MethodHandle` we now create sub-classes of `haxe.jvm.Function`, which is similar to what genjava does. This is much faster and more portable, but comes at the expense of increased code size.

There are still some things to optimize in that regard, but I'll do that a bit later.