### PR TITLE
Allow no type hint for catch var.

### DIFF
--- a/src/context/display/syntaxExplorer.ml
+++ b/src/context/display/syntaxExplorer.ml
@@ -75,7 +75,7 @@ let find_in_syntax symbols (pack,decls) =
 		| ETry(e1,catches) ->
 			expr e1;
 			List.iter (fun (_,th,e,_) ->
-				type_hint th;
+				Option.may type_hint th;
 				expr e
 			) catches;
 		| ECheckType(e1,th) ->

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -212,7 +212,7 @@ and expr_def =
 	| EIf of expr * expr * expr option
 	| EWhile of expr * expr * while_flag
 	| ESwitch of expr * (expr list * expr option * expr option * pos) list * (expr option * pos) option
-	| ETry of expr * (placed_name * type_hint * expr * pos) list
+	| ETry of expr * (placed_name * type_hint option * expr * pos) list
 	| EReturn of expr option
 	| EBreak
 	| EContinue
@@ -692,7 +692,7 @@ let map_expr loop (e,p) =
 		ESwitch (e, cases, def)
 	| ETry (e,catches) ->
 		let e = loop e in
-		let catches = List.map (fun (n,t,e,p) -> n,type_hint t,loop e,p) catches in
+		let catches = List.map (fun (n,t,e,p) -> n,Option.map type_hint t,loop e,p) catches in
 		ETry (e,catches)
 	| EReturn e -> EReturn (opt loop e)
 	| EBreak -> EBreak
@@ -865,8 +865,9 @@ module Printer = struct
 		"case " ^ s_expr_list tabs el ", " ^
 		(match e1 with None -> ":" | Some e -> " if (" ^ s_expr_inner tabs e ^ "):") ^
 		(match e2 with None -> "" | Some e -> s_expr_omit_block tabs e)
-	and s_catch tabs ((n,_),(t,_),e,_) =
-		" catch(" ^ n ^ ":" ^ s_complex_type tabs t ^ ") " ^ s_expr_inner tabs e
+	and s_catch tabs ((n,_),t,e,_) =
+		let hint = Option.map_default (fun (t,_) -> ":" ^ s_complex_type tabs t) "" t in
+		" catch(" ^ n ^ hint ^ ") " ^ s_expr_inner tabs e
 	and s_block tabs el opn nl cls =
 		 opn ^ "\n\t" ^ tabs ^ (s_expr_list (tabs ^ "\t") el (";\n\t" ^ tabs)) ^ ";" ^ nl ^ tabs ^ cls
 	and s_expr_omit_block tabs e =

--- a/src/core/tOther.ml
+++ b/src/core/tOther.ml
@@ -139,7 +139,7 @@ module TExprToExpr = struct
 			let catches = List.map (fun (v,e) ->
 				let ct = try convert_type v.v_type,null_pos with Exit -> assert false in
 				let e = convert_expr e in
-				(v.v_name,v.v_pos),ct,e,(pos e)
+				(v.v_name,v.v_pos),(Some ct),e,(pos e)
 			) catches in
 			ETry (e1,catches)
 		| TReturn e -> EReturn (eopt e)

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -472,7 +472,7 @@ and encode_expr e =
 					encode_obj [
 						"name",encode_placed_name v;
 						"name_pos",encode_pos (pos v);
-						"type",encode_ctype t;
+						"type",null encode_ctype t;
 						"expr",loop e;
 						"pos",encode_pos p
 					]
@@ -791,7 +791,7 @@ and decode_expr v =
 			ESwitch (loop e,cases,opt (fun v -> (if field v "expr" = vnull then None else Some (decode_expr v)),Globals.null_pos) eo)
 		| 17, [e;catches] ->
 			let catches = List.map (fun c ->
-				((decode_placed_name (field c "name_pos") (field c "name")),(decode_ctype (field c "type")),loop (field c "expr"),maybe_decode_pos (field c "pos"))
+				((decode_placed_name (field c "name_pos") (field c "name")),(opt decode_ctype (field c "type")),loop (field c "expr"),maybe_decode_pos (field c "pos"))
 			) (decode_array catches) in
 			ETry (loop e, catches)
 		| 18, [e] ->

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -769,12 +769,12 @@ let optimize_completion_expr e args =
 			(ESwitch (e,cases,def),p)
 		| ETry (et,cl) ->
 			let et = loop et in
