### PR TITLE
[jvm] support the new JVM constant pool tags

### DIFF
--- a/libs/javalib/jData.ml
+++ b/libs/javalib/jData.ml
@@ -89,7 +89,10 @@ type jconstant =
   (** invokeDynamic-specific *)
   | ConstMethodHandle of (reference_type * jconstant) (* tag = 15 *)
   | ConstMethodType of jmethod_signature (* tag = 16 *)
+  | ConstDynamic of (bootstrap_method * unqualified_name * jsignature) (* tag = 17 *)
   | ConstInvokeDynamic of (bootstrap_method * unqualified_name * jsignature) (* tag = 18 *)
+  | ConstModule of unqualified_name (* tag = 19 *)
+  | ConstPackage of unqualified_name (* tag = 20 *)
   | ConstUnusable
 
 type jaccess_flag =
@@ -110,6 +113,7 @@ type jaccess_flag =
   | JInterface (* 0x0200 *)
   | JAbstract (* 0x0400 *)
   | JAnnotation (* 0x2000 *)
+  | JModule (* 0x8000 *)
   (** method flags *)
   | JBridge (* 0x0040 *)
   | JVarArgs (* 0x0080 *)
@@ -204,7 +208,10 @@ type jconstant_raw =
   | KUtf8String of string (* 1 *)
   | KMethodHandle of (reference_type * dynref) (* 15 *)
   | KMethodType of utf8ref (* 16 *)
+  | KDynamic of (bootstrapref * nametyperef) (* 17 *)
   | KInvokeDynamic of (bootstrapref * nametyperef) (* 18 *)
+  | KModule of utf8ref (* 19 *)
+  | KPackage of utf8ref (* 20 *)
   | KUnusable
 
 (* jData debugging *)

--- a/libs/javalib/jWriter.ml
+++ b/libs/javalib/jWriter.ml
@@ -197,10 +197,20 @@ let rec const ctx c =
     | ConstMethodType jmethod_signature (* tag = 16 *) ->
         write_byte ctx.cpool 16;
         write_ui16 ctx.cpool (const ctx (ConstUtf8 (encode_sig ctx (TMethod jmethod_signature))))
+    | ConstDynamic (bootstrap_method, unqualified_name, jsignature) (* tag = 17 *) ->
+        write_byte ctx.cpool 17;
+        write_ui16 ctx.cpool bootstrap_method;
+        write_ui16 ctx.cpool (const ctx (ConstNameAndType(unqualified_name, jsignature)))
     | ConstInvokeDynamic (bootstrap_method, unqualified_name, jsignature) (* tag = 18 *) ->
         write_byte ctx.cpool 18;
         write_ui16 ctx.cpool bootstrap_method;
         write_ui16 ctx.cpool (const ctx (ConstNameAndType(unqualified_name, jsignature)))
+    | ConstModule unqualified_name (* tag = 19 *) ->
+        write_byte ctx.cpool 19;
+        write_ui16 ctx.cpool (const ctx (ConstUtf8 (unqualified_name)));
+    | ConstPackage unqualified_name (* tag = 20 *) ->
+        write_byte ctx.cpool 20;
+        write_ui16 ctx.cpool (const ctx (ConstUtf8 (unqualified_name)));
     | ConstUnusable -> assert false);
     ctx.ccount <- ret + 1;
     ret


### PR DESCRIPTION
Not sure this is entirely correct, but it makes the "invalid constant" errors you get when you include a .jar using some of these go away (the one I was running into was `19` / `KModule`).

https://docs.oracle.com/javase/specs/jvms/se12/html/jvms-4.html#jvms-4.4