### PR TITLE
Remove parameter from TDynamic

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -103,11 +103,8 @@ let update_cache_dependencies t =
 			| _ -> ())
 		| TLazy f ->
 			check_t m (lazy_type f)
-		| TDynamic t ->
-			if t == t_dynamic then
-				()
-			else
-				check_t m t
+		| TDynamic ->
+			()
 	and check_field m cf =
 		check_t m cf.cf_type
 	in

--- a/src/codegen/gencommon/closuresToClass.ml
+++ b/src/codegen/gencommon/closuresToClass.ml
@@ -283,8 +283,8 @@ let rec get_type_params acc t =
 			List.filter (fun t -> not (List.memq t acc)) (cl :: params) @ acc;
 		| TFun (params,tret) ->
 			List.fold_left get_type_params acc ( tret :: List.map (fun (_,_,t) -> t) params )
-		| TDynamic t ->
-			(match t with | TDynamic _ -> acc | _ -> get_type_params acc t)
+		| TDynamic ->
+			acc
 		| TAbstract (a, pl) when not (Meta.has Meta.CoreType a.a_meta) ->
 				get_type_params acc ( Abstract.get_underlying_type a pl)
 		| TAnon a ->

--- a/src/codegen/gencommon/dynamicFieldAccess.ml
+++ b/src/codegen/gencommon/dynamicFieldAccess.ml
@@ -99,7 +99,7 @@ let configure gen (is_dynamic:texpr->Type.tfield_access->bool) (change_expr:texp
 
 		| TCall ({ eexpr = TField (_, FStatic({ cl_path = ([], "Reflect") }, { cf_name = "field" })) }, [obj; { eexpr = TConst (TString field) }]) ->
 			let t = match gen.greal_type obj.etype with
-			| TDynamic _ | TAnon _ | TMono _ -> t_dynamic
+			| TDynamic | TAnon _ | TMono _ -> t_dynamic
 			| t -> t
 			in
 			change_expr (mk_field_access gen { obj with etype = t } field obj.epos) (run obj) field None false

--- a/src/codegen/gencommon/fixOverrides.ml
+++ b/src/codegen/gencommon/fixOverrides.ml
@@ -98,7 +98,7 @@ let run ~explicit_fn_name ~get_vmtype gen =
 								(* different return types are the trickiest cases to deal with *)
 								(* check for covariant return type *)
 								let is_covariant = match follow r1, follow r2 with
-									| _, TDynamic _ -> false
+									| _, TDynamic -> false
 									| r1, r2 -> try
 										unify r1 r2;
 										if like_int r1 then like_int r2 else true

--- a/src/codegen/gencommon/gencommon.ml
+++ b/src/codegen/gencommon/gencommon.ml
@@ -1080,7 +1080,7 @@ let rec replace_mono t =
 		List.iter (fun (_,_,t) -> replace_mono t) args;
 		replace_mono ret
 	| TAnon _
-	| TDynamic _ -> ()
+	| TDynamic -> ()
 	| TLazy f ->
 		replace_mono (lazy_type f)
 
@@ -1248,7 +1248,7 @@ let rec field_access gen (t:t) (field:string) : (tfield_access) =
 		| _ when PMap.mem field gen.gbase_class_fields ->
 			let cf = PMap.find field gen.gbase_class_fields in
 			FClassField(gen.gclasses.cl_dyn, [t_dynamic], gen.gclasses.cl_dyn, cf, false, cf.cf_type, cf.cf_type)
-		| TDynamic t -> FDynamicField t
+		| TDynamic -> FDynamicField t_dynamic
 		| TMono _ -> FDynamicField t_dynamic
 		| _ -> FNotFound
 

--- a/src/codegen/gencommon/hardNullableSynf.ml
+++ b/src/codegen/gencommon/hardNullableSynf.ml
@@ -83,9 +83,9 @@ let configure gen unwrap_null wrap_val null_to_dynamic has_value opeq_handler =
 	let handle_unwrap to_t e =
 		let e_null_t = get (is_null_t e.etype) in
 		match gen.greal_type to_t with
-			| TDynamic _ | TMono _ | TAnon _ ->
+			| TDynamic | TMono _ | TAnon _ ->
 				(match e_null_t with
-					| TDynamic _ | TMono _ | TAnon _ ->
+					| TDynamic | TMono _ | TAnon _ ->
 						gen.ghandle_cast to_t e_null_t (unwrap_null e)
 					| _ -> null_to_dynamic e
 				)

--- a/src/codegen/gencommon/normalize.ml
+++ b/src/codegen/gencommon/normalize.ml
@@ -58,7 +58,7 @@ let rec filter_param (stack:t list) t =
 		mk_anon ~fields a.a_status
 	| TFun(args,ret) ->
 		TFun(List.map (fun (n,o,t) -> (n,o,filter_param stack t)) args, filter_param stack ret)
-	| TDynamic _ ->
+	| TDynamic ->
 		t
 	| TLazy f ->
 		filter_param stack (lazy_type f)

--- a/src/codegen/gencommon/realTypeParams.ml
+++ b/src/codegen/gencommon/realTypeParams.ml
@@ -505,7 +505,7 @@ struct
 				| TInst (cl,_) -> cl.cl_path
 				| TEnum (e,_) -> e.e_path
 				| TAbstract (a,_) -> a.a_path
-				| TMono _ | TDynamic _ -> ([], "Dynamic")
+				| TMono _ | TDynamic -> ([], "Dynamic")
 				| _ -> Globals.die "" __LOC__
 			in
 			List.map (fun (cf, t_cl, t_cf) ->

--- a/src/codegen/gencommon/reflectionCFs.ml
+++ b/src/codegen/gencommon/reflectionCFs.ml
@@ -972,7 +972,7 @@ let implement_get_set ctx cl =
 			if is_float then
 				List.filter (fun (_,cf) -> (* TODO: maybe really apply_params in cf.cf_type. The benefits would be limited, though *)
 					match follow (ctx.rcf_gen.greal_type (ctx.rcf_gen.gfollow#run_f cf.cf_type)) with
-						| TDynamic _ | TMono _
+						| TDynamic | TMono _
 						| TInst ({ cl_kind = KTypeParameter _ }, _) -> true
 						| t when like_float t && not (like_i64 t) -> true
 						| _ -> false

--- a/src/codegen/genxml.ml
+++ b/src/codegen/genxml.ml
@@ -122,7 +122,7 @@ let rec gen_type ?(values=None) t =
 		) args in
 		node "f" (("a",names) :: values) (List.map gen_type (args @ [r]))
 	| TAnon a -> node "a" [] (pmap (fun f -> gen_field [] { f with cf_flags = unset_flag f.cf_flags (int_of_class_field_flag CfPublic) }) a.a_fields)
-	| TDynamic t2 -> node "d" [] (if t == t2 then [] else [gen_type t2])
+	| TDynamic -> node "d" [] []
 	| TLazy f -> gen_type (lazy_type f)
 
 and gen_type_decl n t pl =

--- a/src/codegen/overloads.ml
+++ b/src/codegen/overloads.ml
@@ -136,7 +136,7 @@ struct
 			| Some t -> simplify_t t
 			| None -> t_dynamic)
 		| TAnon _ -> t_dynamic
-		| TDynamic _ -> t
+		| TDynamic -> t
 		| TLazy f -> simplify_t (lazy_type f)
 		| TFun _ -> t
 
@@ -189,13 +189,13 @@ struct
 		| TEnum(ef,tlf), TEnum(ea, tla) ->
 			if ef != ea then raise Not_found;
 			(cacc, rate_tp tlf tla)
-		| TDynamic _, TDynamic _ ->
+		| TDynamic, TDynamic ->
 			(cacc, 0)
-		| TDynamic _, _ ->
+		| TDynamic, _ ->
 			(max_int, 0) (* a function with dynamic will always be worst of all *)
-		| TAbstract(a, _), TDynamic _ when Meta.has Meta.CoreType a.a_meta && a.a_path <> ([],"Null") ->
+		| TAbstract(a, _), TDynamic when Meta.has Meta.CoreType a.a_meta && a.a_path <> ([],"Null") ->
 			(cacc + 2, 0) (* a dynamic to a basic type will have an "unboxing" penalty *)
-		| _, TDynamic _ ->
+		| _, TDynamic ->
 			(cacc + 1, 0)
 		| TAbstract({ a_path = [], "Null" }, [tf]), TAbstract({ a_path = [], "Null" }, [ta]) ->
 			rate_conv (cacc+0) tf ta

--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -395,7 +395,7 @@ let promote_type_hints tctx =
 		| TType(({t_name_pos = pn;t_path = (_,name)}),_)
 		| TAbstract(({a_name_pos = pn;a_path = (_,name)}),_) ->
 			md.m_type_hints <- (p,pn) :: md.m_type_hints;
-		| TDynamic _ -> ()
+		| TDynamic -> ()
 		| TFun _ | TAnon _ -> ()
 	in
 	List.iter explore_type_hint tctx.g.type_hints

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -690,6 +690,7 @@ let create version s_version args =
 			tnull = (fun _ -> die "" __LOC__);
 			tstring = m;
 			tarray = (fun _ -> die "" __LOC__);
+			tdynamic = (fun _ -> die "" __LOC__);
 		};
 		file_lookup_cache = Hashtbl.create 0;
 		file_keys = new file_keys;

--- a/src/context/display/displayEmitter.ml
+++ b/src/context/display/displayEmitter.ml
@@ -45,8 +45,8 @@ let rec display_type ctx t p =
 		display_module_type ctx (module_type_of_type t) p
 	with Exit ->
 		match follow t,follow !t_dynamic_def with
-		| _,TDynamic _ -> () (* sanity check in case it's still t_dynamic *)
-		| TDynamic _,_ -> display_type ctx !t_dynamic_def p
+		| _,TDynamic -> () (* sanity check in case it's still t_dynamic *)
+		| TDynamic,_ -> display_type ctx !t_dynamic_def p
 		| _ ->
 			match dm.dms_kind with
 			| DMHover ->
@@ -81,7 +81,7 @@ let raise_position_of_type t =
 				| TMono r -> (match r.tm_type with None -> raise_positions [null_pos] | Some t -> follow_null t)
 				| TLazy f -> follow_null (lazy_type f)
 				| TAbstract({a_path = [],"Null"},[t]) -> follow_null t
-				| TDynamic _ -> !t_dynamic_def
+				| TDynamic -> !t_dynamic_def
 				| _ -> t
 		in
 		try

--- a/src/core/display/completionItem.ml
+++ b/src/core/display/completionItem.ml
@@ -372,7 +372,7 @@ module CompletionType = struct
 		| CTAbstract of ct_path_with_params
 		| CTFunction of ct_function
 		| CTAnonymous of ct_anonymous
-		| CTDynamic of t option
+		| CTDynamic
 
 	let rec generate_path_with_params ctx pwp = jobject [
 		"path",jobject [
@@ -424,7 +424,7 @@ module CompletionType = struct
 			| CTAbstract pwp -> "TAbstract",Some (generate_path_with_params ctx pwp)
 			| CTFunction ctf -> "TFun",Some (generate_function ctx ctf)
 			| CTAnonymous cta -> "TAnonymous",Some (generate_anon ctx cta)
-			| CTDynamic cto -> "TDynamic",Option.map (generate_type ctx) cto;
+			| CTDynamic -> "TDynamic",None
 		in
 		generate_adt ctx None name args
 
@@ -489,8 +489,8 @@ module CompletionType = struct
 					ct_fields = PMap.fold (fun cf acc -> afield cf :: acc) an.a_fields [];
 					ct_status = !(an.a_status);
 				}
-			| TDynamic t ->
-				CTDynamic (if t == t_dynamic then None else Some (from_type PMap.empty t))
+			| TDynamic ->
+				CTDynamic
 		in
 		from_type values t
 end

--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -187,8 +187,8 @@ module BetterErrors = struct
 					let fl = PMap.fold (fun f acc -> ((if Meta.has Meta.Optional f.cf_meta then " ?" else " ") ^ f.cf_name) :: acc) a.a_fields [] in
 					"{" ^ String.concat "," fl ^ " }"
 			end
-		| TDynamic t2 ->
-			"Dynamic" ^ s_type_params ctx (if t == t2 then [] else [t2])
+		| TDynamic ->
+			"Dynamic"
 		| TLazy f ->
 			s_type ctx (lazy_type f)
 

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -213,7 +213,7 @@ let rec generate_type ctx t =
 			let t = lazy_type f in
 			(* return_partial_type := false; *)
 			loop t
-		| TDynamic t -> "TDynamic",Some (if t == t_dynamic then jnull else generate_type ctx t)
+		| TDynamic -> "TDynamic",Some jnull
 		| TInst(c,tl) -> "TInst",Some (generate_type_path_with_params ctx c.cl_module.m_path c.cl_path tl c.cl_meta)
 		| TEnum(en,tl) -> "TEnum",Some (generate_type_path_with_params ctx en.e_module.m_path en.e_path tl en.e_meta)
 		| TType(td,tl) -> "TType",Some (generate_type_path_with_params ctx td.t_module.m_path td.t_path tl td.t_meta)

--- a/src/core/tOther.ml
+++ b/src/core/tOther.ml
@@ -52,8 +52,8 @@ module TExprToExpr = struct
 					} :: acc
 				) a.a_fields [])
 			end
-		| (TDynamic t2) as t ->
-			tpath ([],"Dynamic") ([],"Dynamic") (if t == t_dynamic then [] else [tparam t2])
+		| TDynamic ->
+			tpath ([],"Dynamic") ([],"Dynamic") []
 		| TLazy f ->
 			convert_type (lazy_type f)
 

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -19,7 +19,7 @@ let rec s_type_kind t =
 	| TAbstract(a,tl) -> Printf.sprintf "TAbstract(%s, [%s])" (s_type_path a.a_path) (map tl)
 	| TFun(tl,r) -> Printf.sprintf "TFun([%s], %s)" (String.concat ", " (List.map (fun (n,b,t) -> Printf.sprintf "%s%s:%s" (if b then "?" else "") n (s_type_kind t)) tl)) (s_type_kind r)
 	| TAnon an -> "TAnon"
-	| TDynamic t2 -> "TDynamic"
+	| TDynamic -> "TDynamic"
 	| TLazy _ -> "TLazy"
 
 let s_module_type_kind = function
@@ -82,8 +82,8 @@ let rec s_type ctx t =
 				let fl = PMap.fold (fun f acc -> ((if Meta.has Meta.Optional f.cf_meta then " ?" else " ") ^ f.cf_name ^ " : " ^ s_type ctx f.cf_type) :: acc) a.a_fields [] in
 				"{" ^ String.concat "," fl ^ " }"
 		end
-	| TDynamic t2 ->
-		"Dynamic" ^ s_type_params ctx (if t == t2 then [] else [t2])
+	| TDynamic ->
+		"Dynamic"
 	| TLazy f ->
 		s_type ctx (lazy_type f)
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -39,7 +39,7 @@ type t =
 	| TType of tdef * tparams
 	| TFun of tsignature
 	| TAnon of tanon
-	| TDynamic of t
+	| TDynamic
 	| TLazy of tlazy ref
 	| TAbstract of tabstract * tparams
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -373,6 +373,7 @@ type basic_types = {
 	mutable tnull : t -> t;
 	mutable tstring : t;
 	mutable tarray : t -> t;
+	mutable tdynamic : t -> t;
 }
 
 type class_field_scope =

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -805,7 +805,7 @@ and type_string_suff suffix haxe_type remap =
       | EnumStatics e -> type_string_suff suffix (TEnum (e,List.map snd e.e_params))
       | _ -> "Dynamic"  ^ suffix )
       *)
