### PR TITLE
add postfix ! operator for Null<T>

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1101,7 +1101,7 @@ and type_unop ctx op flag e p =
 		let make e =
 			let t = (match op with
 			| Not ->
-				if flag = Postfix then error "Postfix ! is not supported" p;
+				if flag = Postfix then error ("Postfix ! is not supported for " ^ (s_type (print_context()) e.etype)) p;
 				unify ctx e.etype ctx.t.tbool e.epos;
 				ctx.t.tbool
 			| NegBits ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1121,7 +1121,12 @@ and type_unop ctx op flag e p =
 			) in
 			mk (TUnop (op,flag,e)) t p
 		in
-		try (match follow e.etype with
+		let etype = follow_without_null e.etype in
+		match op, flag, etype with
+		| Not, Postfix, TAbstract ( { a_path = [],"Null" }, [ real_t ]) ->
+			{ e with etype = real_t; epos = p }
+		| _ -> 
+		try (match follow etype with
 			| TAbstract ({a_impl = Some c} as a,pl) ->
 				let rec loop opl = match opl with
 					| [] -> raise Not_found

--- a/std/StdTypes.hx
+++ b/std/StdTypes.hx
@@ -80,7 +80,17 @@
 **/
 @:forward
 @:coreType
-abstract Null<T> from T to T {}
+abstract Null<T> from T to T {
+	/**
+		Return this value typed as `T`.
+
+		This is useful in combination with Null Safety, in cases where the checker
+		is not able to determine that a value can not be null.
+
+		@see https://haxe.org/manual/cr-null-safety.html
+	**/
+	@:op(v!) function _():T; // implemented in the compiler
+}
 
 /**
 	The standard Boolean type, which can either be `true` or `false`.

--- a/tests/unit/src/unit/issues/Issue9476.hx
+++ b/tests/unit/src/unit/issues/Issue9476.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+import unit.HelperMacros.typeString;
+
+class Issue9476 extends unit.Test {
+	static var a:Null<Int> = 42;
+	@:nullSafety
+	function test() {
+		var b = a!;
+		eq("Int", typeString(b));
+		eq(42, b);
+	}
+}


### PR DESCRIPTION
This PR adds new semantics for the postfix `!` operator on `Null<T>` (currently is a compile error): re-type the expression as `T` (so lose `Null`).

This is useful together with `@:nullSafety`, because in a lot of cases it is not able to figure out that a value is non-null and give false positives. For example, the following will complain about `arg` being potentially `null`, while in reality that's not possible:

```haxe
@:nullSafety
function main() {
	var args = Sys.args();
	while (args.length > 0) {
		var arg = args.shift();
		trace(arg.toLowerCase());
	}
}
```

While theoretically this can/should be solved by method contracts, this is a whole new and huge topic for Haxe and I don't see it being implemented any time soon. And even with contracts in place, there probably can still be cases where they are not enough.

The only semi-correct solution to this example without this PR is to use `@:nullSafety(Off)` metadata together with an explicit type hint like this:

```haxe
@:nullSafety(Off) var arg:String = args.shift();
```

However this brings big syntatic overhead, and is actually not safe, because in the absence of specific var medata syntax, `@:nullSafety(Off)` will be applied to the whole `var` expression, which can miss actual null mistakes. And this problem is not specific to var declarations, the same applies to e.g. `f(args.shift())` (where `f` is `String->Void`).

With this PR, we can do `var arg = args.shift()!;`, and `arg` will be simply typed as `String`. Similarly with the `f` example we can do `f(args.shift()!)`.

---

PS We could also have a `-D` define that would insert a run-time null-check there, but I'm not sure if this is something we should do in the compiler rather than a build-macro. We can revisit this idea when we'll be talking about null-traversal operators (`?.` and friends) again.