### PR TITLE
Fix arrow function syntax printing edge-case

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -128,7 +128,11 @@ class Printer {
 					default: true;
 				}
 				var argStr = args.map(printComplexType).join(", ");
-				(wrapArgumentsInParentheses ? '($argStr)' : argStr) + " -> " + printComplexType(ret);
+				(wrapArgumentsInParentheses ? '($argStr)' : argStr) + " -> " + switch ret {
+					// wrap return type in parentheses if it's also a function
+					case TFunction(_): '(${printComplexType(ret)})';
+					default: printComplexType(ret);
+				}
 			case TAnonymous(fields): "{ " + [for (f in fields) printField(f) + "; "].join("") + "}";
 			case TParent(ct): "(" + printComplexType(ct) + ")";
 			case TOptional(ct): "?" + printComplexType(ct);

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -128,11 +128,11 @@ class Printer {
 					default: true;
 				}
 				var argStr = args.map(printComplexType).join(", ");
-				(wrapArgumentsInParentheses ? '($argStr)' : argStr) + " -> " + switch ret {
+				(wrapArgumentsInParentheses ? '($argStr)' : argStr) + " -> " + (switch ret {
 					// wrap return type in parentheses if it's also a function
 					case TFunction(_): '(${printComplexType(ret)})';
 					default: printComplexType(ret);
-				}
+				});
 			case TAnonymous(fields): "{ " + [for (f in fields) printField(f) + "; "].join("") + "}";
 			case TParent(ct): "(" + printComplexType(ct) + ")";
 			case TOptional(ct): "?" + printComplexType(ct);

--- a/tests/unit/src/unit/TestMacro.hx
+++ b/tests/unit/src/unit/TestMacro.hx
@@ -84,6 +84,12 @@ class TestMacro extends Test {
 			p.printComplexType( TFunction( [ TOptional( TNamed('a', macro :Int) ) ], macro :Int) ),
 			"(?a:Int) -> Int"
 		);
+		//	function returning function
+		eq(
+			// see issue #9385
+			p.printComplexType( TFunction( [], TFunction([], macro :Int)) ),
+			"() -> (() -> Int)"
+		);
 		eq(p.printComplexType(macro :(a:X) -> Y), "(a:X) -> Y");
 		eq(p.printComplexType(macro :(?a:X) -> Y), "(?a:X) -> Y");
 		eq(p.printComplexType(macro :((?a:X)) -> Y), "((?a:X)) -> Y");


### PR DESCRIPTION
Fixes #9385

When printing the following complex type `:() -> (() -> R)`, the syntax printer fails to wrap the returning function in parentheses which is a syntax error

Repro
```haxe
new Printer().printComplexType(TFunction( [], TFunction([], macro :Int)))
// prints () -> () -> Int
// instead of () -> (() -> Int)
```

This PR wraps the return type in parentheses if it is a `TFunction`

Added a regression test that fails before this PR