-   | TDynamic haxe_type -> "Dynamic" ^ suffix
+   | TDynamic -> "Dynamic" ^ suffix
    | TLazy func -> type_string_suff suffix (lazy_type func) remap
    | TAbstract (abs,pl) when abs.a_impl <> None ->
       type_string_suff suffix (Abstract.get_underlying_type abs pl) remap
@@ -1765,7 +1765,7 @@ let rec cpp_type_of stack ctx haxe_type =
 
       | TFun _ -> TCppObject
       | TAnon _ -> TCppObject
-      | TDynamic _ -> TCppDynamic
+      | TDynamic -> TCppDynamic
       | TLazy func -> cpp_type_of stack ctx (lazy_type func)
       )
    end

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -97,7 +97,7 @@ let is_exactly_bool gen t =
 
 let is_dynamic gen t =
 	match follow (gen.greal_type t) with
-		| TDynamic _ -> true
+		| TDynamic -> true
 		| _ -> false
 
 let is_pointer gen t =
@@ -913,7 +913,7 @@ let generate con =
 
 		let has_tdyn tl =
 			List.exists (fun t -> match follow t with
-			| TDynamic _ | TMono _ -> true
+			| TDynamic | TMono _ -> true
 			| _ -> false
 		) tl
 		in
@@ -1009,11 +1009,11 @@ let generate con =
 				| true, TInst _
 				| true, TEnum _
 				| true, TAbstract _ when is_cs_basic_type t_changed -> t
