### PR TITLE
[php] Add externs for the `Collator` and `Locale` classes

### DIFF
--- a/std/php/Collator.hx
+++ b/std/php/Collator.hx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C)2005-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package php;
+
+import haxe.extern.EitherType;
+
+/**
+	@see https://www.php.net/manual/en/class.collator.php
+**/
+@:native("Collator")
+extern class Collator {
+	@:phpClassConst static final ALTERNATE_HANDLING: Int;
+	@:phpClassConst static final CASE_FIRST: Int;
+	@:phpClassConst static final CASE_LEVEL: Int;
+	@:phpClassConst static final DEFAULT_STRENGTH: Int;
+	@:phpClassConst static final DEFAULT_VALUE: Int;
+	@:phpClassConst static final FRENCH_COLLATION: Int;
+	@:phpClassConst static final HIRAGANA_QUATERNARY_MODE: Int;
+	@:phpClassConst static final IDENTICAL: Int;
+	@:phpClassConst static final LOWER_FIRST: Int;
+	@:phpClassConst static final NON_IGNORABLE: Int;
+	@:phpClassConst static final NORMALIZATION_MODE: Int;
+	@:phpClassConst static final NUMERIC_COLLATION: Int;
+	@:phpClassConst static final OFF: Int;
+	@:phpClassConst static final ON: Int;
+	@:phpClassConst static final PRIMARY: Int;
+	@:phpClassConst static final QUATERNARY: Int;
+	@:phpClassConst static final SECONDARY: Int;
+	@:phpClassConst static final SHIFTED: Int;
+	@:phpClassConst static final SORT_NUMERIC: Int;
+	@:phpClassConst static final SORT_REGULAR: Int;
+	@:phpClassConst static final SORT_STRING: Int;
+	@:phpClassConst static final STRENGTH: Int;
+	@:phpClassConst static final TERTIARY: Int;
+	@:phpClassConst static final UPPER_FIRST: Int;
+
+	function new(locale: String);
+	function asort(arr: Ref<NativeAssocArray<String>>, ?sort_flag: Int): Bool;
+	function compare(str1: String, str2: String): EitherType<Int, Bool>;
+	static function create(locale: String): Null<Collator>;
+	function getAttribute(attr: Int): EitherType<Int, Bool>;
+	function getErrorCode(): Int;
+	function getErrorMessage(): String;
+	function getLocale(type: Int): EitherType<String, Bool>;
+	function getSortKey(str: String): EitherType<String, Bool>;
+	function getStrength(): EitherType<Int, Bool>;
+	function setAttribute(attr: Int, val: Int): Bool;
+	function setStrength(strength: Int): Bool;
+	function sort(arr: Ref<NativeArray>, ?sort_flag: Int): Bool;
+	function sortWithSortKeys(arr: Ref<NativeArray>): Bool;
+}

--- a/std/php/Const.hx
+++ b/std/php/Const.hx
@@ -521,4 +521,26 @@ extern class Const {
 	static final INTL_IDNA_VARIANT_2003:Int;
 	static final INTL_IDNA_VARIANT_UTS46:Int;
 	static final INTL_MAX_LOCALE_LEN:Int;
+
+	/**
+		@see http://php.net/manual/en/array.constants.php
+	**/
+	static final CASE_LOWER:Int;
+	static final CASE_UPPER:Int;
+	static final EXTR_IF_EXISTS:Int;
+	static final EXTR_OVERWRITE:Int;
+	static final EXTR_PREFIX_ALL:Int;
+	static final EXTR_PREFIX_IF_EXISTS:Int;
+	static final EXTR_PREFIX_INVALID:Int;
+	static final EXTR_PREFIX_SAME:Int;
+	static final EXTR_REFS:Int;
+	static final EXTR_SKIP:Int;
+	static final SORT_ASC:Int;
+	static final SORT_DESC:Int;
+	static final SORT_FLAG_CASE:Int;
+	static final SORT_LOCALE_STRING:Int;
+	static final SORT_NATURAL:Int;
+	static final SORT_NUMERIC:Int;
+	static final SORT_REGULAR:Int;
+	static final SORT_STRING:Int;
 }

