### PR TITLE
increase priority of @:using extensions

### DIFF
--- a/tests/unit/src/unit/issues/Issue9681.hx
+++ b/tests/unit/src/unit/issues/Issue9681.hx
@@ -1,0 +1,25 @@
+package unit.issues;
+
+using Lambda;
+
+class Issue9681 extends Test {
+  function test() {
+    var array = [0,1];
+
+    var foo: Foo<Array<Int>> = array;
+    eq(false, foo.empty());
+    eq(2, foo.count());
+
+    var bar: Bar<Array<Int>> = array;
+    eq(false, bar.empty());
+    eq(0, bar.count());
+  }
+
+  public static function count<T>(array: Array<T>)
+    return 0;
+}
+
+private abstract Foo<T>(T) from T to T {}
+
+@:using(unit.issues.Issue9681)
+private abstract Bar<T>(T) from T to T {}


### PR DESCRIPTION
Closes #9681 (but with different approach).

Introduces a `!` modifier to a path in `@:using` meta which sets priority of the extension to be higher than any module `using`:
```haxe
@:using(MyTypeTools!) class MyType {}
```
Adds a way to resolve (currently unresolvable) static extensions clashes for unifiable types.

Concrete example (which depends on #9682 being merged too):
```haxe
@:using(MaybeArrayTools!) 
abstract Maybe<T>(Null<T>) from Null<T> to Null<T> {}

class MaybeArrayTools {
  public static function isEmpty<T>(that: Maybe<Array<T>>) 
    return that == null || that.length == 0;
}

class ArrayTools { 
  public static function isEmpty<T>(that: Array<T>) 
    return that.length == 0;
}
```

With such types `using ArrayTools` will apply to arrays and `MaybeArrayTools` to maybe arrays.

`@:using` accepts multiple paths arguments, so needed some modifier for a single expression, preferably short one. Went with postfix bang to denote higher importance of a provided extension and to not break alignment of paths when multiple `@:using` are used on separate lines.