### PR TITLE
fix comparing underlying recursive type in variance unification

### DIFF
--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -492,6 +492,18 @@ let rec follow_without_null t =
 		follow_without_null (apply_params t.t_params tl t.t_type)
 	| _ -> t
 
+let rec follow_without_type t =
+	match t with
+	| TMono r ->
+		(match r.tm_type with
+		| Some t -> follow_without_type t
+		| _ -> t)
+	| TLazy f ->
+		follow_without_type (lazy_type f)
+	| TAbstract({a_path = [],"Null"},[t]) ->
+		follow_without_type t
+	| _ -> t
+
 let rec ambiguate_funs t =
 	match follow t with
 	| TFun _ -> TFun ([], t_dynamic)

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -35,6 +35,7 @@ type unification_context = {
 	allow_abstract_cast   : bool; (* allows a non-transitive abstract cast (from,to,@:from,@:to) *)
 	allow_dynamic_to_cast : bool; (* allows a cast from dynamic to non-dynamic *)
 	equality_kind         : eq_kind;
+	equality_underlying   : bool;
 }
 
 type unify_min_result =
@@ -57,6 +58,7 @@ let default_unification_context = {
 	allow_abstract_cast   = true;
 	allow_dynamic_to_cast = true;
 	equality_kind         = EqStrict;
+	equality_underlying   = false;
 }
 
 module Monomorph = struct
@@ -444,6 +446,10 @@ let rec type_eq uctx a b =
 		| EqDoNotFollowNull -> not (is_explicit_null t)
 		| _ -> true
 	in
+	let can_follow_abstract ab = uctx.equality_underlying && match ab.a_this with
+		| TAbstract (ab',_) -> ab' != ab
+		| _ -> true
+	in
 	if a == b then
 		()
 	else match a , b with
@@ -457,6 +463,12 @@ let rec type_eq uctx a b =
 		(match t.tm_type with
 		| None -> if param = EqCoreType || not (link t b a) then error [cannot_unify a b]
 		| Some t -> type_eq uctx a t)
+	| TDynamic a , TDynamic b ->
+		type_eq uctx a b
+	| _ , _ when a == t_dynamic && param = EqBothDynamic ->
+		()
+	| _ , _ when b == t_dynamic && (param = EqRightDynamic || param = EqBothDynamic) ->
+		()
 	| TAbstract ({a_path=[],"Null"},[t1]),TAbstract ({a_path=[],"Null"},[t2]) ->
 		type_eq uctx t1 t2
 	| TAbstract ({a_path=[],"Null"},[t]),_ when param <> EqDoNotFollowNull ->
@@ -491,11 +503,12 @@ let rec type_eq uctx a b =
 				let msg = if !i = 0 then Invalid_return_type else Invalid_function_argument(!i,List.length l1) in
 				error (cannot_unify a b :: msg :: l)
 		)
-	| TDynamic a , TDynamic b ->
-		type_eq uctx a b
-	| TAbstract (a1,tl1) , TAbstract (a2,tl2) ->
-		if a1 != a2 && not (param = EqCoreType && a1.a_path = a2.a_path) then error [cannot_unify a b];
+	| TAbstract (a1,tl1) , TAbstract (a2,tl2) when a1 == a2 || (param = EqCoreType && a1.a_path = a2.a_path) ->
 		type_eq_params uctx a b tl1 tl2
