### PR TITLE
Preserve Float-typed values when they are written as such in JSON 

### DIFF
--- a/std/haxe/format/JsonParser.hx
+++ b/std/haxe/format/JsonParser.hx
@@ -302,7 +302,7 @@ class JsonParser {
 
 		var f = Std.parseFloat(str.substr(start, pos - start));
 		var i = Std.int(f);
-		return if (i == f) i else f;
+		return if (!point && i == f) i else f;
 	}
 
 	inline function nextChar() {


### PR DESCRIPTION
In the following JSON, the Float-hinted value "someFloat" is incorrectly turned into a runtime Int while parsing it:

```
{ 
  someFloat : 1.0, // becomes an Int in the returned anonymous object
  someInt : 1,
}
````

This PR change now keeps the float type if the number contains a point.