### PR TITLE
[syntax] support overload modifier

### DIFF
--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -394,7 +394,7 @@ let convert_ilmethod ctx p is_interface m is_explicit_impl =
 				| _ -> name)
 		| name -> name
 	in
-	let meta = [Meta.Overload, [], p] in
+	let meta = [] in
 	let acc, meta = match m.mflags.mf_access with
 		| FAFamily | FAFamOrAssem ->
 			(APrivate,null_pos), ((Meta.Protected, [], p) :: meta)
@@ -411,6 +411,7 @@ let convert_ilmethod ctx p is_interface m is_explicit_impl =
 		| CMFinal -> acc, Some true
 		| _ -> acc, is_final
 	) ([acc],None) m.mflags.mf_contract in
+	let acc = (AOverload,p) :: acc in
 	if PMap.mem "net_loader_debug" ctx.ncom.defines.Define.values then
 		Printf.printf "\t%smethod %s : %s\n" (if !is_static then "static " else "") cff_name (IlMetaDebug.ilsig_s m.msig.ssig);
 

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -346,7 +346,7 @@ let convert_java_enum ctx p pe =
 						(local_names !i,null_pos), false, [], Some(convert_signature ctx p s,null_pos), None
 					) args in
 					let t = Option.map_default (convert_signature ctx p) (mk_type_path ctx ([], "Void") []) ret in