-				| true, TDynamic _ -> t
+				| true, TDynamic -> t
 				| true, x ->
 					dynamic_anon
 			in
-			if is_hxgeneric && (erase_generics || List.exists (fun t -> match follow t with | TDynamic _ -> true | _ -> false) tl) then
+			if is_hxgeneric && (erase_generics || List.exists (fun t -> match follow t with | TDynamic -> true | _ -> false) tl) then
 				List.map (fun _ -> t_dynamic) tl
 			else
 				List.map ret tl
@@ -1023,7 +1023,7 @@ let generate con =
 		and change_param_type = change_param_type [] in
 
 		let is_dynamic t = match real_type t with
-			| TMono _ | TDynamic _
+			| TMono _ | TDynamic
 			| TInst({ cl_kind = KTypeParameter _ }, _) -> true
 			| TAnon anon ->
 				(match !(anon.a_status) with
@@ -1092,7 +1092,7 @@ let generate con =
 					(match !(anon.a_status) with
 						| Statics _ | EnumStatics _ -> "System.Type"
 						| _ -> "object")
-				| TDynamic _ -> "object"
+				| TDynamic -> "object"
 				| TAbstract(a,pl) when not (Meta.has Meta.CoreType a.a_meta) ->
 					t_s (Abstract.get_underlying_type a pl)
 				(* No Lazy type nor Function type made. That's because function types will be at this point be converted into other types *)
@@ -2270,7 +2270,7 @@ let generate con =
 					let is_override = is_override || match cf.cf_name, follow cf.cf_type with
 						| "Equals", TFun([_,_,targ], tret) ->
 							(match follow targ, follow tret with
-								| TDynamic _, TAbstract({ a_path = ([], "Bool") }, []) -> true
+								| TDynamic, TAbstract({ a_path = ([], "Bool") }, []) -> true
 								| _ -> false)
 						| "GetHashCode", TFun([],_) -> true
 						| _ -> false
@@ -2955,7 +2955,7 @@ let generate con =
 			)
 			(fun v t has_value ->
 				match has_value, real_type v.etype with
-					| true, TDynamic _ | true, TAnon _ | true, TMono _ ->
+					| true, TDynamic | true, TAnon _ | true, TMono _ ->
 						{
 							eexpr = TCall(mk_static_field_access_infer null_t "ofDynamic" v.epos [t], [mk_tp t v.epos; v]);
 							etype = TInst(null_t, [t]);
@@ -3024,7 +3024,7 @@ let generate con =
 		let rcf_static_insert, rcf_static_remove =
 			let get_specialized_postfix t = match t with
 				| TAbstract({a_path = [],("Float" | "Int" as name)}, _) -> name
-				| TAnon _ | TDynamic _ -> "Dynamic"
+				| TAnon _ | TDynamic -> "Dynamic"
 				| _ -> print_endline (debug_type t); die "" __LOC__
 			in
 			(fun t -> mk_static_field_access_infer (get_cl (get_type gen (["haxe";"lang"], "FieldLookup"))) ("insert" ^ get_specialized_postfix t) null_pos []),
@@ -3161,7 +3161,7 @@ let generate con =
 			match e.eexpr with
 				| TArray(e1, e2) ->
 					(match follow e1.etype with
-						| TDynamic _ | TAnon _ | TMono _ -> true
+						| TDynamic | TAnon _ | TMono _ -> true
 						| TInst({ cl_kind = KTypeParameter _ }, _) -> true
 						| TInst(c,p) when erase_generics && is_hxgeneric (TClassDecl c) && is_hxgen (TClassDecl c) -> (match c.cl_path with
 							| [],"String"
@@ -3169,7 +3169,7 @@ let generate con =
 							| _ ->
 								true)
 						| _ -> match binop, change_param_type (t_to_md e1.etype) [e.etype] with
-							| Some(Ast.OpAssignOp _), ([TDynamic _] | [TAnon _]) ->
+							| Some(Ast.OpAssignOp _), ([TDynamic] | [TAnon _]) ->
 								true
 							| _ -> false)
 				| _ -> die "" __LOC__
@@ -3224,7 +3224,7 @@ let generate con =
 
 		let should_handle_opeq t =
 			match real_type t with
-				| TDynamic _ | TAnon _ | TMono _
+				| TDynamic | TAnon _ | TMono _
 				| TInst( { cl_kind = KTypeParameter _ }, _ )
 				| TInst( { cl_path = (["haxe";"lang"], "Null") }, _ ) -> true
 				| _ -> false
@@ -3278,8 +3278,8 @@ let generate con =
 			(fun e1 e2 ->
 				let is_basic = is_cs_basic_type (follow e1.etype) || is_cs_basic_type (follow e2.etype) in
 				let is_ref = if is_basic then false else match follow e1.etype, follow e2.etype with
-					| TDynamic _, _
-					| _, TDynamic _
+					| TDynamic, _
+					| _, TDynamic
 					| TInst( { cl_path = ([], "String") }, [] ), _
 					| _, TInst( { cl_path = ([], "String") }, [] )
 					| TInst( { cl_kind = KTypeParameter _ }, [] ), _

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -421,7 +421,7 @@ let rec to_type ?tref ctx t =
 			Array.iteri (fun i (n,_,_) -> vp.vindex <- PMap.add n i vp.vindex) vp.vfields;
 			t
 		)
-	| TDynamic _ ->
+	| TDynamic ->
 		HDyn
 	| TEnum (e,_) ->
 		enum_type ~tref ctx e

--- a/src/generators/genhxold.ml
+++ b/src/generators/genhxold.ml
@@ -104,8 +104,8 @@ let generate_type com t =
 			"{" ^ String.concat ", " fields ^ "}"
 		| TLazy f ->
 			stype (lazy_type f)
-		| TDynamic t2 ->
-			if t == t2 then "Dynamic" else "Dynamic<" ^ stype t2 ^ ">"
+		| TDynamic ->
+			"Dynamic"
 		| TFun ([],ret) ->
 			"() -> " ^ ftype ret
 		| TFun (args,ret) ->

--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -1276,8 +1276,8 @@ let generate con =
 								path_s_import pos (["java";"lang"], "Class") []
 						| _ ->
 								path_s_import pos (["java";"lang"], "Object") [])
-					| TDynamic ->
-							path_s_import pos (["java";"lang"], "Object") []
+				| TDynamic | TAbstract({a_path=([],"Dynamic")},_) ->
+					path_s_import pos (["java";"lang"], "Object") []
 				(* No Lazy type nor Function type made. That's because function types will be at this point be converted into other types *)
 				| _ -> if !strict_mode then begin trace ("[ !TypeError " ^ (Type.s_type (Type.print_context()) t) ^ " ]"); die "" __LOC__ end else "[ !TypeError " ^ (Type.s_type (Type.print_context()) t) ^ " ]"
 		end

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -359,7 +359,7 @@ let is_dynamic_iterator ctx e =
 			| TInst ({ cl_path = [],"Array" },_)
 			| TInst ({ cl_kind = KTypeParameter _}, _)
 			| TAnon _
-			| TDynamic _
+			| TDynamic
 			| TMono _ ->
 				true
 			| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) ->

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -132,7 +132,7 @@ let rec jsignature_of_type gctx stack t =
 				else
 					jsignature_of_type (Abstract.get_underlying_type a tl)
 		end
-	| TDynamic _ -> object_sig
+	| TDynamic -> object_sig
 	| TMono r ->
 		begin match r.tm_type with
 		| Some t -> jsignature_of_type t

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -272,7 +272,7 @@ let is_string_expr e = is_string_type e.etype
 (* /from genphp *)
 
 let is_dynamic t = match follow t with
-    | TMono _ | TDynamic _
+    | TMono _ | TDynamic
     | TInst({ cl_kind = KTypeParameter _ }, _) -> true
     | TAnon anon ->
         (match !(anon.a_status) with
@@ -285,7 +285,7 @@ let is_dynamic_expr e = is_dynamic e.etype
 
 let is_structural_type t =
     match follow t with
-    | TDynamic _ -> true
+    | TDynamic -> true
     | TAnon a -> true
     | TType ({t_type = TAnon _},_) -> true
     | _ -> false

--- a/src/generators/genneko.ml
+++ b/src/generators/genneko.ml
@@ -333,7 +333,7 @@ and gen_expr ctx e =
 					| TInst (c,_) -> Some c.cl_path
 					| TEnum (e,_) -> Some e.e_path
 					| TAbstract (a,_) -> Some a.a_path
-					| TDynamic _ -> None
+					| TDynamic -> None
 					| _ -> die "" __LOC__
 				) in
 				let cond = (match path with

--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -239,7 +239,7 @@ let fail ?msg p = Globals.die (Option.default "" msg) ~p
 (**
 	Check if `target` is a `Dynamic` type
 *)
-let rec is_dynamic_type (target:Type.t) = match follow target with TDynamic _ -> true | _ -> false
+let rec is_dynamic_type (target:Type.t) = match follow target with TDynamic -> true | _ -> false
 
 (**
 	Check if `target` is `php.Ref`
@@ -1335,7 +1335,7 @@ class code_writer (ctx:php_generator_context) hx_type_path php_name =
 					)
 				| TFun _ -> self#use ~prefix:false ([], "Closure")
 				| TAnon _ -> "object"
-				| TDynamic _ -> "mixed"
+				| TDynamic -> "mixed"
 				| TLazy _ -> fail ~msg:"TLazy not implemented" self#pos __LOC__
 				| TMono mono ->
 					(match mono.tm_type with

--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -1047,7 +1047,7 @@ module Printer = struct
 	let rec is_anon_or_dynamic t = match follow t with
 		| TAbstract(a,tl) ->
 			is_anon_or_dynamic (Abstract.get_underlying_type a tl)
-		| TAnon _ | TDynamic _ -> true
+		| TAnon _ | TDynamic -> true
 		| _ -> false
 
 	let handle_keywords s =
@@ -1292,11 +1292,11 @@ module Printer = struct
 					Printf.sprintf "%s(%s,%s)" (third ops) (print_expr pctx e1) (print_expr pctx e2)
 				| _, TInst({ cl_kind = KTypeParameter(_) }, _) ->
 					Printf.sprintf "%s(%s,%s)" (third ops) (print_expr pctx e1) (print_expr pctx e2)
-				| TDynamic _, TDynamic _ ->
+				| TDynamic, TDynamic ->
 					Printf.sprintf "%s(%s,%s)" (third ops) (print_expr pctx e1) (print_expr pctx e2)
-				| TDynamic _, x when is_list_or_anon x ->
+				| TDynamic, x when is_list_or_anon x ->
 					Printf.sprintf "%s(%s,%s)" (third ops) (print_expr pctx e1) (print_expr pctx e2)
-				| x, TDynamic _ when is_list_or_anon x ->
+				| x, TDynamic when is_list_or_anon x ->
 					Printf.sprintf "%s(%s,%s)" (third ops) (print_expr pctx e1) (print_expr pctx e2)
 				| _,_ -> Printf.sprintf "(%s %s %s)" (print_expr pctx e1) (snd ops) (print_expr pctx e2))
 			| TBinop(OpMod,e1,e2) when (is_type1 "" "Int")(e1.etype) && (is_type1 "" "Int")(e2.etype) ->
@@ -1332,7 +1332,7 @@ module Printer = struct
 				let e1_str = safe_string e1 in
 				let e2_str = safe_string e2 in
 				Printf.sprintf "(%s + %s)" e1_str e2_str
-			| TBinop(OpAdd,e1,e2) when (match follow e.etype with TDynamic _ -> true | _ -> false) ->
+			| TBinop(OpAdd,e1,e2) when (match follow e.etype with TDynamic -> true | _ -> false) ->
 				Printf.sprintf "python_Boot._add_dynamic(%s,%s)" (print_expr pctx e1) (print_expr pctx e2)
 			| TBinop(op,e1,e2) ->
 				Printf.sprintf "(%s %s %s)" (print_expr pctx e1) (print_binop op) (print_expr pctx e2)

--- a/src/generators/genswf.ml
+++ b/src/generators/genswf.ml
@@ -83,8 +83,8 @@ let build_dependencies t =
 			add_type_rec (t::l) t2;
 		| TAnon a ->
 			PMap.iter (fun _ f -> add_type_rec (t::l) f.cf_type) a.a_fields
-		| TDynamic t2 ->
-			add_type_rec (t::l) t2;
+		| TDynamic ->
+			()
 		| TLazy f ->
 			add_type_rec l (lazy_type f)
 		| TMono r ->

--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -247,7 +247,7 @@ let rec type_id ctx t =
 
 let type_opt ctx t =
 	match follow_basic t with
-	| TDynamic _ | TMono _ | TAbstract ({a_path = [],"Void"},_) -> None
+	| TDynamic | TMono _ | TAbstract ({a_path = [],"Void"},_) -> None
 	| _ -> Some (type_id ctx t)
 
 let type_void ctx t =
@@ -285,7 +285,7 @@ let classify ctx t =
 		KType (type_id ctx t)
 	| TMono _
 	| TType _
-	| TDynamic _ ->
+	| TDynamic ->
 		KDynamic
 	| TLazy _ ->
 		die "" __LOC__

--- a/src/macro/eval/evalJit.ml
+++ b/src/macro/eval/evalJit.ml
@@ -30,7 +30,7 @@ open EvalMisc
 
 let rope_path t = match follow t with
 	| TInst({cl_path=path},_) | TEnum({e_path=path},_) | TAbstract({a_path=path},_) -> s_type_path path
-	| TDynamic _ -> "Dynamic"
+	| TDynamic -> "Dynamic"
 	| TFun _ | TAnon _ | TMono _ | TType _ | TLazy _ -> die "" __LOC__
 
 let eone = mk (TConst(TInt (Int32.one))) t_dynamic null_pos

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -552,7 +552,7 @@ let handle_decoding_error f v t =
 			end
 		| TLazy r ->
 			loop tabs (lazy_type r) v
-		| TDynamic _ ->
+		| TDynamic ->
 			()
 	in
 	loop "" t v;

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1081,6 +1081,8 @@ and encode_type t =
 			6, [vnull]
 		| TLazy f ->
 			loop (lazy_type f)
+		| TAbstract ({a_path=([],"Dynamic")},[t]) ->
+			6, [encode_type t]
 		| TAbstract (a, pl) ->
 			8, [encode_abref a; encode_tparams pl]
 	in

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -148,6 +148,8 @@ module type InterpApi = sig
 	val handle_decoding_error : (string -> unit) -> value -> Type.t -> (string * int) list
 
 	val get_api_call_pos : unit -> pos
+
+	val make_dynamic : (Type.t -> Type.t) ref
 end
 
 let enum_name = function
@@ -1120,7 +1122,7 @@ and decode_type t =
 	| 3, [t; pl] -> TType (decode_ref t, List.map decode_type (decode_array pl))
 	| 4, [pl; r] -> TFun (List.map (fun p -> decode_string (field p "name"), decode_bool (field p "opt"), decode_type (field p "t")) (decode_array pl), decode_type r)
 	| 5, [a] -> TAnon (decode_ref a)
-	| 6, [t] -> t_dynamic (* DYNAMICTODO *)
+	| 6, [t] -> if t == vnull then t_dynamic else (!make_dynamic) (decode_type t)
 	| 7, [f] -> TLazy (decode_lazytype f)
 	| 8, [a; pl] -> TAbstract (decode_ref a, List.map decode_type (decode_array pl))
 	| _ -> raise Invalid_expr

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1075,11 +1075,8 @@ and encode_type t =
 			4 , [encode_array pl; encode_type ret]
 		| TAnon a ->
 			5, [encode_ref a encode_tanon (fun() -> "<anonymous>")]
-		| TDynamic tsub as t ->
-			if t == t_dynamic then
-				6, [vnull]
-			else
-				6, [encode_type tsub]
+		| TDynamic ->
+			6, [vnull]
 		| TLazy f ->
 			loop (lazy_type f)
 		| TAbstract (a, pl) ->
@@ -1123,7 +1120,7 @@ and decode_type t =
 	| 3, [t; pl] -> TType (decode_ref t, List.map decode_type (decode_array pl))
 	| 4, [pl; r] -> TFun (List.map (fun p -> decode_string (field p "name"), decode_bool (field p "opt"), decode_type (field p "t")) (decode_array pl), decode_type r)
 	| 5, [a] -> TAnon (decode_ref a)
-	| 6, [t] -> if t = vnull then t_dynamic else TDynamic (decode_type t)
+	| 6, [t] -> t_dynamic (* DYNAMICTODO *)
 	| 7, [f] -> TLazy (decode_lazytype f)
 	| 8, [a; pl] -> TAbstract (decode_ref a, List.map decode_type (decode_array pl))
 	| _ -> raise Invalid_expr
@@ -1812,7 +1809,7 @@ let macro_api ccom get_api =
 					| Some t -> t)
 				| TAbstract (a,tl) when not (Meta.has Meta.CoreType a.a_meta) ->
 					Abstract.get_underlying_type a tl
-				| TAbstract _ | TEnum _ | TInst _ | TFun _ | TAnon _ | TDynamic _ ->
+				| TAbstract _ | TEnum _ | TInst _ | TFun _ | TAnon _ | TDynamic ->
 					t
 				| TType (t,tl) ->
 					apply_params t.t_params tl t.t_type

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -181,7 +181,7 @@ let type_change_ok com t1 t2 =
 		in
 		(* Check equality again to cover cases where TMono became t_dynamic *)
 		t1 == t2 || match follow t1,follow t2 with
-			| TDynamic _,_ | _,TDynamic _ -> false
+			| TDynamic,_ | _,TDynamic -> false
 			| _ ->
 				if com.config.pf_static && is_nullable_or_whatever t1 <> is_nullable_or_whatever t2 then false
 				else type_iseq t1 t2

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -249,7 +249,7 @@ and mark_t dce p t =
 			List.iter (mark_t dce p) pl;
 			if not (Meta.has Meta.CoreType a.a_meta) then
 				mark_t dce p (Abstract.get_underlying_type a pl)
-		| TLazy _ | TDynamic _ | TType _ | TAnon _ | TMono _ -> ()
+		| TLazy _ | TDynamic | TType _ | TAnon _ | TMono _ -> ()
 		end;
 		dce.t_stack <- List.tl dce.t_stack
 	end
@@ -312,11 +312,8 @@ let rec to_string dce t = match t with
 		| _ -> ())
 	| TLazy f ->
 		to_string dce (lazy_type f)
-	| TDynamic t ->
-		if t == t_dynamic then
-			()
-		else
-			to_string dce t
+	| TDynamic ->
+		()
 	| TEnum _ | TFun _ | TAnon _ | TAbstract({a_impl = None},_) ->
 		(* if we to_string these it does not imply that we need all its sub-types *)
 		()
@@ -416,7 +413,7 @@ and is_array t = match follow t with
 
 and is_dynamic t = match follow t with
 	| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> is_dynamic (Abstract.get_underlying_type a tl)
-	| TDynamic _ -> true
+	| TDynamic -> true
 	| _ -> false
 
 and is_string t = match follow t with
@@ -585,11 +582,11 @@ and expr dce e =
 		check_and_add_feature dce "unsafe_string_concat";
 		expr dce e1;
 		expr dce e2;
-	| TArray(({etype = TDynamic t} as e1),e2) when t == t_dynamic ->
+	| TArray(({etype = TDynamic} as e1),e2) ->
 		check_and_add_feature dce "dynamic_array_read";
 		expr dce e1;
 		expr dce e2;
-	| TBinop( (OpAssign | OpAssignOp _), ({eexpr = TArray({etype = TDynamic t},_)} as e1), e2) when t == t_dynamic ->
+	| TBinop( (OpAssign | OpAssignOp _), ({eexpr = TArray({etype = TDynamic},_)} as e1), e2) ->
 		check_and_add_feature dce "dynamic_array_write";
 		expr dce e1;
 		expr dce e2;

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -403,7 +403,7 @@ let rec type_field cfg ctx e i p mode =
 		with Not_found ->
 			if PMap.mem i c.cl_statics then error ("Cannot access static field " ^ i ^ " from a class instance") pfield;
 			no_field())
