### PR TITLE
[ILIB] Add Linux Amd64 and OSX Amd64

### DIFF
--- a/libs/ilib/peData.ml
+++ b/libs/ilib/peData.ml
@@ -52,6 +52,8 @@ type machine_type =
 	| TTriCore (* 0x0520 Infineon *)
 	| TAmd64 (* 0x8664 AMD x64 and Intel E64T *)
 	| TM32R (* 0x9041 M32R *)
+	| TOSXAmd64 (* 0xC020 = 0x8664 xor 0x4644 OSX AMD x64 *)
+	| TLinuxAmd64 (* 0xFD1D = 0x8664 xor 0x7B79 Linux AMD x64 *)
 
 type coff_prop =
 	| RelocsStripped (* 0x1 *)

--- a/libs/ilib/peDataDebug.ml
+++ b/libs/ilib/peDataDebug.ml
@@ -48,6 +48,8 @@ let machine_type_s m = match m with
 	| TTriCore -> "TTriCore"
 	| TAmd64 -> "TAmd64"
 	| TM32R -> "TM32R"
+	| TOSXAmd64 -> "TOSXAmd64"
+	| TLinuxAmd64 -> "TLinuxAmd64"
 
 let coff_prop_s p = match p with
 	| RelocsStripped -> "RelocsStripped"

--- a/libs/ilib/peReader.ml
+++ b/libs/ilib/peReader.ml
@@ -77,6 +77,8 @@ let machine_type_of_int i = match i with
 	| 0x0520 -> TTriCore (* 0x0520 Infineon *)
 	| 0x8664 -> TAmd64 (* 0x8664 AMD x64 and Intel E64T *)
 	| 0x9041 -> TM32R (* 0x9041 M32R *)
+	| 0xC020 -> TOSXAmd64 (* 0xC020 OSX AMD x64 *)
+	| 0xFD1D -> TLinuxAmd64 (* 0xFD1D Linux AMD x64 *)
 	| _ -> assert false
 
 let coff_props_of_int iprops = List.fold_left (fun acc i ->

--- a/libs/ilib/peWriter.ml
+++ b/libs/ilib/peWriter.ml
@@ -59,6 +59,8 @@ let int_of_machine_type t = match t with
 	| TTriCore -> 0x0520 (* 0x0520 Infineon *)
 	| TAmd64 -> 0x8664 (* 0x8664 AMD x64 and Intel E64T *)
 	| TM32R -> 0x9041 (* 0x9041 M32R *)
+	| TOSXAmd64 -> 0xC020 (* 0xC020 = 0x8664 xor 0x4644 OSX AMD x64 *)
+	| TLinuxAmd64 -> 0xFD1D (* 0xFD1D = 0x8664 xor 0x7B79 Linux AMD x64 *)
 
 let int_of_coff_props props = List.fold_left (fun acc prop ->
 		(match prop with


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/36364

Needed for .NET 5.0 std dlls