### PR TITLE
make ParserEntry.parse/parse_string methods accept grammar entry

### DIFF
--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -283,6 +283,20 @@ let sharp_ident = [%sedlex.regexp?
 	)
 ]
 
+let is_whitespace = function
+	| ' ' | '\n' | '\r' | '\t' -> true
+	| _ -> false
+
+let string_is_whitespace s =
+	try
+		for i = 0 to String.length s - 1 do
+			if not (is_whitespace (String.unsafe_get s i)) then
+				raise Exit
+		done;
+		true
+	with Exit ->
+		false
+
 let idtype = [%sedlex.regexp? Star '_', 'A'..'Z', Star ('_' | 'a'..'z' | 'A'..'Z' | '0'..'9')]
 
 let integer = [%sedlex.regexp? ('1'..'9', Star ('0'..'9')) | '0']

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -204,7 +204,7 @@ class dead_block_collector conds = object(self)
 end
 
 (* parse main *)
-let parse ctx code file =
+let parse entry ctx code file =
 	let old = Lexer.save() in
 	let restore_cache = TokenCache.clear () in
 	let was_display = !in_display in
@@ -360,7 +360,7 @@ let parse ctx code file =
 		Some t
 	) in
 	try
-		let l = parse_file s in
+		let l = entry s in
 		(match !mstack with p :: _ -> syntax_error Unclosed_conditional ~pos:(Some p) sraw () | _ -> ());
 		let was_display_file = !in_display_file in
 		restore();
@@ -384,7 +384,7 @@ let parse ctx code file =
 			restore();
 			raise e
 
-let parse_string com s p error inlined =
+let parse_string entry com s p error inlined =
 	let old = Lexer.save() in
 	let old_file = (try Some (Hashtbl.find Lexer.all_files p.pfile) with Not_found -> None) in
 	let old_display = display_position#get in
@@ -409,7 +409,7 @@ let parse_string com s p error inlined =
 		in_display_file := false;
 	end;
 	let result = try
-		parse com (Sedlexing.Utf8.from_string s) p.pfile
+		parse entry com (Sedlexing.Utf8.from_string s) p.pfile
 	with Error (e,pe) ->
 		restore();
 		error (error_msg e) (if inlined then pe else p)
@@ -421,13 +421,16 @@ let parse_string com s p error inlined =
 	result
 
 let parse_expr_string com s p error inl =
-	let head = "class X{static function main() " in
-	let head = (if p.pmin > String.length head then head ^ String.make (p.pmin - String.length head) ' ' else head) in
-	let rec loop e = let e = Ast.map_expr loop e in (fst e,p) in
-	let extract_expr (_,decls) = match decls with
-		| [EClass { d_data = [{ cff_name = "main",null_pos; cff_kind = FFun { f_expr = Some e } }]},_] -> (if inl then e else loop e)
-		| _ -> raise Exit
-	in
-	match parse_string com (head ^ s ^ ";}") p error inl with
-	| ParseSuccess(data,is_display_file,pdi) -> ParseSuccess(extract_expr data,is_display_file,pdi)
-	| ParseError(data,error,errors) -> ParseError(extract_expr data,error,errors)
+	let s = if p.pmin > 0 then (String.make p.pmin ' ') ^ s else s in
+	let result = parse_string expr com s p error inl in
+	if inl then
+		result
+	else begin
+		let rec loop e =
+			let e = map_expr loop e in
+			(fst e,p)
+		in
+		match result with
+		| ParseSuccess(data,is_display_file,pdi) -> ParseSuccess(loop data,is_display_file,pdi)
+		| ParseError(data,error,errors) -> ParseError(loop data,error,errors)
+	end

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -126,14 +126,10 @@ let load_macro_ref : (typer -> bool -> path -> string -> pos -> (typer * ((strin
 let make_macro_api ctx p =
 	let parse_expr_string s p inl =
 		typing_timer ctx false (fun() ->
-			try
-				begin match ParserEntry.parse_expr_string ctx.com.defines s p error inl with
-					| ParseSuccess(data,true,_) when inl -> data (* ignore errors when inline-parsing in display file *)
-					| ParseSuccess(data,_,_) -> data
-					| ParseError _ -> raise MacroApi.Invalid_expr
-				end
-			with Exit ->
-				raise MacroApi.Invalid_expr)
+			match ParserEntry.parse_expr_string ctx.com.defines s p error inl with
+				| ParseSuccess(data,true,_) when inl -> data (* ignore errors when inline-parsing in display file *)
+				| ParseSuccess(data,_,_) -> data
+				| ParseError _ -> raise MacroApi.Invalid_expr)
 	in
 	let parse_metadata s p =
 		try

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -36,7 +36,7 @@ let parse_file_from_lexbuf com file p lexbuf =
 	Lexer.init file;
 	incr stats.s_files_parsed;
 	let parse_result = try
-		ParserEntry.parse com.defines lexbuf file
+		ParserEntry.parse Grammar.parse_file com.defines lexbuf file
 	with
 		| Sedlexing.MalFormed ->
 			t();

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1551,16 +1551,16 @@ and format_string ctx s p =
 		let slen = send - pos - 1 in
 		let scode = String.sub s (pos + 1) slen in
 		min := !min + 2;
-		if slen > 0 then begin
+		begin
 			let e =
 				let ep = { p with pmin = !pmin + pos + 2; pmax = !pmin + send + 1 } in
-				try
-					begin match ParserEntry.parse_expr_string ctx.com.defines scode ep error true with
-						| ParseSuccess(data,_,_) -> data
-						| ParseError(_,(msg,p),_) -> error (Parser.error_msg msg) p
-					end
-				with Exit ->
-					error "Invalid interpolated expression" ep
+				let error msg pos =
+					if Lexer.string_is_whitespace scode then error "Expression cannot be empty" ep
+					else error msg pos
+				in
+				match ParserEntry.parse_expr_string ctx.com.defines scode ep error true with
+					| ParseSuccess(data,_,_) -> data
+					| ParseError(_,(msg,p),_) -> error (Parser.error_msg msg) p
 			in
 			add_expr e slen
 		end;

--- a/tests/misc/projects/Issue6826/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue6826/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
-Main.hx:5: characters 20-21 : Invalid interpolated expression
+Main.hx:5: characters 20-21 : Expression cannot be empty
 Main.hx:5: characters 20-21 : For function argument 'v'

--- a/tests/unit/src/unit/issues/Issue3531.hx
+++ b/tests/unit/src/unit/issues/Issue3531.hx
@@ -1,7 +1,0 @@
-package unit.issues;
-
-class Issue3531 extends Test {
-	function test() {
-		eq("ab", 'a${}b');
-	}
-}


### PR DESCRIPTION
so we don't need to concat fake types to the thing we want to parse