### PR TITLE
Minor spelling corrections in EventLoop.hx doc

### DIFF
--- a/std/sys/thread/EventLoop.hx
+++ b/std/sys/thread/EventLoop.hx
@@ -51,7 +51,7 @@ class EventLoop {
 	}
 
 	/**
-		Prevent execution of a previousely scheduled event in current loop.
+		Prevent execution of a previously scheduled event in current loop.
 	**/
 	public function cancel(eventHandler:EventHandler):Void {
 		mutex.acquire();
@@ -162,7 +162,7 @@ class EventLoop {
 	}
 
 	/**
-		`.pogress` implementation with a resuable array for internal usage.
+		`.progress` implementation with a reusable array for internal usage.
 		The `nextEventAt` field of the return value denotes when the next event
 		is expected to run:
 		* -1 - never


### PR DESCRIPTION
Just a few small spelling tweaks in docs

(Currently loving exploring the new threading system! It's making it much easier to embed haxe programs in other native projects, thanks for all the hard work that's gone into it!)