### PR TITLE
Build a class before unification with an anonymous structure

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -680,6 +680,7 @@ let rec unify (uctx : unification_context) a b =
 				(* one of the constraints must unify with { } *)
 				if not (List.exists (fun t -> match follow t with TInst _ | TAnon _ -> true | _ -> false) pl) then error [cannot_unify a b]
 			| _ -> ());
+		ignore(c.cl_build());
 		(try
 			PMap.iter (fun n f2 ->
 				(*

--- a/tests/misc/projects/Issue9769/Main.hx
+++ b/tests/misc/projects/Issue9769/Main.hx
@@ -1,0 +1,32 @@
+#if macro
+import haxe.macro.Context;
+#end
+
+#if !macro
+class Main {
+	public static function main() {
+		final array:MyArray<String> = ["hello", "world"];
+	}
+}
+#end
+
+#if !macro
+@:build(MyMacro.build())
+#end
+abstract MyArray<T>(Array<T>) from Array<T> to Iterable<T> {}
+
+class MyMacro {
+	#if macro
+	static function build() {
+		switch (Context.getLocalType()) {
+			case TInst(_.get() => type, _):
+				switch (type.kind) {
+					case KAbstractImpl(_.get() => abstractType):
+					default:
+				}
+			default:
+		}
+		return null;
+	}
+	#end
+}

--- a/tests/misc/projects/Issue9769/compile.hxml
+++ b/tests/misc/projects/Issue9769/compile.hxml
@@ -1,0 +1,1 @@
+--main Main


### PR DESCRIPTION
Fixes #9769 

In certain situations (see the issue) unification is run before a class involved is populated with fields.
This PR insures a class is built before trying to unify it with an anon.

This seems to be a correct change in terms of unification.
But I'm not sure if it's the correct issue to solve. 
Maybe the real issue is that an underlying type of an abstract is still not ready when we need to unify it with `from`/`to` types.
