### PR TITLE
[cpp] Add a way to define an extern class type parameter as templated one

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -2833,12 +2833,10 @@ let retype_expression ctx request_type function_args function_type expression_tr
             )
 
          | TNew (class_def,params,args) ->
-            let rec find_constructor c = (match c.cl_constructor, c.cl_super with
-            | (Some constructor), _  -> constructor.cf_type
-            | _ , Some (super,_)  -> find_constructor super
-            | _ -> abort "TNew without constructor " expr.epos
-            ) in
-            let constructor_type = find_constructor class_def in
+            let constructor_type = match OverloadResolution.maybe_resolve_constructor_overload class_def params args with
+               | None -> abort "Could not find overload" expr.epos
+               | Some (_,constructor,_) -> constructor.cf_type
+            in
             let arg_types, _ = cpp_function_type_of_args_ret ctx constructor_type in
             let retypedArgs = retype_function_args args arg_types in
             let created_type = cpp_type_of expr.etype in
@@ -7810,21 +7808,14 @@ class script_writer ctx filename asciiOut =
                      this#checkCast tvar.v_type init false false);
    | TNew (clazz,params,arg_list) ->
       this#write ((this#op IaNew) ^ (this#typeText (TInst(clazz,params))) ^ (string_of_int (List.length arg_list)) ^ "\n");
