### PR TITLE
Allow `overload` on extern methods on all targets

### DIFF
--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -173,7 +173,7 @@ let check_overriding ctx c f =
 		let i = f.cf_name in
 		let check_field f get_super_field is_overload = try
 			(if is_overload && not (has_class_field_flag f CfOverload) then
-				display_error ctx ("Missing @:overload declaration for field " ^ i) p);
+				display_error ctx ("Missing overload declaration for field " ^ i) p);
 			let t, f2 = get_super_field csup i in
 			check_native_name_override ctx f f2;
 			(* allow to define fields that are not defined for this platform version in superclass *)
@@ -181,10 +181,11 @@ let check_overriding ctx c f =
 			| Var { v_read = AccRequire _ } -> raise Not_found;
 			| _ -> ());
 			if (has_class_field_flag f2 CfOverload && not (has_class_field_flag f CfOverload)) then
-				display_error ctx ("Field " ^ i ^ " should be declared with @:overload since it was already declared as @:overload in superclass") p
-			else if not (has_class_field_flag f CfOverride) then
-				display_error ctx ("Field " ^ i ^ " should be declared with 'override' since it is inherited from superclass " ^ s_type_path csup.cl_path) p
-			else if not (has_class_field_flag f CfPublic) && (has_class_field_flag f2 CfPublic) then
+				display_error ctx ("Field " ^ i ^ " should be declared with overload since it was already declared as overload in superclass") p
+			else if not (has_class_field_flag f CfOverride) then begin
+				if has_class_flag c CExtern then add_class_field_flag f CfOverride
+				else display_error ctx ("Field " ^ i ^ " should be declared with 'override' since it is inherited from superclass " ^ s_type_path csup.cl_path) p
+			end else if not (has_class_field_flag f CfPublic) && (has_class_field_flag f2 CfPublic) then
 				display_error ctx ("Field " ^ i ^ " has less visibility (public/private) than superclass one") p
 			else (match f.cf_kind, f2.cf_kind with
 			| _, Method MethInline ->

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -346,7 +346,7 @@ module Inheritance = struct
 			try
 				let t2, f2 = class_field_no_interf c i in
 				let t2, f2 =
-					if ctx.com.config.pf_overload && (f2.cf_overloads <> [] || has_class_field_flag f2 CfOverload) then
+					if f2.cf_overloads <> [] || has_class_field_flag f2 CfOverload then
 						let overloads = Overloads.get_overloads ctx.com c i in
 						is_overload := true;
 						List.find (fun (t1,f1) -> Overloads.same_overload_args t t1 f f1) overloads
@@ -403,7 +403,7 @@ module Inheritance = struct
 		in
 		let check_field i cf =
 			check_field i cf;
-			if ctx.com.config.pf_overload then
+			if has_class_field_flag cf CfOverload then
 				List.iter (check_field i) (List.rev cf.cf_overloads)
 		in
 		PMap.iter check_field intf.cl_fields

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1214,8 +1214,12 @@ let create_method (ctx,cctx,fctx) c f fd p =
 	| Some p ->
 		if ctx.com.config.pf_overload then
 			add_class_field_flag cf CfOverload
+		else if fctx.field_kind = FKConstructor then
+			display_error ctx "Constructors cannot be overloaded on this target" p
+		else if (has_class_flag c CExtern || fctx.is_extern) then
+			add_class_field_flag cf CfOverload
 		else
-			display_error ctx "This platform does not support this kind of overload declaration. Try @:overload(function()... {}) instead" p
+			display_error ctx "Only extern functions may be overloaded on this target" p
 	| None ->
 		()
 	end;

--- a/tests/misc/projects/extern-overloads/ambiguous-static/Main.hx
+++ b/tests/misc/projects/extern-overloads/ambiguous-static/Main.hx
@@ -1,0 +1,4 @@
+extern class Main {
+	overload static inline function f(i:Int):Void {}
+	overload static inline function f(i:Int):Void {}
+}

--- a/tests/misc/projects/extern-overloads/ambiguous-static/compile-fail.hxml
+++ b/tests/misc/projects/extern-overloads/ambiguous-static/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/extern-overloads/ambiguous-static/compile-fail.hxml.stderr
+++ b/tests/misc/projects/extern-overloads/ambiguous-static/compile-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Main.hx:2: characters 2-50 : Another overloaded field of same signature was already declared : f
+Main.hx:3: characters 2-50 : ... The second field is declared here

--- a/tests/misc/projects/extern-overloads/amgiuous-call-site/Main.hx
+++ b/tests/misc/projects/extern-overloads/amgiuous-call-site/Main.hx
@@ -1,0 +1,12 @@
+extern class Ext {
+	function new():Void;
+	overload function f(s:String):Void;
+	overload function f(e:Ext):Void;
+}
+
+class Main {
+	static function main() {
+		var m = new Ext();
+		m.f(null);
+	}
+}

--- a/tests/misc/projects/extern-overloads/amgiuous-call-site/compile-fail.hxml
+++ b/tests/misc/projects/extern-overloads/amgiuous-call-site/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/extern-overloads/amgiuous-call-site/compile-fail.hxml.stderr
+++ b/tests/misc/projects/extern-overloads/amgiuous-call-site/compile-fail.hxml.stderr
@@ -1,0 +1,3 @@
+Main.hx:10: characters 3-12 : Ambiguous overload, candidates follow
+Main.hx:3: characters 20-21 : ... (s : String) -> Void
+Main.hx:4: characters 20-21 : ... (e : Ext) -> Void

--- a/tests/misc/projects/extern-overloads/missing-override/Main.hx
+++ b/tests/misc/projects/extern-overloads/missing-override/Main.hx
@@ -1,0 +1,7 @@
+extern class Parent {
+	overload function f(i:Int):Void;
+}
+
+extern class Child extends Parent {
+	function f(i:Int):Void;
+}

--- a/tests/misc/projects/extern-overloads/missing-override/compile-fail.hxml.disabled
+++ b/tests/misc/projects/extern-overloads/missing-override/compile-fail.hxml.disabled
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/extern-overloads/missing-override/compile-fail.hxml.stderr
+++ b/tests/misc/projects/extern-overloads/missing-override/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:6: characters 11-12 : Field f should be declared with overload since it was already declared as overload in superclass

--- a/tests/misc/projects/extern-overloads/not-not-extern/Main.hx
+++ b/tests/misc/projects/extern-overloads/not-not-extern/Main.hx
@@ -1,0 +1,3 @@
+class Main {
+	overload function test() {}
+}

--- a/tests/misc/projects/extern-overloads/not-not-extern/compile-fail.hxml
+++ b/tests/misc/projects/extern-overloads/not-not-extern/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/extern-overloads/not-not-extern/compile-fail.hxml.stderr
+++ b/tests/misc/projects/extern-overloads/not-not-extern/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:2: characters 2-10 : Only extern functions may be overloaded on this target

--- a/tests/misc/projects/extern-overloads/not-on-constructor/Main.hx
+++ b/tests/misc/projects/extern-overloads/not-on-constructor/Main.hx
@@ -1,0 +1,3 @@
+class Main {
+	overload function new() {}
+}

--- a/tests/misc/projects/extern-overloads/not-on-constructor/compile-fail.hxml
+++ b/tests/misc/projects/extern-overloads/not-on-constructor/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/extern-overloads/not-on-constructor/compile-fail.hxml.stderr
+++ b/tests/misc/projects/extern-overloads/not-on-constructor/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:2: characters 2-10 : Constructors cannot be overloaded on this target

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -101,6 +101,7 @@ function main() {
 		#if (java || cs)
 		new TestOverloads(),
 		#end
+		new TestOverloadsForEveryone(),
 		new TestInterface(),
 		new TestNaN(),
 		#if ((dce == "full") && !interp)

--- a/tests/unit/src/unit/TestOverloadsForEveryone.hx
+++ b/tests/unit/src/unit/TestOverloadsForEveryone.hx
@@ -1,0 +1,36 @@
+package unit;
+
+private class StaticOverloadClass {
+	overload extern static public inline function test(i:Int) {
+		return "Int: " + i;
+	}
+
+	overload extern static public inline function test(s:String) {
+		return "String: " + s;
+	}
+}
+
+private class MemberOverloadClass {
+	public function new() {
+
+	}
+
+	overload extern public inline function test(i:Int) {
+		return "Int: " + i;
+	}
+
+	overload extern public inline function test(s:String) {
+		return "String: " + s;
+	}
+}
+
+class TestOverloadsForEveryone extends Test {
+	function test() {
+		eq("Int: 12", StaticOverloadClass.test(12));
+		eq("String: foo", StaticOverloadClass.test("foo"));
+
+		var moc = new MemberOverloadClass();
+		eq("Int: 12", moc.test(12));
+		eq("String: foo", moc.test("foo"));
+	}
+}


### PR DESCRIPTION
This allows using `overload` methods which are marked `extern` or live on `extern` classes. The idea is that we want to allow this as long as we don't have to worry about generating the overloaded methods on targets that have no native support for it.

Some notes:

* Overloaded constructors are explicitly disallowed
* There are no other restrictions in place because the relevant restrictions should follow from the `extern` status
* `@:overload` is _not_ supported.
* I'm adding one `.disabled` test which checks the presence of `override`. We currently don't run any checks like that on externs at all, so this may or may not be something to look into.

There are now only 4 checks for `pf_overload` left:

1. `@:overload` handling
2. Admit overloads for all methods, not just externs
3. Handle overloaded constructors
4. Don't call `add_constructor` because it doesn't support overloads

While the first two should remain in place, we could at some point look into supporting overloaded constructors as well. This can first be done for true externs, and maybe even extended to extern inline constructors afterwards.

I'm sure there are some missing checks here, but we can add those when we come across them.