### PR TITLE
remove `On static platforms, null can't be used as basic type` check (related to #7736)

### DIFF
--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -95,18 +95,6 @@ let sanitize_expr com e =
 		| _ -> false
 	in
 	match e.eexpr with
-	| TConst TNull ->
-		if com.config.pf_static && not (is_nullable e.etype) then begin
-			let rec loop t = match follow t with
-				| TMono _ -> () (* in these cases the null will cast to default value *)
-				| TFun _ -> () (* this is a bit a particular case, maybe flash-specific actually *)
-				(* TODO: this should use get_underlying_type, but we do not have access to Codegen here.  *)
-				| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> loop (apply_params a.a_params tl a.a_this)
-				| _ -> com.error ("On static platforms, null can't be used as basic type " ^ s_type (print_context()) e.etype) e.epos
-			in
-			loop e.etype
-		end;
-		e
 	| TBinop (op,e1,e2) ->
 		let swap op1 op2 =
 			let p1, left1 = standard_precedence op1 in

--- a/tests/unit/src/unit/issues/Issue7736.hx
+++ b/tests/unit/src/unit/issues/Issue7736.hx
@@ -1,0 +1,20 @@
+package unit.issues;
+
+class Issue7736 extends unit.Test {
+	function testNullBasicType() {
+		// this test checks that an explicit null, assigned to the basic type
+		// behaves exactly the same as if Null<T>-typed null would be assigned to basic type
+
+		var i:Int = null;
+		var f:Float = null;
+		var b:Bool = null;
+
+		eq(i, getDefaultInt());
+		eq(f, getDefaultFloat());
+		eq(b, getDefaultBool());
+	}
+
+	static function getDefaultInt():Int return (null : Null<Int>);
+	static function getDefaultFloat():Float return (null : Null<Float>);
+	static function getDefaultBool():Bool return (null : Null<Bool>);
+}


### PR DESCRIPTION
As discussed on Slack, this PR removes the check that forbids assigning `null` literal to basic types on static platforms, which is the only obstacle for typing `null` literals as `Null<?>` instead of `?` as discussed in #7736.

To prevent immediate "but this check is needed to guard against mistakes" reply, I'll reiterate on points made in https://github.com/HaxeFoundation/haxe/issues/7736#issuecomment-632801617:

* We specify that, when assigned to a basic type, `null` becomes a target-specific default value. In other words, the following is basically specified to trace `0` on static targets:
  ```haxe
  var x:Null<Int> = null, y:Int = x; trace(y);
  ```
  So why do we then disallow `var x:Int = null`? This seems very random.
* The check only handles explicit (or inlined) `var x:Int = null`, it won't catch any of these:
  ```haxe
  function main() {
  	var x:Int = getNullInt();
  	var x:Int = inline getNullInt();
  	var x:Int = getT();
  	var x:Int = getNullT();
  	var x:Int = inline getNullT();
  	var x:Int = cast null;
  }
  
  function getNullInt():Null<Int> return null;
  function getT<T>():T return null;
  function getNullT<T>():Null<T> return null;
  ```
  In all these cases, `x` will be `0` on static targets.
* The Haxe 4 null-safety mechanism supersedes and obsoletes this check, covering much more cases and working consistently across targets (not just static targets).