### PR TITLE
Fix field access print order

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -153,7 +153,12 @@ class Printer {
 			case AExtern: "extern";
 		}
 
-	public function printField(field:Field)
+	public function printField(field:Field) {
+		inline function orderAccess(access: Array<Access>) {
+			// final should always be printed last
+			// (does not modify input array)
+			return access.has(AFinal) ? access.filter(a -> !a.match(AFinal)).concat([AFinal]) : access;
+		}
 		return (field.doc != null
 			&& field.doc != "" ? "/**\n"
 				+ tabs
@@ -164,12 +169,13 @@ class Printer {
 				+ "**/\n"
 				+ tabs : "")
 			+ (field.meta != null && field.meta.length > 0 ? field.meta.map(printMetadata).join('\n$tabs') + '\n$tabs' : "")
-			+ (field.access != null && field.access.length > 0 ? field.access.map(printAccess).join(" ") + " " : "")
+			+ (field.access != null && field.access.length > 0 ? orderAccess(field.access).map(printAccess).join(" ") + " " : "")
 			+ switch (field.kind) {
 				case FVar(t, eo): ((field.access != null && field.access.has(AFinal)) ? '' : 'var ') + '${field.name}' + opt(t, printComplexType, " : ") + opt(eo, printExpr, " = ");
 				case FProp(get, set, t, eo): 'var ${field.name}($get, $set)' + opt(t, printComplexType, " : ") + opt(eo, printExpr, " = ");
 				case FFun(func): 'function ${field.name}' + printFunction(func);
 			}
+	}
 
 	public function printTypeParamDecl(tpd:TypeParamDecl)
 		return tpd.name

--- a/tests/unit/src/unit/TestMacro.hx
+++ b/tests/unit/src/unit/TestMacro.hx
@@ -91,5 +91,16 @@ class TestMacro extends Test {
 		eq(p.printComplexType(macro :(X, Y) -> Z), "(X, Y) -> Z");
 		eq(p.printComplexType(macro :X -> Y -> Z), "(X, Y) -> Z");
 		eq(p.printComplexType(macro :(X -> Y) -> Z), "(X -> Y) -> Z");
+
+		// access order, see #9349
+		eq(
+			p.printField({
+				name: 'x',
+				pos: null,
+				kind: FVar(macro :Any, null),
+				access: [AFinal, AStatic]
+			}),
+			'static final x : Any'
+		);
 	}
 }

--- a/tests/unit/src/unit/TestMacro.hx
+++ b/tests/unit/src/unit/TestMacro.hx
@@ -69,31 +69,27 @@ class TestMacro extends Test {
 		parseAndPrint('(a, b) -> c');
 		parseAndPrint('function(a) return b');
 		parseAndPrint('function named(a) return b');
+
+		var p = new haxe.macro.Printer();
 		// special handling of single arguments (don't add parentheses)
 		//	types
-		printComplexType(macro :X -> Y, "X -> Y");
-		printComplexType(macro :(X) -> Y, "(X) -> Y");
-		printComplexType(macro :((X)) -> Y, "((X)) -> Y");
-		printComplexType(macro :?X -> Y, "?X -> Y");
-		printComplexType(macro :(?X) -> Y, "(?X) -> Y");
+		eq(p.printComplexType(macro :X -> Y), "X -> Y");
+		eq(p.printComplexType(macro :(X) -> Y), "(X) -> Y");
+		eq(p.printComplexType(macro :((X)) -> Y), "((X)) -> Y");
+		eq(p.printComplexType(macro :?X -> Y), "?X -> Y");
+		eq(p.printComplexType(macro :(?X) -> Y), "(?X) -> Y");
 		//	named
-		printComplexType(
-			// see #9353
-			TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int),
+		eq(
+			// see issue #9353
+			p.printComplexType( TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int) ),
 			"(?a:Int) -> Int"
 		);
-		printComplexType(macro :(a:X) -> Y, "(a:X) -> Y");
-		printComplexType(macro :(?a:X) -> Y, "(?a:X) -> Y");
-		printComplexType(macro :((?a:X)) -> Y, "((?a:X)) -> Y");
+		eq(p.printComplexType(macro :(a:X) -> Y), "(a:X) -> Y");
+		eq(p.printComplexType(macro :(?a:X) -> Y), "(?a:X) -> Y");
+		eq(p.printComplexType(macro :((?a:X)) -> Y), "((?a:X)) -> Y");
 		// multiple arguments are always wrapped with parentheses
-		printComplexType(macro :(X, Y) -> Z, "(X, Y) -> Z");
-		printComplexType(macro :X -> Y -> Z, "(X, Y) -> Z");
-		printComplexType(macro :(X -> Y) -> Z, "(X -> Y) -> Z");
-	}
-
-	static function printComplexType(ct:ComplexType, expected: String) {
-		var p = new haxe.macro.Printer();
-		var printed = p.printComplexType(ct);
-		return eq(expected, printed);
+		eq(p.printComplexType(macro :(X, Y) -> Z), "(X, Y) -> Z");
+		eq(p.printComplexType(macro :X -> Y -> Z), "(X, Y) -> Z");
+		eq(p.printComplexType(macro :(X -> Y) -> Z), "(X -> Y) -> Z");
 	}
 }

--- a/tests/unit/src/unit/TestMacro.hx
+++ b/tests/unit/src/unit/TestMacro.hx
@@ -63,14 +63,37 @@ class TestMacro extends Test {
 		parseAndPrint("var a:() -> A");
 		parseAndPrint("var a:() -> (() -> A)");
 		parseAndPrint("var a:(x:(y:Y) -> Z) -> A");
-		// special case with 1 argument
-		parseAndPrint("var a:X -> Y");
-		parseAndPrint("var a:(X) -> Y");
 		// local functions
 		parseAndPrint('a -> b');
 		parseAndPrint('(a:Int) -> b');
 		parseAndPrint('(a, b) -> c');
 		parseAndPrint('function(a) return b');
 		parseAndPrint('function named(a) return b');
+		// special handling of single arguments (don't add parentheses)
+		//	types
+		printComplexType(macro :X -> Y, "X -> Y");
+		printComplexType(macro :(X) -> Y, "(X) -> Y");
+		printComplexType(macro :((X)) -> Y, "((X)) -> Y");
+		printComplexType(macro :?X -> Y, "?X -> Y");
+		printComplexType(macro :(?X) -> Y, "(?X) -> Y");
+		//	named
+		printComplexType(
+			// see #9353
+			TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int),
+			"(?a:Int) -> Int"
+		);
+		printComplexType(macro :(a:X) -> Y, "(a:X) -> Y");
+		printComplexType(macro :(?a:X) -> Y, "(?a:X) -> Y");
+		printComplexType(macro :((?a:X)) -> Y, "((?a:X)) -> Y");
+		// multiple arguments are always wrapped with parentheses
+		printComplexType(macro :(X, Y) -> Z, "(X, Y) -> Z");
+		printComplexType(macro :X -> Y -> Z, "(X, Y) -> Z");
+		printComplexType(macro :(X -> Y) -> Z, "(X -> Y) -> Z");
+	}
+
+	static function printComplexType(ct:ComplexType, expected: String) {
+		var p = new haxe.macro.Printer();
+		var printed = p.printComplexType(ct);
+		return eq(expected, printed);
 	}
 }


### PR DESCRIPTION
Extends PR #9360 so merge that first

Fixes #9349

When printing fields in `haxe.macro.Printer`, always print `final` as the last modifier (independent of order of access array)

(Added regression test)