### PR TITLE
[cpp] Fix typing for abstracts

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -1749,7 +1749,7 @@ let rec cpp_type_of stack ctx haxe_type =
 
       | TAbstract (abs,pl) when not (Meta.has Meta.CoreType abs.a_meta) ->
          cpp_type_from_path stack ctx abs.a_path pl (fun () ->
-               cpp_type_of stack ctx (Abstract.get_underlying_type abs pl) )
+               cpp_type_of stack ctx (Abstract.get_underlying_type ~return_first:true abs pl) )
 
       | TAbstract (a,params) ->
          cpp_type_from_path stack ctx a.a_path params (fun () ->

--- a/tests/unit/src/unit/issues/Issue9542.hx
+++ b/tests/unit/src/unit/issues/Issue9542.hx
@@ -1,0 +1,18 @@
+package unit.issues;
+#if (cpp && !cppia)
+
+class Issue9542 extends unit.Test {
+  @:analyzer(no_optimize)
+  function test() {
+    var foo = 0;
+    var bar: Bar = foo;
+    foo += 1;
+    eq(bar, 1);
+  }
+}
+
+private abstract Bar(cpp.Reference<Int>) from cpp.Reference<Int> {}
+
+#else
+class Issue9542 extends unit.Test {}
+#end


### PR DESCRIPTION
When you use an abstract with an underlying type of typedef or an other abstract, typing skips resolving the underlying type itself jumping straight to resolving most concrete type instead.

Example why this problematic - if the underlying type is 
`Star<T>`, `Reference<T>` or `Struct<T>`, the runtime C++ type end up being just `T` not `T*`, `T&` or `cpp::Struct<T>`:

```haxe
@:structAccess
extern class Foo {
  @:native('new Foo')
  static function create(): cpp.Star<Foo>;
}

abstract Bar(cpp.Star<Foo>) from cpp.Star<Foo> {}

class Main5 {
  public static function main() {
    var bar: Bar = Foo.create();
  }
}
```

Cpp output:
```cpp
::Foo bar = (*((new Foo())));
```

Don't know how to properly check resulted C++ runtime type in a test.