### PR TITLE
[Java/CS] Do not check abstract fields in libs

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -590,7 +590,7 @@ let create_field_context (ctx,cctx) c cff =
 			()
 	) cff.cff_meta;
 	let is_inline = List.mem_assoc AInline cff.cff_access in
-	if is_abstract then begin
+	if (is_abstract && not (has_meta Meta.LibType c.cl_meta)) then begin
 		if is_static then
 			display_error ctx "Static methods may not be abstract" (pos cff.cff_name)
 		else if !is_final then


### PR DESCRIPTION
.NET 5.0 std triggers an error here for `IAsyncEnumerable<T>.GetAsyncEnumerator` field

https://github.com/HaxeFoundation/haxe/blob/2a5e959ed06495d5e5fa6eb7dc106efa641f5712/src-json/meta.json#L674