--- a/std/php/Global.hx
+++ b/std/php/Global.hx
@@ -1783,4 +1783,24 @@ extern class Global {
 		@see http://php.net/manual/en/function.idn-to-utf8.php
 	**/
 	static function idn_to_utf8(domain:String, ?options:Int, ?variant:Int, ?idna_info:Ref<NativeAssocArray<Dynamic>>):EitherType<String, Bool>;
+
+	/**
+		@see http://php.net/manual/en/function.intl-error-name.php
+	**/
+	static function intl_error_name(error_code:Int):String;
+
+	/**
+		@see http://php.net/manual/en/function.intl-get-error-code.php
+	**/
+	static function intl_get_error_code():Int;
+
+	/**
+		@see http://php.net/manual/en/function.intl-get-error-message.php
+	**/
+	static function intl_get_error_message():String;
+
+	/**
+		@see http://php.net/manual/en/function.intl-is-failure.php
+	**/
+	static function intl_is_failure(error_code:Int):Bool;
 }

--- a/std/php/Locale.hx
+++ b/std/php/Locale.hx
@@ -22,8 +22,6 @@
 
 package php;
 
-import haxe.extern.EitherType;
-
 /**
 	@see https://www.php.net/manual/en/class.locale.php
 **/

--- a/std/php/Locale.hx
+++ b/std/php/Locale.hx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C)2005-2020 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package php;
+
+import haxe.extern.EitherType;
+
+/**
+	@see https://www.php.net/manual/en/class.locale.php
+**/
+@:native("Locale")
+extern class Locale {
+	@:phpClassConst static final ACTUAL_LOCALE: String;
+	@:phpClassConst static final DEFAULT_LOCALE: Null<String>;
+	@:phpClassConst static final EXTLANG_TAG: String;
+	@:phpClassConst static final GRANDFATHERED_LANG_TAG: String;
+	@:phpClassConst static final LANG_TAG: String;
+	@:phpClassConst static final PRIVATE_TAG: String;
+	@:phpClassConst static final REGION_TAG: String;
+	@:phpClassConst static final SCRIPT_TAG: String;
+	@:phpClassConst static final VALID_LOCALE: String;
+	@:phpClassConst static final VARIANT_TAG: String;
+
+	static function acceptFromHttp(header: String): String;
+	static function canonicalize(locale: String): String;
+	static function composeLocale(subtags: NativeAssocArray<String>): String;
+	static function filterMatches(langtag: String, locale: String, canonicalize: Bool = false): Bool;
+	static function getAllVariants(locale: String): Null<NativeIndexedArray<String>>;
+	static function getDefault(): String;
+	static function getDisplayLanguage(locale: String, ?in_locale: String): String;
+	static function getDisplayName(locale: String, ?in_locale: String): String;
+	static function getDisplayRegion(locale: String, ?in_locale: String): String;
+	static function getDisplayScript(locale: String, ?in_locale: String): String;
+	static function getDisplayVariant(locale: String, ?in_locale: String): String;
+	static function getKeywords(locale: String): NativeAssocArray<String>;
+	static function getPrimaryLanguage(locale: String): Null<String>;
+	static function getRegion(locale: String): Null<String>;
+	static function getScript(locale: String): Null<String>;
+	static function lookup(langtag: NativeIndexedArray<String>, locale: String, canonicalize: Bool = false, ?defaultLocale: String): String;
+	static function parseLocale(locale: String): Null<NativeAssocArray<String>>;
+	static function setDefault(locale: String): Bool;
+}


### PR DESCRIPTION
Externs for:

- [`Collator` class](https://www.php.net/manual/en/class.collator.php)
- [`Locale` class](https://www.php.net/manual/en/class.locale.php)
- [Intl functions](https://www.php.net/manual/en/ref.intl.php)
- [array constants](https://www.php.net/manual/en/array.constants.php) (the missing ones)