### PR TITLE
[typer] fix some inconsistency in recursive comparison

### DIFF
--- a/tests/misc/compiler_loops/projects/Issue5189/compile-fail.hxml.stderr
+++ b/tests/misc/compiler_loops/projects/Issue5189/compile-fail.hxml.stderr
@@ -1,3 +1,3 @@
 Main.hx:18: characters 9-29 : error: { c : Array<TT_A>, b : String, a : Int } has no field d
-Main.hx:18: characters 9-29 : ... have: { c: Array<{ c, b, a }> }
+Main.hx:18: characters 9-29 : ... have: { c: Array<TT_A> }
 Main.hx:18: characters 9-29 : ... want: { c: Array<TT_B> }

--- a/tests/misc/projects/Issue7227/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7227/compile-fail.hxml.stderr
@@ -1,3 +1,3 @@
-Main.hx:4: characters 9-81 : error: { url : String, method : String } should be String
-Main.hx:4: characters 9-81 : ... have: Generic<{ url: { url, method } }>
+Main.hx:4: characters 9-81 : error: Struct should be String
+Main.hx:4: characters 9-81 : ... have: Generic<{ url: Struct }>
 Main.hx:4: characters 9-81 : ... want: Generic<{ url: String }>

--- a/tests/unit/src/unit/issues/Issue9761.hx
+++ b/tests/unit/src/unit/issues/Issue9761.hx
@@ -24,12 +24,15 @@ class Issue9761 extends Test {
     ((null: Array<YT<YT<Int>>>): Array<YT<XT<Int>>>);
     ((null: Array<YT<YT<Int>>>): Array<XT<XT<Int>>>);
 
+    ((null: X): Z);
+
     noAssert();
   }
 }
 
 private typedef X = {?x: X}
 private abstract Y(X) from X to X {}
+private abstract Z({?x: Z}) from X to X {}
 
 private typedef XT<T> = {?x: XT<T>, ?t: T}
 private abstract YT<T>(XT<T>) from XT<T> to XT<T> {}


### PR DESCRIPTION
1) In `type_eq` recursive stack was used in `_,typedef` case but wasn't in `typedef,_`.

2) Typedef recursion in `type_eq` produces a unification error, while same recursion in `unify_with_variance` was treated as a pass. Strangely it works either way, went for error version.