### PR TITLE
More details for -D filter-times

### DIFF
--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -735,9 +735,9 @@ let run com tctx main =
 	NullSafety.run com new_types;
 	(* PASS 1: general expression filters *)
 	let filters = [
-		"ForRemap.apply",ForRemap.apply tctx;
-		"VarLazifier.apply",VarLazifier.apply com;
-		"AbstractCast.handle_abstract_casts",AbstractCast.handle_abstract_casts tctx;
+		"ForRemap",ForRemap.apply tctx;
+		"VarLazifier",VarLazifier.apply com;
+		"handle_abstract_casts",AbstractCast.handle_abstract_casts tctx;
 	] in
 	(* let t = filter_timer detail_times ["expr 0"] in *)
 	List.iter (run_expression_filters (timer_label detail_times ["expr 0"]) tctx filters) new_types;

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -739,9 +739,7 @@ let run com tctx main =
 		"VarLazifier",VarLazifier.apply com;
 		"handle_abstract_casts",AbstractCast.handle_abstract_casts tctx;
 	] in
-	(* let t = filter_timer detail_times ["expr 0"] in *)
 	List.iter (run_expression_filters (timer_label detail_times ["expr 0"]) tctx filters) new_types;
-	(* t(); *)
 	let filters = [
 		"fix_return_dynamic_from_void_function",fix_return_dynamic_from_void_function tctx true;
 		"check_local_vars_init",check_local_vars_init tctx.com;

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -762,9 +762,7 @@ let run com tctx main =
 			filters
 		| _ -> filters
 	in
-	(* let t = filter_timer detail_times ["expr 1"] in *)
 	List.iter (run_expression_filters (timer_label detail_times ["expr 1"]) tctx filters) new_types;
-	(* t(); *)
 	(* PASS 1.5: pre-analyzer type filters *)
 	let filters =
 		match com.platform with
@@ -795,9 +793,7 @@ let run com tctx main =
 		| _ -> RenameVars.run tctx locals);
 		"mark_switch_break_loops",mark_switch_break_loops;
 	] in
-	(* let t = filter_timer detail_times ["expr 2"] in *)
 	List.iter (run_expression_filters (timer_label detail_times ["expr 2"]) tctx filters) new_types;
