### PR TITLE
Send `with_type` to more places and add more information to `access_mode`

### DIFF
--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -46,8 +46,8 @@ type macro_mode =
 
 type access_mode =
 	| MGet
-	| MSet
-	| MCall
+	| MSet of Ast.expr option (* rhs, if exists *)
+	| MCall of Ast.expr list (* call arguments *)
 
 type typer_pass =
 	| PBuildModule			(* build the module structure and setup module type parameters *)

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -112,7 +112,7 @@ let call_to_string ctx ?(resume=false) e =
 	let gen_to_string e =
 		(* Ignore visibility of the toString field. *)
 		ctx.meta <- (Meta.PrivateAccess,[],e.epos) :: ctx.meta;
-		let acc = type_field (TypeFieldConfig.create resume) ctx e "toString" e.epos MCall in
+		let acc = type_field (TypeFieldConfig.create resume) ctx e "toString" e.epos MCall (WithType.with_type ctx.t.tstring) in
 		ctx.meta <- List.tl ctx.meta;
 		!build_call_ref ctx acc [] (WithType.with_type ctx.t.tstring) e.epos
 	in
@@ -890,6 +890,6 @@ let array_access ctx e1 e2 mode p =
 *)
 let field_chain ctx path e =
 	List.fold_left (fun e (f,_,p) ->
-		let e = acc_get ctx (e MGet) p in
+		let e = acc_get ctx (e MGet WithType.value (* WITHTYPETODO *)) p in
 		type_field_default_cfg ctx e f p
 	) e path

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -119,14 +119,14 @@ module IterationKind = struct
 					)
 			in
 			try
