### PR TITLE
Update ocamldebug note in CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Please also bear the following in mind:
 
 ### Using a debugger
 
-To debug the Haxe compiler, you can use either a system debugger (`gdb`/`lldb`), or [ocamldebug](http://caml.inria.fr/pub/docs/manual-ocaml/debugger.html). `ocamldebug` provides a better debugging experience. To use it, compile with `make BYTECODE=1`.
+To debug the Haxe compiler, you can use either a system debugger (`gdb`/`lldb`), or [ocamldebug](http://caml.inria.fr/pub/docs/manual-ocaml/debugger.html). `ocamldebug` provides a better debugging experience. To use it, uncomment `(mode byte)` from [src/dune](src/dune) and recompile.
 
 ### Using printf
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Please also bear the following in mind:
 
 ### Using a debugger
 
-To debug the Haxe compiler, you can use either a system debugger (`gdb`/`lldb`), or [ocamldebug](http://caml.inria.fr/pub/docs/manual-ocaml/debugger.html). `ocamldebug` provides a better debugging experience. To use it, uncomment `(mode byte)` from [src/dune](src/dune) and recompile.
+To debug the Haxe compiler, you can use either a system debugger (`gdb`/`lldb`), or [ocamldebug](http://caml.inria.fr/pub/docs/manual-ocaml/debugger.html). `ocamldebug` provides a better debugging experience. To use it, uncomment `(modes byte)` from [src/dune](src/dune) and recompile.
 
 ### Using printf
 

--- a/src/dune
+++ b/src/dune
@@ -28,4 +28,6 @@
 	(libraries haxe)
 	(modules haxe)
 	(link_flags (:include ../lib.sexp))
+	; Uncomment to enable bytecode output for ocamldebug support
+	; (modes byte)
 )


### PR DESCRIPTION
I think `BYTECODE=1` no longer works after the switch to dune, I've updated the note