-	| TDynamic t ->
+	| TDynamic as t | TAbstract({a_path=([],"Dynamic")},[t]) ->
 		(try
 			using_field ctx mode e i p
 		with Not_found ->

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -88,7 +88,7 @@ module IterationKind = struct
 		let e1 = try
 			let e = AbstractCast.cast_or_unify_raise ctx t e p in
 			match Abstract.follow_with_abstracts e.etype with
-			| TDynamic _ | TMono _ ->
+			| TDynamic | TMono _ ->
 				(* try to find something better than a dynamic value to iterate on *)
 				dynamic_iterator := Some e;
 				raise (Error (Unify [Unify_custom "Avoid iterating on a dynamic value"], p))
@@ -185,7 +185,7 @@ module IterationKind = struct
 			| Some result -> result
 			| None ->
 				match Abstract.follow_with_abstracts e1.etype with
-					| (TMono _ | TDynamic _) -> dynamic_iterator e1;
+					| (TMono _ | TDynamic) -> dynamic_iterator e1;
 					| _ -> (IteratorIterator,e1,pt)
 		in
 		let try_forward_array_iterator () =
@@ -251,7 +251,7 @@ module IterationKind = struct
 			with Not_found -> check_iterator ())
 		| _,TInst ({ cl_kind = KGenericInstance ({ cl_path = ["haxe";"ds"],"GenericStack" },[pt]) } as c,[]) ->
 			IteratorGenericStack c,e,pt
