### PR TITLE
[ilib] Handle null value for attributes expecting System.Type values

### DIFF
--- a/libs/ilib/ilMetaReader.ml
+++ b/libs/ilib/ilMetaReader.ml
@@ -1556,8 +1556,11 @@ let read_custom_attr ctx attr_type s pos =
 			let pos, cons = read_constant ctx (sig_to_const ilsig) s pos in
 			pos, InstConstant (cons)
 		| SClass c when is_type (["System"],"Type") c ->
-			let pos, len = read_compressed_i32 s pos in
-			pos+len, InstType (String.sub s pos len)
+			if (sget s pos) == 0xff then
+				pos+1, InstConstant INull
+			else
+				let pos, len = read_compressed_i32 s pos in
+				pos+len, InstType (String.sub s pos len)
 		| SType ->
 			let pos, len = read_compressed_i32 s pos in
 			pos+len, InstType (String.sub s pos len)


### PR DESCRIPTION
Something is going wrong while parsing some metadata like `[MyAttr(null)]` when `MyAttrAttribute` is expecting an argument of type `System.Type`. When using a dll with such metadata, we get this compilation error while parsing the dll:
> PeReader.Error_message("Error reading compressed data. Invalid first byte: ff")

According to https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-335.pdf section II.23.2:
> A null string should be represented with the reserved single byte 0xFF, and no following data

#9946 fails 17 times at:
https://github.com/HaxeFoundation/haxe/blob/97686d4022166c14d2e7268740188160e1ea2fe9/libs/ilib/ilMetaReader.ml#L1559
With a value of `0xFF`. Returning `InstConstant INull` there when the value is `0xFF` makes the problem go away.

~~I don't know how to test this properly, but as said in slack it seems kinda safe, since:~~
- ~~any dll ending up in this fix was not compiling at all before, failing with `PeReader.Error_message("Error reading compressed data. Invalid first byte: ff")`~~
- ~~`0xFF` seems to mean something pretty close to that anyway~~
- ~~this all happens in metadata in net libs, which haxe doesn't really care about?~~

I could reproduce the issue here https://github.com/kLabz/haxe-repro-9946 both with UnityEditor.dll and a generated minimal dll