### PR TITLE
[nullsafety] fix null unfold for abstract over null

### DIFF
--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -339,6 +339,7 @@ let rec unfold_null t =
 	match t with
 		| TMono r -> (match r.tm_type with None -> t | Some t -> unfold_null t)
 		| TAbstract ({ a_path = ([],"Null") }, [t]) -> unfold_null t
+		| TAbstract (abstr,tl) when not (Meta.has Meta.CoreType abstr.a_meta) -> unfold_null (apply_params abstr.a_params tl abstr.a_this)
 		| TLazy f -> unfold_null (lazy_type f)
 		| TType (t,tl) -> unfold_null (apply_params t.t_params tl t.t_type)
 		| _ -> t

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -946,6 +946,12 @@ class TestStrict {
 		x += x;
 	}
 
+	static function issue9649_nullCheckedAbstractShouldUnify_shouldPass() {
+		var x:NullFloat = null;
+		var y:Float = 0.0;
+		if(x!=null) y = x;
+	}
+
 	static function issue8443_nullPassedToInline_shouldPass() {
 		inline function method(?map: (Int)->Int) {
 			return map != null ? map(0) : -1;


### PR DESCRIPTION
Closes #9649.

(`unfold_null` used only for unification check and unification check unwraps abstract anyway, so should be safe to unwrap it here for null removal.) 