### PR TITLE
Use hx-lua-simdjson for Lua json parsing

### DIFF
--- a/std/lua/_std/haxe/format/JsonParser.hx
+++ b/std/lua/_std/haxe/format/JsonParser.hx
@@ -42,7 +42,8 @@ class JsonParser {
 		If `str` is null, the result is unspecified.
 	**/
 	static public inline function parse(str:String):Dynamic {
-		return new JsonParser(str).doParse();
+		// return new JsonParser(str).doParse();
+		return lua.lib.hxluasimdjson.Json.parse(str);
 	}
 
 	var str:String;

--- a/std/lua/lib/hxluasimdjson/Json.hx
+++ b/std/lua/lib/hxluasimdjson/Json.hx
@@ -1,0 +1,5 @@
+package lua.lib.hxluasimdjson;
+@:luaRequire("hxsimdjson")
+extern class Json {
+    public static function parse(str:String) : Dynamic;
+}

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -69,7 +69,7 @@ class Lua {
 			// Note: don't use a user config
 			// runCommand("luarocks", ["config", "--user-config"], false, true);
 
-			installLib("haxe-deps", "0.0.1-4");
+			installLib("haxe-deps", "0.0.1-5");
 
 			changeDirectory(unitDir);
 			runCommand("haxe", ["compile-lua.hxml"].concat(args));

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -69,7 +69,7 @@ class Lua {
 			// Note: don't use a user config
 			// runCommand("luarocks", ["config", "--user-config"], false, true);
 
-			installLib("haxe-deps", "0.0.1-5");
+			installLib("haxe-deps", "0.0.1-6");
 
 			changeDirectory(unitDir);
 			runCommand("haxe", ["compile-lua.hxml"].concat(args));


### PR DESCRIPTION
This commit turns on the new simdjson parsing feature for Lua. 
Simdjson is a fast json parsing library leveraging advanced SIMD instructions:
https://github.com/simdjson/simdjson

We use a haxe-specific lua wrapper to support the special Haxe array/object behaviors:
https://github.com/jdonaldson/hx-lua-simdjson