### PR TITLE
Auto-init Int,Float,Bool fields with @:basicDefaults meta

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -849,6 +849,12 @@
 		"links": ["https://haxe.org/manual/cr-null-safety.html"]
 	},
 	{
+		"name": "BasicDefaults",
+		"metadata": ":basicDefaults",
+		"doc": "Automatically set default values for fields of Int, Float and Bool types.",
+		"targets": ["TClass", "TClassField"]
+	},
+	{
 		"name": "Objc",
 		"metadata": ":objc",
 		"doc": "Declares a class or interface that is used to interoperate with Objective-C code.",

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -770,7 +770,8 @@ let bind_var (ctx,cctx,fctx) cf e =
 			| TLazy { contents = LAvailable t } -> default_value t
 			| TType({ t_type = t },_) -> default_value t
 			| TAbstract({ a_path = [],"Null" },_) -> None
-			| TAbstract({ a_path = [],("Int"|"Float") },[]) -> Some ((EConst (Int "0")),cf.cf_pos)
+			| TAbstract({ a_path = [],("Int") },[]) -> Some ((EConst (Int "0")),cf.cf_pos)
+			| TAbstract({ a_path = [],("Float") },[]) -> Some ((EConst (Float "0.0")),cf.cf_pos)
 			| TAbstract({ a_path = [],"Bool" },[]) -> Some ((EConst (Ident "false")),cf.cf_pos)
 			| TAbstract(a,_) when not (Meta.has Meta.CoreType a.a_meta) -> default_value a.a_this
 			| _ -> None

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -427,6 +427,17 @@ class Compiler {
 	}
 
 	/**
+		Automatically set default values to the fields of `Int`, `Float` and `Bool` types in `path`.
+		`Int` and `Float` fields get `0` and `Bool` get `false`.
+
+		@param path A package, module or sub-type dot path to apply default values to.
+		@param recursive If true, recurses into sub-packages for package paths.
+	**/
+	public static function basicDefaults(path:String, recursive:Bool = true) {
+		addGlobalMetadata(path, '@:basicDefaults', recursive);
+	}
+
+	/**
 		Adds metadata `meta` to all types (if `toTypes = true`) or fields (if
 		`toFields = true`) whose dot-path matches `pathFilter`.
 

--- a/tests/unit/src/unit/TestBasicDefaults.hx
+++ b/tests/unit/src/unit/TestBasicDefaults.hx
@@ -1,0 +1,28 @@
+package unit;
+
+abstract W(Int) from Int to Int {}
+
+class TestBasicDefaults extends Test {
+
+	static var staticInt:Int;
+	static var staticFloat:Float;
+	static var staticBool:Bool;
+	static var staticAbstract:W;
+
+	var instanceInt:Int;
+	var instanceFloat:Float;
+	var instanceBool:Bool;
+	var instanceAbstract:W;
+
+	function test(){
+		eq(0, staticInt);
+		eq(0, staticFloat);
+		eq(false, staticBool);
+		eq(0, staticAbstract);
+
+		eq(0, instanceInt);
+		eq(0, instanceFloat);
+		eq(false, instanceBool);
+		eq(0, instanceAbstract);
+	}
+}

--- a/tests/unit/src/unit/TestBasicDefaults.hx
+++ b/tests/unit/src/unit/TestBasicDefaults.hx
@@ -1,18 +1,18 @@
 package unit;
 
-abstract W(Int) from Int to Int {}
+private abstract Abstr(Int) from Int to Int {}
 
 class TestBasicDefaults extends Test {
 
 	static var staticInt:Int;
 	static var staticFloat:Float;
 	static var staticBool:Bool;
-	static var staticAbstract:W;
+	static var staticAbstract:Abstr;
 
 	var instanceInt:Int;
 	var instanceFloat:Float;
 	var instanceBool:Bool;
-	var instanceAbstract:W;
+	var instanceAbstract:Abstr;
 
 	function test(){
 		eq(0, staticInt);


### PR DESCRIPTION
Closes #7002

```haxe
@:basicDefaults
class Main {
	static public var field:Int;

	static function main() {
		trace(field); // "0" on all targets
	}
}
```
Also possible with `--macro basicDefaults(path, recursive)`.