### PR TITLE
Use FieldAccess for constructors too

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -528,7 +528,8 @@ module UnificationCallback = struct
 				{e with eexpr = TCall(e1,el)}
 			| TNew(c,tl,el) ->
 				begin try
-					let tcf,_ = get_constructor (fun cf -> apply_params c.cl_params tl cf.cf_type) c in
+					let cf = get_constructor c in
+					let tcf = apply_params c.cl_params tl cf.cf_type in
 					let el = check_call f el tcf in
 					{e with eexpr = TNew(c,tl,el)}
 				with Not_found ->

--- a/src/core/display/completionItem.ml
+++ b/src/core/display/completionItem.ml
@@ -188,7 +188,7 @@ module CompletionModuleType = struct
 		let ctor c =
 			try
 				if has_class_flag c CAbstract then raise Not_found;
-				let _,cf = get_constructor (fun cf -> cf.cf_type) c in
+				let cf = get_constructor c in
 				if (has_class_flag c CExtern) || (has_class_field_flag cf CfPublic) then Yes else YesButPrivate
 			with Not_found ->
 				No

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -737,17 +737,15 @@ let quick_field_dynamic t s =
 	try quick_field t s
 	with Not_found -> FDynamic s
 
-let rec get_constructor build_type c =
+let rec get_constructor c =
 	match c.cl_constructor, c.cl_super with
-	| Some c, _ -> build_type c, c
+	| Some c, _ -> c
 	| None, None -> raise Not_found
-	| None, Some (csup,cparams) ->
-		let t, c = get_constructor build_type csup in
-		apply_params csup.cl_params cparams t, c
+	| None, Some (csup,_) -> get_constructor csup
 
 let has_constructor c =
 	try
