### PR TITLE
make Map abstract transitive, fixes #9874

### DIFF
--- a/std/haxe/ds/Map.hx
+++ b/std/haxe/ds/Map.hx
@@ -46,6 +46,7 @@ import haxe.Constraints.IMap;
 
 	@see https://haxe.org/manual/std-Map.html
 **/
+@:transitive
 @:multiType(@:followWithAbstracts K)
 abstract Map<K, V>(IMap<K, V>) {
 	/**

--- a/tests/unit/src/unit/issues/Issue9874.hx
+++ b/tests/unit/src/unit/issues/Issue9874.hx
@@ -1,0 +1,14 @@
+package unit.issues;
+
+import haxe.Constraints.IMap;
+
+@:forward abstract ArrayMap<K, V>(IMap<K, Array<V>>) from IMap<K, Array<V>> to IMap<K, Array<V>> {}
+
+class Issue9874 extends unit.Test {
+	function test() {
+		var m:ArrayMap<String, String> = new Map();
+		var m2:ArrayMap<String, String> = new Map<String, Array<String>>();
+		var m3:ArrayMap<String, String> = new haxe.ds.StringMap<Array<String>>();
+		utest.Assert.pass();
+	}
+}


### PR DESCRIPTION
Closes #9874 

There might be some other abstracts in std that can be transitive, but I wasn't sure about potential pitfalls, so I only added it to `haxe.ds.Map`.
Includes a test, hopefully well written.