### PR TITLE
[typer] fix overload meta on overload

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1609,7 +1609,7 @@ let init_class ctx c p context_init herits fields =
 						let mainf = PMap.find cf.cf_name (if fctx.is_static then c.cl_statics else c.cl_fields) in
 						if is_var mainf then display_error ctx "Cannot declare a variable with same name as a method" mainf.cf_pos;
 						(if not (has_class_field_flag mainf CfOverload) then display_error ctx ("Overloaded methods must have @:overload metadata") mainf.cf_pos);
-						mainf.cf_overloads <- cf :: mainf.cf_overloads
+						mainf.cf_overloads <- cf :: cf.cf_overloads @ mainf.cf_overloads
 					else
 						let type_kind,path = match c.cl_kind with
 							| KAbstractImpl a -> "abstract",a.a_path


### PR DESCRIPTION
Currently:
```haxe
extern class Foo {
  @:overload(function(value: String): String {}) // this one is picked up
  static overload function foo(value: Int): Int;

  @:overload(function(value: Bool): Bool {}) // this one isn't
  static overload function foo(value: Float): Float;
}
```
Now second one will get picked too.