### PR TITLE
Allow `object."field"` syntax (see #7722)

### DIFF
--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -274,7 +274,7 @@ let inline_constructors ctx e =
 			end
 		| TNew({ cl_constructor = Some ({cf_kind = Method MethInline; cf_expr = Some _} as cf)} as c,_,pl),_ when is_extern_ctor c cf ->
 			error "Extern constructor could not be inlined" e.epos;
-		| TObjectDecl fl, _ when captured && fl <> [] && List.for_all (fun((s,_,_),_) -> Lexer.is_valid_identifier s) fl ->
+		| TObjectDecl fl, _ when captured && fl <> [] && List.for_all (fun((s,_,_),_) -> Lexer.is_valid_identifier s) fl -> (* TODO: check what we wanna do with is_valid_identifier here *)
 			let v = alloc_var VGenerated "inlobj" e.etype e.epos in
 			let ev = mk (TLocal v) v.v_type e.epos in
 			let el = List.map (fun ((s,_,_),e) ->

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -471,7 +471,7 @@ let inline_constructors ctx e =
 					begin try
 						let ev = mk (TLocal v) v.v_type e.epos in
 						let el = List.fold_left (fun acc ((s,_,_),e) ->
-							if not (Lexer.is_valid_identifier s) then raise Exit;
+							if not (Lexer.is_valid_identifier s) then raise Exit; (* TODO: check what we wanna do with is_valid_identifier here *)
 							let ef = mk (TField(ev,FDynamic s)) e.etype e.epos in
 							let e = mk (TBinop(OpAssign,ef,e)) e.etype e.epos in
 							e :: acc

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1478,6 +1478,7 @@ and parse_field e1 p s =
 		| [< '(Kwd New,p2) when p.pmax = p2.pmin; s >] -> expr_next (EField (e1,"new") , punion (pos e1) p2) s
 		| [< '(Kwd k,p2) when !parsing_macro_cond && p.pmax = p2.pmin; s >] -> expr_next (EField (e1,s_keyword k) , punion (pos e1) p2) s
 		| [< '(Const (Ident f),p2) when p.pmax = p2.pmin; s >] -> expr_next (EField (e1,f) , punion (pos e1) p2) s
+		| [< '(Const (String (f,_)),p2) when p.pmax = p2.pmin; s >] -> expr_next (EField (e1,f) , punion (pos e1) p2) s
 		| [< '(Dollar v,p2); s >] -> expr_next (EField (e1,"$"^v) , punion (pos e1) p2) s
 		| [< >] ->
 			(* turn an integer followed by a dot into a float *)

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2476,8 +2476,8 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 	| EField ((EConst (String(s,_)),ps),"code") ->
 		if UTF8.length s <> 1 then error "String must be a single UTF8 char" ps;
 		mk (TConst (TInt (Int32.of_int (UCharExt.code (UTF8.get s 0))))) ctx.t.tint p
-	| EField(_,n) when starts_with n '$' ->
-		error "Field names starting with $ are not allowed" p
+(* 	| EField(_,n) when starts_with n '$' -> TODO: this should be only allowed for quoted fields
+		error "Field names starting with $ are not allowed" p *)
 	| EConst (Ident s) ->
 		if s = "super" && with_type <> WithType.NoValue && not ctx.in_display then error "Cannot use super as value" p;
 		let e = maybe_type_against_enum ctx (fun () -> type_ident ctx s p mode) with_type false p in

--- a/tests/unit/src/unit/issues/Issue3547.hx
+++ b/tests/unit/src/unit/issues/Issue3547.hx
@@ -3,6 +3,7 @@ package unit.issues;
 private typedef Option = {
 	?foo: Int,
 	?bar: Int,
+	"x-bar": Int,
 }
 
 class Issue3547 extends Test {

--- a/tests/unit/src/unit/issues/Issue7722.hx
+++ b/tests/unit/src/unit/issues/Issue7722.hx
@@ -1,0 +1,30 @@
+package unit.issues;
+
+private typedef Schema = {
+	final "$ref":String;
+	var ?"enum":Int;
+	var "default":{"$id":Int, "class":String};
+}
+
+class Issue7722 extends unit.Test {
+	function test() {
+		var a:Schema = {
+			"$ref": "hi",
+			"enum": 42,
+			"default": {"$id": 10, "class": "bye"}
+		};
+		var b = {
+			"$ref": "hi",
+			"enum": 42,
+			"default": {"$id": 10, "class": "bye"}
+		};
+		eq("hi", a."$ref");
+		eq(42, a."enum");
+		eq(10, a."default"."$id");
+		eq("bye", a."default"."class");
+		eq("hi", b."$ref");
+		eq(42, b."enum");
+		eq(10, b."default"."$id");
+		eq("bye", b."default"."class");
+	}
+}

--- a/tests/unit/src/unit/issues/Issue7722.hx
+++ b/tests/unit/src/unit/issues/Issue7722.hx
@@ -4,6 +4,7 @@ private typedef Schema = {
 	final "$ref":String;
 	var ?"enum":Int;
 	var "default":{"$id":Int, "class":String};
+	var "aria-details":String;
 }
 
 class Issue7722 extends unit.Test {
@@ -11,20 +12,24 @@ class Issue7722 extends unit.Test {
 		var a:Schema = {
 			"$ref": "hi",
 			"enum": 42,
-			"default": {"$id": 10, "class": "bye"}
+			"default": {"$id": 10, "class": "bye"},
+			"aria-details": "yep",
 		};
 		var b = {
 			"$ref": "hi",
 			"enum": 42,
-			"default": {"$id": 10, "class": "bye"}
+			"default": {"$id": 10, "class": "bye"},
+			"aria-details": "yep",
 		};
 		eq("hi", a."$ref");
 		eq(42, a."enum");
 		eq(10, a."default"."$id");
 		eq("bye", a."default"."class");
+		eq("yep", a."aria-details");
 		eq("hi", b."$ref");
 		eq(42, b."enum");
 		eq(10, b."default"."$id");
 		eq("bye", b."default"."class");
+		eq("yep", b."aria-details");
 	}
 }


### PR DESCRIPTION
Implements #7722.

```
typedef Schema = {
	final "$ref":String;
	var ?"enum":Int;
	var "default":{"$id":Int, "class":String};
}

var a:Schema = {
	"$ref": "hi",
	"enum": 42,
	"default": {"$id": 10, "class": "bye"}
};
```

Unresolved:
- [ ] preserve quote status in EField? (also required for "field-starts-with-$" check, because o."$id" should be allowed)
- [ ] disable reification for `macro o."$id"` (also needs EField quote status), `macro {"$id": e}` and `macro : {"$id":Int}` (needs quote status too) (anything else?)
- [ ] special-character escaping for field and inlined locals (target-specific? some generic one could be provided), allow inlining object declarations with non-valid-identifier fields?
- [ ] do we really accept full range of string characters? (newlines? unicode?)
- [ ] allow such fields on classes? (technically might be needed for interop)

Tooling comments:
 - tmLanguage coloring breaks horribly
 - tokentree/formatter probably breaks?
 - vshaxe autocompletes unquoted fields (and thus invalid syntax)
 - vshaxe hover hints show unquoted fields
