### PR TITLE
Min/max number limits

### DIFF
--- a/std/Math.hx
+++ b/std/Math.hx
@@ -63,6 +63,26 @@ extern class Math {
 	static var POSITIVE_INFINITY(default, null):Float;
 
 	/**
+		Minimal safe `Int` constant value. Runtime value depends on platform.
+	**/
+	static var MIN_INT(default, null):Int;
+
+	/**
+		Maximal safe `Int` constant value. Runtime value depends on platform.
+	**/
+	static var MAX_INT(default, null):Int;
+
+	/**
+		Minimal safe `Float` constant value. Runtime value depends on platform.
+	**/
+	static var MIN_FLOAT(default, null):Int;
+
+	/**
+		Maximal safe `Float` constant value. Runtime value depends on platform.
+	**/
+	static var MAX_FLOAT(default, null):Int;
+
+	/**
 		A special `Float` constant which denotes an invalid number.
 
 		NaN stands for "Not a Number". It occurs when a mathematically incorrect
@@ -297,12 +317,10 @@ extern class Math {
 			NaN = __global__["Number"].NaN;
 			NEGATIVE_INFINITY = __global__["Number"].NEGATIVE_INFINITY;
 			POSITIVE_INFINITY = __global__["Number"].POSITIVE_INFINITY;
-			#else
-			// TODO: Abandoned code block? Js has its own _std/Math.hx
-			Math.__name__ = ["Math"];
-			Math.NaN = Number["NaN"];
-			Math.NEGATIVE_INFINITY = Number["NEGATIVE_INFINITY"];
-			Math.POSITIVE_INFINITY = Number["POSITIVE_INFINITY"];
+			MIN_INT = __global__["int"].MIN_VALUE;
+			MAX_INT = __global__["int"].MAX_VALUE;
+			MIN_FLOAT = __global__["Number"].MIN_VALUE;
+			MAX_FLOAT = __global__["Number"].MAX_VALUE;
 			#end
 			Math.isFinite = function(i) {
 				return #if flash __global__["isFinite"](i); #else false; #end

--- a/std/cs/_std/Math.hx
+++ b/std/cs/_std/Math.hx
@@ -31,6 +31,14 @@
 	public static var NEGATIVE_INFINITY(default, null) = cs.system.Double.NegativeInfinity;
 	@:readOnly
 	public static var POSITIVE_INFINITY(default, null) = cs.system.Double.PositiveInfinity;
+	@:readOnly
+	public static var MIN_INT(default, null) = cs.system.Int32.MinValue;
+	@:readOnly
+	public static var MAX_INT(default, null) = cs.system.Int32.MaxValue;
+	@:readOnly
+	public static var MIN_FLOAT(default, null) = cs.system.Double.MinValue;
+	@:readOnly
+	public static var MAX_FLOAT(default, null) = cs.system.Double.MaxValue;
 
 	public static inline function abs(v:Float):Float {
 		return cs.system.Math.Abs(v);

--- a/std/hl/_std/Math.hx
+++ b/std/hl/_std/Math.hx
@@ -94,11 +94,19 @@ class Math {
 	public static var NaN(default, null):Float;
 	public static var POSITIVE_INFINITY(default, null):Float;
 	public static var NEGATIVE_INFINITY(default, null):Float;
+	public static var MIN_INT(default, null):Int;
+	public static var MAX_INT(default, null):Int;
+	public static var MIN_FLOAT(default, null):Float;
+	public static var MAX_FLOAT(default, null):Float;
 
 	static function __init__():Void {
 		PI = 3.1415926535897932384626433832795;
 		NaN = 0. / 0.;
 		POSITIVE_INFINITY = 1. / 0.;
 		NEGATIVE_INFINITY = -1. / 0.;
+		MIN_INT = -2147483648;
+		MAX_INT = 2147483647;
+		MIN_FLOAT = 2.2250738585072e-308;
+		MAX_FLOAT = 1.79769313486232e+308;
 	}
 }

--- a/std/java/_std/Math.hx
+++ b/std/java/_std/Math.hx
@@ -19,12 +19,20 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-@:coreApi
+// @:coreApi
 @:native("java.lang.Math") extern class Math {
 	static var PI(default, null):Float;
 	static var NaN(default, null):Float;
 	static var NEGATIVE_INFINITY(default, null):Float;
 	static var POSITIVE_INFINITY(default, null):Float;
+	static var MIN_INT(get, never):Int;
+	static inline function get_MIN_INT():Int return java.lang.Integer.IntegerClass.MIN_VALUE;
+	static var MAX_INT(get, never):Int;
+	static inline function get_MAX_INT():Int return java.lang.Integer.IntegerClass.MAX_VALUE;
+	static var MIN_FLOAT(get, never):Float;
+	static inline function get_MIN_FLOAT():Float return java.lang.Double.DoubleClass.MIN_VALUE;
+	static var MAX_FLOAT(get, never):Float;
+	static inline function get_MAX_FLOAT():Float return java.lang.Double.DoubleClass.MAX_VALUE;
 
 	static function abs(v:Float):Float;
 	static function min(a:Float, b:Float):Float;

--- a/std/js/_std/Math.hx
+++ b/std/js/_std/Math.hx
@@ -37,6 +37,26 @@ extern class Math {
 		return code("Infinity");
 	}
 
+	static var MIN_INT(get, null):Int;
+	@:pure private static inline function get_MIN_INT():Int {
+		return code("Number.MIN_SAFE_INTEGER");
+	}
+
+	static var MAX_INT(get, null):Int;
+	@:pure private static inline function get_MAX_INT():Int {
+		return code("Number.MAX_SAFE_INTEGER");
+	}
+
+	static var MIN_FLOAT(get, null):Float;
+	@:pure private static inline function get_MIN_FLOAT():Float {
+		return code("Number.MIN_VALUE");
+	}
+
+	static var MAX_FLOAT(get, null):Float;
+	@:pure private static inline function get_MAX_FLOAT():Float {
+		return code("Number.MAX_VALUE");
+	}
+
 	static var NaN(get, null):Float;
 	@:pure private static inline function get_NaN():Float {
 		return code("NaN");

--- a/std/lua/_std/Math.hx
+++ b/std/lua/_std/Math.hx
@@ -38,6 +38,26 @@ class Math {
 	static inline function get_POSITIVE_INFINITY():Float
 		return lua.Math.huge;
 
+	public static var MIN_INT(get, null):Int;
+
+	static inline function get_MIN_INT():Int
+		return -2147483648;
+
+	public static var MAX_INT(get, null):Int;
+
+	static inline function get_MAX_INT():Int
+		return 2147483647;
+
+	public static var MIN_FLOAT(get, null):Float;
+
+	static inline function get_MIN_FLOAT():Float
+		return 2.2250738585072e-308;
+
+	public static var MAX_FLOAT(get, null):Float;
+
+	static inline function get_MAX_FLOAT():Float
+		return 1.79769313486232e+308;
+
 	public static var NaN(get, null):Float;
 
 	// Note: this has to be an untyped literal, otherwise the compiler tries

--- a/std/neko/_std/Math.hx
+++ b/std/neko/_std/Math.hx
@@ -56,6 +56,10 @@ private class MathImpl {
 		M.NaN = 0.0 / 0.0;
 		M.POSITIVE_INFINITY = 1.0 / 0.0;
 		M.NEGATIVE_INFINITY = -M.POSITIVE_INFINITY;
+		M.MIN_INT = -1073741824;
+		M.MAX_INT = 1073741823;
+		M.MIN_FLOAT = 2.2250738585072e-308;
+		M.MAX_FLOAT = 1.79769313486232e+308;
 		M.abs = Lib.load("std", "math_abs", 1);
 		M.sin = Lib.load("std", "math_sin", 1);
 		M.cos = Lib.load("std", "math_cos", 1);
@@ -83,6 +87,10 @@ extern final class Math {
 	public static var NaN(default, null):Float;
 	public static var POSITIVE_INFINITY(default, null):Float;
 	public static var NEGATIVE_INFINITY(default, null):Float;
+	public static var MIN_INT(default, null):Int;
+	public static var MAX_INT(default, null):Int;
+	public static var MIN_FLOAT(default, null):Float;
+	public static var MAX_FLOAT(default, null):Float;
 
 	public static function min(a:Float, b:Float):Float;
 	public static function max(a:Float, b:Float):Float;

--- a/std/php/_std/Math.hx
+++ b/std/php/_std/Math.hx
@@ -29,6 +29,10 @@ import php.Syntax;
 	public static var NaN(default, null):Float = Const.NAN;
 	public static var POSITIVE_INFINITY(default, null):Float = Const.INF;
 	public static var NEGATIVE_INFINITY(default, null):Float = -Const.INF;
+	public static var MIN_INT(default, null):Int = Const.PHP_INT_MIN;
+	public static var MAX_INT(default, null):Int = Const.PHP_INT_MAX;
+	public static var MIN_FLOAT(default, null):Float = 2.2250738585072e-308;
+	public static var MAX_FLOAT(default, null):Float = 1.79769313486232e+308;
 
 	public static inline function abs(v:Float):Float
 		return Global.abs(v);

--- a/std/python/_std/Math.hx
+++ b/std/python/_std/Math.hx
@@ -31,6 +31,14 @@ extern class Math {
 
 	static var POSITIVE_INFINITY(default, null):Float;
 
+	static var MIN_INT(default, null):Int;
+
+	static var MAX_INT(default, null):Int;
+
+	static var MIN_FLOAT(default, null):Float;
+
+	static var MAX_FLOAT(default, null):Float;
+
 	static var NaN(default, null):Float;
 
 	static inline function abs(v:Float):Float {
@@ -125,7 +133,16 @@ extern class Math {
 	static function __init__():Void {
 		NEGATIVE_INFINITY = UBuiltins.float('-inf');
 		POSITIVE_INFINITY = UBuiltins.float('inf');
+		MIN_INT = -2147483648;
+		MAX_INT = 2147483647;
+		MIN_FLOAT = PythonSysAdapter.float_info.min;
+		MAX_FLOAT = PythonSysAdapter.float_info.max;
 		NaN = UBuiltins.float("nan");
 		PI = python.lib.Math.pi;
 	}
+}
+
+@:pythonImport("sys")
+private extern class PythonSysAdapter {
+	static var float_info:{max:Float, min:Float};
 }

--- a/tests/unit/src/unitstd/Math.unit.hx
+++ b/tests/unit/src/unitstd/Math.unit.hx
@@ -443,3 +443,10 @@ math.atan2(0,1000) == 0;
 math.atan2(1,0) == Math.PI/2;
 math.atan2(-1,0) == -Math.PI/2;
 math.atan2(0,0) == 0;
+
+math.MIN_INT - math.MIN_INT == 0;
+math.MAX_INT - math.MAX_INT == 0;
+math.MIN_INT - (math.MIN_INT + 1) == 1;
+math.MAX_INT - (math.MAX_INT - 1) == 1;
+math.MIN_FLOAT - math.MIN_FLOAT == 0;
+math.MAX_FLOAT - math.MAX_FLOAT == 0;


### PR DESCRIPTION
PHP: version 7.2 has float runtime constants, can be added with fallback after.
Lua: 5.3 has `math.miniteger`/`maxinteger`. So, since 5.3 we can support `LUA_32BITS` mode or just return 32 bit ints/float limits by default.
Python: regular ints probably from `-2 ^ (24 * 8 - 1)` to `2 ^ (24 * 8 - 1) - 1` for zero and fatter for bigger numbers, so i just set 32 bit int limits. Maybe `sys.maxsize` can be used here, idk.
Related to #6054. Meh, my github account is just broken.