### PR TITLE
Add @:functionalInterface

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -422,6 +422,12 @@
 		"links": ["https://haxe.org/manual/types-abstract-implicit-casts.html"]
 	},
 	{
+		"name": "FunctionalInterface",
+		"metadata": ":functionalInterface",
+		"doc": "Marks single-method interfaces",
+		"targets": ["TClass"]
+	},
+	{
 		"name": "FunctionCode",
 		"metadata": ":functionCode",
 		"doc": "Used to inject platform-native code into a function.",

--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -621,6 +621,13 @@
 		"internal": true
 	},
 	{
+		"name": "JvmDefault",
+		"metadata": ":jvm.default",
+		"doc": "Marks interface methods as having default implementations",
+		"platforms": ["java"],
+		"targets": ["TClassField"]
+	},
+	{
 		"name": "JvmSynthetic",
 		"metadata": ":jvm.synthetic",
 		"doc": "Mark generated class, field or method as synthetic",

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -674,6 +674,19 @@ let rec unify (uctx : unification_context) a b =
 			Unify_error l ->
 				let msg = if !i = 0 then Invalid_return_type else Invalid_function_argument(!i,List.length l1) in
 				error (cannot_unify a b :: msg :: l))
+	| TFun _ , TInst(c,tl) ->
+		begin try
+			let (_,el,_) = Meta.get Meta.FunctionalInterface c.cl_meta in
+			begin match el with
+			| [(EConst(String(name,_)),_)] ->
+				let cf = PMap.find name c.cl_fields in
+				unify uctx a (apply_params c.cl_params tl cf.cf_type)
+			| _ ->
+				raise Not_found
+			end
+		with Not_found ->
+			error [cannot_unify a b]
+		end
 	| TInst (c,tl) , TAnon an ->
 		if PMap.is_empty an.a_fields then (match c.cl_kind with
 			| KTypeParameter pl ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1203,6 +1203,18 @@ and type_local_function ctx kind f with_type p =
 					| _,TMono _ -> unify ctx rt tr p
 					| _ -> ()
 				end
+			| TInst(c,tl) when Meta.has Meta.FunctionalInterface c.cl_meta ->
+				begin match Meta.get Meta.FunctionalInterface c.cl_meta with
+				| (_,[EConst (String(name,_)),_],_) ->
+					begin try
+						let cf = PMap.find name c.cl_fields in
+						loop (apply_params c.cl_params tl cf.cf_type)
+					with Not_found ->
+						()
+					end;
+				| _ ->
+					()
+				end
 			| TAbstract(a,tl) ->
 				loop (Abstract.get_underlying_type a tl)
 			| _ -> ())

--- a/tests/unit/src/unit/issues/Issue9576.hx
+++ b/tests/unit/src/unit/issues/Issue9576.hx
@@ -3,7 +3,7 @@ package unit.issues;
 class Issue9576 extends Test {
 	#if jvm
 	function test() {
-		eq(6, foo(cast i -> i * 2));
+		eq(6, foo(i -> i * 2));
 	}
 
 	function foo(f:java.util.function.Function<Int, Int>) {


### PR DESCRIPTION
The first commit allows tagging interfaces with `@:functionalInterface(methodName)`. When something that is typed as `TFun` is assigned to such an interface, the compiler extracts the field corresponding to `methodName` and unifies the function against that field type. It is then up to the target generator to generate proper code for this.

... which is what the second commit does for the JVM target. The Java API has some functional interfaces which are intended to be used by assigning lambda expressions to it. The JVM generator checks all created functions against such interfaces and `implements` them accordingly. This makes an extended example from #9576 work:

```haxe
import java.util.function.Function;

function foo(f:Function<Int, Int>) {
	trace(f.apply(3));
}

function timesThree(i:Int) {
	return i * 3;
}

function main() {
	foo(i -> i * 2);
	foo(timesThree);
}
```

And this is unfortunately what the closure looks like:

```java
    public static class Closure_main_0 extends haxe.jvm.Function implements Comparable<Integer>, Function<Integer, Integer>, IntFunction<Integer>, IntUnaryOperator, ToIntFunction<Integer> {
        public static final Main_Fields_.Closure_main_0 Main_Fields_$Closure_main_0 = new Main_Fields_.Closure_main_0();

        Closure_main_0() {
        }

        public int invoke(int i) {
            return i * 2;
        }

        public int applyAsInt(int arg0) {
            return this.invoke(arg0);
        }

        public int apply(int arg0) {
            return this.invoke(arg0);
        }

        public int compareTo(int arg0) {
            return this.invoke(arg0);
        }

        public int applyAsInt(java.lang.Object arg0) {
            return this.invoke(arg0);
        }

        public int apply(java.lang.Object arg0) {
            return this.invoke(arg0);
        }

        public int compareTo(java.lang.Object arg0) {
            return this.invoke(arg0);
        }

        public java.lang.Object apply(java.lang.Object arg0) {
            return this.invoke(arg0);
        }
    }
```

I don't know if this is sane. For lambdas, the alternative would be to only implement the interface they are actually being assigned to. That would lead to less ridiculous code, though we likely still want to do that for field closures.