### PR TITLE
[std] allow ReadOnlyArray.concat(ReadOnlyArray)

### DIFF
--- a/std/haxe/ds/ReadOnlyArray.hx
+++ b/std/haxe/ds/ReadOnlyArray.hx
@@ -30,7 +30,7 @@ package haxe.ds;
 	Other code holding a reference to the underlying `Array` can still modify it,
 	and the reference can be obtained with a `cast`.
 **/
-@:forward(concat, copy, filter, indexOf, iterator, keyValueIterator, join, lastIndexOf, map, slice, contains, toString)
+@:forward(copy, filter, indexOf, iterator, keyValueIterator, join, lastIndexOf, map, slice, contains, toString)
 abstract ReadOnlyArray<T>(Array<T>) from Array<T> to Iterable<T> {
 	/**
 		The length of `this` Array.
@@ -42,4 +42,21 @@ abstract ReadOnlyArray<T>(Array<T>) from Array<T> to Iterable<T> {
 
 	@:arrayAccess inline function get(i:Int)
 		return this[i];
+
+	/**
+		Returns a new Array by appending the elements of `a` to the elements of
+		`this` Array.
+
+		This operation does not modify `this` Array.
+
+		If `a` is the empty Array `[]`, a copy of `this` Array is returned.
+
+		The length of the returned Array is equal to the sum of `this.length`
+		and `a.length`.
+
+		If `a` is `null`, the result is unspecified.
+	**/
+	public inline function concat(a:ReadOnlyArray<T>):Array<T> {
+		return this.concat(cast a);
+	}
 }

--- a/tests/unit/src/unit/issues/Issue9710.hx
+++ b/tests/unit/src/unit/issues/Issue9710.hx
@@ -1,0 +1,11 @@
+package unit.issues;
+
+import haxe.ds.ReadOnlyArray;
+
+class Issue9710 extends unit.Test {
+	function test() {
+		var a:ReadOnlyArray<Int> = [1];
+		var b:ReadOnlyArray<Int> = [2];
+		aeq([1, 2], a.concat(b));
+	}
+}


### PR DESCRIPTION
Before this, it wasn't possible to do `a.concat(b)` if both `a` and `b` are typed as `ReadOnlyArray`, which is a bit awkward.

Not entirely sure if the return type should be a plain array, but making that a `ReadOnlyArray` too would be breaking.