-		| _,(TMono _ | TDynamic _) ->
+		| _,(TMono _ | TDynamic) ->
 			dynamic_iterator e
 		| _ ->
 			check_iterator ()
@@ -501,7 +501,7 @@ let type_for_loop ctx handle_display it e2 p =
 		end
 	| IKKeyValue((ikey,pkey,dkokey),(ivalue,pvalue,dkovalue)) ->
 		(match follow e1.etype with
-		| TDynamic _ | TMono _ ->
+		| TDynamic | TMono _ ->
 			display_error ctx "You can't iterate on a Dynamic value, please specify KeyValueIterator or KeyValueIterable" e1.epos;
 		| _ -> ()
 		);

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -50,7 +50,7 @@ let make_generic ctx ps pt p =
 				| _ when not top ->
 					follow_or t top (fun() -> "_") (* allow unknown/incompatible types as type parameters to retain old behavior *)
 				| TMono { tm_type = None } -> raise (Generic_Exception (("Could not determine type for parameter " ^ s), p))
-				| TDynamic _ -> "Dynamic"
+				| TDynamic -> "Dynamic"
 				| t ->
 					follow_or t top (fun() -> raise (Generic_Exception (("Unsupported type parameter: " ^ (s_type (print_context()) t) ^ ")"), p)))
 			and loop_tl top tl = match tl with
