### PR TITLE
[cpp] Support new and super for native classes

### DIFF
--- a/tests/unit/src/unit/issues/Issue9516.hx
+++ b/tests/unit/src/unit/issues/Issue9516.hx
@@ -1,0 +1,81 @@
+package unit.issues;
+#if (cpp && !cppia)
+import cpp.Pointer;
+import cpp.Reference;
+import cpp.Star;
+import cpp.Struct;
+
+class Issue9516 extends unit.Test {
+  function test() {
+    var justFoo = new Foo(1);
+    var structFoo: Struct<Foo> = new Foo(2);
+    var starFoo: Star<Foo> = new Foo(3);
+    var referenceFoo: Reference<Foo> = starFoo;
+
+    eq(1, justFoo.fun());
+    eq(2, structFoo.fun());
+    eq(3, starFoo.fun());
+    eq(3, referenceFoo.fun());
+
+    var justBar = new Bar(4);
+    var structBar: Struct<Bar> = new Bar(5);
+    var starBar: Star<Bar> = new Bar(6);
+    var referenceBar: Reference<Bar> = starBar;
+
+    eq(4, justBar.fun());
+    eq(5, structBar.fun());
+    eq(6, starBar.fun());
+    eq(6, referenceBar.fun());
+
+    var justBaz = new Baz(3, 4);
+    var structBaz: Struct<Baz> = new Baz(2, 6);
+    var starBaz: Star<Baz> = new Baz(5, 4);
+    var referenceBaz: Reference<Baz> = starBaz;
+
+    eq(7, justBaz.fun());
+    eq(8, structBaz.fun());
+    eq(9, starBaz.fun());
+    eq(9, referenceBaz.fun());
+
+    Pointer.fromStar(starFoo).destroy();
+    Pointer.fromStar(starBar).destroy();
+    Pointer.fromStar(starBaz).destroy();
+  }
+}
+
+@:nativeGen
+@:structAccess
+private class Foo {
+  var value:Int;
+
+  public function new(value: Int) {
+    this.value = value;
+  }
+
+  public function fun() return value;
+}
+
+@:native("::unit::issues::_Issue9516::Foo")
+@:include("unit/issues/_Issue9516/Foo.h")
+@:structAccess
+private extern class Bar {
+  function new(value: Int);
+  function fun(): Int;
+}
+
+@:nativeGen
+@:structAccess
+private class Baz extends Bar {
+  var delta:Int;
+
+  public function new(value: Int, delta: Int) {
+    this.delta = delta;
+    super(value);
+  }
+
+  public override function fun() return super.fun() + delta;
+}
+
+#else
+class Issue9516 extends unit.Test {}
+#end


### PR DESCRIPTION
This PR adds support for specifying a constructor as function new, constructing with operator new and calling a parent's constructor/method with super for native (extern or nativeGen) classes.

Notes:

This continues #9498, so i'll rebase if previous one is merged. Just opened for feedback for now.

In all examples below it is omitted that `import cpp.*` is used and that every native class has `@:structAccess` meta.

#### Function new

Right now to specify a constructor for extern class you need to write this:
```haxe
extern class Foo {
  @:native('new Foo')
  static function create(): Star<Foo>;
  // and/or
  @:native('Foo')
  static function make(): Struct<Foo>;
}
```

With this changes you will be able to write this instead:
```haxe
extern class Foo {
  function new();
}
```

For nativeGen classes that will require and allow to provide implementation.

#### Operator new

Because `function new` now specified haxe will allow to use `new` with native classes. Usage with previous extern `Foo`:
```haxe
class Main {
  public static function main() {
    var justFoo = new Foo();
    var structFoo: Struct<Foo> = new Foo();
    var starFoo: Star<Foo> = new Foo();
    var pointerFoo = Pointer.fromStar(new Foo());
  }
}
```

`justFoo` and `structFoo` are created on the stack without c++ `new` keyword, `starFoo` and `pointerFoo` - on the heap.

#### Super

For nativeGen classes there is added support for `super` keyword. Example:
```haxe
extern class Foo {
  function new(value: Int);
  function fun(): Void;
}

@:nativeGen class Bar extends Foo {
  public function new() {
    super(0);
  }
  public override function fun() {
    super.fun();
    trace('fun');
  }
}
```

#### Implementation notes

Added `CppNew` cpp expression which simply prepends "new " before wrapped expression. Call to new is wrapped in `CppNew` if expected result is `TCppStar`.

Constructor body searched for `super` call. In C++ parent's constructor call is not inside a constructor body, but inside an initialization list. So even though in haxe `super` call can be anywhere in C++ it will be called first and can't be passed variables defined in child constructor body. I wanted to enforce that `super` should be the first expression, but since macros can prepend expressions to constructor, decided not to do it.

As i know nothing about cppia i put abort placeholders for usage of `new` and `super` with native classes.

Bonus one line addition - conversion from `TCppStar` to `TCppReference` by dereference.