### PR TITLE
Add method inlining to inline constructors filter

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -574,6 +574,12 @@
 		"internal": true
 	},
 	{
+		"name": "InlineObject",
+		"metadata": ":inlineObject",
+		"doc": "Internally used by inline constructors filter to mark potentially inlineable objects.",
+		"internal": true
+	},
+	{
 		"name": "Internal",
 		"metadata": ":internal",
 		"doc": "Generates the annotated field/class with 'internal' access.",

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -380,6 +380,8 @@ let inline_constructors ctx e =
 		| _ ->
 			handle_default_case e
 	in
+	let original_e = e in
+	let e = mark_ctors e in
 	ignore(analyze_aliases [] false false (mark_ctors e));
 	let rec get_iv_var_decls (iv:inline_var) : texpr list =
 		match iv with
@@ -508,7 +510,7 @@ let inline_constructors ctx e =
 	in
 	if IntMap.for_all (fun _ io -> io.io_cancelled) !inline_objs then begin
 		IntMap.iter (fun _ iv -> let v = iv.iv_var in if v.v_id < 0 then v.v_id <- -v.v_id ) !vars;
-		e
+		original_e
 	end else begin
 		let el,_ = final_map e in
 		let cf = ctx.curfield in

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -32,8 +32,8 @@ let basDebugPrint2 ctx printer =
 let basDebugPrint title ctx e =
 	let printer () = 
 		print_endline title;
-		let se t = s_expr_ast true "\t" (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
-		print_endline (se "\t" e);
+		(*let se t = s_expr_ast true "\t" (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
+		print_endline (se "\t" e);*)
 		let se t = s_expr_pretty true "\t" true (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
 		print_endline (se "\t" e)
 	in basDebugPrint2 ctx printer
@@ -283,7 +283,6 @@ let inline_constructors ctx e =
 			| TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl),_
 			(*| TMeta((Meta.Inline,_,_),{eexpr = TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl)}),_*)
 				when captured && not (List.memq cf seen_ctors) ->
-				basDebugPrint2 ctx (fun _ -> print_endline "TNew inline object case");
 				begin
 					let rec loop (vs, es) el = match el with
 						| e :: el ->
@@ -372,11 +371,6 @@ let inline_constructors ctx e =
 			handle_inline_object_case io_id true e
 		| TMeta((Meta.Custom "inline_object", [(EConst(Int (id_str)), _)], _), e) ->
 			let io_id = int_of_string id_str in
-			basDebugPrint2 ctx (fun _ ->
-				print_endline "inline object case";
-				print_endline (string_of_int io_id);
-				basDebugPrint "ioc" ctx e
-			);
 			handle_inline_object_case io_id false e
 		| TVar(v,None) -> ignore(add v IVKLocal); None
 		| TVar(v,Some rve) ->
@@ -452,7 +446,6 @@ let inline_constructors ctx e =
 	in
 	let original_e = e in
 	let e = mark_ctors e in
-	basDebugPrint "marked" ctx e;
 	ignore(analyze_aliases [] false false e);
 	let rec get_iv_var_decls (iv:inline_var) : texpr list =
 		match iv with

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -24,20 +24,6 @@ open Typecore
 open Error
 open Globals
 
-let basDebugPrint2 ctx printer =
-	if Meta.has (Meta.Custom ":basdebug") ctx.curfield.cf_meta then begin
-		printer()
-	end
-
-let basDebugPrint title ctx e =
-	let printer () = 
-		print_endline title;
-		let se t = s_expr_ast true "\t" (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
-		print_endline (se "\t" e);
-		let se t = s_expr_pretty true "\t" true (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
-		print_endline (se "\t" e)
-	in basDebugPrint2 ctx printer
-
 (* INLINE CONSTRUCTORS *)
 
 (*
@@ -284,7 +270,6 @@ let inline_constructors ctx e =
 			match e.eexpr, e.etype with
 			| TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl),_
 				when captured && not (List.memq cf seen_ctors) ->
-				basDebugPrint2 ctx (fun _ -> print_endline "TNew inline object case");
 				begin
 					let rec loop (vs, es) el = match el with
 						| e :: el ->
@@ -374,11 +359,6 @@ let inline_constructors ctx e =
 			handle_inline_object_case io_id true e
 		| TMeta((Meta.Custom "inline_object", [(EConst(Int (id_str)), _)], _), e) ->
 			let io_id = int_of_string id_str in
-			basDebugPrint2 ctx (fun _ ->
-				print_endline "inline object case";
-				print_endline (string_of_int io_id);
-				basDebugPrint "ioc" ctx e
-			);
 			handle_inline_object_case io_id false e
 		| TVar(v,None) -> ignore(add v IVKLocal); None
 		| TVar(v,Some rve) ->
@@ -475,7 +455,6 @@ let inline_constructors ctx e =
 	in
 	let original_e = e in
 	let e = mark_ctors e in
-	basDebugPrint "marked" ctx e;
 	ignore(analyze_aliases [] false false e);
 	let rec get_iv_var_decls (iv:inline_var) : texpr list =
 		match iv with
@@ -653,6 +632,5 @@ let inline_constructors ctx e =
 				v.v_name <- get_pretty_name iv
 			end
 		) !vars;
-		basDebugPrint "inlined" ctx e;
 		e
 	end

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -283,7 +283,6 @@ let inline_constructors ctx e =
 		let handle_inline_object_case (io_id:int) (force_inline:bool) (e:texpr) =
 			match e.eexpr, e.etype with
 			| TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl),_
-			(*| TMeta((Meta.Inline,_,_),{eexpr = TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl)}),_*)
 				when captured && not (List.memq cf seen_ctors) ->
 				basDebugPrint2 ctx (fun _ -> print_endline "TNew inline object case");
 				begin

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -452,7 +452,12 @@ let inline_constructors ctx e =
 				| Some e ->
 					let e = mark_ctors e in
 					io.io_inline_methods <- io.io_inline_methods @ [e];
-					analyze_aliases false e (* TODO: Forward the value of captured and make cancelling the parent io cancel the resulting inline variable *)
+					begin match analyze_aliases captured e with
+						| Some(iv) ->
+							io.io_dependent_vars <- iv.iv_var :: io.io_dependent_vars;
+							Some(iv)
+						| None -> None
+					end
 				| None ->
 					cancel_io io e.epos;
 					None

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -24,6 +24,20 @@ open Typecore
 open Error
 open Globals
 
+let basDebugPrint2 ctx printer =
+	if Meta.has (Meta.Custom ":basdebug") ctx.curfield.cf_meta then begin
+		printer()
+	end
+
+let basDebugPrint title ctx e =
+	let printer () = 
+		print_endline title;
+		let se t = s_expr_ast true "\t" (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
+		print_endline (se "\t" e);
+		let se t = s_expr_pretty true "\t" true (s_type (print_context())) in (*s_expr_pretty true t true (s_type (print_context())) in*)
+		print_endline (se "\t" e)
+	in basDebugPrint2 ctx printer
+
 (* INLINE CONSTRUCTORS *)
 
 (*
@@ -238,6 +252,7 @@ let inline_constructors ctx e =
 			| TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl),_
 			(*| TMeta((Meta.Inline,_,_),{eexpr = TNew({ cl_constructor = Some ({cf_expr = Some ({eexpr = TFunction tf})} as cf)} as c,tl,pl)}),_*)
 				when captured && not (List.memq cf seen_ctors) ->
+				basDebugPrint2 ctx (fun _ -> print_endline "TNew inline object case");
 				begin
 					let rec loop (vs, es) el = match el with
 						| e :: el ->
@@ -326,6 +341,11 @@ let inline_constructors ctx e =
 			handle_inline_object_case io_id true e
 		| TMeta((Meta.Custom "inline_object", [(EConst(Int (id_str)), _)], _), e) ->
 			let io_id = int_of_string id_str in
+			basDebugPrint2 ctx (fun _ ->
+				print_endline "inline object case";
+				print_endline (string_of_int io_id);
+				basDebugPrint "ioc" ctx e
+			);
 			handle_inline_object_case io_id false e
 		| TVar(v,None) -> ignore(add v IVKLocal); None
 		| TVar(v,Some rve) ->
@@ -378,6 +398,7 @@ let inline_constructors ctx e =
 	in
 	let original_e = e in
 	let e = mark_ctors e in
+	basDebugPrint "marked" ctx e;
 	ignore(analyze_aliases [] false false e);
 	let rec get_iv_var_decls (iv:inline_var) : texpr list =
 		match iv with

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -292,7 +292,8 @@ let inline_constructors ctx original_e =
 				begin match get_io_inline_method io fname with
 				| Some(c, tl, cf, tf)->
 					let method_type = apply_params c.cl_params tl cf.cf_type in
-					if type_iseq_strict method_type efield.etype then
+					let field_is_function = match efield.etype with | TFun _  -> true	| _ -> false in
+					if field_is_function && Type.does_unify method_type efield.etype then
 						IOFInlineMethod(io,iv,c,tl,cf,tf)
 					else begin
 						cancel_iv iv efield.epos;

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -225,10 +225,10 @@ let inline_constructors ctx e =
 			when captured && not (List.memq cf seen_ctors) ->
 			begin
 				let io_id = !current_io_id in
-				let rec loop (vs, decls, es) el = match el with
+				let rec loop (vs, es) el = match el with
 					| e :: el ->
 						begin match e.eexpr with
-						| TConst _ -> loop (vs, decls, e::es) el
+						| TConst _ -> loop (vs, e::es) el
 						| _ ->
 							let v = alloc_var VGenerated "arg" e.etype e.epos in
 							let decle = mk (TVar(v, Some e)) ctx.t.tvoid e.epos in
@@ -236,11 +236,11 @@ let inline_constructors ctx e =
 							ignore(analyze_aliases true decle);
 							let mde = (Meta.InlineConstructorArgument (v.v_id, io_id_start)), [], e.epos in
 							let e = mk (TMeta(mde, e)) e.etype e.epos in
-							loop (v::vs, decle::decls, e::es) el
+							loop (v::vs, e::es) el
 						end
-					| [] -> vs, (List.rev decls), (List.rev es)
+					| [] -> vs, (List.rev es)
 				in
-				let argvs, argvdecls, pl = loop ([],[],[]) pl in
+				let argvs, pl = loop ([],[]) pl in
 				let _, cname = c.cl_path in
 				let v = alloc_var VGenerated ("inl"^cname) e.etype e.epos in
 				match Inline.type_inline_ctor ctx c cf tf (mk (TLocal v) (TInst (c,tl)) e.epos) pl e.epos with

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -199,7 +199,7 @@ let inline_constructors ctx e =
 		Finds all instances of inline objects in an expression and wraps them with metadata @:inline_object(id).
 		The id is incremented each time and is used later in the final_map phase to identify the correct inline object.
 	*)
-	let rec mark_ctors ?(force_inline=false) e =
+	let rec mark_ctors ?(force_inline=false) e : texpr =
 		let is_meta_inline = match e.eexpr with (TMeta((Meta.Inline,_,_),e)) -> true | _ -> false in
 		let e = Type.map_expr (mark_ctors ~force_inline:is_meta_inline) e in
 		match e.eexpr, force_inline with

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -64,7 +64,7 @@ let basDebugPrint title ctx e =
 *)
 
 type inline_object_kind =
