### PR TITLE
[hl] avoid race condition in sys.thread.Thread.getQueue

### DIFF
--- a/std/hl/_std/sys/thread/Thread.hx
+++ b/std/hl/_std/sys/thread/Thread.hx
@@ -36,11 +36,12 @@ abstract Thread(ThreadHandle) {
 	static var queue_mutex:Mutex = null;
 	static var threads_queues:Array<{t:ThreadHandle, q:Deque<Dynamic>}> = null;
 
+	public static function __init__() {
+		queue_mutex = new Mutex();
+		threads_queues = [];
+	}
+
 	static function getQueue(t:ThreadHandle) {
-		if (queue_mutex == null) {
-			queue_mutex = new Mutex();
-			threads_queues = [];
-		}
 		queue_mutex.acquire();
 		var q = null;
 		for (tq in threads_queues)

--- a/std/hl/_std/sys/thread/Thread.hx
+++ b/std/hl/_std/sys/thread/Thread.hx
@@ -36,7 +36,7 @@ abstract Thread(ThreadHandle) {
 	static var queue_mutex:Mutex = null;
 	static var threads_queues:Array<{t:ThreadHandle, q:Deque<Dynamic>}> = null;
 
-	public static function __init__() {
+	static function __init__() {
 		queue_mutex = new Mutex();
 		threads_queues = [];
 	}


### PR DESCRIPTION
From HaxeFoundation/hashlink/issues/395.

Initialise hashlink sys.thread.Thread static message queues vars from `__init__` to avoid a race condition.

