### PR TITLE
proot-of-concept trace rework

### DIFF
--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -412,9 +412,6 @@ let collect ctx tk with_type sort =
 				Try; New; Throw; Untyped; Cast; Inline;
 			] in
 			List.iter (fun kwd -> add(make_ci_keyword kwd) (Some (s_keyword kwd))) kwds;
-
-			(* builtins *)
-			add (make_ci_literal "trace" (tpair (TFun(["value",false,t_dynamic],ctx.com.basic.tvoid)))) (Some "trace")
 		end
 	end;
 

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -81,6 +81,7 @@ type typer_globals = {
 	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	mutable module_check_policies : (string list * module_check_policy list * bool) list;
 	mutable global_using : (tclass * pos) list;
+	mutable global_statics : (string, (module_type * string * pos)) PMap.t;
 	(* Indicates that Typer.create() finished building this instance *)
 	mutable complete : bool;
 	mutable type_hints : (module_def_display * pos * t) list;

--- a/src/core/tOther.ml
+++ b/src/core/tOther.ml
@@ -80,10 +80,7 @@ module TExprToExpr = struct
 			if snd mp = snd p then p else (fst mp) @ [snd mp],snd p
 		in
 		let mk_path = expr_of_type_path in
-		let mk_ident = function
-			| "`trace" -> Ident "trace"
-			| n -> Ident n
-		in
+		let mk_ident n = Ident n in
 		let eopt = function None -> None | Some e -> Some (convert_expr e) in
 		((match e.eexpr with
 		| TConst c ->

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -545,7 +545,7 @@ and expr dce e =
 		List.iter (expr dce) args;
 
 	(* keep toString method when the class is argument to Std.string or haxe.Log.trace *)
-	| TCall ({eexpr = TField({eexpr = TTypeExpr (TClassDecl ({cl_path = (["haxe"],"Log")} as c))},FStatic (_,{cf_name="trace"}))} as ef, ((e2 :: el) as args))
+	| TCall ({eexpr = TField({eexpr = TTypeExpr (TClassDecl ({cl_path = (["haxe"],("Log" | "Trace"))} as c))},FStatic (_,{cf_name="trace"}))} as ef, ((e2 :: el) as args))
 	| TCall ({eexpr = TField({eexpr = TTypeExpr (TClassDecl ({cl_path = ([],"Std")} as c))},FStatic (_,{cf_name="string"}))} as ef, ((e2 :: el) as args)) ->
 		mark_class dce c;
 		to_string dce e2.etype;

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -328,8 +328,7 @@ let rec is_dead_end e =
 *)
 let is_trace expr =
 	match expr.eexpr with
-	| TIdent "`trace" -> true
-	| TField (_, FStatic ({ cl_path = (["haxe"], "Log") }, { cf_name = "trace" })) -> true
+	| TField (_, FStatic ({ cl_path = (["haxe"], ("Trace" | "Log")) }, { cf_name = "trace" })) -> true
 	| _ -> false
 
 (**

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -158,7 +158,7 @@ let display_dollar_type ctx p make_type =
 		raise_signatures [(convert_function_signature ctx PMap.empty (arg,mono),doc)] 0 0 SKCall
 	| DMHover ->
 		let t = TFun(arg,mono) in
-		raise_hover (make_ci_expr (mk (TIdent "trace") t p) (make_type t)) (Some (WithType.named_argument "expression")) p
+		raise_hover (make_ci_expr (mk (TIdent "$type") t p) (make_type t)) (Some (WithType.named_argument "expression")) p
 	| DMDefinition | DMTypeDefinition ->
 		raise_positions []
 	| _ ->
@@ -230,9 +230,6 @@ let rec handle_signature_display ctx e_ast with_type =
 				try
 					acc_get ctx (!type_call_target_ref ctx e1 with_type false (pos e1)) (pos e1)
 				with
-				| Error (Unknown_ident "trace",_) ->
-					let e = expr_of_type_path (["haxe";"Log"],"trace") p in
-					type_expr ctx e WithType.value
 				| Error (Unknown_ident "$type",p) ->
 					display_dollar_type ctx p (fun t -> t,(CompletionType.from_type (get_import_status ctx) t))
 			in
@@ -502,22 +499,6 @@ let handle_display ?resume_typing ctx e_ast dk with_type =
 	let e = match e_ast,with_type with
 	| (EConst (Ident "$type"),p),_ ->
 		display_dollar_type ctx p tpair
-	| (EConst (Ident "trace"),_),_ ->
-		let doc = doc_from_string "Print given arguments" in
-		let arg = ["value",false,t_dynamic] in
-		let ret = ctx.com.basic.tvoid in
-		let p = pos e_ast in
-		begin match ctx.com.display.dms_kind with
-		| DMSignature ->
-			raise_signatures [(convert_function_signature ctx PMap.empty (arg,ret),doc)] 0 0 SKCall
-		| DMHover ->
-			let t = TFun(arg,ret) in
-			raise_hover (make_ci_expr (mk (TIdent "trace") t p) (tpair t)) (Some (WithType.named_argument "value")) p
-		| DMDefinition | DMTypeDefinition ->
-			raise_positions []
-		| _ ->
-			error "Unsupported method" p
-		end
 	| (EConst (Ident "_"),p),WithType.WithType(t,_) ->
 		mk (TConst TNull) t p (* This is "probably" a bind skip, let's just use the expected type *)
 	| (_,p),_ -> try

--- a/std/haxe/Trace.hx
+++ b/std/haxe/Trace.hx
@@ -1,0 +1,15 @@
+package haxe;
+
+import haxe.extern.Rest;
+import haxe.Log;
+
+extern class Trace {
+	/**
+		Print given arguments
+	**/
+	#if !no_traces
+	static function trace(arg:Dynamic, rest:Rest<Dynamic>):Void;
+	#else
+	static inline function trace(arg:Dynamic, rest:Rest<Dynamic>):Void {}
+	#end
+}


### PR DESCRIPTION
*I've accidentally stumbled upon one of my old branches and found it interesting :)*

This is a proof-of-concept of how `trace` could be handled in a less hacky and more versatile way:

Instead of hard-coding `trace` and everything about it into the typer (and `` `trace`` as well), we provide a global static import from `haxe.Trace.trace`, where `haxe.Trace` is an extern class with the static `trace` method that takes `Rest` arguments.

Then, at the filters stage we rewrite calls to it into `haxe.Log.trace` calls so it behaves the same. But the cool part is that the user can provide their own `haxe.Trace` with their own implementation (could as well be a `macro` that generates something native or just a normal rest-arg method if/when we have #9274).

