### PR TITLE
KeyLocation default in KeyboardEvent constructor flagged when using dox

### DIFF
--- a/std/flash/ui/KeyboardType.hx
+++ b/std/flash/ui/KeyboardType.hx
@@ -1,6 +1,6 @@
 package flash.ui;
 
-@:native("flash.ui.KeyboardType") extern enum abstract KeyboardType(String) {
+@:native("flash.ui.KeyLocation") extern enum abstract KeyLocation(UInt) from UInt to UInt {
 	var ALPHANUMERIC;
 	var KEYPAD;
 	var NONE;


### PR DESCRIPTION
Error
```
/usr/local/lib/haxe/std/flash/events/KeyboardEvent.hx:10: characters 173-174 : Int should be flash.ui.KeyLocation
```
issue new function default KeyLocation not able to cast, not able to provide dox
```haxe
extern class KeyboardEvent extends Event {
function new(type : String, bubbles : Bool = true, cancelable : Bool = false, charCodeValue : UInt = 0, keyCodeValue : UInt = 0, keyLocationValue : flash.ui.KeyLocation = 0, ctrlKeyValue : Bool = false, altKeyValue : Bool = false, shiftKeyValue : Bool = false) : Void;
```
I see no reason not to allow user to cast to and from UInt, seems simplest change, I doubt flash cares either way.