### PR TITLE
StringTools ES6 output

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -233,7 +233,7 @@ class StringTools {
 		#elseif python
 		return python.NativeStringTools.startswith(s, start);
 		#elseif (js && js_es >= 6)
-		return untyped s.startWith(start);
+		return untyped s.startsWith(start);
 		#else
 		return (s.length >= start.length && s.lastIndexOf(start, 0) == 0);
 		#end

--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -210,7 +210,7 @@ class StringTools {
 	**/
 	public static inline function contains(s:String, value:String):Bool {
 		#if (js && js_es >= 6)
-		return untyped s.includes(value);
+		return (cast s).includes(value);
 		#else 
 		return s.indexOf(value) != -1;
 		#end
@@ -227,7 +227,7 @@ class StringTools {
 		#if java
 		return (cast s : java.NativeString).startsWith(start);
 		#elseif cs
-		return untyped s.StartsWith(start);
+		return (cast s).StartsWith(start);
 		#elseif hl
 		return @:privateAccess (s.length >= start.length && s.bytes.compare(0, start.bytes, 0, start.length << 1) == 0);
 		#elseif python
@@ -258,7 +258,7 @@ class StringTools {
 		#elseif python
 		return python.NativeStringTools.endswith(s, end);
 		#elseif (js && js_es >= 6)
-		return untyped s.endsWith(end);
+		return (cast s).endsWith(end);
 		#else
 		var elen = end.length;
 		var slen = s.length;

--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -227,13 +227,13 @@ class StringTools {
 		#if java
 		return (cast s : java.NativeString).startsWith(start);
 		#elseif cs
-		return (cast s).StartsWith(start);
+		return s.StartsWith(start);
 		#elseif hl
 		return @:privateAccess (s.length >= start.length && s.bytes.compare(0, start.bytes, 0, start.length << 1) == 0);
 		#elseif python
 		return python.NativeStringTools.startswith(s, start);
 		#elseif (js && js_es >= 6)
-		return untyped s.startsWith(start);
+		return (cast s).startsWith(start);
 		#else
 		return (s.length >= start.length && s.lastIndexOf(start, 0) == 0);
 		#end

--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -227,7 +227,7 @@ class StringTools {
 		#if java
 		return (cast s : java.NativeString).startsWith(start);
 		#elseif cs
-		return s.StartsWith(start);
+		return untyped s.StartsWith(start);
 		#elseif hl
 		return @:privateAccess (s.length >= start.length && s.bytes.compare(0, start.bytes, 0, start.length << 1) == 0);
 		#elseif python

--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -420,8 +420,6 @@ class StringTools {
 			return s.split(sub).join(by);
 		else
 			return untyped s.Replace(sub, by);
-		#elseif (js && js_es >= 6)
-		return untyped s.replace(sub, by);
 		#else
 		return s.split(sub).join(by);
 		#end

--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -209,7 +209,11 @@ class StringTools {
 		When `value` is `null`, the result is unspecified.
 	**/
 	public static inline function contains(s:String, value:String):Bool {
+		#if (js && js_es >= 6)
+		return untyped s.includes(value);
+		#else 
 		return s.indexOf(value) != -1;
+		#end
 	}
 
 	/**
@@ -219,7 +223,7 @@ class StringTools {
 
 		If `start` is the empty String `""`, the result is true.
 	**/
-	public static #if (cs || java || python) inline #end function startsWith(s:String, start:String):Bool {
+	public static #if (cs || java || python || (js && js_es >= 6)) inline #end function startsWith(s:String, start:String):Bool {
 		#if java
 		return (cast s : java.NativeString).startsWith(start);
 		#elseif cs
@@ -228,6 +232,8 @@ class StringTools {
 		return @:privateAccess (s.length >= start.length && s.bytes.compare(0, start.bytes, 0, start.length << 1) == 0);
 		#elseif python
 		return python.NativeStringTools.startswith(s, start);
+		#elseif (js && js_es >= 6)
+		return untyped s.startWith(start);
 		#else
 		return (s.length >= start.length && s.lastIndexOf(start, 0) == 0);
 		#end
@@ -240,7 +246,7 @@ class StringTools {
 
 		If `end` is the empty String `""`, the result is true.
 	**/
-	public static #if (cs || java || python) inline #end function endsWith(s:String, end:String):Bool {
+	public static #if (cs || java || python || (js && js_es >= 6)) inline #end function endsWith(s:String, end:String):Bool {
 		#if java
 		return (cast s : java.NativeString).endsWith(end);
 		#elseif cs
@@ -251,6 +257,8 @@ class StringTools {
 		return @:privateAccess (slen >= elen && s.bytes.compare((slen - elen) << 1, end.bytes, 0, elen << 1) == 0);
 		#elseif python
 		return python.NativeStringTools.endswith(s, end);
+		#elseif (js && js_es >= 6)
+		return untyped s.endsWith(end);
 		#else
 		var elen = end.length;
 		var slen = s.length;
@@ -412,6 +420,8 @@ class StringTools {
 			return s.split(sub).join(by);
 		else
 			return untyped s.Replace(sub, by);
+		#elseif (js && js_es >= 6)
+		return untyped s.replace(sub, by);
 		#else
 		return s.split(sub).join(by);
 		#end


### PR DESCRIPTION
Make ES6 output a bit nicer:
- use native startsWith / endsWith
- use native string.includes instead of indexof() != -1

This should work where ES6 works