-	(* t(); *)
 	next_compilation();
 	let t = filter_timer detail_times ["callbacks"] in
 	List.iter (fun f -> f()) (List.rev com.callbacks#get_before_save); (* macros onGenerate etc. *)

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -48,9 +48,19 @@ let is_overridden cls field =
 	in
 	List.exists (fun d -> loop_inheritance d) cls.cl_descendants
 
-let run_expression_filters ctx filters t =
+let run_expression_filters time_details ctx filters t =
 	let run e =
-		List.fold_left (fun e f -> f e) e filters
+		List.fold_left
+			(fun e (filter_name,f) ->
+				match time_details with
+				| Some timer_label ->
+					let t = Timer.timer (timer_label @ [filter_name]) in
+					let e = f e in
+					t();
+					e
+				| None -> f e
+			)
+			e filters
 	in
 	match t with
 	| TClassDecl c when is_removable_class c -> ()

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -415,10 +415,10 @@ and flush_macro_context mint ctx =
 	mctx.com.Common.modules <- modules;
 	(* we should maybe ensure that all filters in Main are applied. Not urgent atm *)
 	let expr_filters = [
-		"VarLazifier.apply",VarLazifier.apply mctx.com;
-		"AbstractCast.handle_abstract_casts",AbstractCast.handle_abstract_casts mctx;
-		"Exceptions.filter",Exceptions.filter mctx;
-		"CapturedVars.captured_vars",CapturedVars.captured_vars mctx.com;
+		"VarLazifier",VarLazifier.apply mctx.com;
+		"handle_abstract_casts",AbstractCast.handle_abstract_casts mctx;
+		"Exceptions",Exceptions.filter mctx;
+		"captured_vars",CapturedVars.captured_vars mctx.com;
 	] in
 	(*
 		some filters here might cause side effects that would break compilation server.

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -415,10 +415,10 @@ and flush_macro_context mint ctx =
 	mctx.com.Common.modules <- modules;
 	(* we should maybe ensure that all filters in Main are applied. Not urgent atm *)
 	let expr_filters = [
-		VarLazifier.apply mctx.com;
-		AbstractCast.handle_abstract_casts mctx;
-		Exceptions.filter mctx;
-		CapturedVars.captured_vars mctx.com;
+		"VarLazifier.apply",VarLazifier.apply mctx.com;
+		"AbstractCast.handle_abstract_casts",AbstractCast.handle_abstract_casts mctx;
+		"Exceptions.filter",Exceptions.filter mctx;
+		"CapturedVars.captured_vars",CapturedVars.captured_vars mctx.com;
 	] in
 	(*
 		some filters here might cause side effects that would break compilation server.


### PR DESCRIPTION
Sample result for our unit tests:
```
$ haxe compile-js.hxml --times -D filter-times
src/unit/issues/Issue3861.hx:6: characters 29-30 : Warning : Local variable a might be used before being initialized
name                                        | time(s) |   % |  p% |      # | info
----------------------------------------------------------------------------
typing                                      |   0.934 |  25 |  25 |   5025 | 
analyzer                                    |   0.729 |  19 |  19 | 107596 | 
macro                                       |   0.647 |  17 |  17 |   2898 | 
  add_types                                 |   0.022 |   1 |   3 |     88 | 
  jit                                       |   0.014 |   0 |   2 |    985 | 
parsing                                     |   0.593 |  16 |  16 |   1914 | 
filters                                     |   0.590 |  16 |  16 | 136798 | 
  expr 1                                    |   0.236 |   6 |  40 |  69168 | 
    inline_constructors                     |   0.087 |   2 |  37 |   8646 | 
    Exceptions_filter                       |   0.061 |   2 |  26 |   8646 | 
    reduce_expression                       |   0.021 |   1 |   9 |   8646 | 
    captured_vars                           |   0.021 |   1 |   9 |   8646 | 
    fix_return_dynamic_from_void_function   |   0.020 |   1 |   9 |   8646 | 
    check_local_vars_init                   |   0.012 |   0 |   5 |   8646 | 
    Tre                                     |   0.009 |   0 |   4 |   8646 | 
    check_abstract_as_value                 |   0.005 |   0 |   2 |   8646 | 
  expr 0                                    |   0.105 |   3 |  18 |  25938 | 
    handle_abstract_casts                   |   0.051 |   1 |  49 |   8646 | 
    VarLazifier                             |   0.030 |   1 |  29 |   8646 | 
    ForRemap                                |   0.024 |   1 |  23 |   8646 | 
  dce                                       |   0.090 |   2 |  15 |      1 | 
  expr 2                                    |   0.063 |   2 |  11 |  34584 | 
    sanitize                                |   0.026 |   1 |  42 |   8646 | 
    RenameVars                              |   0.024 |   1 |  38 |   8646 | 
    mark_switch_break_loops                 |   0.011 |   0 |  17 |   8646 | 
    add_final_return                        |   0.002 |   0 |   3 |   8646 | 
  save state                                |   0.015 |   0 |   3 |      1 | 
  type 3                                    |   0.011 |   0 |   2 |      1 | 
  insert_save_stacks                        |   0.008 |   0 |   1 |   7100 | 
  type 2                                    |   0.007 |   0 |   1 |      1 | 
generate                                    |   0.252 |   7 |   7 |      1 | 
  js                                        |   0.252 |   7 | 100 |      1 | 
haxelib                                     |   0.019 |   0 |   0 |      1 | 
null safety                                 |   0.004 |   0 |   0 |      1 | 
----------------------------------------------------------------------------
total                                       |   3.766 | 100 | 100 | 254235 | 
```