### PR TITLE
Rewrite JAR loader

### DIFF
--- a/libs/javalib/jData.ml
+++ b/libs/javalib/jData.ml
@@ -150,6 +150,7 @@ type jattribute =
   | AttrVisibleAnnotations of jannotation list
   | AttrInvisibleAnnotations of jannotation list
   | AttrLocalVariableTable of jlocal list
+  | AttrMethodParameters of (string * int) list
   | AttrUnknown of string * string
 
 type jcode = jattribute list (* TODO *)

--- a/libs/javalib/jReader.ml
+++ b/libs/javalib/jReader.ml
@@ -448,6 +448,14 @@ let parse_attribute on_special consts ch =
 		}
 	) in
 	Some (AttrLocalVariableTable locals)
+  | "MethodParameters" ->
+	let len = IO.read_byte ch in
+	let parameters = List.init len (fun _ ->
+		let name = get_string consts ch in
+		let flags = read_ui16 ch in
+		(name,flags)
+	) in
+	Some (AttrMethodParameters parameters)
   | "RuntimeVisibleAnnotations" ->
     let anncount = read_ui16 ch in
     Some (AttrVisibleAnnotations (List.init anncount (fun _ -> parse_annotation consts ch)))

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -281,8 +281,8 @@
 		"doc": "The code is compiled to be run with `--interp`."
 	},
 	{
-		"name": "JavaLegacyLoader",
-		"define": "java-legacy-loader",
+		"name": "JarLegacyLoader",
+		"define": "jar-legacy-loader",
 		"doc": "Use the legacy loader to load .jar files on the JVM target.",
 		"platforms": ["java"]
 	},

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -281,6 +281,12 @@
 		"doc": "The code is compiled to be run with `--interp`."
 	},
 	{
+		"name": "JavaLegacyLoader",
+		"define": "java-legacy-loader",
+		"doc": "Use the legacy loader to load .jar files on the JVM target.",
+		"platforms": ["java"]
+	},
+	{
 		"name": "JavaVer",
 		"define": "java_ver",
 		"doc": "Sets the Java version to be targeted.",

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -1212,7 +1212,7 @@ class java_library_dir com name file_path = object(self)
 			| _ -> None
 end
 
-let add_java_lib com name std extern =
+let add_java_lib com name std extern modern =
 	let file = if Sys.file_exists name then
 		name
 	else try Common.find_file com name with
@@ -1220,11 +1220,14 @@ let add_java_lib com name std extern =
 		| Not_found ->
 			failwith ("Java lib " ^ name ^ " not found")
 	in
-	let java_lib = match (Unix.stat file).st_kind with
+	let java_lib =
+		if modern then
+			(new JavaModern.java_library_modern com name file :> (java_lib_type,unit) native_library)
+		else match (Unix.stat file).st_kind with
 		| S_DIR ->
-			(new java_library_dir com name file :> java_library)
+			(new java_library_dir com name file :> (java_lib_type,unit) native_library)
 		| _ ->
-			(new java_library_jar com name file :> java_library)
+			(new java_library_jar com name file :> (java_lib_type,unit) native_library)
 	in
 	if std then java_lib#add_flag FlagIsStd;
 	if extern then java_lib#add_flag FlagIsExtern;

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -744,8 +744,9 @@ module Converter = struct
 			in
 			let rec loop attribs = match attribs with
 				| AttrLocalVariableTable locals :: _ ->
+					let shift = if is_static then 0 else -1 in
 					List.map (fun loc ->
-						loc.ld_index,loc.ld_name
+						loc.ld_index + shift,loc.ld_name
 					) locals
 				| AttrMethodParameters l :: _ ->
 					List.mapi (fun i (name,_) ->

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -1,0 +1,464 @@
+open Globals
+open Ast
+open ExtString
+open NativeLibraries
+open JData
+
+type java_lib_ctx = {
+	type_params : (string,complex_type) PMap.t;
+}
+
+let jname_to_hx name =
+	let name =
+		if name <> "" && (String.get name 0 < 'A' || String.get name 0 > 'Z') then
+			Char.escaped (Char.uppercase (String.get name 0)) ^ String.sub name 1 (String.length name - 1)
+		else
+			name
+	in
+	let name = String.concat "__" (String.nsplit name "_") in
+	match String.nsplit name "$" with
+	| [] ->
+		die "" __LOC__
+	| [_] ->
+		None,name
+	| x :: l ->
+		Some x,String.concat "_" (x :: l)
+
+let normalize_pack pack =
+	List.map (function
+		| "" -> ""
+		| str when String.get str 0 >= 'A' && String.get str 0 <= 'Z' ->
+			String.lowercase str
+		| str -> str
+	) pack
+
+let jpath_to_hx' (pack,name) =
+	let pack,name = match pack,name with
+	| ["haxe";"root"],name ->
+		[],name
+	| "com" :: ("oracle" | "sun") :: _, _
+	| "javax" :: _, _
+	| "org" :: ("ietf" | "jcp" | "omg" | "w3c" | "xml") :: _, _
+	| "sun" :: _, _
+	| "sunw" :: _, _ ->
+		"java" :: pack,name
+	| _ ->
+		pack,name
+	in
+	let pack = normalize_pack pack in
+	pack,jname_to_hx name
+
+let jpath_to_hx path =
+	let pack,(mname,name) = jpath_to_hx' path in
+	let pack,name = match mname with
+		| None -> pack,name
+		| Some mname -> pack @ [mname],name
+	in
+	pack,name
+
+let is_haxe_keyword = function
+	| "cast" | "extern" | "function" | "in" | "typedef" | "using" | "var" | "untyped" | "inline" -> true
+	| _ -> false
+
+let mk_type_path path params =
+	let pack,(mname,name) = jpath_to_hx' path in
+	match mname with
+	| None ->
+		CTPath {
+			tpackage = pack;
+			tname = name;
+			tparams = params;
+			tsub = None;
+		}
+	| Some mname ->
+		CTPath {
+			tpackage = pack;
+			tname = mname;
+			tparams = params;
+			tsub = Some name;
+		}
+
+let ct_type_param name = CTPath {
+	tpackage = [];
+	tname = name;
+	tparams = [];
+	tsub = None
+}
+
+let ct_void = CTPath {
+	tpackage = [];
+	tname = "Void";
+	tparams = [];
+	tsub = None;
+}
+
+let ct_dynamic = CTPath {
+	tpackage = [];
+	tname = "Dynamic";
+	tparams = [];
+	tsub = None;
+}
+
+let ct_string = CTPath {
+	tpackage = [];
+	tname = "String";
+	tparams = [];
+	tsub = None;
+}
+
+let rec convert_arg ctx p arg =
+	match arg with
+	| TAny | TType (WSuper, _) -> TPType (mk_type_path ([], "Dynamic") [],p)
+	| TType (_, jsig) -> TPType (convert_signature ctx p jsig,p)
+
+and convert_signature ctx p jsig =
+	match jsig with
+	| TByte -> mk_type_path (["java"; "types"], "Int8") []
+	| TChar -> mk_type_path (["java"; "types"], "Char16") []
+	| TDouble -> mk_type_path ([], "Float") []
+	| TFloat -> mk_type_path ([], "Single") []
+	| TInt -> mk_type_path ([], "Int") []
+	| TLong -> mk_type_path (["haxe"], "Int64") []
+	| TShort -> mk_type_path (["java"; "types"], "Int16") []
+	| TBool -> mk_type_path ([], "Bool") []
+	| TObject ( (["haxe";"root"], name), args ) -> mk_type_path ([], name) (List.map (convert_arg ctx p) args)
+	| TObject ( (["java";"lang"], "Object"), [] ) -> mk_type_path ([], "Dynamic") []
+	| TObject ( (["java";"lang"], "String"), [] ) -> mk_type_path ([], "String") []
+	| TObject ( (["java";"lang"], "Enum"), [_] ) -> mk_type_path ([], "EnumValue") []
+	| TObject ( path, [] ) ->
+		mk_type_path path []
+	| TObject ( path, args ) -> mk_type_path path (List.map (convert_arg ctx p) args)
+	| TObjectInner (pack, (name, params) :: inners) ->
+		let actual_param = match List.rev inners with
+		| (_, p) :: _ -> p
+		| _ -> die "" __LOC__ in
+		mk_type_path (pack, name ^ "$" ^ String.concat "$" (List.map fst inners)) (List.map (fun param -> convert_arg ctx p param) actual_param)
+	| TObjectInner (pack, inners) -> die "" __LOC__
+	| TArray (jsig, _) -> mk_type_path (["java"], "NativeArray") [ TPType (convert_signature ctx p jsig,p) ]
+	| TMethod _ -> JReader.error "TMethod cannot be converted directly into Complex Type"
+	| TTypeParameter s ->
+		try
+			PMap.find s ctx.type_params
+		with Not_found ->
+			ct_dynamic
+
+let get_type_path ct = match ct with | CTPath p -> p | _ -> die "" __LOC__
+
+module Converter = struct
+
+	let convert_type_parameter ctx (name,extends,implements) p =
+		let jsigs = match extends with
+			| Some jsig -> jsig :: implements
+			| None -> implements
+		in
+		let constraints = List.map (fun jsig ->
+			convert_signature ctx p jsig,p
+		) jsigs in
+		let tp = {
+			tp_name = (name,p);
+			tp_params = [];
+			tp_meta = [];
+			tp_constraints = match constraints with
+				| [] -> None
+				| _ -> Some (CTIntersection constraints,p)
+		} in
+		tp
+
+	let convert_enum (jc : jclass) (file : string) =
+		let p = {
+			pfile = file;
+			pmin = 0;
+			pmax = 0
+		} in
+		let meta = ref [] in
+		let add_meta m = meta := m :: !meta in
+		let data = ref [] in
+		List.iter (fun f ->
+			match f.jf_vmsignature with
+			| TObject( path, [] ) when path = jc.cpath && List.mem JStatic f.jf_flags && List.mem JFinal f.jf_flags ->
+				data := { ec_name = f.jf_name,p; ec_doc = None; ec_meta = []; ec_args = []; ec_pos = p; ec_params = []; ec_type = None; } :: !data;
+			| _ -> ()
+		) jc.cfields;
+		let _,class_name = jname_to_hx (snd jc.cpath) in
+		add_meta (Meta.Native, [EConst (String (s_type_path jc.cpath,SDoubleQuotes) ),p],p);
+		let d = {
+			d_name = (class_name,p);
+			d_doc = None;
+			d_params = []; (* enums never have type parameters *)
+			d_meta = !meta;
+			d_flags = [EExtern];
+			d_data = List.rev !data;
+		} in
+		(EEnum d,p)
+
+	let type_param_lut acc params =
+		List.fold_left (fun acc (s,_,_) ->
+			PMap.add s (ct_type_param s) acc
+		) acc params
+
+	let convert_field ctx (jc : jclass) (jf : jfield) p =
+		let ctx = {
+			type_params = type_param_lut ctx.type_params jf.jf_types;
+		} in
+		let p = {p with pfile = p.pfile ^ "@" ^ jf.jf_name} in
+		let is_static = List.mem JStatic jf.jf_flags in
+		let access = ref [] in
+		let meta = ref [] in
+		let add_access a = access := a :: !access in
+		let add_meta m = meta := m :: !meta in
+		if is_static then add_access (AStatic,p);
+		List.iter (function
+			| AttrDeprecated when jc.cpath <> (["java";"util"],"Date") ->
+				add_meta (Meta.Deprecated,[],p);
+			| AttrVisibleAnnotations ann ->
+				List.iter (function
+					| { ann_type = TObject( (["java";"lang"], "Override"), [] ) } ->
+						add_access (AOverride,null_pos);
+					| _ -> ()
+				) ann
+			| _ -> ()
+		) jf.jf_attributes;
+		let add_native_meta () =
+			add_meta (Meta.Native, [EConst (String (jf.jf_name,SDoubleQuotes) ),p],p)
+		in
+		let name = match String.nsplit jf.jf_name "$" with
+			| ["<init>"] ->
+				"new"
+			| [name] ->
+				if is_haxe_keyword name then begin
+					add_native_meta();
+					"_" ^ name
+				end else
+					name
+			| parts ->
+				add_native_meta();
+				String.concat "_" parts
+		in
+		if jf.jf_kind = JKMethod then add_meta (Meta.Overload,[],p);
+		if List.mem JFinal jf.jf_flags then add_access (AFinal,p);
+		let extract_local_names () =
+			let default i =
+				"param" ^ string_of_int i
+			in
+			match jf.jf_code with
+			| None ->
+				default
+			| Some attribs -> try
+				let rec loop attribs = match attribs with
+					| AttrLocalVariableTable locals :: _ ->
+						locals
+					| _ :: attribs ->
+						loop attribs
+					| [] ->
+						raise Not_found
+				in
+				let locals = loop attribs in
+				let h = Hashtbl.create 0 in
+				List.iter (fun local ->
+					Hashtbl.replace h local.ld_index local.ld_name
+				) locals;
+				(fun i ->
+					try Hashtbl.find h (i - 1) (* they are 1-based *)
+					with Not_found -> "param" ^ string_of_int i
+				)
+			with Not_found ->
+				default
+		in
+		let kind = match jf.jf_kind with
+			| JKField ->
+				FVar(Some (convert_signature ctx p jf.jf_signature,p),None)
+			| JKMethod ->
+				begin match jf.jf_signature with
+				| TMethod(args,ret) ->
+					let local_names = extract_local_names() in
+					let convert_arg i jsig =
+						let name = local_names (i + 1) in
+						((name,p),false,[],Some (convert_signature ctx p jsig,p),None)
+					in
+					let f = {
+						f_params = List.map (fun tp -> convert_type_parameter ctx tp p) jf.jf_types;
+						f_args = List.mapi convert_arg args;
+						f_type = Some (Option.map_default (fun jsig -> convert_signature ctx p jsig,p) (ct_void,p) ret);
+						f_expr = None;
+					} in
+					FFun f
+				| _ ->
+					assert false
+				end
+		in
+		let cff = {
+			cff_name = (name,p);
+			cff_doc = None;
+			cff_pos = p;
+			cff_meta = !meta;
+			cff_access = !access;
+			cff_kind = kind;
+		} in
+		cff
+
+	let convert_class ctx (jc : jclass) (file : string) =
+		let p = {
+			pfile = file;
+			pmin = 0;
+			pmax = 0
+		} in
+		let flags = ref [HExtern] in
+		let meta = ref [] in
+		let add_flag f = flags := f :: !flags in
+		let add_meta m = meta := m :: !meta in
+		add_meta (Meta.LibType,[],p);
+		let is_interface = List.mem JInterface jc.cflags in
+		if is_interface then add_flag HInterface;
+		begin match jc.csuper with
+			| TObject( (["java";"lang"], "Object"), _ ) ->
+				()
+			| jsig ->
+				add_flag (HExtends (get_type_path (convert_signature ctx p jsig),p))
+		end;
+		List.iter (fun jsig ->
+			let path = (get_type_path (convert_signature ctx p jsig),p) in
+			if is_interface then
+				add_flag (HExtends path)
+			else
+				add_flag (HImplements path)
+		) jc.cinterfaces;
+		let fields = DynArray.create () in
+		let known_names = Hashtbl.create 0 in
+		let known_sigs = Hashtbl.create 0 in
+		if jc.cpath <> (["java";"lang"], "CharSequence") then begin
+			List.iter (fun jf ->
+				Hashtbl.replace known_names jf.jf_name jf;
+				let sig_key = match jf.jf_signature with
+					| TMethod(jsigs,_) -> TMethod(jsigs,None) (* lack of return type variance *)
+					| jsig -> jsig
+				in
+				let key = (jf.jf_name,sig_key) in
+				if not (Hashtbl.mem known_sigs key) then begin
+					Hashtbl.add known_sigs key jf;
+					DynArray.add fields (convert_field ctx jc jf p)
+				end
+			) jc.cmethods;
+			List.iter (fun jf ->
+				if not (Hashtbl.mem known_names jf.jf_name) then begin
+					Hashtbl.add known_names jf.jf_name jf;
+					DynArray.add fields (convert_field ctx jc jf p)
+				end
+			) jc.cfields;
+		end;
+		let _,class_name = jname_to_hx (snd jc.cpath) in
+		add_meta (Meta.Native, [EConst (String (s_type_path jc.cpath,SDoubleQuotes) ),p],p);
+		let d = {
+			d_name = (class_name,p);
+			d_doc = None;
+			d_params = List.map (fun tp -> convert_type_parameter ctx tp p) jc.ctypes;
+			d_meta = !meta;
+			d_flags = !flags;
+			d_data = DynArray.to_list fields;
+		} in
+		(EClass d,p)
+
+	let convert_type ctx jc file =
+		if List.mem JEnum jc.cflags then convert_enum jc file else convert_class ctx jc file
+
+	let convert_module lookup jc file =
+		let types = DynArray.create () in
+		let paths = Hashtbl.create 0 in
+		let _,module_name = jname_to_hx (snd jc.cpath) in
+		let rec loop jc file =
+			if not (Hashtbl.mem paths jc.cpath) then begin
+				Hashtbl.add paths jc.cpath ();
+				let ctx = {
+					type_params = type_param_lut PMap.empty jc.ctypes;
+				} in
+				DynArray.add types (convert_type ctx jc file);
+				List.iter (fun (path,_,_,_) ->
+					let pack,(mname,name) = jpath_to_hx' path in
+					match mname with
+					| Some mname when mname = module_name ->
+						begin match lookup (pack @ [mname],name) with
+						| Some(jc',_,file) ->
+							loop jc' file
+						| None ->
+							print_endline (Printf.sprintf "%s: TYPE NOT FOUND: %s" (s_type_path jc.cpath) (s_type_path path));
+						end
+					| _ ->
+						()
+				) jc.cinner_types
+			end
+		in
+		loop jc file;
+		let types = DynArray.to_list types in
+		(fst jc.cpath,types)
+end
+
+class java_library_modern com name file_path = object(self)
+	inherit [java_lib_type,unit] native_library name file_path as super
+
+	val zip = lazy (Zip.open_in file_path)
+	val cached_types = Hashtbl.create 0
+	val mutable cached_files = []
+	val hxpack_to_jpack = Hashtbl.create 0
+	val mutable loaded = false
+	val mutable closed = false
+
+	method load =
+		if not loaded then begin
+			loaded <- true;
+			List.iter (function
+				| { Zip.is_directory = false; Zip.filename = filename } when String.ends_with filename ".class" ->
+					let pack = String.nsplit filename "/" in
+					(match List.rev pack with
+						| [] -> ()
+						| name :: pack ->
+							let name = String.sub name 0 (String.length name - 6) in
+							let pack = List.rev pack in
+							let path = jpath_to_hx (pack,name) in
+							cached_files <- path :: cached_files;
+							Hashtbl.add hxpack_to_jpack path (pack,name))
+				| _ -> ()
+			) (Zip.entries (Lazy.force zip))
+		end
+
+	method private lookup' (pack,name) =
+		let zip = Lazy.force zip in
+		let location = (String.concat "/" (pack @ [name]) ^ ".class") in
+		let entry = Zip.find_entry zip location in
+		let data = Zip.read_entry zip entry in
+		(JReader.parse_class (IO.input_string data),file_path,file_path ^ "@" ^ location)
+
+	method lookup path : java_lib_type =
+		try
+			Hashtbl.find cached_types path
+		with Not_found ->
+			let t = try
+				let path = Hashtbl.find hxpack_to_jpack path in
+				Some (self#lookup' path)
+			with Not_found ->
+				None
+			in
+			Hashtbl.add cached_types path t;
+			t
+
+	method close =
+		if not closed then begin
+			closed <- true;
+			Zip.close_in (Lazy.force zip)
+		end
+
+	method list_modules : path list =
+		cached_files
+
+	method build path (p : pos) : Ast.package option =
+		let rec build path =
+			if path = (["java";"lang"],"String") then
+				None
+			else match self#lookup path with
+			| Some(jc,_,file) ->
+				Some (Converter.convert_module self#lookup jc file)
+			| None ->
+				None
+		in
+		build path
+
+	method get_data = ()
+end

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -372,7 +372,7 @@ module JReaderModern = struct
 			AttrDeprecated
 		| "LocalVariableTable" ->
 			let len = read_ui16 ch in
-			let locals = List.init len (fun _ ->
+			let locals = ExtList.List.init len (fun _ ->
 				let start_pc = read_ui16 ch in
 				let length = read_ui16 ch in
 				let name = consts.strings.(read_ui16 ch) in
@@ -389,7 +389,7 @@ module JReaderModern = struct
 			AttrLocalVariableTable locals
 		| "MethodParameters" ->
 			let len = IO.read_byte ch in
-			let parameters = List.init len (fun _ ->
+			let parameters = ExtList.List.init len (fun _ ->
 				let name = consts.strings.(read_ui16 ch) in
 				let flags = read_ui16 ch in
 				(name,flags)
@@ -447,11 +447,11 @@ module JReaderModern = struct
 		let flags = read_ui16 ch in
 		let this = consts.paths.(read_ui16 ch) in
 		let super = TObject(consts.paths.(read_ui16 ch),[]) in
-		let interfaces = List.init (read_ui16 ch) (fun _ ->
+		let interfaces = ExtList.List.init (read_ui16 ch) (fun _ ->
 			TObject(consts.paths.(read_ui16 ch),[])
 		) in
-		let fields = List.init (read_ui16 ch) (fun _ -> parse_field consts false ch) in
-		let methods = List.init (read_ui16 ch) (fun _ -> parse_field consts true ch) in
+		let fields = ExtList.List.init (read_ui16 ch) (fun _ -> parse_field consts false ch) in
+		let methods = ExtList.List.init (read_ui16 ch) (fun _ -> parse_field consts true ch) in
 		let attributes = parse_attributes consts ch in
 		let types = ref [] in
 		let interfaces = ref interfaces in

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -394,7 +394,7 @@ module JReaderModern = struct
 			ValAnnotation (parse_annotation consts ch)
 		| '[' ->
 			let num_vals = read_ui16 ch in
-			ValArray (List.init (num_vals) (fun _ -> parse_element_value consts ch))
+			ValArray (ExtList.List.init (num_vals) (fun _ -> parse_element_value consts ch))
 		| tag ->
 			failwith ("Invalid element value: '" ^  Char.escaped tag ^ "'")
 
@@ -408,7 +408,7 @@ module JReaderModern = struct
 		let count = read_ui16 ch in
 		{
 			ann_type = anntype;
-			ann_elements = List.init count (fun _ -> parse_ann_element consts ch)
+			ann_elements = ExtList.List.init count (fun _ -> parse_ann_element consts ch)
 		}
 
 	let rec parse_attribute consts ch =
@@ -455,7 +455,7 @@ module JReaderModern = struct
 			AttrMethodParameters parameters
 		| "RuntimeVisibleAnnotations" ->
     		let count = read_ui16 ch in
-    		AttrVisibleAnnotations (List.init count (fun _ -> parse_annotation consts ch))
+    		AttrVisibleAnnotations (ExtList.List.init count (fun _ -> parse_annotation consts ch))
 		| "Signature" ->
 			let s = consts.strings.(read_ui16 ch) in
 			AttrSignature s

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -21,6 +21,8 @@ let jname_to_hx name =
 		die "" __LOC__
 	| [_] ->
 		None,name
+	| [x;""] ->
+		None,x ^ "_" (* trailing $ *)
 	| x :: l ->
 		let name = String.concat "_" (x :: l) in
 		if x = "" then None,name (* leading $ *)

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -425,11 +425,12 @@ class java_library_modern com name file_path = object(self)
 							let pack,(mname,tname) = jpath_to_hx (pack,name) in
 							let path = jpath_to_path (pack,(mname,tname)) in
 							let mname = match mname with
-								| None -> tname
+								| None ->
+									cached_files <- path :: cached_files;
+									tname
 								| Some mname -> mname
 							in
 							Hashtbl.add modules (pack,mname) (filename,entry);
-							cached_files <- path :: cached_files;
 						end
 				| _ -> ()
 			) (Zip.entries (Lazy.force zip));

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -152,8 +152,11 @@ module Converter = struct
 			| Some jsig -> jsig :: implements
 			| None -> implements
 		in
-		let constraints = List.map (fun jsig ->
-			convert_signature ctx p jsig,p
+		let constraints = ExtList.List.filter_map (fun jsig -> match jsig with
+			| TTypeParameter name' when name = name' ->
+				None
+			| _ ->
+				Some (convert_signature ctx p jsig,p)
 		) jsigs in
 		let tp = {
 			tp_name = (name,p);

--- a/src/codegen/overloads.ml
+++ b/src/codegen/overloads.ml
@@ -211,7 +211,7 @@ struct
 			raise Not_found
 
 	let is_best arg1 arg2 =
-		(List.for_all2 (fun v1 v2 ->
+		(Ast.safe_for_all2 (fun v1 v2 ->
 			v1 <= v2)
 		arg1 arg2) && (List.exists2 (fun v1 v2 ->
 			v1 < v2)

--- a/src/context/nativeLibraryHandler.ml
+++ b/src/context/nativeLibraryHandler.ml
@@ -24,9 +24,10 @@ let add_native_lib com file is_extern = match com.platform with
 	| Globals.Flash ->
 		SwfLoader.add_swf_lib com file is_extern
 	| Globals.Java ->
+		let use_modern = Common.defined com Define.Jvm && not (Common.defined com Define.JavaLegacyLoader) in
 		let add file =
 			let std = file = "lib/hxjava-std.jar" in
-			Java.add_java_lib com file std is_extern (Define.raw_defined com.defines "java-modern-loader")
+			Java.add_java_lib com file std is_extern use_modern
 		in
 		if try Sys.is_directory file with Sys_error _ -> false then
 			let dir = file in

--- a/src/context/nativeLibraryHandler.ml
+++ b/src/context/nativeLibraryHandler.ml
@@ -24,7 +24,7 @@ let add_native_lib com file is_extern = match com.platform with
 	| Globals.Flash ->
 		SwfLoader.add_swf_lib com file is_extern
 	| Globals.Java ->
-		let use_modern = Common.defined com Define.Jvm && not (Common.defined com Define.JavaLegacyLoader) in
+		let use_modern = Common.defined com Define.Jvm && not (Common.defined com Define.JarLegacyLoader) in
 		let add file =
 			let std = file = "lib/hxjava-std.jar" in
 			Java.add_java_lib com file std is_extern use_modern

--- a/src/context/nativeLibraryHandler.ml
+++ b/src/context/nativeLibraryHandler.ml
@@ -26,7 +26,7 @@ let add_native_lib com file is_extern = match com.platform with
 	| Globals.Java ->
 		let add file =
 			let std = file = "lib/hxjava-std.jar" in
-			Java.add_java_lib com file std is_extern
+			Java.add_java_lib com file std is_extern (Define.raw_defined com.defines "java-modern-loader")
 		in
 		if try Sys.is_directory file with Sys_error _ -> false then
 			let dir = file in

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -202,8 +202,8 @@ let rec unify_call_args' ctx el args r callp inline force_inline =
 			begin match List.rev !skipped with
 				| [] ->
 					if ctx.is_display_file && not (Diagnostics.is_diagnostics_run ctx.com p) then begin
-						let e = type_expr ctx (e,p) WithType.value in
-						(e,false) :: loop el []
+						ignore(type_expr ctx (e,p) WithType.value);
+						loop el []
 					end	else call_error Too_many_arguments p
 				| (s,ul,p) :: _ -> arg_error ul s true p
 			end

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1509,7 +1509,7 @@ let init_class ctx c p context_init herits fields =
 			end;
 			if fctx.is_field_debug then print_endline ("Created field: " ^ Printer.s_tclass_field "" cf);
 			if fctx.is_static && c.cl_interface && fctx.field_kind <> FKInit && not cctx.is_lib && not (c.cl_extern) then
-				error "You can't declare static fields in interfaces" p;
+				error "You can only declare static fields in extern interfaces" p;
 			let set_feature s =
 				ctx.m.curmod.m_extra.m_if_feature <- (s,(c,cf,fctx.is_static)) :: ctx.m.curmod.m_extra.m_if_feature
 			in

--- a/std/java/db/Jdbc.hx
+++ b/std/java/db/Jdbc.hx
@@ -22,9 +22,9 @@
 
 package java.db;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import haxe.io.Bytes;
 import java.sql.Types;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @:native('haxe.java.db.Jdbc')
 class Jdbc {
@@ -143,7 +143,8 @@ private class JdbcConnection implements sys.db.Connection {
 				s = r.matchedRight();
 			}
 			newst.add(s);
-			var stmt = cnx.prepareStatement(newst.toString(), java.sql.Statement.Statement_Statics.RETURN_GENERATED_KEYS);
+			var stmt = cnx.prepareStatement(newst.toString(),
+				#if jvm java.sql.Statement.RETURN_GENERATED_KEYS #else java.sql.Statement.Statement_Statics.RETURN_GENERATED_KEYS #end);
 			for (i in 0...sentArray.length) {
 				stmt.setObject(i + 1, sentArray[i]);
 			}

--- a/tests/unit/compile-jvm.hxml
+++ b/tests/unit/compile-jvm.hxml
@@ -7,3 +7,4 @@ compile-each.hxml
 --main unit.TestMain
 --java-lib native_java/native.jar
 --jvm bin/unit.jar
+-D java-modern-loader

--- a/tests/unit/compile-jvm.hxml
+++ b/tests/unit/compile-jvm.hxml
@@ -7,4 +7,3 @@ compile-each.hxml
 --main unit.TestMain
 --java-lib native_java/native.jar
 --jvm bin/unit.jar
--D java-modern-loader


### PR DESCRIPTION
This is still a bit work-in-progress. I'll enable it by default for the JVM target and add a flag to use the old loader. ~For now it can be tested with `-D java-modern-loader`.~ It is enabled by default and can be switched off with `-D jar-legacy-loader`.

There's a whole bunch of code in `java.ml` that does "something". It's very hard for me to tell how much of that is only there because genjava generates syntax. We will probably come across various regressions in various .jar libs and then can work towards fixing those.

closes #3397
closes #5725
closes #9569
closes #9570
closes #9573

Edit: I should probably mention that I'm only adapting this to support the JVM target, not the old Java target.