@@ -231,8 +231,8 @@ let rec build_generic ctx c p tl =
 				| Some t -> loop t)
 			| TLazy f ->
 				loop (lazy_type f);
-			| TDynamic t2 ->
-				if t == t2 then () else loop t2
+			| TDynamic ->
+				()
 			| TAnon a ->
 				PMap.iter (fun _ f -> loop f.cf_type) a.a_fields
 			| TFun (args,ret) ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -31,6 +31,8 @@ module Eval = struct
 	include EvalValue
 	include EvalContext
 	include EvalMain
+
+	let make_dynamic = ref (fun _ -> die "" __LOC__)
 end
 
 module InterpImpl = Eval (* Hlmacro *)
@@ -139,6 +141,7 @@ let make_macro_api ctx p =
 		with _ ->
 			error "Malformed metadata string" p
 	in
+	Eval.make_dynamic := ctx.com.basic.tdynamic;
 	{
 		MacroApi.pos = p;
 		MacroApi.get_com = (fun() -> ctx.com);

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -394,7 +394,7 @@ module Pattern = struct
 						in
 						let patterns = loop el tl in
 						PatTuple patterns
-					| TInst({cl_path=[],"Array"},[t2]) | (TDynamic _ as t2) ->
+					| TInst({cl_path=[],"Array"},[t2]) | (TDynamic as t2) ->
 						let patterns = ExtList.List.mapi (fun i e ->
 							make pctx false t2 e
 						) el in
@@ -1367,7 +1367,7 @@ module TexprConverter = struct
 				e,t,true
 		in
 		let e,t,inferred = match follow e.etype with
-			| TDynamic _ | TMono _ ->
+			| TDynamic | TMono _ ->
 				infer_type()
 			| _ ->
 				e,e.etype,false

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -370,7 +370,7 @@ let rec can_pass_type src dst =
 			| TType (t, tl) -> can_pass_type src (apply_params t.t_params tl t.t_type)
 			| TFun _ -> true
 			| TAnon _ -> true
-			| TDynamic _ -> true
+			| TDynamic -> true
 			| TLazy _ -> true
 			| TAbstract ({ a_path = ([],"Null") }, [t]) -> true
 			| TAbstract _ -> true

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -332,11 +332,8 @@ let rec load_instance' ctx (t,p) allow_no_params =
 		if allow_no_params && t.tparams = [] && not is_rest then begin
 			let monos = Monomorph.spawn_constrained_monos (fun t -> t) types in
 			f (monos)
-		end else if path = ([],"Dynamic") then
-			match t.tparams with
-			| [] -> t_dynamic
-			| [TPType t] -> TDynamic (load_complex_type ctx true t)
-			| _ -> error "Too many parameters for Dynamic" p
+		end else if path = ([],"Dynamic") && t.tparams = [] then
+			t_dynamic
 		else begin
 			let is_java_rest = ctx.com.platform = Java && is_extern in
 			let is_rest = is_rest || is_java_rest in

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -487,7 +487,7 @@ module Inheritance = struct
 						check_cancel_build intf;
 						process_meta intf;
 					)
