### PR TITLE
[php] Add externs for some filesystem functions

### DIFF
--- a/std/php/Const.hx
+++ b/std/php/Const.hx
@@ -446,4 +446,35 @@ extern class Const {
 	static final PHP_OUTPUT_HANDLER_START:Int;
 	static final PHP_OUTPUT_HANDLER_STDFLAGS:Int;
 	static final PHP_OUTPUT_HANDLER_WRITE:Int;
+
+	/**
+		@see http://php.net/manual/en/function.flock.php
+	**/
+	static final LOCK_EX:Int;
+	static final LOCK_NB:Int;
+	static final LOCK_SH:Int;
+	static final LOCK_UN:Int;
+
+	/**
+		@see http://php.net/manual/en/function.fnmatch.php
+	**/
+	static final FNM_CASEFOLD:Int;
+	static final FNM_NOESCAPE:Int;
+	static final FNM_PATHNAME:Int;
+	static final FNM_PERIOD:Int;
+
+	/**
+		@see http://php.net/manual/en/function.parse-ini-file.php
+	**/
+	static final INI_SCANNER_NORMAL:Int;
+	static final INI_SCANNER_RAW:Int;
+	static final INI_SCANNER_TYPED:Int;
+
+	/**
+		@see http://php.net/manual/en/function.pathinfo.php
+	**/
+	static final PATHINFO_BASENAME:Int;
+	static final PATHINFO_DIRNAME:Int;
+	static final PATHINFO_EXTENSION:Int;
+	static final PATHINFO_FILENAME:Int;
 }

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -1713,7 +1713,7 @@ extern class Global {
 	**/
 	static function ob_start(output_callback: (String, ?Int) -> String = null, chunk_size:Int = 0, ?flags:Int):Bool;
 
-  /**
+	/**
 		@see http://php.net/manual/en/function.strip-tags.php
 	**/
 	static function strip_tags(str: String, ?allowable_tags:EitherType<String, Array<String>>):String;

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -1702,4 +1702,14 @@ extern class Global {
 		@see http://php.net/manual/en/function.ob-start.php
 	**/
 	static function ob_start(output_callback: (String, ?Int) -> String = null, chunk_size:Int = 0, ?flags:Int):Bool;
+
+	/**
+		@see http://php.net/manual/en/function.parse-ini-file.php
+	**/
+	static function parse_ini_file(filename:String, process_sections:Bool = false, ?scanner_mode:Int): EitherType<NativeAssocArray<Dynamic>, Bool>;
+
+	/**
+		@see http://php.net/manual/en/function.parse-ini-string.php
+	**/
+	static function parse_ini_string(ini:String, process_sections:Bool = false, ?scanner_mode:Int): EitherType<NativeAssocArray<Dynamic>, Bool>;
 }

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -686,6 +686,11 @@ extern class Global {
 	static function fflush(handle:Resource):Bool;
 
 	/**
+		@see http://php.net/manual/en/function.flock.php
+	**/
+	static function flock(handle:Resource, operation:Int, ?wouldblock:Ref<Int>):Bool;
+
+	/**
 		@see http://php.net/manual/en/function.fwrite.php
 	**/
 	static function fwrite(handle:Resource, string:String, ?length:Int):EitherType<Int, Bool>;

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -751,6 +751,11 @@ extern class Global {
 	static function stat(filename:String):EitherType<NativeArray, Bool>;
 
 	/**
+		@see http://php.net/manual/en/function.fnmatch.php
+	**/
+	static function fnmatch(pattern:String, string:String, flags:Int = 0):Bool;
+
+	/**
 		@see http://php.net/manual/en/function.pathinfo.php
 	**/
 	static function pathinfo(path:String, ?options:Int):EitherType<String, NativeAssocArray<String>>;

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -751,6 +751,11 @@ extern class Global {
 	static function stat(filename:String):EitherType<NativeArray, Bool>;
 
 	/**
+		@see http://php.net/manual/en/function.pathinfo.php
+	**/
+	static function pathinfo(path:String, ?options:Int):EitherType<String, NativeAssocArray<String>>;
+
+	/**
 		@see http://php.net/manual/en/function.realpath.php
 	**/
 	static function realpath(path:String):EitherType<String, Bool>;


### PR DESCRIPTION
Externs for:
- `flock()`
- `fnmatch()`
- `pathinfo()`
- `parse_ini_file()`
- `parse_ini_string()`