### PR TITLE
Add CfConstructor flag

### DIFF
--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -412,6 +412,7 @@ let convert_ilmethod ctx p is_interface m is_explicit_impl =
 		| _ -> acc, is_final
 	) ([acc],None) m.mflags.mf_contract in
 	let acc = (AOverload,p) :: acc in
+	let acc = if cff_name = "new" then (AConstructor,null_pos) :: acc else acc in
 	if PMap.mem "net_loader_debug" ctx.ncom.defines.Define.values then
 		Printf.printf "\t%smethod %s : %s\n" (if !is_static then "static " else "") cff_name (IlMetaDebug.ilsig_s m.msig.ssig);
 

--- a/src/codegen/gencommon/abstractImplementationFix.ml
+++ b/src/codegen/gencommon/abstractImplementationFix.ml
@@ -24,7 +24,7 @@ let add_abstract_params = function
 	| TClassDecl ({ cl_kind = KAbstractImpl a } as c) ->
 		List.iter (
 			function
-			| ({ cf_name = "_new" } as cf) ->
+			| cf when has_class_field_flag cf CfConstructor ->
 				cf.cf_params <- cf.cf_params @ a.a_params
 			| cf when has_class_field_flag cf CfImpl ->
 				(match cf.cf_expr with

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -244,7 +244,9 @@ let convert_java_enum ctx p pe =
 		let cff_meta = ref [] in
 		let cff_access = ref [] in
 		let cff_name = match field.jf_name with
-			| "<init>" -> "new"
+			| "<init>" ->
+				cff_access := (AConstructor,null_pos) :: !cff_access;
+				"new"
 			| "<clinit>"-> raise Exit (* __init__ field *)
 			| name when String.length name > 5 ->
 					(match String.sub name 0 5 with

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -785,6 +785,7 @@ module Converter = struct
 		in
 		let name = match String.nsplit jf.jf_name "$" with
 			| ["<init>"] ->
+				add_access (AConstructor,null_pos);
 				"new"
 			| [name] ->
 				if is_haxe_keyword name then begin

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -327,6 +327,7 @@ let build_class com c file =
 		let t = if name = "endian" then Some (HMPath (["flash";"utils"],"Endian")) else t in
 		let flags, accessor_flags = [APublic,null_pos], [APrivate,null_pos] in
 		let flags, accessor_flags = if stat then (AStatic,null_pos) :: flags, (AStatic,null_pos) :: accessor_flags else flags, accessor_flags in
+		let flags = if name = "new" then (AConstructor,null_pos) :: flags else flags in
 		let property_typehint = Some (make_dyn_type t,null_pos) in
 		let fields = [] in
 		let read_access, fields =

--- a/src/context/display/documentSymbols.ml
+++ b/src/context/display/documentSymbols.ml
@@ -55,7 +55,7 @@ let collect_module_symbols mname with_locals (pack,decls) =
 			if with_locals then expr_opt field_parent eo
 		| FFun f ->
 			add_field (
-				if fst cff_name = "new" then Constructor
+				if List.mem_assoc AConstructor cff_access then Constructor
 				else if ((parent_kind = EnumAbstract or parent_kind = Abstract) && Meta.has_one_of [Meta.Op; Meta.ArrayAccess; Meta.Resolve] cff_meta) then Operator
 				else Method
 			);

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -256,6 +256,7 @@ and access =
 	| AExtern
 	| AAbstract
 	| AOverload
+	| AConstructor
 
 and placed_access = access * pos
 
@@ -437,6 +438,7 @@ let s_access = function
 	| AExtern -> "extern"
 	| AAbstract -> "abstract"
 	| AOverload -> "overload"
+	| AConstructor -> "constructor"
 
 let s_placed_access (a,_) = s_access a
 

--- a/src/core/display/completionItem.ml
+++ b/src/core/display/completionItem.ml
@@ -79,7 +79,7 @@ module CompletionModuleType = struct
 		| EClass d ->
 			let ctor =
 				try
-					let cff = List.find (fun cff -> fst cff.cff_name = "new") d.d_data in
+					let cff = List.find (fun cff -> List.mem_assoc AConstructor cff.cff_access) d.d_data in
 					if List.mem HExtern d.d_flags || List.exists (fun (acc,_) -> acc = APublic) cff.cff_access then Yes
 					else YesButPrivate
 				with Not_found ->
@@ -136,7 +136,7 @@ module CompletionModuleType = struct
 		| EAbstract d ->
 			let ctor =
 				try
-					let cff = List.find (fun cff -> fst cff.cff_name = "new") d.d_data in
+					let cff = List.find (fun cff -> List.mem_assoc AConstructor cff.cff_access) d.d_data in
 					if List.exists (fun (acc,_) -> acc = APublic) cff.cff_access then Yes else YesButPrivate
 				with Not_found ->
 					No

--- a/src/core/display/completionItem.ml
+++ b/src/core/display/completionItem.ml
@@ -176,14 +176,9 @@ module CompletionModuleType = struct
 			raise Exit
 
 	let of_module_type mt =
-		let actor a = match a.a_impl with
-			| None -> No
-			| Some c ->
-				try
-					let cf = PMap.find "_new" c.cl_statics in
-					if (has_class_flag c CExtern) || (has_class_field_flag cf CfPublic) then Yes else YesButPrivate
-				with Not_found ->
-					No
+		let actor a = match a.a_constructor,a.a_impl with
+			| Some cf,Some c -> if (has_class_flag c CExtern) || (has_class_field_flag cf CfPublic) then Yes else YesButPrivate
+			| _ -> No
 		in
 		let ctor c =
 			try

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -204,6 +204,7 @@ let null_abstract = {
 	a_ops = [];
 	a_unops = [];
 	a_impl = None;
+	a_constructor = None;
 	a_this = t_dynamic;
 	a_from = [];
 	a_from_field = [];

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -303,6 +303,7 @@ and tabstract = {
 	mutable a_ops : (Ast.binop * tclass_field) list;
 	mutable a_unops : (Ast.unop * unop_flag * tclass_field) list;
 	mutable a_impl : tclass option;
+	mutable a_constructor : tclass_field option;
 	mutable a_this : t;
 	mutable a_from : t list;
 	mutable a_from_field : (t * tclass_field) list;
@@ -396,6 +397,7 @@ type flag_tclass_field =
 	| CfImpl
 	| CfEnum
 	| CfGeneric
+	| CfConstructor
 
 type flag_tvar =
 	| VCaptured

--- a/src/filters/defaultArguments.ml
+++ b/src/filters/defaultArguments.ml
@@ -64,7 +64,7 @@ let rec change_func com cl cf =
 	| Var _, _ | Method MethDynamic, _ ->
 		()
 	| _, TFun(args, ret) ->
-		let is_ctor = cf.cf_name = "new" in
+		let is_ctor = has_class_field_flag cf CfConstructor in
 		let basic = com.basic in
 
 		let found = ref false in

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -476,6 +476,7 @@ let add_field_inits locals ctx t =
 					tf_expr = mk (TBlock el) ctx.com.basic.tvoid c.cl_pos;
 				}) ct c.cl_pos in
 				let ctor = mk_field "new" ct c.cl_pos null_pos in
+				add_class_field_flag ctor CfConstructor;
 				ctor.cf_kind <- Method MethNormal;
 				{ ctor with cf_expr = Some ce }
 			| Some cf ->

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -695,12 +695,15 @@ and decode_class_field_kind v =
 and decode_field v =
 	let fkind = decode_class_field_kind (field v "kind") in
 	let pos = decode_pos (field v "pos") in
+	let name = decode_string (field v "name"),decode_pos_default (field v "name_pos") pos in
+	let access = List.map decode_access (opt_list decode_array (field v "access")) in
+	let access = if fst name = "new" && not (List.mem_assoc AConstructor access) then (AConstructor,Globals.null_pos) :: access else access in
 	{
-		cff_name = (decode_string (field v "name"),decode_pos_default (field v "name_pos") pos);
+		cff_name = name;
 		cff_doc = decode_doc (field v "doc");
 		cff_pos = pos;
 		cff_kind = fkind;
-		cff_access = List.map decode_access (opt_list decode_array (field v "access"));
+		cff_access = access;
 		cff_meta = opt_list decode_meta_content (field v "meta");
 	}
 

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -316,6 +316,7 @@ and encode_access a =
 		| AExtern -> 8
 		| AAbstract -> 9
 		| AOverload -> 10
+		| AConstructor -> 11
 	in
 	encode_enum ~pos:(Some (pos a)) IAccess tag []
 
@@ -668,6 +669,7 @@ and decode_access v =
 	| 8 -> AExtern
 	| 9 -> AAbstract
 	| 10 -> AOverload
+	| 11 -> AConstructor
 	| _ -> raise Invalid_expr
 	in
 	a,p

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -114,7 +114,7 @@ let rec keep_field dce cf c is_static =
 	|| has_class_field_flag cf CfExtern
 	|| (not is_static && overrides_extern_field cf c)
 	|| (
-		cf.cf_name = "new"
+		has_class_field_flag cf CfConstructor
 		&& match c.cl_super with (* parent class kept constructor *)
 			| Some ({ cl_constructor = Some ctor } as csup, _) -> keep_field dce ctor csup false
 			| _ -> false
@@ -160,7 +160,7 @@ and mark_field dce c cf stat =
 			check_feature dce (Printf.sprintf "%s.%s" (s_type_path c.cl_path) cf.cf_name);
 		end
 	in
-	if cf.cf_name = "new" then begin
+	if has_class_field_flag cf CfConstructor then begin
 		let rec loop c =
 			begin match c.cl_constructor with
 				| Some cf -> add cf

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -251,7 +251,7 @@ let inline_default_config cf t =
 let inline_config cls_opt cf call_args return_type =
 	match cls_opt with
 	| Some ({cl_kind = KAbstractImpl _}) when has_class_field_flag cf CfImpl ->
-		let t = if cf.cf_name = "_new" then
+		let t = if has_class_field_flag cf CfConstructor then
 			return_type
 		else if call_args = [] then
 			error "Invalid abstract implementation function" cf.cf_pos
@@ -588,7 +588,7 @@ class inline_state ctx ethis params cf f p = object(self)
 			(match follow ethis.etype with
 			| TAnon a -> (match !(a.a_status) with
 				| Statics {cl_kind = KAbstractImpl a } when has_class_field_flag cf CfImpl ->
-					if cf.cf_name <> "_new" then begin
+					if not (has_class_field_flag cf CfConstructor) then begin
 						(* the first argument must unify with a_this for abstract implementation functions *)
 						let tb = (TFun(("",false,map_type a.a_this) :: (List.tl tl),tret)) in
 						unify_raise ctx mt tb p

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -864,7 +864,7 @@ and parse_enum_param = parser
 	| [< name, _ = ident; t = parse_type_hint >] -> (name,false,t)
 
 and parse_function_field doc meta al = parser
-	| [< '(Kwd Function,p1); name = parse_fun_name; pl = parse_constraint_params; '(POpen,_); args = psep Comma parse_fun_param; '(PClose,_); t = popt parse_type_hint; s >] ->
+	| [< '(Kwd Function,p1); name,is_ctor = parse_fun_name; pl = parse_constraint_params; '(POpen,_); args = psep Comma parse_fun_param; '(PClose,_); t = popt parse_type_hint; s >] ->
 		let e, p2 = (match s with parser
 			| [< e = expr; s >] ->
 				ignore(semicolon s);
@@ -878,6 +878,7 @@ and parse_function_field doc meta al = parser
 			f_type = t;
 			f_expr = e;
 		} in
+		let al = if is_ctor then (AConstructor,null_pos) :: al else al in
 		name,punion p1 p2,FFun f,al,meta
 
 and parse_var_field_assignment = parser
@@ -982,8 +983,8 @@ and parse_cf_rights = parser
 	| [< '(Kwd Overload,p) >] -> AOverload,p
 
 and parse_fun_name = parser
-	| [< name,p = dollar_ident >] -> name,p
-	| [< '(Kwd New,p) >] -> "new",p
+	| [< name,p = dollar_ident >] -> (name,p),false
+	| [< '(Kwd New,p) >] -> ("new",p),true
 
 and parse_fun_param s =
 	let meta = parse_meta s in

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -184,6 +184,7 @@ let reify in_macro =
 			| AExtern -> "AExtern"
 			| AAbstract -> "AAbstract"
 			| AOverload -> "AOverload"
+			| AConstructor -> "AConstructor"
 			) in
 			mk_enum "Access" n [] p
 		in

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -50,7 +50,7 @@ let make_call ctx e params t ?(force_inline=false) p =
 		(match cl, ctx.curclass.cl_kind, params with
 			| Some c, KAbstractImpl _, { eexpr = TLocal { v_meta = v_meta } } :: _ when c == ctx.curclass ->
 				if
-					f.cf_name <> "_new"
+					not (has_class_field_flag f CfConstructor)
 					&& has_meta Meta.This v_meta
 					&& has_class_field_flag f CfModifiesThis
 				then
@@ -221,7 +221,7 @@ let unify_field_call ctx fa el_typed el p inline =
 			cfl,Some c,false,TClass.get_map_function c tl,(fun t -> t)
 		| FHAbstract(a,tl,c) ->
 			let map = apply_params a.a_params tl in
-			let tmap = if fa.fa_field.cf_name = "_new" (* TODO: BAD BAD BAD BAD *) then (fun t -> t) else (fun t -> map a.a_this) in
+			let tmap = if has_class_field_flag fa.fa_field CfConstructor then (fun t -> t) else (fun t -> map a.a_this) in
 			expand_overloads fa.fa_field,Some c,true,map,tmap
 	in
 	let is_forced_inline = is_forced_inline co fa.fa_field in

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -211,7 +211,7 @@ let unify_field_call ctx fa el_typed el p inline =
 			expand_overloads fa.fa_field,None,false,(fun t -> t),(fun t -> t)
 		| FHInstance(c,tl) ->
 			let cf = fa.fa_field in
-			let cfl = if cf.cf_name = "new" || not (has_class_field_flag cf CfOverload) then
+			let cfl = if has_class_field_flag cf CfConstructor || not (has_class_field_flag cf CfOverload) then
 				cf :: cf.cf_overloads
 			else
 				List.map (fun (t,cf) ->

--- a/src/typing/magicTypes.ml
+++ b/src/typing/magicTypes.ml
@@ -33,11 +33,11 @@ let extend_remoting ctx c t p async prot =
 	ctx.com.package_rules <- rules;
 	let base_fields = [
 		{ cff_name = "__cnx",null_pos; cff_pos = p; cff_doc = None; cff_meta = []; cff_access = []; cff_kind = FVar (Some (CTPath (mk_type_path (["haxe";"remoting"],if async then "AsyncConnection" else "Connection")),null_pos),None) };
-		{ cff_name = "new",null_pos; cff_pos = p; cff_doc = None; cff_meta = []; cff_access = [APublic,null_pos]; cff_kind = FFun { f_args = [("c",null_pos),false,[],None,None]; f_type = None; f_expr = Some (EBinop (OpAssign,(EConst (Ident "__cnx"),p),(EConst (Ident "c"),p)),p); f_params = [] } };
+		{ cff_name = "new",null_pos; cff_pos = p; cff_doc = None; cff_meta = []; cff_access = [(APublic,null_pos);(AConstructor,null_pos)]; cff_kind = FFun { f_args = [("c",null_pos),false,[],None,None]; f_type = None; f_expr = Some (EBinop (OpAssign,(EConst (Ident "__cnx"),p),(EConst (Ident "c"),p)),p); f_params = [] } };
 	] in
 	let tvoid = CTPath (mk_type_path ([],"Void")) in
 	let build_field is_public acc f =
-		if fst f.cff_name = "new" then
+		if List.mem_assoc AConstructor f.cff_access then
 			acc
 		else match f.cff_kind with
 		| FFun fd when (is_public || List.mem_assoc APublic f.cff_access) && not (List.mem_assoc AStatic f.cff_access) ->

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -524,7 +524,7 @@ and load_complex_type' ctx allow_display (t,p) =
 				| None -> error ("Explicit type required for field " ^ n) p
 				| Some t -> load_complex_type ctx allow_display t
 			in
-			if n = "new" then ctx.com.warning "Structures with new are deprecated, use haxe.Constraints.Constructible instead" p;
+			if List.mem_assoc AConstructor f.cff_access then ctx.com.warning "Structures with new are deprecated, use haxe.Constraints.Constructible instead" p;
 			let no_expr = function
 				| None -> ()
 				| Some (_,p) -> error "Expression not allowed here" p

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -544,7 +544,7 @@ and load_complex_type' ctx allow_display (t,p) =
 					pub := false;
 				| ADynamic when (match f.cff_kind with FFun _ -> true | _ -> false) -> dyn := true
 				| AFinal -> final := true
-				| AStatic | AOverride | AInline | ADynamic | AMacro | AExtern | AAbstract | AOverload as a -> error ("Invalid access " ^ Ast.s_access a) p
+				| AStatic | AOverride | AInline | ADynamic | AMacro | AExtern | AAbstract | AOverload | AConstructor as a -> error ("Invalid access " ^ Ast.s_access a) p
 			) f.cff_access;
 			let t , access = (match f.cff_kind with
 				| FVar(t,e) when !final ->

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -321,6 +321,7 @@ let add_constructor ctx c force_constructor p =
 			tf_expr = mk (TBlock []) ctx.t.tvoid p;
 		}) (tfun [] ctx.t.tvoid) p in
 		let cf = mk_field "new" constr.etype p null_pos in
+		add_class_field_flag cf CfConstructor;
 		cf.cf_expr <- Some constr;
 		cf.cf_type <- constr.etype;
 		cf.cf_meta <- [Meta.CompilerGenerated,[],null_pos];

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -326,6 +326,7 @@ let module_pass_1 ctx m tdecls loadp =
 				a_ops = [];
 				a_unops = [];
 				a_impl = None;
+				a_constructor = None;
 				a_array = [];
 				a_this = mk_mono();
 				a_read = None;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1369,7 +1369,7 @@ and type_array_comprehension ctx e with_type p =
 	]) v.v_type p
 
 and type_return ?(implicit=false) ctx e with_type p =
-	let is_abstract_ctor = ctx.curfun = FunMemberAbstract && ctx.curfield.cf_name = "_new" in
+	let is_abstract_ctor = ctx.curfun = FunMemberAbstract && has_class_field_flag ctx.curfield CfConstructor in
 	match e with
 	| None when is_abstract_ctor ->
 		let e_cast = mk (TCast(get_this ctx p,None)) ctx.ret p in

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -134,7 +134,7 @@ let assign_to_this_is_allowed ctx =
 		| KAbstractImpl _ ->
 			(match ctx.curfield.cf_kind with
 				| Method MethInline -> true
-				| Method _ when ctx.curfield.cf_name = "_new" -> true
+				| Method _ when has_class_field_flag ctx.curfield CfConstructor -> true
 				| _ -> false
 			)
 		| _ -> false
@@ -399,7 +399,10 @@ module FieldAccess = struct
 	let get_constructor_access c params p =
 		match c.cl_kind with
 		| KAbstractImpl a ->
-			let cf = (try PMap.find "_new" c.cl_statics with Not_found -> raise_error (No_constructor (TAbstractDecl a)) p) in
+			let cf = match a.a_constructor with
+				| Some cf -> cf
+				| None -> raise_error (No_constructor (TAbstractDecl a)) p
+			in
 			create (Builder.make_static_this c p) cf (FHAbstract(a,params,c)) false p
 		| _ ->
 			let cf = (try Type.get_constructor c with Not_found -> raise_error (No_constructor (TClassDecl c)) p) in

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -596,9 +596,9 @@ let handle_display ctx e_ast dk mode with_type =
 						let mt = ctx.g.do_load_type_def ctx null_pos {tpackage=mt.pack;tname=mt.module_name;tsub=Some mt.name;tparams=[]} in
 						begin match resolve_typedef mt with
 						| TClassDecl c when has_constructor c -> true
-						| TAbstractDecl {a_impl = Some c} ->
+						| TAbstractDecl ({a_impl = Some c} as a) ->
 							ignore(c.cl_build());
-							PMap.mem "_new" c.cl_statics
+							a.a_constructor <> None
 						| _ -> false
 						end
 					with _ ->

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -862,6 +862,11 @@ enum Access {
 		Abstract access modifier.
 	**/
 	AAbstract;
+
+	/**
+		Field is a constructor.
+	**/
+	AConstructor;
 }
 
 /**
@@ -968,6 +973,7 @@ enum TypeDefKind {
 		Represents a module-level field.
 	**/
 	TDField(kind:FieldType, ?access:Array<Access>); // ignore TypeDefinition.fields
+
 }
 
 /**

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -160,6 +160,7 @@ class Printer {
 			case AFinal: "final";
 			case AExtern: "extern";
 			case AAbstract: "abstract";
+			case AConstructor: "constructor";
 		}
 
 	public function printField(field:Field) {


### PR DESCRIPTION
Replaces some checks against `"_new"` with checks against a new class field flag `CfConstructor`. Also adds `a_constructor` to avoid by-name lookups into the implementation class statics.

This only affects abstracts at the moment, but we can probably use this flag for normal constructors as well as a next step.