-			let cl = List.map (fun ((n,pn),(t,pt),e,p) ->
+			let cl = List.map (fun ((n,pn),th,e,p) ->
 				let old = save() in
-				decl n (Some t) None;
+				decl n (Option.map fst th) None;
 				let e = loop e in
 				old();
-				(n,pn), (t,pt), e, p
+				(n,pn), th, e, p
 			) cl in
 			(ETry (et,cl),p)
 		| ECall(e1,el) when DisplayPosition.display_position#enclosed_in p ->

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1474,6 +1474,9 @@ and parse_catch etry = parser
 	| [< '(Kwd Catch,p); '(POpen,_); name, pn = dollar_ident; s >] ->
 		match s with parser
 		| [< t,pt = parse_type_hint; '(PClose,_); e = secure_expr >] -> ((name,pn),(t,pt),e,punion p (pos e)),(pos e)
+		| [< '(PClose,_); e = secure_expr >] ->
+			let hint = (CTPath { tpackage = ["haxe"]; tname = "Exception"; tsub = None; tparams = [] },null_pos) in
+			((name,pn),hint,e,punion p (pos e)),(pos e)
 		| [< '(_,p) >] -> error Missing_type p
 
 and parse_catches etry catches pmax = parser

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1473,10 +1473,8 @@ and parse_switch_cases eswitch cases = parser
 and parse_catch etry = parser
 	| [< '(Kwd Catch,p); '(POpen,_); name, pn = dollar_ident; s >] ->
 		match s with parser
-		| [< t,pt = parse_type_hint; '(PClose,_); e = secure_expr >] -> ((name,pn),(t,pt),e,punion p (pos e)),(pos e)
-		| [< '(PClose,_); e = secure_expr >] ->
-			let hint = (CTPath { tpackage = ["haxe"]; tname = "Exception"; tsub = None; tparams = [] },null_pos) in
-			((name,pn),hint,e,punion p (pos e)),(pos e)
+		| [< t,pt = parse_type_hint; '(PClose,_); e = secure_expr >] -> ((name,pn),(Some (t,pt)),e,punion p (pos e)),(pos e)
+		| [< '(PClose,_); e = secure_expr >] -> ((name,pn),None,e,punion p (pos e)),(pos e)
 		| [< '(_,p) >] -> error Missing_type p
 
 and parse_catches etry catches pmax = parser

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -305,7 +305,7 @@ let reify in_macro =
 			expr "ESwitch" [loop e1;to_array scase cases p;to_opt (fun (e,_) -> to_opt to_expr e) def p]
 		| ETry (e1,catches) ->
 			let scatch ((n,_),t,e,_) p =
-				to_obj [("name",to_string n p);("type",to_ctype t p);("expr",loop e)] p
+				to_obj [("name",to_string n p);("type",to_opt to_ctype t p);("expr",loop e)] p
 			in
 			expr "ETry" [loop e1;to_array scatch catches p]
 		| EReturn eo ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1814,7 +1814,8 @@ and type_try ctx e1 catches with_type p =
 		| [] , name -> name)
 	in
 	let catches,el = List.fold_left (fun (acc1,acc2) ((v,pv),t,e_ast,pc) ->
-		let t = Typeload.load_complex_type ctx true t in
+		let th = Option.default (CTPath { tpackage = ["haxe"]; tname = "Exception"; tsub = None; tparams = [] },null_pos) t in
+		let t = Typeload.load_complex_type ctx true th in
 		let rec loop t = match follow t with
 			| TInst ({ cl_kind = KTypeParameter _} as c,_) when not (TypeloadCheck.is_generic_parameter ctx c) ->
 				error "Cannot catch non-generic type parameter" p

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -339,7 +339,7 @@ typedef Catch = {
 	/**
 		The type of the catch.
 	**/
-	var type:ComplexType;
+	var ?type:ComplexType;
 
 	/**
 		The expression of the catch.

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -250,7 +250,7 @@ class Printer {
 				tabs = old;
 				s + '\n$tabs}';
 			case ETry(e1, cl):
-				'try ${printExpr(e1)}' + cl.map(function(c) return ' catch(${c.name}:${printComplexType(c.type)}) ${printExpr(c.expr)}').join("");
+				'try ${printExpr(e1)}' + cl.map(function(c) return ' catch(${c.name}${c.type == null ? '' : (':' + printComplexType(c.type))}) ${printExpr(c.expr)}').join("");
 			case EReturn(eo): "return" + opt(eo, printExpr, " ");
 			case EBreak: "break";
 			case EContinue: "continue";

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -303,6 +303,14 @@ class TestExceptions extends Test {
 		return result;
 	}
 
+	function testCatch_noTypeHint() {
+		try {
+			({}:Dynamic)();
+		} catch(e) {
+			Assert.notNull(Std.downcast(e, Exception));
+		}
+	}
+
 #if java
 	function testCatchChain() {
 		eq("caught NativeExceptionChild: msg", raise(() -> throw new NativeExceptionChild("msg")));

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -4,6 +4,7 @@ import haxe.Exception;
 import haxe.ValueException;
 import haxe.CallStack;
 import utest.Assert;
+import unit.HelperMacros;
 
 private enum EnumError {
 	EError;
@@ -309,6 +310,9 @@ class TestExceptions extends Test {
 		} catch(e) {
 			Assert.notNull(Std.downcast(e, Exception));
 		}
+
+		HelperMacros.parseAndPrint('try { } catch(e) { }');
+		eq('haxe.Exception', HelperMacros.typeString(try throw new Exception('') catch(e) e));
 	}
 
 #if java

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -305,7 +305,7 @@ class TestExceptions extends Test {
 
 	function testCatch_noTypeHint() {
 		try {
-			({}:Dynamic)();
+			throw new Exception('Terrible error');
 		} catch(e) {
 			Assert.notNull(Std.downcast(e, Exception));
 		}


### PR DESCRIPTION
Allows to omit type hint for a catch var. 
Catch vars without type hint are automatically typed as `haxe.Exception`:
```haxe
try {
	(null)();
} catch(e) {
	$type(e); // Warning: haxe.Exception
	trace(e.message); // null is not a function
}
```
Plays nice with underscore:
```haxe
try {
  logSomething();
} catch(_) {
  //I don't care if logging fails
}
```