-      let rec matched_args clazz = match clazz.cl_constructor, clazz.cl_super with
-         | None, Some super -> matched_args (fst super)
-         | None, _ -> false
-         | Some ctr, _ ->
-            (match ctr.cf_type with
-            | TFun(args,_) ->
-               ( try (
-                  List.iter2 (fun (_,_,protoT) arg -> this#checkCast protoT arg false false)  args arg_list;
-                  true; )
-                 with Invalid_argument _ -> (*print_endline "Bad count?";*) false )
-            | _ -> false
-            )
-      in
-      if not (matched_args clazz) then
-         List.iter this#gen_expression arg_list;
+      (try
+         match OverloadResolution.maybe_resolve_constructor_overload clazz params arg_list with
+         | Some (_,{ cf_type = TFun(args,_) },_) ->
+            List.iter2 (fun (_,_,protoT) arg -> this#checkCast protoT arg false false) args arg_list;
+         | _ ->
+            raise (Invalid_argument "")
+      with Invalid_argument _ ->
+         List.iter this#gen_expression arg_list)
 
    | TReturn optval -> (match optval with
          | None -> this#writeOpLine IaReturn;

--- a/tests/unit/src/unit/issues/Issue9516.hx
+++ b/tests/unit/src/unit/issues/Issue9516.hx
@@ -1,0 +1,81 @@
+package unit.issues;
+#if (cpp && !cppia)
+import cpp.Pointer;
+import cpp.Reference;
+import cpp.Star;
+import cpp.Struct;
+
+class Issue9516 extends unit.Test {
+  function test() {
+    var justFoo = new Foo(1);
+    var structFoo: Struct<Foo> = new Foo(2);
+    var starFoo: Star<Foo> = new Foo(3);
+    var referenceFoo: Reference<Foo> = starFoo;
+
+    eq(1, justFoo.fun());
+    eq(2, structFoo.fun());
+    eq(3, starFoo.fun());
+    eq(3, referenceFoo.fun());
+
+    var justBar = new Bar(4);
+    var structBar: Struct<Bar> = new Bar(5);
+    var starBar: Star<Bar> = new Bar(6);
+    var referenceBar: Reference<Bar> = starBar;
+
+    eq(4, justBar.fun());
+    eq(5, structBar.fun());
+    eq(6, starBar.fun());
+    eq(6, referenceBar.fun());
+
+    var justBaz = new Baz(3, 4);
+    var structBaz: Struct<Baz> = new Baz(2, 6);
+    var starBaz: Star<Baz> = new Baz(5, 4);
+    var referenceBaz: Reference<Baz> = starBaz;
+
+    eq(7, justBaz.fun());
+    eq(8, structBaz.fun());
+    eq(9, starBaz.fun());
+    eq(9, referenceBaz.fun());
+
+    Pointer.fromStar(starFoo).destroy();
+    Pointer.fromStar(starBar).destroy();
+    Pointer.fromStar(starBaz).destroy();
+  }
+}
+
+@:nativeGen
+@:structAccess
+private class Foo {
+  var value:Int;
+
+  public function new(value: Int) {
+    this.value = value;
+  }
+
+  public function fun() return value;
+}
+
+@:native("::unit::issues::_Issue9516::Foo")
+@:include("unit/issues/_Issue9516/Foo.h")
+@:structAccess
+private extern class Bar {
+  function new(value: Int);
+  function fun(): Int;
+}
+
+@:nativeGen
+@:structAccess
+private class Baz extends Bar {
+  var delta:Int;
+
+  public function new(value: Int, delta: Int) {
+    this.delta = delta;
+    super(value);
+  }
+
+  public override function fun() return super.fun() + delta;
+}
+
+#else
+class Issue9516 extends unit.Test {}
+#end

--- a/tests/unit/src/unit/issues/Issue9545.hx
+++ b/tests/unit/src/unit/issues/Issue9545.hx
@@ -1,0 +1,52 @@
+package unit.issues;
+#if (cpp && !cppia)
+
+class Issue9545 extends unit.Test {
+  function test() {
+    var first = new Vector<Bool>();
+    first.push_back(true);
+    eq(first.empty(), false);
+
+    var second = new BoolVector();
+    second.push_back(true);
+    eq(second.empty(), false);
+
+    var third = new Vector<Bool>(second);
+    eq(third.empty(), false);
+
+    var fourth = new GenVector<Bool>();
+    fourth.push_back(true);
+    eq(fourth.empty(), false);
+  }
+}
+
+@:include('vector')
+@:native('std::vector')
+@:structAccess
+private extern class Vector<T> {
+  @:overload(function(other: cpp.Reference<Vector<T>>): Void {})
+  function new(): Void;
+
+  function push_back(value: T): Void;
+  function empty(): Bool;
+}
+
+@:nativeGen
+@:structAccess
+private class BoolVector extends Vector<Bool> {
+  public function new() {
+    super();
+  }
+}
+
+@:nativeGen
+@:structAccess
+private class GenVector<T> extends Vector<T> {
+  public function new() {
+    super();
+  }
+}
+
+#else
+class Issue9545 extends unit.Test {}
+#end

--- a/tests/unit/src/unit/issues/Issue9807.hx
+++ b/tests/unit/src/unit/issues/Issue9807.hx
@@ -1,0 +1,49 @@
+package unit.issues;
+#if (cpp && !cppia)
+
+class Issue9807 extends unit.Test {
+  function test() {
+    var first = new BoolVector();
+    first.push_back(true);
+
+    var second = new BoolVector(first);
+    eq(second.empty(), false);
+
+    var third = new BoolVectorChild0();
+    third.push_back(true);
+
+    var fourth = new BoolVectorChild1(third);
+    eq(fourth.empty(), false);
+  }
+}
+
+@:include('vector')
+@:native('std::vector<bool>')
+@:structAccess
+private extern class BoolVector {
+  @:overload(function(other: cpp.Reference<BoolVector>): Void {})
+  function new(): Void;
+
+  function push_back(bool: Bool): Void;
+  function empty(): Bool;
+}
+
+@:nativeGen
+@:structAccess
+private class BoolVectorChild0 extends BoolVector {
+  public function new() {
+    super();
+  }
+}
+
+@:nativeGen
+@:structAccess
+private class BoolVectorChild1 extends BoolVector {
+  public function new(other: cpp.Reference<BoolVector>) {
+    super(other);
+  }
+}
+
+#else
+class Issue9807 extends unit.Test {}
+#end


### PR DESCRIPTION
Fixes #5824.

To make parameters appear in C++ type each should be marked with `@:extern` meta, so not to make a breaking change and still allow virtual ones.

Decided to reuse `@:extern` meta and not to introduce new one, since it is easier, shorter and more universal.

The same code changes can apply to interfaces, but have not touched them yet, so did it only for classes.

Will rebase after previous PR get merged.