### PR TITLE
Refactor haxe.Resource

### DIFF
--- a/std/neko/_std/haxe/Resource.hx
+++ b/std/neko/_std/haxe/Resource.hx
@@ -22,56 +22,33 @@
 
 package haxe;
 
-/**
-	Resource can be used to access resources that were added through the
-	`--resource file@name` command line parameter.
-
-	Depending on their type they can be obtained as `String` through
-	`getString(name)`, or as binary data through `getBytes(name)`.
-
-	A list of all available resource names can be obtained from `listNames()`.
-**/
+@:coreApi
 class Resource {
-	static var content:Array<{name:String, data:String, str:String}> = untyped __resources__();
+	static var content:Array<{name:String, data:String, str:String}>;
 
-	/**
-		Lists all available resource names. The resource name is the name part
-		of the `--resource file@name` command line parameter.
-	**/
 	public static function listNames():Array<String> {
 		return [for (x in content) x.name];
 	}
 
-	/**
-		Retrieves the resource identified by `name` as a `String`.
-
-		If `name` does not match any resource name, `null` is returned.
-	**/
 	public static function getString(name:String):String {
 		for (x in content)
 			if (x.name == name) {
-				if (x.str != null)
-					return x.str;
-				var b:haxe.io.Bytes = haxe.crypto.Base64.decode(x.data);
-				return b.toString();
+				return new String(x.data);
 			}
 		return null;
 	}
 
-	/**
-		Retrieves the resource identified by `name` as an instance of
-		haxe.io.Bytes.
-
-		If `name` does not match any resource name, `null` is returned.
-	**/
 	public static function getBytes(name:String):haxe.io.Bytes {
 		for (x in content)
 			if (x.name == name) {
-				if (x.str != null)
-					return haxe.io.Bytes.ofString(x.str);
-				return haxe.crypto.Base64.decode(x.data);
+				return haxe.io.Bytes.ofData(cast x.data);
 			}
 		return null;
+	}
+
+	static function __init__() : Void {
+		var tmp = untyped __resources__();
+		content = untyped Array.new1(tmp, __dollar__asize(tmp));
 	}
 
 }


### PR DESCRIPTION
Here's a proposal for refactoring haxe.Resource.   FWIW I'm not trying to fix or address static initialization issues in general, I'm just trying to work around them for dealing with common haxe.Resource use cases.

The PR does a few things:

The static variable `haxe.Resource.content` is now set to `__resource__` when it is declared (rather than ini `__init__`).   This enables resources to be reliably used in other `__init__` blocks and contexts, since `__init__` happens after variable initialization.

Neko had a lot of target-specific behavior, so I refactored it out into its own library (and retained its specific `__init__` behavior for legacy purposes).



