### PR TITLE
Keep `Method MethInline` for cf_kind even if inlining is disabled

### DIFF
--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -6,6 +6,10 @@ open Common
 open Typecore
 open Error
 
+let needs_inline ctx is_extern_class cf =
+	cf.cf_kind = Method MethInline
+	&& (ctx.g.doinline || is_extern_class || has_class_field_flag cf CfExtern)
+
 let mk_untyped_call name p params =
 	{
 		eexpr = TCall({ eexpr = TIdent name; etype = t_dynamic; epos = p }, params);

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -304,7 +304,7 @@ let rec reduce_loop ctx e =
 				(match inl with
 				| None -> reduce_expr ctx e
 				| Some e -> reduce_loop ctx e)
-			| {eexpr = TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf)))} when cf.cf_kind = Method MethInline && not (rec_stack_memq cf inline_stack) ->
+			| {eexpr = TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf)))} when needs_inline ctx cl.cl_extern cf && not (rec_stack_memq cf inline_stack) ->
 				begin match cf.cf_expr with
 				| Some {eexpr = TFunction tf} ->
 					let config = inline_config (Some cl) cf el e.etype in

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -29,7 +29,8 @@ let make_call ctx e params t ?(force_inline=false) p =
 				raise Exit
 		in
 		if not force_inline then begin
-			if f.cf_kind <> Method MethInline then raise Exit;
+			let is_extern_class = match cl with Some c -> c.cl_extern | _ -> false in
+			if not (Inline.needs_inline ctx is_extern_class f) then raise Exit;
 		end else begin
 			match cl with
 			| None ->

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -567,11 +567,7 @@ let create_field_context (ctx,cctx) c cff =
 		| _ ->
 			()
 	) cff.cff_meta;
-	let allow_inline = cctx.abstract <> None || match cff.cff_kind with
-		| FFun _ -> ctx.g.doinline || !is_extern || c.cl_extern
-		| _ -> true
-	in
-	let is_inline = allow_inline && List.mem_assoc AInline cff.cff_access in
+	let is_inline = List.mem_assoc AInline cff.cff_access in
 	let override = try Some (List.assoc AOverride cff.cff_access) with Not_found -> None in
 	let is_macro = List.mem_assoc AMacro cff.cff_access in
 	let field_kind = match fst cff.cff_name with

--- a/tests/server/src/cases/display/issues/Issue9266.hx
+++ b/tests/server/src/cases/display/issues/Issue9266.hx
@@ -1,0 +1,18 @@
+package cases.display.issues;
+
+class Issue9266 extends DisplayTestCase {
+	/**
+		class Main {
+			static public function main() {
+				te{-1-}st;
+			}
+
+			static public inline function test() {}
+		}
+	**/
+	function test(_) {
+		runHaxeJson([], DisplayMethods.Hover, {file: file, offset: offset(1)});
+		var result = parseHover().result;
+		Assert.equals('MethInline', result.item.args.field.kind.args);
+	}
+}


### PR DESCRIPTION
Fixes #9266 

Currently `inline` methods get typed as `Method MethNormal` in display mode or with `--no-inline`:
https://github.com/HaxeFoundation/haxe/blob/1c018c009af68a86ad45ae1e8335665a43bd1e85/src/typing/typer.ml#L2660
https://github.com/HaxeFoundation/haxe/blob/1c018c009af68a86ad45ae1e8335665a43bd1e85/src/typing/typeloadFields.ml#L570-L574
https://github.com/HaxeFoundation/haxe/blob/1c018c009af68a86ad45ae1e8335665a43bd1e85/src/typing/typeloadFields.ml#L1142

This PR makes `inline` methods to always get `Method MethInline` kind even if inlining is disabled. And instead check if inlining is enabled upon each inlining attempt.