-					cff_meta := (Meta.Overload, [], p) :: !cff_meta;
+					cff_access := (AOverload,p) :: !cff_access;
 					let types = List.map (function
 						| (name, Some ext, impl) ->
 							{

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -796,7 +796,7 @@ module Converter = struct
 				add_native_meta();
 				String.concat "_" parts
 		in
-		if is_method then add_meta (Meta.Overload,[],p);
+		if is_method then add_access (AOverload,p);
 		if AccessFlags.has_flag jf.jf_flags MFinal then add_access (AFinal,p);
 		if not is_interface && AccessFlags.has_flag jf.jf_flags MAbstract then add_access (AAbstract,p);
 		let extract_local_names () =

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -255,6 +255,7 @@ and access =
 	| AFinal
 	| AExtern
 	| AAbstract
+	| AOverload
 
 and placed_access = access * pos
 
@@ -434,6 +435,7 @@ let s_access = function
 	| AFinal -> "final"
 	| AExtern -> "extern"
 	| AAbstract -> "abstract"
+	| AOverload -> "overload"
 
 let s_placed_access (a,_) = s_access a
 

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -315,6 +315,7 @@ and encode_access a =
 		| AFinal -> 7
 		| AExtern -> 8
 		| AAbstract -> 9
+		| AOverload -> 10
 	in
 	encode_enum ~pos:(Some (pos a)) IAccess tag []
 
@@ -666,6 +667,7 @@ and decode_access v =
 	| 7 -> AFinal
 	| 8 -> AExtern
 	| 9 -> AAbstract
+	| 10 -> AOverload
 	| _ -> raise Invalid_expr
 	in
 	a,p

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -476,7 +476,7 @@ and resume tdecl fdecl s =
 		| Kwd New :: Kwd Function :: _ when fdecl ->
 			junk_tokens (k - 2);
 			true
-		| Kwd Macro :: _ | Kwd Public :: _ | Kwd Static :: _ | Kwd Var :: _ | Kwd Override :: _ | Kwd Dynamic :: _ | Kwd Inline :: _ when fdecl ->
+		| Kwd Macro :: _ | Kwd Public :: _ | Kwd Static :: _ | Kwd Var :: _ | Kwd Override :: _ | Kwd Dynamic :: _ | Kwd Inline :: _ | Kwd Overload :: _ when fdecl ->
 			junk_tokens (k - 1);
 			true
 		| BrClose :: _ when tdecl ->
@@ -980,6 +980,7 @@ and parse_cf_rights = parser
 	| [< '(Kwd Inline,p) >] -> AInline,p
 	| [< '(Kwd Extern,p) >] -> AExtern,p
 	| [< '(Kwd Abstract,p) >] -> AAbstract,p
+	| [< '(Kwd Overload,p) >] -> AOverload,p
 
 and parse_fun_name = parser
 	| [< name,p = dollar_ident >] -> name,p

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -183,6 +183,7 @@ let reify in_macro =
 			| AFinal -> "AFinal"
 			| AExtern -> "AExtern"
 			| AAbstract -> "AAbstract"
+			| AOverload -> "AOverload"
 			) in
 			mk_enum "Access" n [] p
 		in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -544,7 +544,7 @@ and load_complex_type' ctx allow_display (t,p) =
 					pub := false;
 				| ADynamic when (match f.cff_kind with FFun _ -> true | _ -> false) -> dyn := true
 				| AFinal -> final := true
-				| AStatic | AOverride | AInline | ADynamic | AMacro | AExtern | AAbstract as a -> error ("Invalid access " ^ Ast.s_access a) p
+				| AStatic | AOverride | AInline | ADynamic | AMacro | AExtern | AAbstract | AOverload as a -> error ("Invalid access " ^ Ast.s_access a) p
 			) f.cff_access;
 			let t , access = (match f.cff_kind with
 				| FVar(t,e) when !final ->

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -66,6 +66,7 @@ type field_init_ctx = {
 	is_final : bool;
 	is_static : bool;
 	override : pos option;
+	overload : pos option;
 	is_extern : bool;
 	is_abstract : bool;
 	is_macro : bool;
@@ -585,6 +586,7 @@ let create_field_context (ctx,cctx) c cff =
 		end;
 	end;
 	let override = try Some (List.assoc AOverride cff.cff_access) with Not_found -> None in
+	let overload = try Some (List.assoc AOverload cff.cff_access) with Not_found -> None in
 	let is_macro = List.mem_assoc AMacro cff.cff_access in
 	let field_kind = match fst cff.cff_name with
 		| "new" -> FKConstructor
@@ -595,6 +597,7 @@ let create_field_context (ctx,cctx) c cff =
 		is_inline = is_inline;
 		is_static = is_static;
 		override = override;
+		overload = overload;
 		is_macro = is_macro;
 		is_extern = !is_extern;
 		is_abstract = is_abstract;
@@ -1149,6 +1152,15 @@ let create_method (ctx,cctx,fctx) c f fd p =
 	if fctx.is_final then add_class_field_flag cf CfFinal;
 	if fctx.is_extern then add_class_field_flag cf CfExtern;
 	if fctx.is_abstract then add_class_field_flag cf CfAbstract;
+	begin match fctx.overload with
+	| Some p ->
+		if ctx.com.config.pf_overload then
+			add_class_field_flag cf CfOverload
+		else
+			display_error ctx "This platform does not support this kind of overload declaration. Try @:overload(function()... {}) instead" p
+	| None ->
+		()
+	end;
 	cf.cf_meta <- List.map (fun (m,el,p) -> match m,el with
 		| Meta.AstSource,[] -> (m,(match fd.f_expr with None -> [] | Some e -> [e]),p)
 		| _ -> m,el,p
@@ -1412,7 +1424,7 @@ let init_field (ctx,cctx,fctx) f =
 	List.iter (fun acc ->
 		match (fst acc, f.cff_kind) with
 		| APublic, _ | APrivate, _ | AStatic, _ | AFinal, _ | AExtern, _ -> ()
-		| ADynamic, FFun _ | AOverride, FFun _ | AMacro, FFun _ | AInline, FFun _ | AInline, FVar _ | AAbstract, FFun _-> ()
+		| ADynamic, FFun _ | AOverride, FFun _ | AMacro, FFun _ | AInline, FFun _ | AInline, FVar _ | AAbstract, FFun _ | AOverload, FFun _ -> ()
 		| _, FVar _ -> display_error ctx ("Invalid accessor '" ^ Ast.s_placed_access acc ^ "' for variable " ^ name) (snd acc)
 		| _, FProp _ -> display_error ctx ("Invalid accessor '" ^ Ast.s_placed_access acc ^ "' for property " ^ name) (snd acc)
 	) f.cff_access;

--- a/tests/unit/src/unit/TestConstrainedMonomorphs.hx
+++ b/tests/unit/src/unit/TestConstrainedMonomorphs.hx
@@ -21,15 +21,15 @@ private class MyNotString {
 #if java
 @:native("unit.DetectiveHaxeExtern")
 extern private class DetectiveHaxeExtern {
-	@:overload static function itWasYou(i1:Int, i2:Int):String;
-	@:overload static function itWasYou(s1:String, s2:String):String;
-	@:overload static function itWasYou(f1:Float, f2:Float):String;
+	overload static function itWasYou(i1:Int, i2:Int):String;
+	overload static function itWasYou(s1:String, s2:String):String;
+	overload static function itWasYou(f1:Float, f2:Float):String;
 }
 
 @:native("unit.DetectiveHaxeExtern")
 @:keep
 private class DetectiveHaxeImplementation {
-	@:overload static function itWasYou(s1:String, s2:String) {
+	overload static function itWasYou(s1:String, s2:String) {
 		return s1 + s2;
 	}
 }

--- a/tests/unit/src/unit/TestOverloads.hx
+++ b/tests/unit/src/unit/TestOverloads.hx
@@ -67,7 +67,7 @@ class TestOverloads extends Test
 		eq(t.m1(dyn), "Bool");
 		eq(UsingTest1.m2(true), "Dynamic");
 
-		//using won't be influenced by @:overload or @:overload resolution
+		//using won't be influenced by overload or overload resolution
 		eq(t.m3(1.0,1), "Float,Int");
 		// t(typeError(t.m3(1,1.0))); //typeError doesn't work with using statements
 		// t(typeError(t.m3(dyn)));
@@ -210,58 +210,58 @@ class TestOverloads extends Test
 
 private class Primitives
 {
-	@:overload public static function prim(v:Dynamic):String
+	overload public static function prim(v:Dynamic):String
 	{
 		return "Dynamic";
 	}
 
-	@:overload public static function prim(v:Dynamic, ?nothing:Dynamic):String
+	overload public static function prim(v:Dynamic, ?nothing:Dynamic):String
 	{
 		return "Dynamic,?";
 	}
 
-	@:overload public static function prim(v:Null<Float>, ?nothing:String):String
+	overload public static function prim(v:Null<Float>, ?nothing:String):String
 	{
 		return "Null<Float>";
 	}
 
-	@:overload public static function prim(v:Float, ?nothing:Dynamic):String
+	overload public static function prim(v:Float, ?nothing:Dynamic):String
 	{
 		return "Float,?";
 	}
 
-	@:overload public static function prim(v:Float):String
+	overload public static function prim(v:Float):String
 	{
 		return "Float";
 	}
 
-	@:overload public static function prim(v:Int):String
+	overload public static function prim(v:Int):String
 	{
 		return "Int";
 	}
 
-	@:overload public static function prim(v:Int, ?nothing:Dynamic):String
+	overload public static function prim(v:Int, ?nothing:Dynamic):String
 	{
 		return "Int,?";
 	}
 
-	@:overload public static function prim(v:Null<Int>, ?nothing:haxe.io.Bytes):String
+	overload public static function prim(v:Null<Int>, ?nothing:haxe.io.Bytes):String
 	{
 		return "Null<Int>";
 	}
 
 #if (java || cs)
-	@:overload public static function prim(v:Single):String
+	overload public static function prim(v:Single):String
 	{
 		return "Single";
 	}
 
-	@:overload public static function prim(v:Single, ?nothing:haxe.io.Bytes):String
+	overload public static function prim(v:Single, ?nothing:haxe.io.Bytes):String
 	{
 		return "Single,?";
 	}
 
-	@:overload public static function prim(v:Null<Single>, ?nothing:I0):String
+	overload public static function prim(v:Null<Single>, ?nothing:I0):String
 	{
 		return "Null<Single>";
 	}
@@ -274,12 +274,12 @@ private interface I0
 
 private interface I1 extends I0
 {
-	@:overload function m(obj:Dynamic):String;
+	overload function m(obj:Dynamic):String;
 }
 
 private interface I2 extends I1
 {
-	@:overload function m(i:Int):String;
+	overload function m(i:Int):String;
 }
 
 private class InterfaceTest implements I2
@@ -289,12 +289,12 @@ private class InterfaceTest implements I2
 
 	}
 
-	@:overload public function m(obj:Dynamic):String
+	overload public function m(obj:Dynamic):String
 	{
 		return "Dynamic";
 	}
 
-	@:overload public function m(i:Int):String
+	overload public function m(i:Int):String
 	{
 		return "Int";
 	}
@@ -306,42 +306,42 @@ private class Ambiguous
 
 	}
 
-	@:overload public function amb1(i:Int, f:Float):String
+	overload public function amb1(i:Int, f:Float):String
 	{
 		return "Int,Float";
 	}
 
-	@:overload public function amb1(f:Float, i:Int):String
+	overload public function amb1(f:Float, i:Int):String
 	{
 		return "Float,Int";
 	}
 
-	@:overload public function amb1(i:Int, d:Dynamic):String
+	overload public function amb1(i:Int, d:Dynamic):String
 	{
 		return "Int,Dynamic";
 	}
 
-	@:overload public function amb1(i:Null<Int>, d:Dynamic, ?a:Bool):String
+	overload public function amb1(i:Null<Int>, d:Dynamic, ?a:Bool):String
 	{
 		return "Null<Int>,Dynamic,Bool";
 	}
 
-	@:overload public function amb1(i:Int, d:Dynamic, ?a:String):String
+	overload public function amb1(i:Int, d:Dynamic, ?a:String):String
 	{
 		return "Int,Dynamic,String";
 	}
 
-	@:overload public static function amb2(i:Int, f:Float):String
+	overload public static function amb2(i:Int, f:Float):String
 	{
 		return "Int,Float";
 	}
 
-	@:overload public static function amb2(f:Float, i:Int):String
+	overload public static function amb2(f:Float, i:Int):String
 	{
 		return "Float,Int";
 	}
 
-	@:overload public static function amb2(i:Int, d:Dynamic):String
+	overload public static function amb2(i:Int, d:Dynamic):String
 	{
 		return "Int,Dynamic";
 	}
@@ -349,12 +349,12 @@ private class Ambiguous
 
 private class AmbiguousChild extends Ambiguous
 {
-	@:overload override public function amb1(i:Int, d:Dynamic):String
+	overload override public function amb1(i:Int, d:Dynamic):String
 	{
 		return "Int,Dynamic-2";
 	}
 
-	@:overload public function amb1(i:Int, b:Bool):String
+	overload public function amb1(i:Int, b:Bool):String
 	{
 		return "Int,Bool-2";
 	}
@@ -367,17 +367,17 @@ class UsingTest1
 
 	}
 
-	@:overload public function m1(i:Int, f:Float):String
+	overload public function m1(i:Int, f:Float):String
 	{
 		return "Int,Float";
 	}
 
-	@:overload public function m1(b:Bool):String
+	overload public function m1(b:Bool):String
 	{
 		return "Bool";
 	}
 
-	@:overload public static function m2(d:Dynamic):String
+	overload public static function m2(d:Dynamic):String
 	{
 		return "Dynamic";
 	}
@@ -385,37 +385,37 @@ class UsingTest1
 
 class UsingTest2
 {
-	@:overload public static function m1(me:UsingTest1, f:Float, i:Int):String
+	overload public static function m1(me:UsingTest1, f:Float, i:Int):String
 	{
 		return "Float,Int";
 	}
 
-	@:overload public static function m1(me:UsingTest1, d:Dynamic):String
+	overload public static function m1(me:UsingTest1, d:Dynamic):String
 	{
 		return "Dynamic";
 	}
 
-	@:overload public static function m2(me:Class<UsingTest1>, b:Bool):String
+	overload public static function m2(me:Class<UsingTest1>, b:Bool):String
 	{
 		return "Bool";
 	}
 
-	@:overload public static function m3(me:UsingTest1, f:Float, i:Int):String
+	overload public static function m3(me:UsingTest1, f:Float, i:Int):String
 	{
 		return "Float,Int";
 	}
 
-	@:overload public static function m3(me:UsingTest1, i:Int, f:Float):String
+	overload public static function m3(me:UsingTest1, i:Int, f:Float):String
 	{
 		return "Int,Float";
 	}
 
-	@:overload public static function m3(me:UsingTest1, b:Bool):String
+	overload public static function m3(me:UsingTest1, b:Bool):String
 	{
 		return "Bool";
 	}
 
-	@:overload public static function m4(me:UsingTest1, i:Int, f:Float):String
+	overload public static function m4(me:UsingTest1, i:Int, f:Float):String
 	{
 		return "Int,Float";
 	}
@@ -423,7 +423,7 @@ class UsingTest2
 
 class UsingTest3
 {
-	@:overload public static function m4(me:UsingTest1, f:Float, i:Int):String
+	overload public static function m4(me:UsingTest1, f:Float, i:Int):String
 	{
 		return "Float,Int";
 	}
@@ -436,17 +436,17 @@ private class A<T>
 
 	}
 
-	@:overload public function foo(t:T):String
+	overload public function foo(t:T):String
 	{
 		return "T";
 	}
 
-	@:overload public function foo(t:String):String
+	overload public function foo(t:String):String
 	{
 		return "String";
 	}
 
-	@:overload public function bar(t:T):String
+	overload public function bar(t:T):String
 	{
 		return "T";
 	}
@@ -454,7 +454,7 @@ private class A<T>
 
 private class B<T : I1> extends A<T>
 {
-	@:overload override public function foo(t:T):String
+	overload override public function foo(t:T):String
 	{
 		return "T-2";
 	}
@@ -462,22 +462,22 @@ private class B<T : I1> extends A<T>
 
 private class C extends B<InterfaceTest>
 {
-	@:overload override public function foo(t:InterfaceTest):String
+	overload override public function foo(t:InterfaceTest):String
 	{
 		return "InterfaceTest";
 	}
 
-	@:overload public function foo(t:I0):String
+	overload public function foo(t:I0):String
 	{
 		return "I0";
 	}
 
-	@:overload public function bar(notChosen:I0):String
+	overload public function bar(notChosen:I0):String
 	{
 		return "I0";
 	}
 
-	@:overload public function bar(unrelated:String):String
+	overload public function bar(unrelated:String):String
 	{
 		return "String";
 	}
@@ -492,37 +492,37 @@ class BaseJava implements NormalInterface
 	public var s:String;
 	public var f:Float;
 
-	@:overload public function new(i:Int):Void
+	overload public function new(i:Int):Void
 	{
 		this.i = i;
 	}
 
-	@:overload public function new(s:String):Void
+	overload public function new(s:String):Void
 	{
 		this.s = s;
 	}
 
-	@:overload public function new(f:Float):Void
+	overload public function new(f:Float):Void
 	{
 		this.f = f;
 	}
 
-	@:overload public function someField(b:haxe.io.Bytes):Int
+	overload public function someField(b:haxe.io.Bytes):Int
 	{
 		return 0;
 	}
 
-	@:overload public function someField(i:Int):Int
+	overload public function someField(i:Int):Int
 	{
 		return 1;
 	}
 
-	@:overload public function someField(s:String):Int
+	overload public function someField(s:String):Int
 	{
 		return 2;
 	}
 
-	@:overload public function someField(s:Bool):Int
+	overload public function someField(s:Bool):Int
 	{
 		return -1;
 	}
@@ -532,22 +532,22 @@ class ChildJava extends BaseJava implements OverloadedInterface
 {
 	public var initialized = 10;
 
-	@:overload public function new(b:haxe.io.Bytes)
+	overload public function new(b:haxe.io.Bytes)
 	{
 		super(b.toString());
 	}
 
-	@:overload public function new(i:Int)
+	overload public function new(i:Int)
 	{
 		super(i + 1);
 	}
 
-	@:overload public function someField(f:Float):Int
+	overload public function someField(f:Float):Int
 	{
 		return 3;
 	}
 
-	@:overload override public function someField(b:haxe.io.Bytes)
+	overload override public function someField(b:haxe.io.Bytes)
 	{
 		return 2;
 	}
@@ -557,26 +557,26 @@ class ChildJava2<T> extends ChildJava
 {
 	public var initialized2 = "20";
 
-	@:overload public function new(x:Float)
+	overload public function new(x:Float)
 	{
 		super(Std.int(x));
 	}
-	@:overload public function new(b:haxe.io.Bytes)
+	overload public function new(b:haxe.io.Bytes)
 	{
 		super(b);
 	}
 
-	@:overload override public function someField(f:Float):Int
+	overload override public function someField(f:Float):Int
 	{
 		return 50;
 	}
 
-	@:overload public function someField(t:T):T
+	overload public function someField(t:T):T
 	{
 		return t;
 	}
 
-	@:overload public function someField(c:Class<T>):Int
+	overload public function someField(c:Class<T>):Int
 	{
 		return 51;
 	}
@@ -586,17 +586,17 @@ class ChildJava3<A, T : BaseJava> extends ChildJava2<T>
 {
 	public var initialized3 = true;
 
-	@:overload override public function someField(t:T):T
+	overload override public function someField(t:T):T
 	{
 		return null;
 	}
 
-	@:overload public function someField<Z>(a:A, t:T, z:Z):Z
+	overload public function someField<Z>(a:A, t:T, z:Z):Z
 	{
 		return z;
 	}
 
-	@:overload public function someField(a:A, c:Int):Int
+	overload public function someField(a:A, c:Int):Int
 	{
 		return 52;
 	}
@@ -613,7 +613,7 @@ interface NormalInterface
 
 interface OverloadedInterface extends NormalInterface
 {
-	@:overload function someField(s:String):Int;
-	@:overload function someField(f:Float):Int;
+	overload function someField(s:String):Int;
+	overload function someField(f:Float):Int;
 }
 


### PR DESCRIPTION
This allows using `overload` instead of `@:overload`. The `@:overload(function() {})` syntax remains unaffected. This shouldn't affect anything else.