### PR TITLE
Apply texpr.for_remap in ForRemap filter when a TFor escapes

### DIFF
--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -672,7 +672,10 @@ module ForRemap = struct
 			let restore = save_locals ctx in
 			let e = ForLoop.IterationKind.to_texpr ctx v iterator e2 e.epos in
 			restore();
-			e
+			begin match e.eexpr with
+			| TFor _ -> for_remap ctx.com.basic v e1 e2 e.epos
+			| _ -> e
+			end
 		| _ ->
 			Type.map_expr loop e
 		in

--- a/tests/optimization/src/TestInlineConstructors.hx
+++ b/tests/optimization/src/TestInlineConstructors.hx
@@ -19,6 +19,13 @@ class InlineClass {
 	}
 }
 
+class InlineIterator {
+	public var i = 0;
+	public inline function new() {};
+	public inline function hasNext() return i < 10;
+	public inline function next() return i++;
+}
+
 class NestedInlineClass {
 	public var a : InlineClass;
 	public var b : Array<Int>;
@@ -112,5 +119,15 @@ class TestInlineConstructors extends TestBase {
 		var a : {function cancelThis() : Array<Int>;} = new InlineClass();
 		var arr = a.cancelThis();
 		return [arr[0], arr[1]];
+	}
+
+	@:js('var v_i = 0;var acc = 0;while(v_i < 10) acc += v_i++;return acc;')
+	static function testIteratorMethodInliningInForLoop() {
+		var iter : Iterator<Int> = new InlineIterator();
+		var acc = 0;
+		for ( v in iter ) {
+			acc += v;
+		}
+		return acc;
 	}
 }


### PR DESCRIPTION
It seems to pass the tests but I'm not sure if this is the right way to approach this.

In conjunction with the changes to the constructor inliner filter this code now inlines the iterator:
```haxe
var arr = [1,2];
var iter : Iterator<Int> = arr.iterator();
for ( v in iter ) {
	trace(v);
}
```