### PR TITLE
Fix Utf8 "iter" issue

### DIFF
--- a/std/cpp/_std/haxe/Utf8.hx
+++ b/std/cpp/_std/haxe/Utf8.hx
@@ -57,7 +57,7 @@ class Utf8 {
 
 	public #if !cppia inline #end static function iter(s:String, chars:Int->Void):Void {
 		var src = s.c_str();
-		var end = src.add(s.length);
+		var end = src.add(untyped strlen(s));
 
 		while (src.lt(end))
 			chars(src.ptr.utf8DecodeAdvance());


### PR DESCRIPTION
Fix for issue https://github.com/HaxeFoundation/haxe/issues/8983
In haxe4 string length not the same as cpp strlen, compare to haxe3