### PR TITLE
[abstracts] change handling of transitive casts

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -1197,6 +1197,12 @@
 		"targets": ["TClassField"]
 	},
 	{
+		"name": "Transitive",
+		"metadata": ":transitive",
+		"doc": "Allows transitive casts with an abstract.",
+		"targets": ["TAbstract"]
+	},
+	{
 		"name": "ValueUsed",
 		"metadata": ":valueUsed",
 		"doc": "Internally used by DCE to mark an abstract value as used.",

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -32,6 +32,7 @@ type eq_kind =
 
 type unification_context = {
 	allow_transitive_cast : bool;
+	allow_abstract_cast   : bool; (* allows a non-transitive abstract cast (from,to,@:from,@:to) *)
 	equality_kind         : eq_kind;
 }
 
@@ -52,6 +53,7 @@ let unify_min_ref : (unification_context -> t -> t list -> unify_min_result) ref
 
 let default_unification_context = {
 	allow_transitive_cast = true;
+	allow_abstract_cast   = true;
 	equality_kind         = EqStrict;
 }
 
@@ -630,6 +632,8 @@ let rec unify (uctx : unification_context) a b =
 	| TAbstract ({ a_path = ["haxe"],"NotVoid" },[]), _
 	| _, TAbstract ({ a_path = ["haxe"],"NotVoid" },[]) ->
 		()
+	| TAbstract _, TAbstract ({ a_path = ["haxe"],("FlatEnum" | "Function" | "Constructible") },_) ->
+		error [cannot_unify a b]
 	| TAbstract (a1,tl1) , TAbstract (a2,tl2) ->
 		unify_abstracts uctx a b a1 tl1 a2 tl2
 	| TInst (c1,tl1) , TInst (c2,tl2) ->
@@ -655,6 +659,7 @@ let rec unify (uctx : unification_context) a b =
 		in
 		if not (loop c1 tl1) then error [cannot_unify a b]
 	| TFun (l1,r1) , TFun (l2,r2) when List.length l1 = List.length l2 ->
+		let uctx = get_nested_context uctx in
 		let i = ref 0 in
 		(try
 			(match follow r2 with
@@ -873,6 +878,20 @@ and unify_anons uctx a b a1 a2 =
 	with
 		Unify_error l -> error (cannot_unify a b :: l))
 
+and get_abstract_context uctx a b ab =
+	if (Meta.has Meta.CoreType ab.a_meta) || (Meta.has Meta.Transitive ab.a_meta) then
+		uctx
+	else if uctx.allow_abstract_cast then
+		{uctx with allow_abstract_cast = false}
+	else
+		error [cannot_unify a b]
+
+and get_nested_context uctx =
+	{uctx with allow_abstract_cast = true}
+
+and unifies_with_abstract uctx f =
+	(uctx.allow_transitive_cast && f {uctx with allow_transitive_cast = false}) || f uctx
+
 and get_abstract_unify_func uctx equality_kind =
 	if uctx.allow_transitive_cast then unify uctx else type_eq {uctx with equality_kind = equality_kind}
 
@@ -889,26 +908,31 @@ and unify_to uctx a b ab tl =
 	if not (unifies_to uctx a b ab tl) then error [cannot_unify a b]
 
 and unifies_abstracts uctx a b a1 tl1 a2 tl2 =
-	let uctx_no_transitive_casts = {uctx with allow_transitive_cast = false} in
-	(unifies_to uctx_no_transitive_casts a b a1 tl1) || (unifies_from uctx_no_transitive_casts a b a2 tl2)
-	|| (((Meta.has Meta.CoreType a1.a_meta) || (Meta.has Meta.CoreType a2.a_meta))
-		&& ((unifies_to uctx a b a1 tl1) || (unifies_from uctx a b a2 tl2)))
+	unifies_with_abstract uctx (fun uctx ->
+		unifies_to uctx a b a1 tl1 || unifies_from uctx a b a2 tl2
+	)
 
 and unifies_from uctx a b ab tl =
-	List.exists (unifies_from_direct uctx a b ab tl) ab.a_from
+	unifies_with_abstract uctx (fun uctx ->
+		List.exists (unifies_from_direct uctx a b ab tl) ab.a_from
+	)
 
 and unifies_to uctx a b ab tl =
-	List.exists (unifies_to_direct uctx a b ab tl) ab.a_to
+	unifies_with_abstract uctx (fun uctx ->
+		List.exists (unifies_to_direct uctx a b ab tl) ab.a_to
+	)
 
 and unifies_from_direct uctx a b ab tl t =
 	rec_stack_abstract_unifies a b (fun() ->
 		let t = apply_params ab.a_params tl t in
+		let uctx = get_abstract_context uctx a b ab in
 		let unify_func = get_abstract_unify_func uctx EqRightDynamic in
 		unify_func a t)
 
 and unifies_to_direct uctx a b ab tl t =
 	rec_stack_abstract_unifies a b (fun() ->
 		let t = apply_params ab.a_params tl t in
+		let uctx = get_abstract_context uctx a b ab in
 		let unify_func = get_abstract_unify_func uctx EqStrict in
 		unify_func t b)
 
@@ -919,6 +943,7 @@ and unifies_from_field uctx a b ab tl (t,cf) =
 			let map = apply_params ab.a_params tl in
 			let monos = Monomorph.spawn_constrained_monos map cf.cf_params in
 			let map t = map (apply_params cf.cf_params monos t) in
+			let uctx = get_abstract_context uctx a b ab in
 			let unify_func = get_abstract_unify_func uctx EqStrict in
 			unify_func a (map t);
 			unify_func (map r) b;
@@ -931,6 +956,7 @@ and unifies_to_field uctx a b ab tl (t,cf) =
 			let map = apply_params ab.a_params tl in
 			let monos = Monomorph.spawn_constrained_monos map cf.cf_params in
 			let map t = map (apply_params cf.cf_params monos t) in
+			let uctx = get_abstract_context uctx a b ab in
 			let unify_func = get_abstract_unify_func uctx EqStrict in
 			let athis = map ab.a_this in
 			(* we cannot allow implicit casts when the this type is not completely known yet *)
@@ -989,6 +1015,7 @@ and with_variance uctx f t1 t2 =
 		raise (Unify_error l)
 
 and unify_with_access uctx f1 t1 f2 =
+	let uctx = get_nested_context uctx in
 	match f2.cf_kind with
 	(* write only *)
 	| Var { v_read = AccNo } | Var { v_read = AccNever } -> unify uctx f2.cf_type t1

--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -130,6 +130,7 @@ abstract UInt to Int from Int {
 
 	@see https://haxe.org/manual/types-basic-types.html
 **/
+@:transitive
 abstract UInt(Int) from Int to Int {
 	@:op(A + B) private static inline function add(a:UInt, b:UInt):UInt {
 		return a.toInt() + b.toInt();

--- a/std/cpp/_std/haxe/Int64.hx
+++ b/std/cpp/_std/haxe/Int64.hx
@@ -136,6 +136,7 @@ private extern class ___Int64 {
 private typedef __Int64 = ___Int64;
 
 @:coreApi
+@:transitive
 abstract Int64(__Int64) from __Int64 to __Int64 {
 	public #if !cppia inline #end function copy():Int64
 		return this;

--- a/std/cs/_std/haxe/Int64.hx
+++ b/std/cs/_std/haxe/Int64.hx
@@ -29,6 +29,7 @@ import haxe.Int64Helper;
 private typedef __Int64 = cs.StdTypes.Int64;
 
 @:coreApi
+@:transitive
 abstract Int64(__Int64) from __Int64 to __Int64 {
 	public static inline function make(high:Int32, low:Int32):Int64
 		return new Int64((cast(high, __Int64) << 32) | (cast(low, __Int64) & (untyped __cs__('0xffffffffL') : Int64)));

--- a/std/haxe/Int32.hx
+++ b/std/haxe/Int32.hx
@@ -26,6 +26,7 @@ package haxe;
 	Int32 provides a 32-bit integer with consistent overflow behavior across
 	all platforms.
 **/
+@:transitive
 abstract Int32(Int) from Int to Int {
 	@:op(-A) private inline function negate():Int32
 		return clamp(~this + 1);

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -31,6 +31,7 @@ using haxe.Int64;
 #if flash
 @:notNull
 #end
+@:transitive
 abstract Int64(__Int64) from __Int64 to __Int64 {
 	private inline function new(x:__Int64)
 		this = x;

--- a/std/haxe/extern/AsVar.hx
+++ b/std/haxe/extern/AsVar.hx
@@ -27,5 +27,6 @@ package haxe.extern;
 	argument expressions are bound to a local variable.
 **/
 @:forward
+@:transitive
 @:semantics(variable)
 abstract AsVar<T>(T) from T to T {}

--- a/std/haxe/extern/EitherType.hx
+++ b/std/haxe/extern/EitherType.hx
@@ -33,4 +33,5 @@ package haxe.extern;
 
 	@see <https://haxe.org/manual/lf-externs.html>
 **/
+@:transitive
 abstract EitherType<T1, T2>(Dynamic) from T1 to T1 from T2 to T2 {}

--- a/std/hl/_std/UInt.hx
+++ b/std/hl/_std/UInt.hx
@@ -20,6 +20,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 @:coreApi
+@:transitive
 abstract UInt(Int) from Int to Int {
 	@:op(A + B) private static inline function add(a:UInt, b:UInt):UInt {
 		return a.toInt() + b.toInt();

--- a/std/java/_std/haxe/Int64.hx
+++ b/std/java/_std/haxe/Int64.hx
@@ -29,6 +29,7 @@ import haxe.Int64Helper;
 private typedef __Int64 = java.StdTypes.Int64;
 
 @:coreApi
+@:transitive
 abstract Int64(__Int64) from __Int64 to __Int64 {
 	#if jvm
 	extern public static function make(high:Int32, low:Int32):Int64;

--- a/std/java/lang/Boolean.hx
+++ b/std/java/lang/Boolean.hx
@@ -23,8 +23,9 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
-@:forward
-@:forwardStatics abstract Boolean(BooleanClass) from BooleanClass to BooleanClass {
+@:transitive
+@:forwardStatics
+@:forward abstract Boolean(BooleanClass) from BooleanClass to BooleanClass {
 	@:to extern inline public function toBool():Bool
 		return this.booleanValue();
 

--- a/std/java/lang/Byte.hx
+++ b/std/java/lang/Byte.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Byte(ByteClass) from ByteClass to ByteClass {
 	@:to extern inline public function toByte():java.types.Int8

--- a/std/java/lang/Character.hx
+++ b/std/java/lang/Character.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Character(CharacterClass) from CharacterClass to CharacterClass {
 	@:to extern inline public function toCharacter():java.types.Char16

--- a/std/java/lang/Double.hx
+++ b/std/java/lang/Double.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Double(DoubleClass) from DoubleClass to DoubleClass {
 	@:to extern inline public function toFloat():Float

--- a/std/java/lang/Float.hx
+++ b/std/java/lang/Float.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Float(FloatClass) from FloatClass to FloatClass {
 	@:to extern inline public function toFloat():std.StdTypes.Float

--- a/std/java/lang/Integer.hx
+++ b/std/java/lang/Integer.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Integer(IntegerClass) from IntegerClass to IntegerClass {
 	@:to extern inline public function toInt():Int

--- a/std/java/lang/Long.hx
+++ b/std/java/lang/Long.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Long(LongClass) from LongClass to LongClass {
 	@:to extern inline public function toLong():haxe.Int64

--- a/std/java/lang/Short.hx
+++ b/std/java/lang/Short.hx
@@ -23,6 +23,7 @@
 package java.lang;
 
 @:native("") // make sure the generator won't see this
+@:transitive
 @:forwardStatics
 @:forward abstract Short(ShortClass) from ShortClass to ShortClass {
 	@:to extern inline public function toShort():java.types.Int16

--- a/std/js/lib/Promise.hx
+++ b/std/js/lib/Promise.hx
@@ -109,6 +109,7 @@ abstract PromiseHandler<T, TOut>(T->Dynamic) // T->Dynamic, so the compiler alwa
 	A value with a `then` method.
 **/
 @:forward
+@:transitive
 abstract Thenable<T>(ThenableStruct<T>)
 	from ThenableStruct<T> {} // abstract wrapping prevents compiler hanging, see https://github.com/HaxeFoundation/haxe/issues/5785
 

--- a/tests/unit/src/unit/issues/Issue2584.hx
+++ b/tests/unit/src/unit/issues/Issue2584.hx
@@ -13,6 +13,7 @@ private abstract XX (String) {
 	}
 }
 
+@:transitive
 private abstract X2(X) to X {}
 
 private abstract XArr(Array<X>) to Array<X> {}

--- a/tests/unit/src/unit/issues/Issue5385.hx
+++ b/tests/unit/src/unit/issues/Issue5385.hx
@@ -23,4 +23,5 @@ private abstract MyIterator<T>(Iterator<T>) from Iterator<T> to Iterator<T> {
 }
 
 @:forward
+@:transitive
 private abstract Refs(Array<String>) from Array<String> to Array<String> {}


### PR DESCRIPTION
Fixes #9694 and #9688. Includes refactor of abstract unification methods.

- Added `:transitive` meta as whitelist for abstracts who are ok with being used in transitive casts.

- Changed selection of direct/field cast. Now order is this: direct casts by equality, field casts by equality, direct casts by unification, field casts by unification. This handles cases like `UInt`, where there is `to Int`, but also `@:to Float`: if checked only by unification then `to` will win over `@:to`, since `Int` is a core type that also has `to Float`.

- Added a size check for the recursive cast stack, since this currently produces stack overflow instead of a proper error:
```haxe
abstract Foo<T>(T) from T to Foo<Null<T>> {}

class Main {
  static public function main() {
    var x: Foo<Int> = 0;
    var y: Int = x;
  }
}
```

- Changed some method names, a method starts with `unifies` if it returns a boolean result and `unify` if it is expected to throw a unification error. Moved arguments, so that abstract unify functions always start with `uctx a b ab pl`.

- Added `allow_abstract_cast` to unification context to disallow a non-transitive abstract cast after another such one. (`allow_transitive_cast` disallows any cast (abstract/non-abstract, transitive/non-transitive) after abstract one.)

- Added `:transitive` to `UInt` (where it doesn't have `:coreType`) and three places in unit tests where it was needed (two of them are obviously need one, third one about `E3` is tricky and discussed in the first mentioned issue).