-	| IOKCtor of tclass * Type.tparams * tclass_field * bool * tvar list
+	| IOKCtor of tclass * Type.tparams * tclass_field * bool
 	| IOKStructure
 	| IOKArray of int
 
@@ -78,6 +78,7 @@ and inline_object = {
 	mutable io_aliases : inline_var list;
 	mutable io_fields : (string,inline_var) PMap.t;
 	mutable io_inline_methods : texpr list;
+	mutable io_dependent_vars : tvar list;
 }
 
 and inline_var_kind =
@@ -113,8 +114,8 @@ let inline_constructors ctx e =
 			List.iter (fun iv -> cancel_iv iv p) io.io_aliases;
 			PMap.iter (fun _ iv -> cancel_iv iv p) io.io_fields;
 			match io.io_kind with
-			| IOKCtor(_,_,_,isextern,vars) ->
-				List.iter (fun v -> if v.v_id < 0 then cancel_v v p) vars;
+			| IOKCtor(_,_,_,isextern) ->
+				List.iter (fun v -> if v.v_id < 0 then cancel_v v p) io.io_dependent_vars;
 				if isextern then begin
 					display_error ctx "Forced inline constructor could not be inlined" io.io_pos;
 					display_error ctx "Cancellation happened here" p;
@@ -217,6 +218,7 @@ let inline_constructors ctx e =
 				io_aliases = [];
 				io_has_untyped = has_untyped;
 				io_inline_methods = [];