+	| TAbstract (ab,tl) , _ when can_follow_abstract ab ->
+		type_eq uctx (apply_params ab.a_params tl ab.a_this) b
+	| _ , TAbstract (ab,tl) when can_follow_abstract ab ->
+		type_eq uctx a (apply_params ab.a_params tl ab.a_this)
 	| TAnon a1, TAnon a2 ->
 		(try
 			(match !(a2.a_status) with
@@ -523,12 +536,7 @@ let rec type_eq uctx a b =
 		with
 			Unify_error l -> error (cannot_unify a b :: l))
 	| _ , _ ->
-		if b == t_dynamic && (param = EqRightDynamic || param = EqBothDynamic) then
-			()
-		else if a == t_dynamic && param = EqBothDynamic then
-			()
-		else
-			error [cannot_unify a b]
+		error [cannot_unify a b]
 
 and type_eq_params uctx a b tl1 tl2 =
 	let i = ref 0 in
@@ -968,22 +976,7 @@ and unify_with_variance uctx f t1 t2 =
 	let unify_tls tl1 tl2 = List.iter2 unify_nested tl1 tl2 in
 	let get_this_type ab tl = follow_without_type (apply_params ab.a_params tl ab.a_this) in
 	let get_defined_type td tl = follow_without_type (apply_params td.t_params tl td.t_type) in
-	let rec get_underlying_type stack t = match follow_without_type t with
-		| TType(td,tl) ->
-			(match List.exists (fast_eq t) stack with
-			| true -> map (get_underlying_type stack) t
-			| false -> get_underlying_type (t :: stack) (get_defined_type td tl))
-		| t ->
-			(match map (get_underlying_type stack) t with
-			| TAbstract(ab,tl) ->
-				(match get_this_type ab tl with
-				| TAbstract(ab',_) as t when ab == ab' -> t
-				| t -> get_underlying_type stack t)
-			| t -> t)
-	in
-	let compare_underlying () =
-		type_eq {uctx with equality_kind = EqBothDynamic} (get_underlying_type [] t1) (get_underlying_type [] t2)
-	in
+	let compare_underlying () = type_eq {uctx with equality_underlying = true; equality_kind = EqBothDynamic} t1 t2 in
 	let unifies_abstract uctx a b ab tl ats =
 		try
 			let uctx = get_abstract_context uctx a b ab in

--- a/tests/unit/src/unit/issues/Issue9761.hx
+++ b/tests/unit/src/unit/issues/Issue9761.hx
@@ -1,0 +1,35 @@
+package unit.issues;
+
+class Issue9761 extends Test {
+  function test() {
+    ((null: Array<X>): Array<Y>);
+    ((null: Array<Y>): Array<X>);
+
+    ((null: Array<XT<Int>>): Array<YT<Int>>);
+    ((null: Array<YT<Int>>): Array<XT<Int>>);
+
+    ((null: Array<XT<XT<Int>>>): Array<XT<YT<Int>>>);
+    ((null: Array<XT<XT<Int>>>): Array<YT<XT<Int>>>);
+    ((null: Array<XT<XT<Int>>>): Array<YT<YT<Int>>>);
+
+    ((null: Array<XT<YT<Int>>>): Array<XT<XT<Int>>>);
+    ((null: Array<XT<YT<Int>>>): Array<YT<XT<Int>>>);
+    ((null: Array<XT<YT<Int>>>): Array<YT<YT<Int>>>);
+
+    ((null: Array<YT<XT<Int>>>): Array<XT<YT<Int>>>);
+    ((null: Array<YT<XT<Int>>>): Array<XT<XT<Int>>>);
+    ((null: Array<YT<XT<Int>>>): Array<YT<YT<Int>>>);
+
+    ((null: Array<YT<YT<Int>>>): Array<XT<YT<Int>>>);
+    ((null: Array<YT<YT<Int>>>): Array<YT<XT<Int>>>);
+    ((null: Array<YT<YT<Int>>>): Array<XT<XT<Int>>>);
+
+    noAssert();
+  }
+}
+
+private typedef X = {?x: X}
+private abstract Y(X) from X to X {}
+
+private typedef XT<T> = {?x: XT<T>, ?t: T}
+private abstract YT<T>(XT<T>) from XT<T> to XT<T> {}


### PR DESCRIPTION
In first commit made `get_underlying_type` (and `unify_with_variance` in general) working with recursive types.

In second commit removed `get_underlying_type` and added option for `type_eq` to compare underlying types instead (faster and simpler).

Other:

Moved dynamic checks in `type_eq` higher, no need to spend time on things that don't affect unification result (such as resolving typedes and getting underlying for abstracts).

`ForwardVariance` should use `with_variance`, not `unify_with_variance`, minor thing.
