### PR TITLE
[abstracts] fix unify_with_variance continuation

### DIFF
--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -253,7 +253,7 @@ let map loop t =
 		(match r.tm_type with
 		| None -> t
 		| Some t -> loop t) (* erase*)
-	| TEnum (_,[]) | TInst (_,[]) | TType (_,[]) ->
+	| TEnum (_,[]) | TInst (_,[]) | TType (_,[]) | TAbstract (_,[]) ->
 		t
 	| TEnum (e,tl) ->
 		TEnum (e, List.map loop tl)

--- a/tests/unit/src/unit/issues/Issue9721.hx
+++ b/tests/unit/src/unit/issues/Issue9721.hx
@@ -23,18 +23,29 @@ class Issue9721 extends Test {
     ((null: {x: Foo<String>}): {x: String});
     ((null: {x: Bar<String>}): {x: String});
 
+    ((null: {x: Array<Foo<Int>>}): {x: Foo<Array<Int>>});
+
     t(unit.HelperMacros.typeError(((null: Array<Int>): Array<Float>)));
     t(unit.HelperMacros.typeError(((null: Array<MyInt>): Array<Float>)));
 
     t(unit.HelperMacros.typeError(((null: Array<Child>): Array<Parent>)));
     t(unit.HelperMacros.typeError(((null: Array<MyChild>): Array<Parent>)));
+
+    ((null: {x: Baz<Baz<Int>>}): {x: Int});
+    t(unit.HelperMacros.typeError(((null: {x: Foo<Foo<Int>>}): {x: Int})));
+
+    ((null: {x: Int -> Void}): {x: Foo<Int> -> Void});
+    t(unit.HelperMacros.typeError(((null: {x: Int -> Void}): {x: Foo<Float> -> Void})));
   }
 }
 
 private abstract MyArray<T>(Array<T>) from Array<T> to Array<T> {}
 private abstract MyInt(Int) from Int to Int to Float {}
+
 private abstract Foo<T>(T) from T to T {}
 private abstract Bar<T>(Foo<T>) from T to T {}
+@:transitive private abstract Baz<T>(T) from T to T {}
+
 private class Parent {}
 private class Child extends Parent {}
 private abstract MyChild(Child) to Parent {}


### PR DESCRIPTION
Continues #9721.

Fixed getting underlying type - parameters of `TInst` and `TEnum`, structure fields and function signature parts need to be mapped to underlying for comparison. 

Fixed comparison of underlying - underlying type needs to be retrieved not only for abstracts.

Transitive casts now allowed for `@:transitive` or core abstracts.

Added handling of TFun to unify_with_variance.

Also removed unused `rec_stack_bool` and added missing `TAbstract (_,[])` to `tFunctions.map`.