### PR TITLE
Keep inline arg type

### DIFF
--- a/tests/unit/src/unit/issues/Issue9355.hx
+++ b/tests/unit/src/unit/issues/Issue9355.hx
@@ -1,0 +1,16 @@
+package unit.issues;
+
+class Issue9355 extends unit.Test {
+	function test() {
+		var o:Opacity = 0.5;
+		eq('0.5', writeFloat(o));
+	}
+
+	static inline function writeFloat(f:Float)
+		return Std.string(f);
+}
+
+private abstract Opacity(Float) from Float to Float {
+	@:to public function toString():String
+		return 'huh?';
+} 


### PR DESCRIPTION
This is another attempt to fix #9355 
The idea here is to keep the type of an inlined argument if it differs from the type of an expression passed to that argument.

This approach gets dirty even  though it still does not support all the cases we test. 
E.g it breaks #3881, which certainly relies on the argument type being substituted with the type of an expression passed to the argument.
Another thing that needs a special case in this approach is `Int` vs `Float`. Which also defeats the idea.

I still think it's better and less intrusive to handle the special case of `Std.string` instead of going this way.
@Simn what do you think?