### PR TITLE
treat Any as Dynamic in variance unification, add @:forward.variance

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -403,6 +403,12 @@
 		"links": ["https://haxe.org/manual/types-abstract-forward.html"]
 	},
 	{
+		"name": "ForwardVariance",
+		"metadata": ":forward.variance",
+		"doc": "Forwards variance unification to underlying type.",
+		"targets": ["TAbstract"]
+	},
+	{
 		"name": "From",
 		"metadata": ":from",
 		"doc": "Specifies that the field of the abstract is a cast operation from the type identified in the function.",

--- a/std/Any.hx
+++ b/std/Any.hx
@@ -31,6 +31,7 @@
 	to work with the actual value, it needs to be explicitly promoted
 	to another type.
 **/
+@:forward.variance
 abstract Any(Dynamic) {
 	@:noCompletion @:to extern inline function __promote<T>():T
 		return this;

--- a/tests/unit/src/unit/issues/Issue9741.hx
+++ b/tests/unit/src/unit/issues/Issue9741.hx
@@ -1,0 +1,36 @@
+package unit.issues;
+
+class Issue9741 extends Test {
+  function test() {
+    var any: Any = null;
+    checkMainT(any);
+
+    var arrayInt: Array<Int> = [0, 1];
+    checkArrayAny(arrayInt);
+
+    var arrayAny: Array<Any> = arrayInt;
+    checkSameT(arrayInt, arrayInt);
+    checkSameT(arrayAny, arrayAny);
+    checkSameT(arrayAny, arrayInt);
+    t(unit.HelperMacros.typeError(checkSameT(arrayInt, arrayAny)));
+
+    t(unit.HelperMacros.typeError(((null: Bar): Int)));
+    t(unit.HelperMacros.typeError(((null: Int): Bar)));
+    ((null: {x: Bar}): {x: Int});
+    ((null: {x: Int}): {x: Bar});
+  }
+
+  static function checkMainT<T:Issue9741>(v:T) {}
+
+  static function checkArrayAny(a:Array<Any>) {}
+
+  static function checkSameT<T>(a1:T, a2:T) {}
+}
+
+private class Foo {
+  public function new() {}
+}
+
+@:forward.variance private abstract Bar(Int) {
+  public inline function new() this = 0;
+}


### PR DESCRIPTION
Reimplements #8450. (Assertions are taken from there.)

Now `Any` will behave like `Dynamic` when it comes to unification in type parameters and nested fields in anon structures.