### PR TITLE
[cpp] Return access to __s as a RawConstPointer

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -2636,7 +2636,7 @@ let retype_expression ctx request_type function_args function_type expression_tr
                else if fieldName="cca" && obj.cpptype=TCppString then
                   CppFunction( FuncInternal(obj,"cca","."), TCppScalar("int")), TCppDynamic
                else if fieldName="__s" && obj.cpptype=TCppString then
-                  CppVar( VarInternal(obj,".","utf8_str()")), TCppPointer("ConstPointer", TCppScalar("char"))
+                  CppVar( VarInternal(obj,".","utf8_str()")), TCppRawPointer("const ", TCppScalar("char"))
                else if fieldName="__Index" then
                   CppEnumIndex(obj), TCppScalar("int")
                else if is_internal_member fieldName || cpp_is_real_array obj then begin


### PR DESCRIPTION
Closes #9733, seemed to fail before because it was being generated as a cpp.ConstPointer variable. when the analyzer is enabled it doesn't generate the temp variable so tries to cast directory from `cpp::Pointer<char>` to a `const char *` by calling get_raw but utf8_str already returns a `const char *` so it fails to compile. Not sure if there was a reason for it to be a `cpp::Pointer` but it seems to work now.