-				| TDynamic t ->
+				| TDynamic as t ->
 					if c.cl_dynamic <> None then error "Cannot have several dynamics" p;
 					if not c.cl_extern then display_error ctx "In haxe 4, implements Dynamic is only supported on externs" p;
 					c.cl_dynamic <- Some t;

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -487,7 +487,7 @@ module Inheritance = struct
 						check_cancel_build intf;
 						process_meta intf;
 					)
-				| TDynamic as t ->
+				| TDynamic as t | TAbstract({a_path=([],"Dynamic")},[t]) ->
 					if c.cl_dynamic <> None then error "Cannot have several dynamics" p;
 					if not c.cl_extern then display_error ctx "In haxe 4, implements Dynamic is only supported on externs" p;
 					c.cl_dynamic <- Some t;

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -676,7 +676,7 @@ let bind_type (ctx,cctx,fctx) cf r p =
 		match t with
 		| TFun (args,ret) -> is_full_type ret && List.for_all (fun (_,_,t) -> is_full_type t) args
 		| TMono r -> (match r.tm_type with None -> false | Some t -> is_full_type t)
-		| TAbstract _ | TInst _ | TEnum _ | TLazy _ | TDynamic _ | TAnon _ | TType _ -> true
+		| TAbstract _ | TInst _ | TEnum _ | TLazy _ | TDynamic | TAnon _ | TType _ -> true
 	in
 	let force_macro () =
 		(* force macro system loading of this class in order to get completion *)

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2749,7 +2749,9 @@ let rec create com =
 			| "Float" -> ctx.t.tfloat <- TAbstract (a,[]);
 			| "Int" -> ctx.t.tint <- TAbstract (a,[])
 			| "Bool" -> ctx.t.tbool <- TAbstract (a,[])