+				io_dependent_vars = [];
 			} in
 			inline_objs := IntMap.add id io !inline_objs;
 			io
@@ -226,7 +228,7 @@ let inline_constructors ctx e =
 		let analyze_aliases captured e = analyze_aliases seen_ctors captured false e in
 		let get_io_inline_method io fname = 
 			begin match io.io_kind with
-			| IOKCtor(c,tl,_,_,_) ->
+			| IOKCtor(c,tl,_,_) ->
 				begin try
 					let f = PMap.find fname c.cl_fields in
 					begin match f.cf_params, f.cf_kind, f.cf_expr with
@@ -307,7 +309,8 @@ let inline_constructors ctx e =
 						let inlined_expr = mark_ctors inlined_expr in
 						let has_untyped = (Meta.has Meta.HasUntyped cf.cf_meta) in
 						let forced = is_extern_ctor c cf || force_inline in
-						let io = mk_io (IOKCtor(c,tl,cf,forced,argvs)) io_id inlined_expr ~has_untyped:has_untyped in
+						let io = mk_io (IOKCtor(c,tl,cf,forced)) io_id inlined_expr ~has_untyped:has_untyped in
+						io.io_dependent_vars <- argvs;
 						let rec loop (c:tclass) (tl:t list) =
 							let apply = apply_params c.cl_params tl in
 							List.iter (fun cf ->
@@ -429,8 +432,24 @@ let inline_constructors ctx e =
 			let fiv = handle_field_case efield ethis fname (fun _ -> true) in
 			begin match fiv with 
 			| IOFInlineMethod(io,io_var,c,tl,cf,tf) ->
-				(* TODO: Analyze aliases on call args *)
-				begin match Inline.type_inline ctx cf tf (mk (TLocal io_var.iv_var) (TInst (c,tl)) e.epos) call_args e.etype None e.epos true with
+				(* Analyze aliases on call args *)
+				let rec loop (vs, es) el = match el with
+					| e :: el ->
+						begin match e.eexpr with
+						| TConst _ -> loop (vs, e::es) el
+						| _ ->
+							let v = alloc_var VGenerated "arg" e.etype e.epos in
+							let decle = mk (TVar(v, Some e)) ctx.t.tvoid e.epos in
+							ignore(analyze_aliases true decle);
+							let mde = (Meta.InlineConstructorArgument (v.v_id, 0)), [], e.epos in
+							let e = mk (TMeta(mde, e)) e.etype e.epos in
+							loop (v::vs, e::es) el
+						end
+					| [] -> vs, (List.rev es)
+				in
+				let argvs, pl = loop ([],[]) call_args in
+				io.io_dependent_vars <- io.io_dependent_vars @ argvs;
+				begin match Inline.type_inline ctx cf tf (mk (TLocal io_var.iv_var) (TInst (c,tl)) e.epos) pl e.etype None e.epos true with
 				| Some e ->
 					let e = mark_ctors e in
 					io.io_inline_methods <- io.io_inline_methods @ [e];

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -63,8 +63,6 @@ and inline_object = {
 	mutable io_declared : bool;
 	mutable io_aliases : inline_var list;
 	mutable io_fields : (string,inline_var) PMap.t;
-	mutable io_id_start : int;
-	mutable io_id_end : int;
 }
 
 and inline_var_kind =
@@ -197,8 +195,6 @@ let inline_constructors ctx e =
 				io_declared = false;
 				io_fields = PMap.empty;
 				io_aliases = [];
-				io_id_start = id;
-				io_id_end = id;
 				io_has_untyped = has_untyped;
 			} in
 			inline_objs := IntMap.add id io !inline_objs;
