### PR TITLE
[abstracts] fix unification of abstracts and constraints

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -619,8 +619,8 @@ let rec unify (uctx : unification_context) a b =
 	| TAbstract ({ a_path = ["haxe"],"NotVoid" },[]), _
 	| _, TAbstract ({ a_path = ["haxe"],"NotVoid" },[]) ->
 		()
-	| TAbstract _, TAbstract ({ a_path = ["haxe"],("FlatEnum" | "Function" | "Constructible") },_) ->
-		error [cannot_unify a b]
+	| TAbstract (ab,tl), TAbstract ({ a_path = ["haxe"],("FlatEnum" | "Function" | "Constructible") },_) ->
+		unify_to {uctx with allow_transitive_cast = false} a b ab tl
 	| TAbstract (a1,tl1) , TAbstract (a2,tl2) ->
 		unify_abstracts uctx a b a1 tl1 a2 tl2
 	| TInst (c1,tl1) , TInst (c2,tl2) ->

--- a/tests/unit/src/unit/issues/Issue9736.hx
+++ b/tests/unit/src/unit/issues/Issue9736.hx
@@ -1,0 +1,12 @@
+package unit.issues;
+
+import haxe.Constraints.Function;
+
+class Issue9736 extends Test {
+  function test() {
+    ((null: Foo): Function);
+    utest.Assert.pass();
+  }
+}
+
+private abstract Foo(Function) from Function to Function {}


### PR DESCRIPTION
If an abstract has direct cast to a constraint, then the abstract should be able to pass the constraint.