-			| "Dynamic" -> t_dynamic_def := TAbstract(a,List.map snd a.a_params);
+			| "Dynamic" ->
+				t_dynamic_def := TAbstract(a,List.map snd a.a_params);
+				ctx.t.tdynamic <- (fun t -> TAbstract(a,[t]))
 			| "Null" ->
 				let mk_null t =
 					try

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -430,7 +430,7 @@ and display_expr ctx e_ast e dk with_type p =
 		let iterator = try
 			let it = (ForLoop.IterationKind.of_texpr ~resume:true ctx e (fun _ -> false) e.epos) in
 			match follow it.it_type with
-				| TDynamic _ ->  None
+				| TDynamic ->  None
 				| t -> Some t
 			with Error _ | Not_found ->
 				None


### PR DESCRIPTION
This removes the type parameter on `TDynamic` so that it always represents `Dynamic`. The parameter version is now `TAbstract({a_path=([],"Dynamic")},[t])` which is also exactly what you get from normal typeloading.

There are only three places where this is significant:

1. Unification: Special rules exist to decide what can be assigned to and from `Dynamic<T>`
2. Object declaration: Declaring an object against `Dynamic<T>` uses the type-parameter for top-down inference.
3. Field access: Accessing a field on `Dynamic<T>` emits a `TField` that is typed as `T`.

The only problem was decoding the macro version of `TDynamic` as defined in the `Type` enum. In order to create the appropriate `TAbstract`, we need to have access to that abstract. To that end, I've added `tdynamic` to `basic_types` and inject it into `Eval.make_dynamic` whenever we create a macro API via `make_macro_api`. This is pretty hacky, but I couldn't think of a better solution.