### PR TITLE
[CS] Avoid CA2200 warning when rethrowing

### DIFF
--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -401,3 +401,4 @@ type flag_tvar =
 	| VCaptured
 	| VFinal
 	| VUsed (* used by the analyzer *)
+	| VCaught

--- a/src/filters/exceptions.ml
+++ b/src/filters/exceptions.ml
@@ -275,6 +275,7 @@ let catch_native ctx catches t p =
 		(* Everything else falls into `if(Std.is(e, ExceptionType)`-fest *)
 		| rest ->
 			let catch_var = alloc_var VGenerated "`" ctx.wildcard_catch_type null_pos in
+			add_var_flag catch_var VCaught;
 			let catch_local = mk (TLocal catch_var) catch_var.v_type null_pos in
 			let body =
 				let catch = new catch ctx catch_local p in

--- a/src/generators/gencs.ml
+++ b/src/generators/gencs.ml
@@ -1762,6 +1762,8 @@ let generate con =
 					| TContinue -> write w "continue"
 					| TThrow { eexpr = TIdent "__rethrow__" } ->
 						write w "throw"
+					| TThrow { eexpr = TLocal(v) } when (has_var_flag v VCaught) ->
+						write w "throw";
 					| TThrow e ->
 						write w "throw ";
 						expr_s w e


### PR DESCRIPTION
Code like that:
```hx
try {
	throw something;
} catch (eof:haxe.io.Eof) {}
```

Generates:
```cs
try {
	// ...
}
catch (global::System.Exception _g){
	if (( ((object) (global::haxe.Exception.caught(_g).unwrap()) ) is global::haxe.io.Eof )) {
	}
	else {
		throw _g;
	}
	
}
```

Which results in a runtime warning from C#:
> warning CA2200: Re-throwing caught exception changes stack information

According to https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200, `throw _g` here should be just `throw`.

Note: this warning is currently generated with haxe std (haxe.io.Input) too