### PR TITLE
Allow @:noDoc on fields too

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -798,7 +798,7 @@
 	{
 		"name": "NoDoc",
 		"metadata": ":noDoc",
-		"doc": "Prevents a type from being included in documentation generation."
+		"doc": "Prevents a type or field from being included in documentation generation."
 	},
 	{
 		"name": "NoExpr",

--- a/src/codegen/genxml.ml
+++ b/src/codegen/genxml.ml
@@ -219,7 +219,7 @@ let rec gen_type_decl com pos t =
 		) c.cl_ordered_statics in
 		let stats = List.map (gen_field ["static","1"]) stats in
 		let fields = List.filter (fun cf ->
-			not (Meta.has Meta.GenericInstance cf.cf_meta)
+			not (Meta.has Meta.GenericInstance cf.cf_meta) && not (Meta.has Meta.NoDoc cf.cf_meta)
 		) c.cl_ordered_fields in
 		let fields = (match c.cl_super with
 			| None -> List.map (fun f -> f,[]) fields


### PR DESCRIPTION
I wanted more control over `-xml api.xml`, and found no other way to exclude fields from classes