### PR TITLE
[js] Add support for @:js.async and @:js.generator metadata

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -619,6 +619,20 @@
 		"links": ["https://haxe.org/manual/target-javascript-require.html"]
 	},
 	{
+		"name": "JsAsync",
+		"metadata": ":js.async",
+		"doc": "Mark a method as a javascript async function, the js generator will prepend 'async' before the given function.",
+		"platforms": ["js"],
+		"targets": ["TClassField"]
+	},
+	{
+		"name": "JsGenerator",
+		"metadata": ":js.generator",
+		"doc": "Mark a method as a javascript generator function, the js codegen will prepend '*' before the given function.",
+		"platforms": ["js"],
+		"targets": ["TClassField"]
+	},
+	{
 		"name": "LuaRequire",
 		"metadata": ":luaRequire",
 		"doc": "Generate Lua module require expression for given extern.",

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1285,7 +1285,10 @@ let generate_class_es6 ctx c =
 	| _ -> ());
 
 	let method_def_name cf =
-		if valid_js_ident cf.cf_name then cf.cf_name else "\"" ^ cf.cf_name ^ "\""
+		let async = if Meta.has Meta.JsAsync cf.cf_meta then "async " else "" in
+		let generator = if Meta.has Meta.JsGenerator cf.cf_meta then "*" else "" in
+		let name = if valid_js_ident cf.cf_name then cf.cf_name else "\"" ^ cf.cf_name ^ "\"" in
+		async ^ generator ^ name
 	in
 
 	let nonmethod_fields =

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1099,7 +1099,9 @@ let gen_class_static_field ctx c cl_path f =
 			ctx.id_counter <- 0;
 			print ctx "%s = " path;
 			process_expose f.cf_meta (fun () -> (dot_path cl_path) ^ "." ^ f.cf_name) (fun s -> print ctx "$hx_exports%s = " (path_to_brackets s));
+			let clear_mapping = add_mapping ctx e in
 			gen_function ctx field_func e.epos ~keyword:(method_function_keyword f false);
+			clear_mapping ();
 			newline ctx;
 		| _ ->
 			ctx.statics <- (c,f,e) :: ctx.statics
@@ -1123,7 +1125,9 @@ let gen_class_field ctx c f =
 		ctx.id_counter <- 0;
 		(match e.eexpr with
 		| TFunction field_func ->
-			gen_function ctx field_func e.epos ~keyword:(method_function_keyword f false)
+			let clear_mapping = add_mapping ctx e in
+			gen_function ctx field_func e.epos ~keyword:(method_function_keyword f false);
+			clear_mapping ()
 		| _ ->
 			gen_value ctx e);
 		ctx.separator <- false


### PR DESCRIPTION
Adds the metadata `@:js.async` and `@:js.generator` which causes the js codegen to output `async` and `*` on the function definition of class methods.

This would enable the creation of macro libraries that add support for native js async and generator functions to Haxe.

`await` and `yield` can be output by using `js.Syntax("(await {0})", myPromise)` and a macro could fix the types of functions that have the `@js.async` and `@js.generator` metadata

I wanted to add support for `@:js.async` and `@:js.generator` on function expressions too but it doesn't seem like the metadata can reach the codegen phase. It is possible to generate async functions by using `js.Syntax("(async {0})", function() { })` but it's not possible to add the generator `*`.

### Example
```haxe
class Test {
    @:js.async function asyncMethod() {
    }

    @:js.generator function generatorMethod() {
    }

    @:js.async @:js.generator function asyncGeneratorMethod() {
    }

    @:js.async static function staticAsyncMethod() {
    }

    @:js.generator static function staticGeneratorMethod() {
    }

    @:js.async @:js.generator static function staticAsyncGeneratorMethod() {
    }
}
```

### ES6 output:
```js
class Test {
	async asyncMethod() {
	}
	*generatorMethod() {
	}
	async *asyncGeneratorMethod() {
	}
	static async staticAsyncMethod() {
	}
	static *staticGeneratorMethod() {
	}
	static async *staticAsyncGeneratorMethod() {
	}
}
```

### ES3 output:
```js
var Test = function() { };
Test.staticAsyncMethod = async function() {
};
Test.staticGeneratorMethod = function*() {
};
Test.staticAsyncGeneratorMethod = async function*() {
};
Test.prototype = {
	asyncMethod: async function() {
	}
	,generatorMethod: function*() {
	}
	,asyncGeneratorMethod: async function*() {
	}
};
```