@@ -495,7 +491,7 @@ let inline_constructors ctx e =
 			let el, io = loop [] el in
 			let el = if unwrap_block || Option.is_some io then el else [mk (TBlock (List.rev el)) e.etype e.epos] in
 			el, io
-		| TMeta((Meta.InlineConstructorArgument (_,io_id_start),_,_),e) ->
+		| TMeta((Meta.InlineConstructorArgument (_,_),_,_),e) ->
 			final_map e
 		| TParenthesis e' | TCast(e',None) | TMeta(_,e') ->
 			let el, io = final_map e' in

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -496,7 +496,7 @@ let inline_constructors ctx e =
 					| e::el ->
 						io.io_inline_methods <- el;
 						let el, io = final_map e in
-						el, io, true
+						el @ tel, io, true
 					| _ -> die "" __LOC__
 				end
 			| None ->

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -196,8 +196,8 @@ let inline_constructors ctx e =
 	let curr_io_id = ref 0 in
 	(*
 		mark_ctors
-		Finds all instances of inline objects in an expression and wraps them with metadata @:inline_object(id).
-		The id is incremented each time and is used later in the final_map phase to identify the correct inline object.
+		Finds all instances of inline objects in an expression and wraps them with metadata @:inlineObject(id).
+		The id is incremented each time and is used later in the final_map phase to identify the correct inline_object.
 	*)
 	let rec mark_ctors ?(force_inline=false) e : texpr =
 		let is_meta_inline = match e.eexpr with (TMeta((Meta.Inline,_,_),e)) -> true | _ -> false in
@@ -209,7 +209,7 @@ let inline_constructors ctx e =
 			| TNew _, true ->
 				incr curr_io_id;
 				let id_expr = (EConst(Int (string_of_int !curr_io_id)), e.epos) in
-				let meta = (Meta.Custom "inline_object", [id_expr], e.epos) in
+				let meta = (Meta.InlineObject, [id_expr], e.epos) in
 				mk (TMeta(meta, e)) e.etype e.epos
 			| _ -> e
 	in
@@ -378,10 +378,10 @@ let inline_constructors ctx e =
 				handle_default_case e
 		in
 		match e.eexpr with
-		| TMeta((Meta.Inline,_,_),{eexpr = TMeta((Meta.Custom "inline_object", [(EConst(Int (id_str)), _)], _), e)}) ->
+		| TMeta((Meta.Inline,_,_),{eexpr = TMeta((Meta.InlineObject, [(EConst(Int (id_str)), _)], _), e)}) ->
 			let io_id = int_of_string id_str in
 			handle_inline_object_case io_id true e
-		| TMeta((Meta.Custom "inline_object", [(EConst(Int (id_str)), _)], _), e) ->
+		| TMeta((Meta.InlineObject, [(EConst(Int (id_str)), _)], _), e) ->
 			let io_id = int_of_string id_str in
 			handle_inline_object_case io_id false e
 		| TVar(v,None) -> ignore(add v IVKLocal); None
@@ -517,7 +517,7 @@ let inline_constructors ctx e =
 			end
 		in
 		match e.eexpr with
-		| TMeta((Meta.Custom "inline_object", [(EConst(Int (id_str)), _)], _), e) ->
+		| TMeta((Meta.InlineObject, [(EConst(Int (id_str)), _)], _), e) ->
 			let io_id = int_of_string id_str in
 			begin try
 				let io = get_io io_id in

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -290,7 +290,14 @@ let inline_constructors ctx original_e =
 			begin match analyze_aliases true ethis with
 			| Some({iv_state = IVSAliasing io} as iv) when validate_io io ->
 				begin match get_io_inline_method io fname with
-				| Some(c, tl, cf, tf)-> IOFInlineMethod(io,iv,c,tl,cf,tf)
+				| Some(c, tl, cf, tf)->
+					let method_type = apply_params c.cl_params tl cf.cf_type in
+					if type_iseq_strict method_type efield.etype then
+						IOFInlineMethod(io,iv,c,tl,cf,tf)
+					else begin
+						cancel_iv iv efield.epos;
+						IOFNone
+					end
 				| None ->
 					begin try
 						let fiv = get_io_field io fname in

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -65,7 +65,7 @@ and inline_object = {
 	io_kind : inline_object_kind;
 	io_expr : texpr; (* This is the inlined constructor expression *)
 	io_pos : pos; (* The original position of the constructor expression *)
-	io_has_untyped : bool; (* Wether inlining this object would bring untyped expressions into the parent expression *)
+	mutable io_has_untyped : bool; (* Wether inlining this object would bring untyped expressions into the parent expression *)
 	mutable io_cancelled : bool; (* Wether this inline object has been cancelled *)
 	mutable io_declared : bool; (* Wether the variable declarations for this inline object's fields have already been output. (Used in final_map) *)
 	mutable io_aliases : inline_var list; (* List of variables that are aliasing/referencing this inline object *)
@@ -437,6 +437,7 @@ let inline_constructors ctx e =
 			| IOFInlineMethod(io,io_var,c,tl,cf,tf) ->
 				let argvs, pl = analyze_call_args call_args in
 				io.io_dependent_vars <- io.io_dependent_vars @ argvs;
+				io.io_has_untyped <- io.io_has_untyped or (Meta.has Meta.HasUntyped cf.cf_meta);
 				begin match Inline.type_inline ctx cf tf (mk (TLocal io_var.iv_var) (TInst (c,tl)) e.epos) pl e.etype None e.epos true with
 				| Some e ->
 					let e = mark_ctors e in

--- a/tests/misc/projects/inline-constructors/Extern.hx
+++ b/tests/misc/projects/inline-constructors/Extern.hx
@@ -1,0 +1,11 @@
+class Inl {
+	public var i : Int = 0;
+	public extern inline function new() {}
+}
+
+class Extern {
+	public static function main() {
+		var a = new Inl();
+		trace(a);
+	}
+}

--- a/tests/misc/projects/inline-constructors/ForceInline.hx
+++ b/tests/misc/projects/inline-constructors/ForceInline.hx
@@ -1,0 +1,11 @@
+class Inl {
+	public var i : Int = 0;
+	public function new() {}
+}
+
+class ForceInline {
+	public static function main() {
+		var a = inline new Inl();
+		trace(a);
+	}
+}

--- a/tests/misc/projects/inline-constructors/compile-extern-fail.hxml
+++ b/tests/misc/projects/inline-constructors/compile-extern-fail.hxml
@@ -1,0 +1,2 @@
+Extern
+-js extern.js

--- a/tests/misc/projects/inline-constructors/compile-extern-fail.hxml.stderr
+++ b/tests/misc/projects/inline-constructors/compile-extern-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Extern.hx:8: characters 11-20 : Forced inline constructor could not be inlined
+Extern.hx:9: characters 9-10 : Cancellation happened here

--- a/tests/misc/projects/inline-constructors/compile-force-inline-fail.hxml
+++ b/tests/misc/projects/inline-constructors/compile-force-inline-fail.hxml
@@ -1,0 +1,2 @@
+ForceInline
+-js force-inline.js

--- a/tests/misc/projects/inline-constructors/compile-force-inline-fail.hxml.stderr
+++ b/tests/misc/projects/inline-constructors/compile-force-inline-fail.hxml.stderr
@@ -1,0 +1,2 @@
+ForceInline.hx:8: characters 11-27 : Forced inline constructor could not be inlined
+ForceInline.hx:9: characters 9-10 : Cancellation happened here

--- a/tests/optimization/run.hxml
+++ b/tests/optimization/run.hxml
@@ -21,5 +21,6 @@
 --macro Macro.register('TestJs')
 --macro Macro.register('TestLocalDce')
 --macro Macro.register('TestTreGeneration')
+--macro Macro.register('TestInlineConstructors')
 --macro Macro.register('issues')
 --dce std

--- a/tests/optimization/src/TestInlineConstructors.hx
+++ b/tests/optimization/src/TestInlineConstructors.hx
@@ -89,4 +89,12 @@ class TestInlineConstructors extends TestBase {
 		var a : {function method() : String;} = new InlineClass();
 		return a.method();
 	}
+
+	@:js('var b = new InlineClass();return [new InlineClass().method(1),b.method(2)];')
+	static function testIncompatibleMethodCancelling() {
+		// InlineClass.method doesn't take any arguments, the method should not be inlined.
+		var a : {function method(arg : Int) : String;} = cast new InlineClass();
+		var b : Dynamic = new InlineClass();
+		return [a.method(1), b.method(2)];
+	}
 }

--- a/tests/optimization/src/TestInlineConstructors.hx
+++ b/tests/optimization/src/TestInlineConstructors.hx
@@ -1,0 +1,92 @@
+class InlineClass {
+	public var a = 1;
+	public var b = "";
+	public var c = "hello";
+	public inline function new() {
+	}
+
+	public inline function method() {
+		return a + b + c;
+	}
+}
+
+class NestedInlineClass {
+	public var a : InlineClass;
+	public var b : Array<Int>;
+	public var c : {a: Int};
+
+	public inline function new() {
+		a = new InlineClass();
+		b = [1,2,3];
+		c = {a:4};
+	}
+}
+
+class TestInlineConstructors extends TestBase {
+	@:js('return [1,2,3,3];')
+	static function testArrayInlining() {
+		var a = [1,2,3];
+		return [a[0], a[1], a[2], a.length];
+	}
+
+	@:js('return [2,"hello","world"];')
+	static function testAnonymousStructureInlining() {
+		var a = {a: 1, b: "", c: "hello"};
+		a.a = 2;
+		a.b = a.c;
+		a.c = "world";
+		return ([a.a,a.b,a.c] : Array<Dynamic>);
+	}
+
+	@:js('return [2,"hello","world"];')
+	static function testClassConstructorInlining() {
+		var a = new InlineClass();
+		a.a = 2;
+		a.b = a.c;
+		a.c = "world";
+		return return ([a.a,a.b,a.c] : Array<Dynamic>);
+	}
+
+	@:js('return [1,2,4,"test",2,1,4,3,4];')
+	static function testNestedInlining() {
+		var a = {
+			a: new NestedInlineClass(),
+			b: [new NestedInlineClass()],
+			c: {test: new NestedInlineClass()}
+		};
+		a.b[0].a.c = "test";
+		return ([a.a.a.a, a.a.b[1], a.a.c.a, a.b[0].a.c, a.b[0].b[1], a.b.length, a.c.test.c.a, a.c.test.b[2], a.c.test.c.a]:Dynamic);
+	}
+
+	@:js('return [1,"hello","world"];')
+	static function testMultipleAliasingVariables() {
+		var a = new InlineClass();
+		var b = a;
+		var d = [b,a];
+		d[1].b = "hello";
+		a.c = "world";
+		return ([a.a, a.b, d[1].c]:Array<Dynamic>);
+	}
+
+	@:js('return [1,"","hello"];')
+	static function testUnassignedVariables() {
+		var a;
+		a = new InlineClass();
+		return ([a.a, a.b, a.c]:Array<Dynamic>);
+	}
+
+	@:js('return [1,3,"hello"];')
+	static function testNoExplicitVariables() {
+		return ([
+			new InlineClass().a,
+			[1,2,3][2],
+			new NestedInlineClass().a.c
+		]:Array<Dynamic>);
+	}
+
+	@:js('return 1 + "" + "hello";')
+	static function testMethodInlining() {
+		var a : {function method() : String;} = new InlineClass();
+		return a.method();
+	}
+}


### PR DESCRIPTION
Normally inline constructors would immediately cancel if a field that is not a member variable is accessed.

For example:
```haxe
class MyIterator {
	public var i : Int = 0;
	public inline function new() {}
	public inline function hasNext() return true;
	public inline function next() return i++;
}

// ...

var a = new MyIterator();
a.hasNext(); // The call to hasNext is inlined before the inline constructors runs, no problem here.

var b : Iterator<Int> = a;
b.hasNext(); // Oops, hasNext was not inlined beforehand. 'hasNext' is not a member variable of MyIterator so inlining is cancelled.
```

With this PR the inline constructor filter will not give up so easily.

When the filter finds an expression of the form `ethis.method(args)` if `ethis` references an inline object and `method` is an inline method in the inline object then it will be inlined on demand by the filter.

This achieves the goals mentioned in #9432

It also probably solves #3147 (requires implementing proper inlineable iterator for map types and fixing the TFor issue I discussed with simn in slack)

I tested using the IntMap iterator from #8806 and this code:
```haxe
var m = [1 => 2, 3 => 4];
var iter = m.iterator();
while(iter.hasNext()) {
	var i = iter.next();
	trace(i);
}
```
Compiled into js:
```javascript
var iter_map_h = { };
iter_map_h[1] = 2;
iter_map_h[3] = 4;
var a = [];
for( var key in iter_map_h ) (iter_map_h.hasOwnProperty(key) ? a.push(key | 0) : null);
var keys = a;
var iter_keys = keys;
var iter_index = 0;
var iter_count = keys.length;
while(iter_index < iter_count) {
	var i = iter_map_h[iter_keys[iter_index++]];
	console.log("src/Main.hx:31:",i);
}
```

## Explanations about some of the changes

### Identifying inline objects

Previously inline objects were being identified by the order in which they appeared in the code. While it sounds nice in theory, nested inline objects inside inlined constructors make this very problematic. It requires keeping track of the start and end id of every inlined constructor to be able to reproduce the same id's in the final_pass phase.

In this PR the expressions are now mapped with a function called `mark_ctors` which will wrap any `TNew` `TArrayDecl` or `TObjectDecl` with @:inlineObject(curr_io_id++). This makes identifying inline objects in final_map a lot simpler, but it's a bit less efficient (Type.map_expr vs Type.iter).

### handle_field_case

In `analyse_aliases`, the function `handle_field_case` is used to handle analysis of TField and TArray. It used to return either None or Some inline variable that represents a field of an inline object.

`handle_field_case` now has a third possible return value IOFInlineMethod.

In the cases of TArray and TField this third value is ignored and causes cancellation of the inline object (Keeping the same behaviour it used to have).

IOFInlineMethod is only accepted without cancelling the inline object in the new `TCall({eexpr=TField(ethis,fa)},ca)` case of `analyze_aliases`.
