### PR TITLE
[cpp] Fix class path for extern and nativeGen classes

### DIFF
--- a/tests/unit/src/unit/issues/Issue9498.hx
+++ b/tests/unit/src/unit/issues/Issue9498.hx
@@ -1,0 +1,24 @@
+package unit.issues;
+
+class Issue9498 extends unit.Test {
+  #if (cpp && !cppia)
+  function test() {
+    eq(1, Foo.foo());
+    eq(1, ExternFoo.foo());
+  }
+  #end
+}
+
+#if (cpp && !cppia)
+@:nativeGen private class Foo {
+  public static function foo() return 1;
+}
+
+@:native("::unit::issues::_Issue9498::Foo")
+@:include("unit/issues/_Issue9498/Foo.h")
+private extern class ExternFoo {
+  static function foo(): Int;
+}
+
+@:nativeGen @:keep private class Bar extends ExternFoo {}
+#end


### PR DESCRIPTION
My attempt to fix issues reported in #9431.

Added new helper method `is_native_class` which returns true for non-internal extern, nativeGen classes. For those classes do not add `_obj` suffix to get a class path. (If somebody has an extern haxe generated class and this should be supported we can add a check for `@:hxGen` in `is_native_class`.)

Also for super class check if it has `@:include` meta (for externs) to generate an include statement, same code as for interfaces.