### PR TITLE
Float64Array actually use 64-bit floats

### DIFF
--- a/std/haxe/io/Float64Array.hx
+++ b/std/haxe/io/Float64Array.hx
@@ -43,12 +43,12 @@ abstract Float64Array(Float64ArrayData) {
 	}
 
 	@:arrayAccess public inline function get(index:Int):Float {
-		return this.bytes.getFloat((index << 3) + this.byteOffset);
+		return this.bytes.getDouble((index << 3) + this.byteOffset);
 	}
 
 	@:arrayAccess public inline function set(index:Int, value:Float):Float {
 		if (index >= 0 && index < length) {
-			this.bytes.setFloat((index << 3) + this.byteOffset, value);
+			this.bytes.setDouble((index << 3) + this.byteOffset, value);
 			return value;
 		}
 		return 0;


### PR DESCRIPTION
This looks like it was an unfortunate consequence of naming conventions. "Float" is double (64 bit) in Haxe but single (32 bits) for Bytes.

If Bytes had getSingle()/setSingle() this probably never would have happened, but that is pretty awkward.

Maybe getFloat32()/getFloat64() would be more descriptive?