### PR TITLE
Prevent abstract casts handler for Std.string in inlined code

### DIFF
--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -506,6 +506,17 @@ class inline_state ctx ethis params cf f p = object(self)
 				with Not_found ->
 					e
 				end
+			(*
+				This case is a hack for https://github.com/HaxeFoundation/haxe/issues/9355
+				on top of a hack for https://github.com/HaxeFoundation/haxe/issues/2401
+			*)
+			| TCall({eexpr = TField(_,FStatic({cl_path=[],"Std"},{cf_name = "string"}))} as e1,[e2]) ->
+				let e2' = inline_params true false e2 in
+				let e2' =
+					if fast_eq e2.etype e2'.etype then e2'
+					else {e2' with etype = e2.etype}
+				in
+				{e with eexpr = TCall(e1,[e2'])}
 			| TCall(e1,el) ->
 				let e1 = inline_params true false e1 in
 				let el = List.map (inline_params false false) el in

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -513,8 +513,8 @@ class inline_state ctx ethis params cf f p = object(self)
 			| TCall({eexpr = TField(_,FStatic({cl_path=[],"Std"},{cf_name = "string"}))} as e1,[e2]) ->
 				let e2' = inline_params true false e2 in
 				let e2' =
-					if fast_eq e2.etype e2'.etype then e2'
-					else {e2' with etype = e2.etype}
+					if fast_eq (follow e2.etype) (follow e2'.etype) then e2'
+					else {e2 with eexpr = TCast (e2',None) }
 				in
 				{e with eexpr = TCall(e1,[e2'])}
 			| TCall(e1,el) ->

--- a/tests/unit/src/unit/issues/Issue9355.hx
+++ b/tests/unit/src/unit/issues/Issue9355.hx
@@ -1,0 +1,16 @@
+package unit.issues;
+
+class Issue9355 extends unit.Test {
+	function test() {
+		var o:Opacity = 0.5;
+		eq('0.5', writeFloat(o));
+	}
+
+	static inline function writeFloat(f:Float)
+		return Std.string(f);
+}
+
+private abstract Opacity(Float) from Float to Float {
+	@:to public function toString():String
+		return 'huh?';
+}


### PR DESCRIPTION
Fixes #9355 