### PR TITLE
support overloading `is` operator in abstracts

### DIFF
--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -203,6 +203,7 @@ let null_abstract = {
 	a_using = [];
 	a_ops = [];
 	a_unops = [];
+	a_is = None;
 	a_impl = None;
 	a_this = t_dynamic;
 	a_from = [];

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -579,6 +579,7 @@ module Printer = struct
 			"a_params",s_type_params a.a_params;
 			"a_ops",s_list ", " (fun (op,cf) -> Printf.sprintf "%s: %s" (s_binop op) cf.cf_name) a.a_ops;
 			"a_unops",s_list ", " (fun (op,flag,cf) -> Printf.sprintf "%s (%s): %s" (s_unop op) (if flag = Postfix then "postfix" else "prefix") cf.cf_name) a.a_unops;
+			"a_is",s_opt (fun (t,cf) -> Printf.sprintf "%s: %s" (s_type_kind t) cf.cf_name) a.a_is;
 			"a_impl",s_opt (fun c -> s_type_path c.cl_path) a.a_impl;
 			"a_this",s_type_kind a.a_this;
 			"a_from",s_list ", " s_type_kind a.a_from;

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -302,6 +302,7 @@ and tabstract = {
 	(* do not insert any fields above *)
 	mutable a_ops : (Ast.binop * tclass_field) list;
 	mutable a_unops : (Ast.unop * unop_flag * tclass_field) list;
+	mutable a_is : (t * tclass_field) option; (* should this be a list to support overloads? *)
 	mutable a_impl : tclass option;
 	mutable a_this : t;
 	mutable a_from : t list;

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -935,8 +935,8 @@ let type_is ctx e t p_t p =
 			| TAbstractDecl { a_impl = Some c; a_is = Some (arg_t,cf) } ->
 				(* abstract with @:op(v is T) -> generate static call *)
 				let e_method = Texpr.Builder.make_static_field c cf (mk_zero_range_pos p) in
-				let e = AbstractCast.cast_or_unify ctx arg_t e p in
-				let t_ret = match cf.cf_type with TFun (_, t) -> t | _ -> die ~p "unexpected @:op(v is T) type" __LOC__ in
+				let e = AbstractCast.cast_or_unify ctx arg_t e e.epos in
+				let t_ret = match follow cf.cf_type with TFun (_, t) -> t | _ -> die ~p "unexpected @:op(v is T) type" __LOC__ in
 				mk (TCall (e_method, [e])) t_ret p
 
 			| _ ->

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -936,7 +936,8 @@ let type_is ctx e t p_t p =
 				(* abstract with @:op(v is T) -> generate static call *)
 				let e_method = Texpr.Builder.make_static_field c cf (mk_zero_range_pos p) in
 				let e = AbstractCast.cast_or_unify ctx arg_t e p in
-				mk (TCall (e_method, [e])) ctx.com.basic.tbool p
+				let t_ret = match cf.cf_type with TFun (_, t) -> t | _ -> die ~p "unexpected @:op(v is T) type" __LOC__ in
+				mk (TCall (e_method, [e])) t_ret p
 
 			| _ ->
 				(* everything else - generate Std.isOfType(v, T) *)

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1078,7 +1078,7 @@ let check_abstract (ctx,cctx,fctx) c cf fd t ret p =
 							delay ctx PCheckConstraint (fun () ->
 								match follow tr with
 								| TAbstract ({ a_path = [],"Bool" },_) -> ()
-								| _ -> error "`is` overloads must return Bool" cf.cf_pos
+								| _ -> error "`is` overload must return Bool" cf.cf_pos
 							);
 							a.a_is <- Some (t,cf);
 						| _ ->

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1075,14 +1075,9 @@ let check_abstract (ctx,cctx,fctx) c cf fd t ret p =
 					if fctx.is_abstract_member then error "`is` overloads must be static" cf.cf_pos;
 					begin match follow t with
 						| TFun ([(_,false,t)], tr) ->
-							delay ctx PCheckConstraint (fun () ->
-								match follow tr with
-								| TAbstract ({ a_path = [],"Bool" },_) -> ()
-								| _ -> error "`is` overload must return Bool" cf.cf_pos
-							);
 							a.a_is <- Some (t,cf);
 						| _ ->
-							error ("`is` overload must be a function that takes a single non-optional argument and returns Bool") cf.cf_pos
+							error ("`is` overload must be a function that takes a single non-optional argument") cf.cf_pos
 					end
 				| (Meta.Op,[EBinop(op,_,_),_],_) :: _ ->
 					if fctx.is_macro then error (cf.cf_name ^ ": Macro operator functions are not supported") p;

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1082,7 +1082,7 @@ let check_abstract (ctx,cctx,fctx) c cf fd t ret p =
 							);
 							a.a_is <- Some (t,cf);
 						| _ ->
-							error ("`is` overloads must be a function that takes a single non-optional argument and returns Bool") cf.cf_pos
+							error ("`is` overload must be a function that takes a single non-optional argument and returns Bool") cf.cf_pos
 					end
 				| (Meta.Op,[EBinop(op,_,_),_],_) :: _ ->
 					if fctx.is_macro then error (cf.cf_name ^ ": Macro operator functions are not supported") p;

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -325,6 +325,7 @@ let module_pass_1 ctx m tdecls loadp =
 				a_to_field = [];
 				a_ops = [];
 				a_unops = [];
+				a_is = None;
 				a_impl = None;
 				a_array = [];
 				a_this = mk_mono();

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1800,25 +1800,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 	| EMeta (m,e1) ->
 		type_meta ~mode ctx m e1 with_type p
 	| EIs (e,(t,p_t)) ->
-		match t with
-		| CTPath tp ->
-			if tp.tparams <> [] then display_error ctx "Type parameters are not supported for the `is` operator" p_t;
-			let e = type_expr ctx e WithType.value in
-			let e_t = type_type ctx (tp.tpackage,tp.tname) p_t in
-			let e_Std_isOfType =
-				match Typeload.load_type_raise ctx ([],"Std") "Std" p with
-				| TClassDecl c ->
-					let cf =
-						try PMap.find "isOfType" c.cl_statics
-						with Not_found -> die "" __LOC__
-					in
-					Texpr.Builder.make_static_field c cf (mk_zero_range_pos p)
-				| _ -> die "" __LOC__
-			in
-			mk (TCall (e_Std_isOfType, [e; e_t])) ctx.com.basic.tbool p
-		| _ ->
-			display_error ctx "Unsupported type for `is` operator" p_t;
-			Texpr.Builder.make_bool ctx.com.basic false p
+		type_is ctx e t p_t p
 
 (* ---------------------------------------------------------------------- *)
 (* TYPER INITIALIZATION *)


### PR DESCRIPTION
```haxe
abstract A(String) {
	public function new() {
		this = "a";
	}

	@:op(v is T) static function isA(v:Any):Bool {
		return v is String && v == "a";
	}
}

function main() {
	trace(1 is A); // false
	trace("b" is A); // false
	trace("a" is A); // true
}
```

```js
function Main_main() {
	console.log("src/Main.hx:12:",A.isA(1));
	console.log("src/Main.hx:13:",A.isA("b"));
	console.log("src/Main.hx:14:",A.isA("a"));
}
```