### PR TITLE
parse `expr is typepath` outside parenthesis

### DIFF
--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1298,9 +1298,6 @@ and expr = parser
 			| [< t,pt = parse_type_hint; '(PClose,p2); s >] ->
 				let ep = EParenthesis (ECheckType(e,(t,pt)),punion p1 p2), punion p1 p2 in
 				expr_next (ECast (ep,None),punion p1 (pos ep)) s
-			| [< '(Const (Ident "is"),p_is); t = parse_type_path; '(PClose,p2); >] ->
-				let e_is = make_is e t (punion p1 p2) p_is in
-				expr_next (ECast (e_is,None),punion p1 (pos e_is)) s
 			| [< '(PClose,p2); s >] ->
 				let ep = expr_next (EParenthesis(e),punion pp p2) s in
 				expr_next (ECast (ep,None),punion p1 (pos ep)) s
@@ -1341,9 +1338,8 @@ and expr = parser
 						with_args al er
 					| [< >] -> serror())
 				| [< >] -> serror())
-			| [< '(Const (Ident "is"),p_is); t = parse_type_path; '(PClose,p2); >] -> expr_next (make_is e t (punion p1 p2) p_is) s
 			| [< >] ->
-				syntax_error (Expected [")";",";":";"is"]) s (expr_next (EParenthesis e, punion p1 (pos e)) s))
+				syntax_error (Expected [")";",";":"]) s (expr_next (EParenthesis e, punion p1 (pos e)) s))
 		)
 	| [< '(BkOpen,p1); e = parse_array_decl p1; s >] -> expr_next e s
 	| [< '(Kwd Function,p1); e = parse_function p1 false; >] -> e
@@ -1476,6 +1472,11 @@ and expr_next' e1 = parser
 		end
 	| [< '(Kwd In,_); e2 = expr >] ->
 		make_binop OpIn e1 e2
+	| [< '(Const (Ident "is"),p_is); tp = parse_type_path; s >] ->
+		let p1 = pos e1 in
+		let p2 = pos tp in
+		let e_is = make_is e1 tp (punion p1 p2) p_is in
+		expr_next e_is s
 	| [< >] -> e1
 
 and parse_field e1 p s =


### PR DESCRIPTION
I checked the usages of `expr_next` and looks like we're good to lose parenthesis around `expr is Type`.

The error message is quite cryptic in these cases currently:
```
{x;} is Bad;
function f() {} is Bad;
```
because it parses `is` as a normal identifier and then becomes confused about `Bad` going right after it.

TODO:
 - [ ] Parse `ComplexType` instead of just `TypePath`, error on non-typepaths later on typing?
 - [ ] AST representation (`EIs`, `EBinop` with `ECheckType`?)
 - [ ] Precedence (e.g. `@meta a is B` should be like `@meta a + b`?)
 - [ ] Also parse `a !is B` to avoid awkward parens for negation?
 - [ ] Anything else?