### PR TITLE
docs: add missing current system names

### DIFF
--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -92,9 +92,13 @@ extern class Sys {
 	/**
 		Returns the type of the current system. Possible values are:
 		 - `"Windows"`
-		 - `"Linux"`
 		 - `"BSD"`
 		 - `"Mac"`
+		 - `"iOS"`
+		 - `"tvOS"`
+		 - `"Android"`
+		 - `"GNU/kFreeBSD"`
+		 - `"Linux"`
 	**/
 	static function systemName():String;
 


### PR DESCRIPTION
https://github.com/HaxeFoundation/hashlink/blob/842da6cad05dacd90d3bab86bec0353e63375744/src/std/sys.c#L105-L126