### PR TITLE
[abstracts] fix implicit direct cast applicability check

### DIFF
--- a/tests/unit/src/unit/issues/Issue9688.hx
+++ b/tests/unit/src/unit/issues/Issue9688.hx
@@ -1,0 +1,18 @@
+package unit.issues;
+
+class Issue9688 extends Test {
+  function test() {
+    var field: Bar = {x: 0, y: null};
+    eq(1, field.x);
+
+    var direct: Bar = {x: 0};
+    eq(0, direct.x);
+  }
+}
+
+private typedef Foo = {x: Int, ?y: Int, ?z: Int};
+
+@:forward private abstract Bar(Foo) from Foo {
+  @:from static inline function fromX(value: {x: Int, ?y: Int}): Bar
+    return {x: 1, y: 0, z: 0};
+}


### PR DESCRIPTION
Closes #9688.

`allow_implicit_cast` is working name.