### PR TITLE
add haxe.NoData

### DIFF
--- a/std/haxe/NoData.hx
+++ b/std/haxe/NoData.hx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C)2005-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+package haxe;
+
+/**
+	Data type used to indicate the absence of a value instead of `Void` in
+	value-places in types with type parameters.
+**/
+enum abstract NoData(Null<Dynamic>) from Dynamic {
+	var NoData = null;
+}


### PR DESCRIPTION
This is an unit type extracted from #9111, serving the same purpose as e.g. `tink.core.Noise`: to be a dummy value in value-places created by type parameters (e.g. `Future<NoData>`, `Signal<NoData>` and such).

Sample usage:
```haxe
var signal = new Signal<NoData>();
signal.dispatch(NoData);
```

It's implemented as a single-variant enum abstract over Dynamic and is always just a `null` at run-time which is probably the most lightweight implementation.

I still think that normal `Void` could work the same way, but looks like that's not going to happen, so let's at least add this one, because it is needed very often and currently everyone has to implement their own thing.

Also I'm not sure if it should or should not be in `StdTypes`.