### PR TITLE
Mark native methods on jvm

### DIFF
--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -2441,6 +2441,7 @@ class tclass_to_jvm gctx c = object(self)
 		let flags = if mtype = MStatic then MethodAccessFlags.MStatic :: flags else flags in
 		let flags = if has_class_field_flag cf CfFinal then MFinal :: flags else flags in
 		let flags = if Meta.has Meta.JvmSynthetic cf.cf_meta then MSynthetic :: flags else flags in
+		let flags = if Meta.has Meta.NativeJni cf.cf_meta then MNative :: flags else flags in
 		let name,scmode,flags = match mtype with
 			| MConstructor ->
 				let rec has_super_ctor c = match c.cl_super with

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1166,7 +1166,7 @@ let create_method (ctx,cctx,fctx) c f fd p =
 			begin match ctx.com.platform with
 				| Java when is_java_native_function ctx cf.cf_meta cf.cf_pos ->
 					if fd.f_expr <> None then
-						ctx.com.warning "@:native function definitions shouldn't include an expression. This behaviour is deprecated." cf.cf_pos;
+						ctx.com.warning "@:java.native function definitions shouldn't include an expression. This behaviour is deprecated." cf.cf_pos;
 					cf.cf_expr <- None;
 					cf.cf_type <- t
 				| _ ->


### PR DESCRIPTION
Hah, such easy (except i spend one hour with debugging JavaNative meta instead).
Is `@:java.native` fine for jvm target or separated meta would be better?
And demo with C files if someone interested: [jvm_jni.zip](https://github.com/HaxeFoundation/haxe/files/4328983/jvm_jni.zip) (they must be compiled to library first)