### PR TITLE
fix single pattern match for abstracted enum

### DIFF
--- a/src/core/abstract.ml
+++ b/src/core/abstract.ml
@@ -111,3 +111,9 @@ let rec follow_with_abstracts_without_null t = match follow_without_null t with
 		follow_with_abstracts_without_null (get_underlying_type a tl)
 	| t ->
 		t
+
+let rec follow_with_abstracts_forward t = match follow t with
+	| TAbstract(a,tl) when (Meta.has Meta.Forward a.a_meta) && not (Meta.has Meta.CoreType a.a_meta) ->
+		follow_with_abstracts_forward (get_underlying_type ~return_first:true a tl)
+	| t ->
+		t

--- a/tests/unit/src/unit/issues/Issue9577.hx
+++ b/tests/unit/src/unit/issues/Issue9577.hx
@@ -1,0 +1,20 @@
+package unit.issues;
+
+import haxe.ds.Option;
+
+class Issue9577 extends Test {
+  function test() {
+    var foo: Foo = Some(9577);
+    var bar: Bar = Some(9577);
+    eq(true, foo.match(Some(9577)));
+    eq(9578, bar.match(9577));
+  }
+}
+
+@:forward private abstract Foo(Option<Int>) from Option<Int> {}
+
+@:forward private abstract Bar(Option<Int>) from Option<Int> {
+  public function match(value: Int) {
+    return value + 1;
+  }
+}


### PR DESCRIPTION
Fixes #9577.

If a forwarded underlying type of an abstract is an enum and said abstract does not respond to instance method `match` then allow usage of single pattern check with it.