### PR TITLE
[cpp] Allow multiple include meta entries

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -457,7 +457,7 @@ let get_all_meta_string_path meta_list key =
    let extract_meta meta =
       match meta with
       | (k, exprs, pos) when k = key ->
-         List.filter_map (extract_path pos) exprs
+         ExtList.List.filter_map (extract_path pos) exprs
       | _ ->
          [] in
    let all_includes meta key = List.map extract_meta meta in

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -452,16 +452,13 @@ let get_meta_string_path meta key =
 let get_all_meta_string_path meta_list key =
    let extract_path pos expr =
       match expr with
-      | (Ast.EConst (Ast.String(name, _)), _) -> Some (make_path_absolute name pos)
-      | _ -> None in
+      | (Ast.EConst (Ast.String(name, _)), _) -> make_path_absolute name pos
+      | _ -> "" in
    let extract_meta meta =
       match meta with
-      | (k, exprs, pos) when k = key ->
-         ExtList.List.filter_map (extract_path pos) exprs
-      | _ ->
-         [] in
-   let all_includes meta key = List.map extract_meta meta in
-   List.flatten (all_includes meta_list key)
+      | (k, exprs, pos) when k = key -> Some (extract_path pos (List.hd exprs))
+      | _ -> None in
+   ExtList.List.filter_map extract_meta meta_list
 ;;
 
 let get_meta_string_full_filename meta key =


### PR DESCRIPTION
https://github.com/HaxeFoundation/hxcpp/issues/885

I also found myself wishing I could add multiple include metas on a extern type so I decided to try and have a go at adding it. With these changes you can add multiple `include`, `depend`, `cppInclude`, and `headerInclude` meta tags, you can also add multiple strings to a single one of these metas and it will process them all.

```haxe
@:headerInclude("header1.h")
@:headerInclude("header2.h", "header3.h")
@:cppInclude("header4.h", "header5.h")
class Main
{
    static function main()
    {
        SomeLib.someFunc();
    }
}

@:include("other_header1.h", "other_header2.h")
@:include("other_header3.h")
@:depend("Class1.h", "Class2.h")
@:depend("Class3.h")
extern class SomeLib
{
    @:native("someFunc") static function someFunc() : Void;
}
```

I'm still very new to ocaml so sorry if I've done something horrifically wrong!