-				let acc = type_field ({do_resume = true;allow_resolve = false}) ctx e s e.epos MCall (WithType.with_type t) in
+				let acc = type_field ({do_resume = true;allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
 				try_acc acc;
 			with Not_found ->
 				try_last_resort (fun () ->
 					match !dynamic_iterator with
 					| Some e -> e
 					| None ->
-						let acc = type_field ({do_resume = resume;allow_resolve = false}) ctx e s e.epos MCall (WithType.with_type t) in
+						let acc = type_field ({do_resume = resume;allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
 						try_acc acc
 				)
 		in
@@ -232,8 +232,8 @@ module IterationKind = struct
 			(try
 				let v_tmp = gen_local ctx e.etype e.epos in
 				let e_tmp = make_local v_tmp v_tmp.v_pos in
-				let acc_next = type_field type_field_config ctx e_tmp "next" p MCall WithType.value (* WITHTYPETODO *) in
-				let acc_hasNext = type_field type_field_config ctx e_tmp "hasNext" p MCall (WithType.with_type ctx.t.tbool) in
+				let acc_next = type_field type_field_config ctx e_tmp "next" p (MCall []) WithType.value (* WITHTYPETODO *) in
+				let acc_hasNext = type_field type_field_config ctx e_tmp "hasNext" p (MCall []) (WithType.with_type ctx.t.tbool) in
 				(match acc_next, acc_hasNext with
 					| AKExpr({ eexpr = TField(_, FDynamic _)}), _
 					| _, AKExpr({ eexpr = TField(_, FDynamic _)}) -> raise Not_found
@@ -508,8 +508,8 @@ let type_for_loop ctx handle_display it e2 p =
 		let e1,pt = IterationKind.check_iterator ctx "keyValueIterator" e1 e1.epos in
 		let vtmp = gen_local ctx e1.etype e1.epos in
 		let etmp = make_local vtmp vtmp.v_pos in
-		let ehasnext = !build_call_ref ctx (type_field_default_cfg ctx etmp "hasNext" etmp.epos MCall (WithType.with_type ctx.t.tbool)) [] WithType.value etmp.epos in
-		let enext = !build_call_ref ctx (type_field_default_cfg ctx etmp "next" etmp.epos MCall WithType.value (* WITHTYPETODO *)) [] WithType.value etmp.epos in
+		let ehasnext = !build_call_ref ctx (type_field_default_cfg ctx etmp "hasNext" etmp.epos (MCall []) (WithType.with_type ctx.t.tbool)) [] WithType.value etmp.epos in
+		let enext = !build_call_ref ctx (type_field_default_cfg ctx etmp "next" etmp.epos (MCall []) WithType.value (* WITHTYPETODO *)) [] WithType.value etmp.epos in
 		let v = gen_local ctx pt e1.epos in
 		let ev = make_local v v.v_pos in
 		let ekey = Calls.acc_get ctx (type_field_default_cfg ctx ev "key" ev.epos MGet WithType.value) ev.epos in

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -119,14 +119,14 @@ module IterationKind = struct
 					)
 			in
 			try
-				let acc = type_field ({do_resume = true;allow_resolve = false}) ctx e s e.epos MCall in
+				let acc = type_field ({do_resume = true;allow_resolve = false}) ctx e s e.epos MCall (WithType.with_type t) in
 				try_acc acc;
 			with Not_found ->
 				try_last_resort (fun () ->
 					match !dynamic_iterator with
 					| Some e -> e
 					| None ->
-						let acc = type_field ({do_resume = resume;allow_resolve = false}) ctx e s e.epos MCall in
+						let acc = type_field ({do_resume = resume;allow_resolve = false}) ctx e s e.epos MCall (WithType.with_type t) in
 						try_acc acc
 				)
 		in
@@ -232,8 +232,8 @@ module IterationKind = struct
 			(try
 				let v_tmp = gen_local ctx e.etype e.epos in
 				let e_tmp = make_local v_tmp v_tmp.v_pos in
-				let acc_next = type_field type_field_config ctx e_tmp "next" p MCall in
-				let acc_hasNext = type_field type_field_config ctx e_tmp "hasNext" p MCall in
+				let acc_next = type_field type_field_config ctx e_tmp "next" p MCall WithType.value (* WITHTYPETODO *) in
+				let acc_hasNext = type_field type_field_config ctx e_tmp "hasNext" p MCall (WithType.with_type ctx.t.tbool) in
 				(match acc_next, acc_hasNext with
 					| AKExpr({ eexpr = TField(_, FDynamic _)}), _
 					| _, AKExpr({ eexpr = TField(_, FDynamic _)}) -> raise Not_found
@@ -508,12 +508,12 @@ let type_for_loop ctx handle_display it e2 p =
 		let e1,pt = IterationKind.check_iterator ctx "keyValueIterator" e1 e1.epos in
 		let vtmp = gen_local ctx e1.etype e1.epos in
 		let etmp = make_local vtmp vtmp.v_pos in
-		let ehasnext = !build_call_ref ctx (type_field_default_cfg ctx etmp "hasNext" etmp.epos MCall) [] WithType.value etmp.epos in
-		let enext = !build_call_ref ctx (type_field_default_cfg ctx etmp "next" etmp.epos MCall) [] WithType.value etmp.epos in
+		let ehasnext = !build_call_ref ctx (type_field_default_cfg ctx etmp "hasNext" etmp.epos MCall (WithType.with_type ctx.t.tbool)) [] WithType.value etmp.epos in
+		let enext = !build_call_ref ctx (type_field_default_cfg ctx etmp "next" etmp.epos MCall WithType.value (* WITHTYPETODO *)) [] WithType.value etmp.epos in
 		let v = gen_local ctx pt e1.epos in
 		let ev = make_local v v.v_pos in
-		let ekey = Calls.acc_get ctx (type_field_default_cfg ctx ev "key" ev.epos MGet) ev.epos in
-		let evalue = Calls.acc_get ctx (type_field_default_cfg ctx ev "value" ev.epos MGet) ev.epos in
+		let ekey = Calls.acc_get ctx (type_field_default_cfg ctx ev "key" ev.epos MGet WithType.value) ev.epos in
+		let evalue = Calls.acc_get ctx (type_field_default_cfg ctx ev "value" ev.epos MGet WithType.value) ev.epos in
 		let vkey = add_local_with_origin ctx TVOForVariable ikey ekey.etype pkey in
 		let vvalue = add_local_with_origin ctx TVOForVariable ivalue evalue.etype pvalue in
 		let e2 = type_expr ctx e2 NoValue in

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -39,7 +39,7 @@ let make_offset_list left right middle other =
 	(ExtList.List.make left other) @ [middle] @ (ExtList.List.make right other)
 
 let type_field_access ctx ?(resume=false) e name =
-	Calls.acc_get ctx (Fields.type_field (Fields.TypeFieldConfig.create resume) ctx e name e.epos MGet) e.epos
+	Calls.acc_get ctx (Fields.type_field (Fields.TypeFieldConfig.create resume) ctx e name e.epos MGet WithType.value) e.epos
 
 let unapply_type_parameters params monos =
 	let unapplied = ref [] in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -298,6 +298,7 @@ let unify_min_for_type_source ctx el src =
 		unify_min ctx el
 
 let rec type_ident_raise ctx i p mode with_type =
+	let is_set = match mode with MSet _ -> true | _ -> false in
 	match i with
 	| "true" ->
 		if mode = MGet then
@@ -310,13 +311,13 @@ let rec type_ident_raise ctx i p mode with_type =
 		else
 			AKNo i
 	| "this" ->
-		if mode = MSet then add_class_field_flag ctx.curfield CfModifiesThis;
+		if is_set then add_class_field_flag ctx.curfield CfModifiesThis;
 		(match mode, ctx.curclass.cl_kind with
-		| MSet, KAbstractImpl _ ->
+		| MSet _, KAbstractImpl _ ->
 			if not (assign_to_this_is_allowed ctx) then
 				error "Abstract 'this' value can only be modified inside an inline function" p;
 			AKExpr (get_this ctx p)
-		| (MCall, KAbstractImpl _) | (MGet, _)-> AKExpr(get_this ctx p)
+		| (MCall _, KAbstractImpl _) | (MGet, _)-> AKExpr(get_this ctx p)
 		| _ -> AKNo i)
 	| "super" ->
 		let t = (match ctx.curclass.cl_super with
@@ -344,9 +345,9 @@ let rec type_ident_raise ctx i p mode with_type =
 			(match e with
 			| Some ({ eexpr = TFunction f } as e) when ctx.com.display.dms_inline ->
 				begin match mode with
-					| MSet -> error "Cannot set inline closure" p
+					| MSet _ -> error "Cannot set inline closure" p
 					| MGet -> error "Cannot create closure on inline closure" p
-					| MCall ->
+					| MCall _ ->
 						(* create a fake class with a fake field to emulate inlining *)
 						let c = mk_class ctx.m.curmod (["local"],v.v_name) e.epos null_pos in
 						let cf = { (mk_field v.v_name v.v_type e.epos null_pos) with cf_params = params; cf_expr = Some e; cf_kind = Method MethInline } in
@@ -381,7 +382,7 @@ let rec type_ident_raise ctx i p mode with_type =
 			field_access ctx mode f (FStatic (c,f)) (field_type ctx c [] f p) e p
 		)
 	with Not_found -> try
-		let wrap e = if mode = MSet then
+		let wrap e = if is_set then
 				AKNo i
 			else
 				AKExpr e
@@ -523,7 +524,7 @@ let rec type_binop ctx op e1 e2 is_assign_op with_type p =
 	in
 	match op with
 	| OpAssign ->
-		let e1 = type_access ctx (fst e1) (snd e1) MSet with_type in
+		let e1 = type_access ctx (fst e1) (snd e1) (MSet (Some e2)) with_type in
 		let e2 with_type = type_expr ctx e2 with_type in
 		(match e1 with
 		| AKNo s -> error ("Cannot access field or identifier " ^ s ^ " for writing") p
@@ -567,7 +568,7 @@ let rec type_binop ctx op e1 e2 is_assign_op with_type p =
 	| OpAssignOp (OpBoolAnd | OpBoolOr) ->
 		error "The operators ||= and &&= are not supported" p
 	| OpAssignOp op ->
-		(match type_access ctx (fst e1) (snd e1) MSet with_type with
+		(match type_access ctx (fst e1) (snd e1) (MSet (Some e2)) with_type with
 		| AKNo s ->
 			(* try abstract operator overloading *)
 			(try type_non_assign_op true
@@ -777,7 +778,7 @@ and type_binop2 ?(abstract_overload_only=false) ctx op (e1 : texpr) (e2 : Ast.ex
 			| KInt | KFloat | KString -> e
 			| KUnk | KDyn | KNumParam _ | KStrParam _ | KOther ->
 				let std = type_type ctx ([],"Std") e.epos in
-				let acc = acc_get ctx (type_field_default_cfg ctx std "string" e.epos MCall with_type) e.epos in
+				let acc = acc_get ctx (type_field_default_cfg ctx std "string" e.epos (MCall []) with_type) e.epos in
 				ignore(follow acc.etype);
 				let acc = (match acc.eexpr with TField (e,FClosure (Some (c,tl),f)) -> { acc with eexpr = TField (e,FInstance (c,tl,f)) } | _ -> acc) in
 				make_call ctx acc [e] ctx.t.tstring e.epos
@@ -1106,7 +1107,7 @@ and type_binop2 ?(abstract_overload_only=false) ctx op (e1 : texpr) (e2 : Ast.ex
 
 and type_unop ctx op flag e p =
 	let set = (op = Increment || op = Decrement) in
-	let acc = type_access ctx (fst e) (snd e) (if set then MSet else MGet) WithType.value (* WITHTYPETODO *) in
+	let acc = type_access ctx (fst e) (snd e) (if set then (MSet None) else MGet) WithType.value (* WITHTYPETODO *) in
 	let access e =
 		let make e =
 			let t = (match op with
@@ -1405,8 +1406,11 @@ and type_access ctx e p mode with_type =
 		let e1 = type_expr ctx e1 WithType.value in
 		begin match e1.eexpr with
 			| TTypeExpr (TClassDecl c) ->
-				if mode = MSet then error "Cannot set constructor" p;
-				if mode = MCall then error ("Cannot call constructor like this, use 'new " ^ (s_type_path c.cl_path) ^ "()' instead") p;
+				begin match mode with
+				| MSet _ -> error "Cannot set constructor" p;
+				| MCall _ -> error ("Cannot call constructor like this, use 'new " ^ (s_type_path c.cl_path) ^ "()' instead") p;
+				| MGet -> ()
+				end;
 				let monos = Monomorph.spawn_constrained_monos (fun t -> t) (match c.cl_kind with KAbstractImpl a -> a.a_params | _ -> c.cl_params) in
 				let ct, cf = get_constructor ctx c monos p in
 				no_abstract_constructor c p;
@@ -2394,8 +2398,8 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 	ctx.meta <- old;
 	e
 
-and type_call_target ctx e with_type inline p =
-	let e = maybe_type_against_enum ctx (fun () -> type_access ctx (fst e) (snd e) MCall with_type) with_type true p in
+and type_call_target ctx e el with_type inline p =
+	let e = maybe_type_against_enum ctx (fun () -> type_access ctx (fst e) (snd e) (MCall el) with_type) with_type true p in
 	let check_inline cf =
 		if (has_class_field_flag cf CfAbstract) then display_error ctx "Cannot force inline on abstract method" p
 	in
@@ -2420,7 +2424,7 @@ and type_call_target ctx e with_type inline p =
 
 and type_call ?(mode=MGet) ctx e el (with_type:WithType.t) inline p =
 	let def () =
-		let e = type_call_target ctx e with_type inline p in
+		let e = type_call_target ctx e el with_type inline p in
 		build_call ~mode ctx e el with_type p;
 	in
 	match e, el with

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -297,7 +297,7 @@ let unify_min_for_type_source ctx el src =
 	| _ ->
 		unify_min ctx el
 
-let rec type_ident_raise ctx i p mode =
+let rec type_ident_raise ctx i p mode with_type =
 	match i with
 	| "true" ->
 		if mode = MGet then
@@ -432,7 +432,7 @@ let rec type_ident_raise ctx i p mode =
 		let t, name, pi = PMap.find i ctx.m.module_globals in
 		ImportHandling.mark_import_position ctx pi;
 		let e = type_module_type ctx t None p in
-		type_field_default_cfg ctx e name p mode
+		type_field_default_cfg ctx e name p mode with_type
 
 (*
 	We want to try unifying as an integer and apply side effects.
@@ -523,7 +523,7 @@ let rec type_binop ctx op e1 e2 is_assign_op with_type p =
 	in
 	match op with
 	| OpAssign ->
-		let e1 = type_access ctx (fst e1) (snd e1) MSet in
+		let e1 = type_access ctx (fst e1) (snd e1) MSet with_type in
 		let e2 with_type = type_expr ctx e2 with_type in
 		(match e1 with
 		| AKNo s -> error ("Cannot access field or identifier " ^ s ^ " for writing") p
@@ -567,7 +567,7 @@ let rec type_binop ctx op e1 e2 is_assign_op with_type p =
 	| OpAssignOp (OpBoolAnd | OpBoolOr) ->
 		error "The operators ||= and &&= are not supported" p
 	| OpAssignOp op ->
-		(match type_access ctx (fst e1) (snd e1) MSet with
+		(match type_access ctx (fst e1) (snd e1) MSet with_type with
 		| AKNo s ->
 			(* try abstract operator overloading *)
 			(try type_non_assign_op true
@@ -777,7 +777,7 @@ and type_binop2 ?(abstract_overload_only=false) ctx op (e1 : texpr) (e2 : Ast.ex
 			| KInt | KFloat | KString -> e
 			| KUnk | KDyn | KNumParam _ | KStrParam _ | KOther ->
 				let std = type_type ctx ([],"Std") e.epos in
-				let acc = acc_get ctx (type_field_default_cfg ctx std "string" e.epos MCall) e.epos in
+				let acc = acc_get ctx (type_field_default_cfg ctx std "string" e.epos MCall with_type) e.epos in
 				ignore(follow acc.etype);
 				let acc = (match acc.eexpr with TField (e,FClosure (Some (c,tl),f)) -> { acc with eexpr = TField (e,FInstance (c,tl,f)) } | _ -> acc) in
 				make_call ctx acc [e] ctx.t.tstring e.epos
@@ -1106,7 +1106,7 @@ and type_binop2 ?(abstract_overload_only=false) ctx op (e1 : texpr) (e2 : Ast.ex
 
 and type_unop ctx op flag e p =
 	let set = (op = Increment || op = Decrement) in
-	let acc = type_access ctx (fst e) (snd e) (if set then MSet else MGet) in
+	let acc = type_access ctx (fst e) (snd e) (if set then MSet else MGet) WithType.value (* WITHTYPETODO *) in
 	let access e =
 		let make e =
 			let t = (match op with
@@ -1265,9 +1265,9 @@ and type_unop ctx op flag e p =
 	in
 	loop acc
 
-and type_ident ctx i p mode =
+and type_ident ctx i p mode with_type =
 	try
-		type_ident_raise ctx i p mode
+		type_ident_raise ctx i p mode with_type
 	with Not_found -> try
 		(* lookup type *)
 		if is_lower_ident i p then raise Not_found;
@@ -1318,7 +1318,7 @@ and type_ident ctx i p mode =
 				end
 			end
 
-and handle_efield ctx e p0 mode =
+and handle_efield ctx e p0 mode with_type =
 	let open TyperDotPath in
 
 	let dot_path first pnext =
@@ -1395,12 +1395,12 @@ and handle_efield ctx e p0 mode =
 			let e = type_access ctx e p in
 			field_chain ctx dot_path_acc e
 	in
-	loop [] (e,p0) mode
+	loop [] (e,p0) mode with_type
 
-and type_access ctx e p mode =
+and type_access ctx e p mode with_type =
 	match e with
 	| EConst (Ident s) ->
-		type_ident ctx s p mode
+		type_ident ctx s p mode with_type
 	| EField (e1,"new") ->
 		let e1 = type_expr ctx e1 WithType.value in
 		begin match e1.eexpr with
@@ -1433,7 +1433,7 @@ and type_access ctx e p mode =
 			| _ -> error "Binding new is only allowed on class types" p
 		end;
 	| EField _ ->
-		handle_efield ctx e p mode
+		handle_efield ctx e p mode with_type
 	| EArray (e1,e2) ->
 		type_array_access ctx e1 e2 p mode
 	| EDisplay (e,dk) ->
@@ -2395,7 +2395,7 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 	e
 
 and type_call_target ctx e with_type inline p =
-	let e = maybe_type_against_enum ctx (fun () -> type_access ctx (fst e) (snd e) MCall) with_type true p in
+	let e = maybe_type_against_enum ctx (fun () -> type_access ctx (fst e) (snd e) MCall with_type) with_type true p in
 	let check_inline cf =
 		if (has_class_field_flag cf CfAbstract) then display_error ctx "Cannot force inline on abstract method" p
 	in
@@ -2514,11 +2514,11 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 		error "Field names starting with $ are not allowed" p
 	| EConst (Ident s) ->
 		if s = "super" && with_type <> WithType.NoValue && not ctx.in_display then error "Cannot use super as value" p;
-		let e = maybe_type_against_enum ctx (fun () -> type_ident ctx s p mode) with_type false p in
+		let e = maybe_type_against_enum ctx (fun () -> type_ident ctx s p mode with_type) with_type false p in
 		acc_get ctx e p
 	| EField _
 	| EArray _ ->
-		acc_get ctx (type_access ctx e p mode) p
+		acc_get ctx (type_access ctx e p mode with_type) p
 	| EConst (Regexp (r,opt)) ->
 		let str = mk (TConst (TString r)) ctx.t.tstring p in
 		let opt = mk (TConst (TString opt)) ctx.t.tstring p in

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -20,7 +20,7 @@ type object_decl_kind =
 	| ODKPlain
 
 let build_call_ref : (typer -> access_kind -> expr list -> WithType.t -> pos -> texpr) ref = ref (fun _ _ _ _ _ -> die "" __LOC__)
-let type_call_target_ref : (typer -> expr -> WithType.t -> bool -> pos -> access_kind) ref = ref (fun _ _ _ _ _ -> die "" __LOC__)
+let type_call_target_ref : (typer -> expr -> expr list -> WithType.t -> bool -> pos -> access_kind) ref = ref (fun _ _ _ _ _ -> die "" __LOC__)
 
 let relative_path ctx file =
 	let slashes path = String.concat "/" (ExtString.String.nsplit path "\\") in

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -143,9 +143,9 @@ let rec type_module_type ctx t tparams p =
 let type_type ctx tpath p =
 	type_module_type ctx (Typeload.load_type_def ctx p (mk_type_path tpath)) None p
 
-let mk_module_type_access ctx t p : access_mode -> access_kind =
+let mk_module_type_access ctx t p : access_mode -> WithType.t -> access_kind =
 	let e = type_module_type ctx t None p in
-	(fun _ -> AKExpr e)
+	(fun _ _ -> AKExpr e)
 
 let s_access_kind acc =
 	let st = s_type (print_context()) in

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -228,7 +228,7 @@ let rec handle_signature_display ctx e_ast with_type =
 		| ECall(e1,el) ->
 			let def () =
 				try
-					acc_get ctx (!type_call_target_ref ctx e1 with_type false (pos e1)) (pos e1)
+					acc_get ctx (!type_call_target_ref ctx e1 el with_type false (pos e1)) (pos e1)
 				with
 				| Error (Unknown_ident "trace",_) ->
 					let e = expr_of_type_path (["haxe";"Log"],"trace") p in

--- a/src/typing/typerDotPath.ml
+++ b/src/typing/typerDotPath.ml
@@ -103,7 +103,7 @@ let resolve_unqualified ctx name next_path p =
 					let old_on_error = ctx.on_error in
 					ctx.on_error <- (fun _ _ _ -> ());
 					(* raises Not_found *) (* not necessarily a call, but prevent #2602 among others *)
-					ignore (Std.finally (fun () -> ctx.on_error <- old_on_error) f (MCall []) WithType.value)
+					ignore (Std.finally (fun () -> ctx.on_error <- old_on_error) (f (MCall [])) WithType.value)
 				end; (* huge hack *)
 				f, next_path
 			| _ ->

--- a/src/typing/typerDotPath.ml
+++ b/src/typing/typerDotPath.ml
@@ -103,7 +103,7 @@ let resolve_unqualified ctx name next_path p =
 					let old_on_error = ctx.on_error in
 					ctx.on_error <- (fun _ _ _ -> ());
 					(* raises Not_found *) (* not necessarily a call, but prevent #2602 among others *)
-					ignore (Std.finally (fun () -> ctx.on_error <- old_on_error) f MCall WithType.value)
+					ignore (Std.finally (fun () -> ctx.on_error <- old_on_error) f (MCall []) WithType.value)
 				end; (* huge hack *)
 				f, next_path
 			| _ ->

--- a/src/typing/typerDotPath.ml
+++ b/src/typing/typerDotPath.ml
@@ -49,7 +49,7 @@ let resolve_module_field ctx m path p =
 		check_field_access ctx c f true p;
 		let ft = Fields.field_type ctx c [] f p in
 		let e = type_module_type ctx (TClassDecl c) None p in
-		(fun mode -> field_access ctx mode f (FStatic (c,f)) ft e p), path_rest
+		(fun mode _ (* WITHTYPETODO *) -> field_access ctx mode f (FStatic (c,f)) ft e p), path_rest
 
 let resolve_module_type ctx m name p =
 	let t = Typeload.find_type_in_module m name in (* raises Not_found *)
@@ -102,8 +102,8 @@ let resolve_unqualified ctx name next_path p =
 				begin (* huge hack around #9430: we need Not_found, but we don't want any errors *)
 					let old_on_error = ctx.on_error in
 					ctx.on_error <- (fun _ _ _ -> ());
-					(* raises Not_found *) (* not necessarily a call, but prevent #2602 among others *) 
-					ignore (Std.finally (fun () -> ctx.on_error <- old_on_error) f MCall)
+					(* raises Not_found *) (* not necessarily a call, but prevent #2602 among others *)
+					ignore (Std.finally (fun () -> ctx.on_error <- old_on_error) f MCall WithType.value)
 				end; (* huge hack *)
 				f, next_path
 			| _ ->


### PR DESCRIPTION
First commit pipes `with_type` to some places where it's currently absent. This doesn't affect typing in any way, but provides some additional information which I plan to use later.

Second commit adds additional information to `MSet` and `MCall` which I also plan to use later.

I tried various approaches here to make this nicer, but came to the conclusion that we really need a distinct `mode` and `with_type`. For instance, `mode` is unset on `EParenthesis` and other inner recursion of `type_expr`. This is so that the `e` in `(e) = x` is not typed with `MSet`, which makes sense (maybe).