### PR TITLE
[typer] fix typing deep inherited constructor

### DIFF
--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -749,6 +749,12 @@ let quick_field_dynamic t s =
 	try quick_field t s
 	with Not_found -> FDynamic s
 
+let rec get_constructor_class c tl =
+	match c.cl_constructor, c.cl_super with
+	| Some cf, _ -> (cf,c,tl)
+	| None, None -> raise Not_found
+	| None, Some (csup,tlsup) -> get_constructor_class csup (List.map (apply_params c.cl_params tl) tlsup)
+
 let rec get_constructor c =
 	match c.cl_constructor, c.cl_super with
 	| Some c, _ -> c

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -1879,17 +1879,14 @@ class texpr_to_jvm gctx (jc : JvmClass.builder) (jm : JvmMethod.builder) (return
 				[jf#get_jsig]
 			)
 		| TNew(c,tl,el) ->
-			begin match get_constructor c with
-			| cf ->
-				begin match OverloadResolution.maybe_resolve_instance_overload true (apply_params c.cl_params tl) c cf el with
-				| None -> Error.error "Could not find overload" e.epos
-				| Some (c',cf,_) ->
-					let f () =
-						let tl,_ = self#call_arguments  cf.cf_type el in
-						tl
-					in
-					jm#construct ~no_value:(if not (need_val ret) then true else false) (get_construction_mode c' cf) c.cl_path f
-				end
+			begin match OverloadResolution.maybe_resolve_constructor_overload c tl el with
+			| None -> Error.error "Could not find overload" e.epos
+			| Some (c',cf,_) ->
+				let f () =
+					let tl,_ = self#call_arguments cf.cf_type el in
+					tl
+				in
+				jm#construct ~no_value:(if not (need_val ret) then true else false) (get_construction_mode c' cf) c.cl_path f
 			end
 		| TReturn None ->
 			self#emit_block_exits false;


### PR DESCRIPTION
Extracted changes not connected to cpp from #9807.

Fixes inconsistencies in `TypeloadFunction.add_constructor` and `OverloadResolution.maybe_resolve_instance_overload` in cases where non-overloaded constructor is inherited from an externs two levels above, meaning:

class (extern or not) without constructor <- extern class without constructor <- extern class with non-overloaded constructor

In such cases `add_constructor` was using wrong `csup` and `cparams` for inherited constructor. `maybe_resolve_instance_overload` was returning wrong class and weren't applying params with `map_type`.

