### PR TITLE
[typer] fix non-nullable optional arguments

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -164,8 +164,6 @@ type platform_config = {
 	pf_add_final_return : bool;
 	(** does the platform natively support overloaded functions *)
 	pf_overload : bool;
-	(** can the platform use default values for non-nullable arguments *)
-	pf_can_skip_non_nullable_argument : bool;
 	(** type paths that are reserved on the platform *)
 	pf_reserved_type_paths : path list;
 	(** supports function == function **)
@@ -422,7 +420,6 @@ let default_config =
 		pf_pad_nulls = false;
 		pf_add_final_return = false;
 		pf_overload = false;
-		pf_can_skip_non_nullable_argument = true;
 		pf_reserved_type_paths = [];
 		pf_supports_function_equality = true;
 		pf_uses_utf16 = true;
@@ -493,7 +490,6 @@ let get_config com =
 			default_config with
 			pf_sys = false;
 			pf_capture_policy = CPLoopVars;
-			pf_can_skip_non_nullable_argument = false;
 			pf_reserved_type_paths = [([],"Object");([],"Error")];
 			pf_exceptions = { default_config.pf_exceptions with
 				ec_native_throws = [

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -77,7 +77,7 @@ let rec unify_call_args' ctx el args r callp inline force_inline =
 	let skipped = ref [] in
 	let invalid_skips = ref [] in
 	let skip name ul t p =
-		if not ctx.com.config.pf_can_skip_non_nullable_argument && not (is_nullable t) then
+		if not (is_nullable t) then
 			invalid_skips := name :: !invalid_skips;
 		skipped := (name,ul,p) :: !skipped;
 		default_value name t
@@ -108,7 +108,7 @@ let rec unify_call_args' ctx el args r callp inline force_inline =
 			call_error (Not_enough_arguments args) callp
 		| [],(name,true,t) :: args ->
 			begin match loop [] args with
-				| [] when not (inline && (ctx.g.doinline || force_inline)) && not ctx.com.config.pf_pad_nulls ->
+				| [] when not (inline && (ctx.g.doinline || force_inline)) && not (ctx.com.config.pf_pad_nulls && is_nullable t) ->
 					if is_pos_infos t then [mk_pos_infos t,true]
 					else []
 				| args ->

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -320,17 +320,16 @@ let type_bind ctx (e : texpr) (args,ret) params p =
 			let a = if is_pos_infos t then
 					let infos = mk_infos ctx p [] in
 					ordered_args @ [type_expr ctx infos (WithType.with_argument t n)]
-				else if ctx.com.config.pf_pad_nulls then
+				else if ctx.com.config.pf_pad_nulls && is_nullable t then
 					(ordered_args @ [(mk (TConst TNull) t_dynamic p)])
 				else
 					ordered_args
 			in
 			loop args [] given_args missing_args a
-		| (n,o,t) :: _ , (EConst(Ident "_"),p) :: _ when not ctx.com.config.pf_can_skip_non_nullable_argument && o && not (is_nullable t) ->
-			error "Usage of _ is not supported for optional non-nullable arguments" p
 		| (n,o,t) :: args , ([] as params)
 		| (n,o,t) :: args , (EConst(Ident "_"),_) :: params ->
-			let v = alloc_var VGenerated (alloc_name n) (if o then ctx.t.tnull t else t) p in
+			let v = alloc_var VGenerated (alloc_name n) t p in
+			let o = o && is_nullable t in
 			loop args params given_args (missing_args @ [v,o]) (ordered_args @ [vexpr v])
 		| (n,o,t) :: args , param :: params ->
 			let e = type_expr ctx param (WithType.with_argument t n) in

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -82,7 +82,11 @@ object(self)
 		| Some l ->
 			l
 		| None ->
-			let l = List.map (fun (n,eo,t) -> n,eo <> None,t) with_default in
+			let l = List.map (fun (n,eo,t) ->
+				let opt = eo <> None in
+				let t = if opt && not is_extern then ctx.t.tnull t else t in
+				n,opt,t
+			) with_default in
 			type_repr <- Some l;
 			l
 

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1194,7 +1194,7 @@ let create_method (ctx,cctx,fctx) c f fd p =
 		| _ ->
 			None
 	in
-	let is_extern = fctx.is_extern || has_class_flag ctx.curclass CExtern in
+	let is_extern = (fctx.is_extern || has_class_flag ctx.curclass CExtern) && not fctx.is_inline in
 	let type_arg opt t p = FunctionArguments.type_opt ctx cctx.is_core_api p t in
 	let args = new FunctionArguments.function_arguments ctx type_arg is_extern fctx.is_display_field abstract_this fd.f_args in
 	let t = TFun (args#for_type,ret) in

--- a/tests/misc/projects/Issue2232/Main2.hx
+++ b/tests/misc/projects/Issue2232/Main2.hx
@@ -1,8 +1,8 @@
-class Main1 {
+class Main2 {
     static function main() {
 		var v : Float = 0;
 		foo(v);
     }
 
-	static function foo(x=0,y:Float) { }
+	extern static function foo(x=0,y:Float): Void;
 }

--- a/tests/misc/projects/Issue2232/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue2232/compile1-fail.hxml.stderr
@@ -1,2 +1,2 @@
-Main1.hx:4: characters 7-8 : Float should be Int
+Main1.hx:4: characters 7-8 : Float should be Null<Int>
 Main1.hx:4: characters 7-8 : ... For optional function argument 'x'

--- a/tests/misc/projects/Issue2232/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue2232/compile2-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main2.hx:4: characters 3-9 : Cannot skip non-nullable argument x
+Main2.hx:4: characters 3-9 : Not enough arguments, expected y:Float

--- a/tests/unit/src/unit/TestArrowFunctions.hx
+++ b/tests/unit/src/unit/TestArrowFunctions.hx
@@ -10,13 +10,13 @@ class TestArrowFunctions extends Test {
 	var f0_1: () -> W;
 
 	var f1_0: Int->Int;
-	var f1_1: ?Int->Int;
+	var f1_1: ?Null<Int>->Int;
 
 	var f2_0: Int->Int;
 
 	var f3_0: Int->Int->Int;
-	var f3_1: ?Int->String->Int;
-	var f3_2: Int->?Int->Int;
+	var f3_1: ?Null<Int>->String->Int;
+	var f3_2: Int->?Null<Int>->Int;
 
 	var f4:   Int->(Int->Int);
 	var f5:   Int->Int->(Int->Int);
@@ -87,7 +87,6 @@ class TestArrowFunctions extends Test {
 		f3_1 = (?a:Int, b:String) -> a + b.length;
 		f3_2 = (a:Int, ?b:Int) -> a + b;
 
-		#if !(flash || hl) // Cannot skip not nullable argument
 		f3_1 = function (a=1, b:String) return a + b.length;
 		eq(f3_1("--"),3);
 
@@ -108,7 +107,6 @@ class TestArrowFunctions extends Test {
 
 		f3_2 = (a:Int, b=2) -> a + b;
 		eq(f3_2(1),3);
-		#end
 
 		f4 = function (a) return function (b) return a + b;
 		f4 = a -> b -> a + b;

--- a/tests/unit/src/unit/TestMisc.hx
+++ b/tests/unit/src/unit/TestMisc.hx
@@ -377,9 +377,7 @@ class TestMisc extends Test {
 		eq( opt2().x, 5 );
 		eq( opt2().y, "hello" );
 
-		#if !(flash || cpp || cs || java)
 		eq( opt2(null, null).x, 5 );
-		#end
 		eq( opt2(0, null).y, "hello" );
 
 		eq( opt3().x, 5 );
@@ -400,16 +398,12 @@ class TestMisc extends Test {
 		eq( opt3(7.4).y, 7.4 );
 
 		eq( opt4(), 11 );
-		#if !static
 		eq( opt4(null), 11 );
-		#end
 
-		var opt4b : ?Int -> Null<Int> = opt4;
+		var opt4b : ?Null<Int> -> Null<Int> = opt4;
 		eq( opt4b(), 11 );
 		eq( opt4b(3), 4 );
-		#if !static
 		eq( opt4b(null), 11 );
-		#end
 
 		// don't compile because we restrict nullability of function param or return type
 		// var opt4c : ?Null<Int> -> Null<Int> = opt4;

--- a/tests/unit/src/unit/TestType.hx
+++ b/tests/unit/src/unit/TestType.hx
@@ -253,14 +253,9 @@ class TestType extends Test {
  		eq("foo0", f());
 
 		var foo = function(bar = 2) { return bar; };
-		#if flash // Cannot skip not-nullable argument
-		t(typeError(foo.bind(_)));
-		#else
 		var l = foo.bind(_);
 		eq(2, l());
-		#end
 
-		// note that this does not
 		var foo = function(bar:Null<Int> = 2) { return bar; };
 		var l = foo.bind(_);
 		eq(2, l());

--- a/tests/unit/src/unit/issues/Issue7179.hx
+++ b/tests/unit/src/unit/issues/Issue7179.hx
@@ -2,7 +2,7 @@ package unit.issues;
 
 class Issue7179 extends unit.Test {
 	function test() {
-		var f:(?f:Float) -> Void = function(?_) { }
+		var f:(?f:Null<Float>) -> Void = function(?_) { }
 		f();
 		f(1.);
 		noAssert();


### PR DESCRIPTION
Here is an attempt to fix handling of non-nullable optional arguments.

To repeat #9833:

```haxe
// type 1
extern function funNative(value: Int = 0): Void;

// type 2
function funInt(value: Int = 0) {/* value is Int */}

// type 3
function funNull(?value: Int = 0) {/* value is Null<Int> */}
```

Type 1 is about native external optional arguments on static targets - cpp and cs has those, also js can have such signature when defaults are applied depending only on number of received arguments and not on their equality to undefined.

Type 2 and 3 are optional arguments in haxe produced methods.

Type 2 was planned to be as strict as type 1, not allowing any nulls, but for one unfortunate reason or another was implemented as type 3. The problem was that it did not change the signature when the concept changed, keeping one that equals to that of type 1.

To fix it, type 2 has to reflect its true form and show the same signature as type 3 - nullable one. (It does not affect the body of the function, inside an argument's type still will be non-nullable one.)

```haxe
?Int->Void // type 1

?Null<Int>->Void // type 2 and 3
```

Type 1 does not allow passing null (only specified type or omitting), meaning no skips, no padding, on binding loses optionality if not omitted.

This is a breaking change, but as shown from tests, the only breaking part is that if you wrote a type signature for an optional argument without `Null` and then passed null into it (directly, by exotic type skipping or by binding) you would need to change that signature to include `Null`.

The change of signature for type 2 assumes that it is too late to revert the decision and make it as strict as it was initially intended. As it is a more breaking change (not too breaking, but still). Maybe later there will be a new haxe type that will be as strict as native one.

At this point tests for hl, flash and neko do not pass, but they seem to be fixable. Before proceeding with fixing those want to make sure that the change is valid and can be accepted. 