-		ignore(get_constructor (fun cf -> cf.cf_type) c);
+		ignore(get_constructor c);
 		true
 	with Not_found -> false
 

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -1881,8 +1881,8 @@ class texpr_to_jvm gctx (jc : JvmClass.builder) (jm : JvmMethod.builder) (return
 				[jf#get_jsig]
 			)
 		| TNew(c,tl,el) ->
-			begin match get_constructor (fun cf -> cf.cf_type) c with
-			|_,cf ->
+			begin match get_constructor c with
+			| cf ->
 				begin match OverloadResolution.maybe_resolve_instance_overload true (apply_params c.cl_params tl) c cf el with
 				| None -> Error.error "Could not find overload" e.epos
 				| Some (c',cf,_) ->

--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -1717,11 +1717,9 @@ module Generator = struct
 	(* Transformer interface *)
 
 	let transform_expr e =
-		(* let e = Codegen.UnificationCallback.run Transformer.check_unification e in *)
 		Transformer.transform e
 
 	let transform_to_value e =
-		(* let e = Codegen.UnificationCallback.run Transformer.check_unification e in *)
 		Transformer.transform_to_value e
 
 	(* Printer interface *)

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -80,7 +80,7 @@ let get_constructor_access ctx c params p =
 		let cf = (try PMap.find "_new" c.cl_statics with Not_found -> raise_error (No_constructor (TAbstractDecl a)) p) in
 		FieldAccess.create (Builder.make_static_this c p) cf (FHAbstract(a,params,c)) false p
 	| _ ->
-		let _,cf = (try Type.get_constructor (fun f -> field_type ctx c params f p) c with Not_found -> raise_error (No_constructor (TClassDecl c)) p) in
+		let cf = (try Type.get_constructor c with Not_found -> raise_error (No_constructor (TClassDecl c)) p) in
 		FieldAccess.create (Builder.make_static_this c p) cf (FHInstance(c,params)) false p
 
 let check_constructor_access ctx c f p =

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -74,16 +74,6 @@ let field_type ctx c pl f p =
 let no_abstract_constructor c p =
 	if has_class_flag c CAbstract then raise_error (Abstract_class (TClassDecl c)) p
 
-let get_constructor2 ctx c params p =
-	match c.cl_kind with
-	| KAbstractImpl a ->
-		let f = (try PMap.find "_new" c.cl_statics with Not_found -> raise_error (No_constructor (TAbstractDecl a)) p) in
-		let ct = field_type ctx c params f p in
-		apply_params a.a_params params ct, f
-	| _ ->
-		let ct, f = (try Type.get_constructor (fun f -> field_type ctx c params f p) c with Not_found -> raise_error (No_constructor (TClassDecl c)) p) in
-		apply_params c.cl_params params ct, f
-
 let get_constructor_access ctx c params p =
 	match c.cl_kind with
 	| KAbstractImpl a ->

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -74,15 +74,6 @@ let field_type ctx c pl f p =
 let no_abstract_constructor c p =
 	if has_class_flag c CAbstract then raise_error (Abstract_class (TClassDecl c)) p
 
-let get_constructor_access ctx c params p =
-	match c.cl_kind with
-	| KAbstractImpl a ->
-		let cf = (try PMap.find "_new" c.cl_statics with Not_found -> raise_error (No_constructor (TAbstractDecl a)) p) in
-		FieldAccess.create (Builder.make_static_this c p) cf (FHAbstract(a,params,c)) false p
-	| _ ->
-		let cf = (try Type.get_constructor c with Not_found -> raise_error (No_constructor (TClassDecl c)) p) in
-		FieldAccess.create (Builder.make_static_this c p) cf (FHInstance(c,params)) false p
-
 let check_constructor_access ctx c f p =
 	if (Meta.has Meta.CompilerGenerated f.cf_meta) then display_error ctx (error_msg (No_constructor (TClassDecl c))) p;
 	if not (can_access ctx c f true || extends ctx.curclass c) && not ctx.untyped then display_error ctx (Printf.sprintf "Cannot access private constructor of %s" (s_class_path c)) p

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1391,19 +1391,20 @@ class expr_checker mode immediate_execution report =
 				| TNew (cls, params, args) ->
 					let ctor =
 						try
-							Some (get_constructor (fun ctor -> apply_params cls.cl_params params ctor.cf_type) cls)
+							Some (get_constructor cls)
 						with
 							| Not_found -> None
 					in
 					(match ctor with
 						| None ->
 							List.iter self#check_expr args
-						| Some (ctor_type, _) ->
+						| Some cf ->
 							let rec traverse t =
 								match follow t with
 									| TFun (types, _) -> self#check_args e_new args types
 									| _ -> fail ~msg:"Unexpected constructor type." e_new.epos __POS__
 							in
+							let ctor_type = apply_params cls.cl_params params cf.cf_type in
 							traverse ctor_type
 					)
 				| _ -> fail ~msg:"TNew expected" e_new.epos __POS__

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -176,7 +176,7 @@ let type_function ctx args fargs ret fmode e do_display p =
 			None
 		| Some (csup,tl) ->
 			try
-				let _,cf = get_constructor (fun f->f.cf_type) csup in
+				let cf = get_constructor csup in
 				Some (Meta.has Meta.CompilerGenerated cf.cf_meta,TInst(csup,tl))
 			with Not_found ->
 				None
@@ -246,7 +246,7 @@ let add_constructor ctx c force_constructor p =
 			Some(cfsup,csup,cparams)
 		| Some (csup,cparams) ->
 			try
-				let _,cfsup = Type.get_constructor (fun ctor -> apply_params csup.cl_params cparams ctor.cf_type) csup in
+				let cfsup = Type.get_constructor csup in
 				Some(cfsup,csup,cparams)
 			with Not_found ->
 				None

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -558,7 +558,7 @@ and type_access ctx e p mode with_type =
 				| MGet -> ()
 				end;
 				let monos = Monomorph.spawn_constrained_monos (fun t -> t) (match c.cl_kind with KAbstractImpl a -> a.a_params | _ -> c.cl_params) in
-				let fa = get_constructor_access ctx c monos p in
+				let fa = FieldAccess.get_constructor_access c monos p in
 				let cf = fa.fa_field in
 				no_abstract_constructor c p;
 				check_constructor_access ctx c cf p;
@@ -857,7 +857,7 @@ and type_object_decl ctx fl with_type p =
 		let t, fl = type_fields a.a_fields in
 		mk (TObjectDecl fl) t p
 	| ODKWithClass (c,tl) ->
-		let fa = get_constructor_access ctx c tl p in
+		let fa = FieldAccess.get_constructor_access c tl p in
 		let ctor = fa.fa_field in
 		let args = match follow (FieldAccess.get_map_function fa ctor.cf_type) with
 			| TFun(args,_) -> args
@@ -955,7 +955,7 @@ and type_new ctx path el with_type force_inline p =
 		begin match resolve_typedef (Typeload.load_type_def ctx p (fst path)) with
 		| TClassDecl ({cl_constructor = Some cf} as c) ->
 			let monos = Monomorph.spawn_constrained_monos (fun t -> t) c.cl_params in
-			let fa = get_constructor_access ctx c monos p in
+			let fa = FieldAccess.get_constructor_access c monos p in
 			no_abstract_constructor c p;
 			ignore (unify_constructor_call c fa);
 			begin try
@@ -982,7 +982,7 @@ and type_new ctx path el with_type force_inline p =
 	DisplayEmitter.check_display_type ctx t path;
 	let t = follow t in
 	let build_constructor_call ao c tl =
-		let fa = get_constructor_access ctx c tl p in
+		let fa = FieldAccess.get_constructor_access c tl p in
 		let fa = if force_inline then {fa with fa_inline = true} else fa in
 		let cf = fa.fa_field in
 		no_abstract_constructor c p;
@@ -1633,7 +1633,7 @@ and type_call ?(mode=MGet) ctx e el (with_type:WithType.t) inline p =
 		let el, t = (match ctx.curclass.cl_super with
 		| None -> error "Current class does not have a super" p
 		| Some (c,params) ->
-			let fa = get_constructor_access ctx c params p in
+			let fa = FieldAccess.get_constructor_access c params p in
 			let cf = fa.fa_field in
 			let t = TInst (c,params) in
 			let e = mk (TConst TSuper) t sp in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -558,19 +558,18 @@ and type_access ctx e p mode with_type =
 				| MGet -> ()
 				end;
 				let monos = Monomorph.spawn_constrained_monos (fun t -> t) (match c.cl_kind with KAbstractImpl a -> a.a_params | _ -> c.cl_params) in
-				let ct, cf = get_constructor ctx c monos p in
+				let fa = get_constructor_access ctx c monos p in
+				let cf = fa.fa_field in
 				no_abstract_constructor c p;
 				check_constructor_access ctx c cf p;
-				let args = match follow ct with TFun(args,ret) -> args | _ -> die "" __LOC__ in
+				let args = match follow (FieldAccess.get_map_function fa cf.cf_type) with TFun(args,ret) -> args | _ -> die "" __LOC__ in
 				let vl = List.map (fun (n,_,t) -> alloc_var VGenerated n t c.cl_pos) args in
 				let vexpr v = mk (TLocal v) v.v_type p in
 				let el = List.map vexpr vl in
 				let ec,t = match c.cl_kind with
 					| KAbstractImpl a ->
-						let e = type_module_type ctx (TClassDecl c) None p in
-						let e = mk (TField (e,(FStatic (c,cf)))) ct p in
 						let t = TAbstract(a,monos) in
-						make_call ctx e el t p,t
+						(new call_dispatcher ctx (MCall []) WithType.value p)#field_call fa el [],t
 					| _ ->
 						let t = TInst(c,monos) in
 						mk (TNew(c,monos,el)) t p,t
@@ -858,7 +857,7 @@ and type_object_decl ctx fl with_type p =
 		let t, fl = type_fields a.a_fields in
 		mk (TObjectDecl fl) t p
 	| ODKWithClass (c,tl) ->
-		let t,ctor = get_constructor ctx c tl p in
+		let t,ctor = get_constructor2 ctx c tl p in
 		let args = match follow t with
 			| TFun(args,_) -> args
 			| _ -> die "" __LOC__
@@ -925,13 +924,12 @@ and type_new ctx path el with_type force_inline p =
 		end
 	in
 	let unify_constructor_call c fa =
-		(try
+		try
 			let fcc = unify_field_call ctx fa [] el p false in
 			check_constructor_access ctx c fcc.fc_field p;
-			List.map fst fcc.fc_args
+			fcc
 		with Error (e,p) ->
-			display_error ctx (error_msg e) p;
-			[])
+			error (error_msg e) p;
 	in
 	let t = if (fst path).tparams <> [] then begin
 		try
@@ -956,7 +954,7 @@ and type_new ctx path el with_type force_inline p =
 		begin match resolve_typedef (Typeload.load_type_def ctx p (fst path)) with
 		| TClassDecl ({cl_constructor = Some cf} as c) ->
 			let monos = Monomorph.spawn_constrained_monos (fun t -> t) c.cl_params in
-			let ct, f = get_constructor ctx c monos p in
+			let ct, f = get_constructor2 ctx c monos p in
 			no_abstract_constructor c p;
 			let fa = FieldAccess.create (Builder.make_static_this c p) f (FHInstance(c,monos)) false p in
 			ignore (unify_constructor_call c fa);
@@ -984,18 +982,14 @@ and type_new ctx path el with_type force_inline p =
 	DisplayEmitter.check_display_type ctx t path;
 	let t = follow t in
 	let build_constructor_call ao c tl =
-		let ct, f = get_constructor ctx c tl p in
+		let fa = get_constructor_access ctx c tl p in
+		let cf = fa.fa_field in
 		no_abstract_constructor c p;
-		(match f.cf_kind with
-		| Var { v_read = AccRequire (r,msg) } -> (match msg with Some msg -> error msg p | None -> error_require r p)
-		| _ -> ());
-		let fa = match ao with
-			| None -> FHInstance(c,tl)
-			| Some a -> FHAbstract(a,tl,c)
-		in
-		let fa = FieldAccess.create (Builder.make_static_this c p) f fa false p in
-		let el = unify_constructor_call c fa in
-		el,f,ct
+		begin match cf.cf_kind with
+			| Var { v_read = AccRequire (r,msg) } -> (match msg with Some msg -> error msg p | None -> error_require r p)
+			| _ -> ()
+		end;
+		unify_constructor_call c fa
 	in
 	try begin match t with
 	| TInst ({cl_kind = KTypeParameter tl} as c,params) ->
@@ -1008,13 +1002,11 @@ and type_new ctx path el with_type force_inline p =
 			mk (TNew (c,params,el)) t p
 		end
 	| TAbstract({a_impl = Some c} as a,tl) when not (Meta.has Meta.MultiType a.a_meta) ->
-		let el,cf,ct = build_constructor_call (Some a) c tl in
-		let ta = mk_anon ~fields:c.cl_statics (ref (Statics c)) in
-		let e = mk (TTypeExpr (TClassDecl c)) ta p in
-		let e = mk (TField (e,(FStatic (c,cf)))) ct p in
-		make_call ctx e el t ~force_inline p
+		let fcc = build_constructor_call (Some a) c tl in
+		fcc.fc_data ();
 	| TInst (c,params) | TAbstract({a_impl = Some c},params) ->
-		let el,_,_ = build_constructor_call None c params in
+		let fcc = build_constructor_call None c params in
+		let el = List.map fst fcc.fc_args in
 		mk (TNew (c,params,el)) t p
 	| _ ->
 		error (s_type (print_context()) t ^ " cannot be constructed") p
@@ -1640,7 +1632,7 @@ and type_call ?(mode=MGet) ctx e el (with_type:WithType.t) inline p =
 		let el, t = (match ctx.curclass.cl_super with
 		| None -> error "Current class does not have a super" p
 		| Some (c,params) ->
-			let ct, f = get_constructor ctx c params p in
+			let _,f = get_constructor2 ctx c params p in
 			let t = TInst (c,params) in
 			let e = mk (TConst TSuper) t sp in
 			if (Meta.has Meta.CompilerGenerated f.cf_meta) then display_error ctx (error_msg (No_constructor (TClassDecl c))) p;

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -395,6 +395,15 @@ module FieldAccess = struct
 			end
 		| _ ->
 			AccessorInvalid
+
+	let get_constructor_access c params p =
+		match c.cl_kind with
+		| KAbstractImpl a ->
+			let cf = (try PMap.find "_new" c.cl_statics with Not_found -> raise_error (No_constructor (TAbstractDecl a)) p) in
+			create (Builder.make_static_this c p) cf (FHAbstract(a,params,c)) false p
+		| _ ->
+			let cf = (try Type.get_constructor c with Not_found -> raise_error (No_constructor (TClassDecl c)) p) in
+			create (Builder.make_static_this c p) cf (FHInstance(c,params)) false p
 end
 
 let make_static_extension_access c cf e_this inline p =

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -119,7 +119,7 @@ let completion_item_of_expr ctx e =
 				let absent = match absent with [] -> [] | _ -> "\n\nInactive flags:\n\n" :: absent in
 				(TInst(c,tl)),Some ("Regular expression\n\n" ^ (String.concat "\n" (present @ absent)))
 			| _ -> *)
-				let t,cf = get_constructor ctx c tl e.epos in
+				let t,cf = get_constructor2 ctx c tl e.epos in
 				let t = match follow t with
 					| TFun(args,_) -> TFun(args,TInst(c,tl))
 					| _ -> t
@@ -218,7 +218,7 @@ let rec handle_signature_display ctx e_ast with_type =
 			[loop tl,None,PMap.empty]
 		| TInst (c,tl) | TAbstract({a_impl = Some c},tl) ->
 			Display.merge_core_doc ctx (TClassDecl c);
-			let ct,cf = get_constructor ctx c tl p in
+			let ct,cf = get_constructor2 ctx c tl p in
 			let tl = (ct,cf.cf_doc,get_value_meta cf.cf_meta) :: List.rev_map (fun cf' -> cf'.cf_type,cf.cf_doc,get_value_meta cf'.cf_meta) cf.cf_overloads in
 			tl
 		| _ ->
@@ -295,7 +295,7 @@ and display_expr ctx e_ast e dk with_type p =
 	let get_super_constructor () = match ctx.curclass.cl_super with
 		| None -> error "Current class does not have a super" p
 		| Some (c,params) ->
-			let _, f = get_constructor ctx c params p in
+			let _, f = get_constructor2 ctx c params p in
 			f,c
 	in
 	match ctx.com.display.dms_kind with
@@ -321,7 +321,7 @@ and display_expr ctx e_ast e dk with_type p =
 			Display.ReferencePosition.set (snd ti.mt_path,ti.mt_name_pos,symbol_of_module_type mt);
 		| TNew(c,tl,_) ->
 			begin try
-				let _,cf = get_constructor ctx c tl p in
+				let _,cf = get_constructor2 ctx c tl p in
 				Display.ReferencePosition.set (snd c.cl_path,cf.cf_name_pos,SKConstructor cf);
 			with Not_found ->
 				()
@@ -368,7 +368,7 @@ and display_expr ctx e_ast e dk with_type p =
 		| TTypeExpr mt -> [(t_infos mt).mt_name_pos]
 		| TNew(c,tl,_) ->
 			begin try
-				let _,cf = get_constructor ctx c tl p in
+				let _,cf = get_constructor2 ctx c tl p in
 				if Meta.has Meta.CoreApi c.cl_meta then begin
 					let c' = ctx.g.do_load_core_class ctx c in
 					begin match c'.cl_constructor with

--- a/tests/misc/projects/Issue4775/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue4775/compile1-fail.hxml.stderr
@@ -1,4 +1,3 @@
 Main1.hx:7: characters 15-26 : Constraint check failure for Contain.T
 Main1.hx:7: characters 15-26 : ... Main1 should be String
 Main1.hx:7: characters 15-26 : ... For function argument 't'
-Main1.hx:7: characters 3-27 : Could not determine type for parameter T


### PR DESCRIPTION
This is similar to what I changed for fields in general: Instead of juggling some combination of field and type around, we now communicate via `field_access`.

Technically, it's not quite correct to say that instance constructors have an `FHInstance` host and the `fa_on` value doesn't make much sense for them (it just uses the static expression of the class). However, separating this logically would be quite complicated and I don't see much of a point.