### PR TITLE
Improve function type printing

### DIFF
--- a/tests/unit/src/unit/TestMacro.hx
+++ b/tests/unit/src/unit/TestMacro.hx
@@ -69,31 +69,27 @@ class TestMacro extends Test {
 		parseAndPrint('(a, b) -> c');
 		parseAndPrint('function(a) return b');
 		parseAndPrint('function named(a) return b');
+
+		var p = new haxe.macro.Printer();
 		// special handling of single arguments (don't add parentheses)
 		//	types
-		printComplexType(macro :X -> Y, "X -> Y");
-		printComplexType(macro :(X) -> Y, "(X) -> Y");
-		printComplexType(macro :((X)) -> Y, "((X)) -> Y");
-		printComplexType(macro :?X -> Y, "?X -> Y");
-		printComplexType(macro :(?X) -> Y, "(?X) -> Y");
+		eq(p.printComplexType(macro :X -> Y), "X -> Y");
+		eq(p.printComplexType(macro :(X) -> Y), "(X) -> Y");
+		eq(p.printComplexType(macro :((X)) -> Y), "((X)) -> Y");
+		eq(p.printComplexType(macro :?X -> Y), "?X -> Y");
+		eq(p.printComplexType(macro :(?X) -> Y), "(?X) -> Y");
 		//	named
-		printComplexType(
-			// see #9353
-			TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int),
+		eq(
+			// see issue #9353
+			p.printComplexType( TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int) ),
 			"(?a:Int) -> Int"
 		);
-		printComplexType(macro :(a:X) -> Y, "(a:X) -> Y");
-		printComplexType(macro :(?a:X) -> Y, "(?a:X) -> Y");
-		printComplexType(macro :((?a:X)) -> Y, "((?a:X)) -> Y");
+		eq(p.printComplexType(macro :(a:X) -> Y), "(a:X) -> Y");
+		eq(p.printComplexType(macro :(?a:X) -> Y), "(?a:X) -> Y");
+		eq(p.printComplexType(macro :((?a:X)) -> Y), "((?a:X)) -> Y");
 		// multiple arguments are always wrapped with parentheses
-		printComplexType(macro :(X, Y) -> Z, "(X, Y) -> Z");
-		printComplexType(macro :X -> Y -> Z, "(X, Y) -> Z");
-		printComplexType(macro :(X -> Y) -> Z, "(X -> Y) -> Z");
-	}
-
-	static function printComplexType(ct:ComplexType, expected: String) {
-		var p = new haxe.macro.Printer();
-		var printed = p.printComplexType(ct);
-		return eq(expected, printed);
+		eq(p.printComplexType(macro :(X, Y) -> Z), "(X, Y) -> Z");
+		eq(p.printComplexType(macro :X -> Y -> Z), "(X, Y) -> Z");
+		eq(p.printComplexType(macro :(X -> Y) -> Z), "(X -> Y) -> Z");
 	}
 }

--- a/tests/unit/src/unit/TestMacro.hx
+++ b/tests/unit/src/unit/TestMacro.hx
@@ -63,14 +63,37 @@ class TestMacro extends Test {
 		parseAndPrint("var a:() -> A");
 		parseAndPrint("var a:() -> (() -> A)");
 		parseAndPrint("var a:(x:(y:Y) -> Z) -> A");
-		// special case with 1 argument
-		parseAndPrint("var a:X -> Y");
-		parseAndPrint("var a:(X) -> Y");
 		// local functions
 		parseAndPrint('a -> b');
 		parseAndPrint('(a:Int) -> b');
 		parseAndPrint('(a, b) -> c');
 		parseAndPrint('function(a) return b');
 		parseAndPrint('function named(a) return b');
+		// special handling of single arguments (don't add parentheses)
+		//	types
+		printComplexType(macro :X -> Y, "X -> Y");
+		printComplexType(macro :(X) -> Y, "(X) -> Y");
+		printComplexType(macro :((X)) -> Y, "((X)) -> Y");
+		printComplexType(macro :?X -> Y, "?X -> Y");
+		printComplexType(macro :(?X) -> Y, "(?X) -> Y");
+		//	named
+		printComplexType(
+			// see #9353
+			TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int),
+			"(?a:Int) -> Int"
+		);
+		printComplexType(macro :(a:X) -> Y, "(a:X) -> Y");
+		printComplexType(macro :(?a:X) -> Y, "(?a:X) -> Y");
+		printComplexType(macro :((?a:X)) -> Y, "((?a:X)) -> Y");
+		// multiple arguments are always wrapped with parentheses
+		printComplexType(macro :(X, Y) -> Z, "(X, Y) -> Z");
+		printComplexType(macro :X -> Y -> Z, "(X, Y) -> Z");
+		printComplexType(macro :(X -> Y) -> Z, "(X -> Y) -> Z");
+	}
+
+	static function printComplexType(ct:ComplexType, expected: String) {
+		var p = new haxe.macro.Printer();
+		var printed = p.printComplexType(ct);
+		return eq(expected, printed);
 	}
 }


### PR DESCRIPTION
Fixes #9353 

Function type printing requires special cases when there's a single parameter;
`:(a:X) -> Y` is parsed as `TFunction([TParent(TNamed(...))], TPath(...))`, i.e `a:X` gets wrapped in `TParent()` so to avoid printing `:((a:X)) -> Y` we don't add parenthesis in this case

Another case where we don't want to add parentheses is when there's a single parameter that's a TPath(), so `X -> Y` print `X -> Y` not `(X) -> Y`, (this is just a stylistic choice)

Added a regression test to catch the case in #9353 where `(?a:X) -> Y` was printed as `?a:X -> Y`