### PR TITLE
Add test for #9946

### DIFF
--- a/tests/unit/native_cs/hxcs_build.txt
+++ b/tests/unit/native_cs/hxcs_build.txt
@@ -18,6 +18,8 @@ M haxe.test.GenericHelper
 C haxe.test.GenericHelper
 M haxe.test.StaticAndInstanceClash
 C haxe.test.StaticAndInstanceClash
+M haxe.test.AttrWithNullType
+C haxe.test.AttrWithNullType
 M NoPackage
 C NoPackage
 end modules

--- a/tests/unit/native_cs/src/haxe/test/AttrWithNullType.cs
+++ b/tests/unit/native_cs/src/haxe/test/AttrWithNullType.cs
@@ -1,12 +1,17 @@
 using System;
 
 namespace haxe.test {
-	public class Class1 {
-		[MyAttr(null)]
-		public static int test;
-	}
+	[MyAttr(null)]
+	public class AttrWithNullType {}
 
-	class MyAttrAttribute : Attribute {
-		public MyAttrAttribute(System.Type t) {}
+	[MyAttr(typeof(AttrWithNullType))]
+	public class AttrWithNonNullType {}
+
+	public class MyAttrAttribute : Attribute {
+		public bool check;
+
+		public MyAttrAttribute(System.Type t) {
+			check = (t == null);
+		}
 	}
 }

--- a/tests/unit/native_cs/src/haxe/test/AttrWithNullType.cs
+++ b/tests/unit/native_cs/src/haxe/test/AttrWithNullType.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace haxe.test {
+	public class Class1 {
+		[MyAttr(null)]
+		public static int test;
+	}
+
+	class MyAttrAttribute : Attribute {
+		public MyAttrAttribute(System.Type t) {}
+	}
+}

--- a/tests/unit/src/unit/issues/Issue9946.hx
+++ b/tests/unit/src/unit/issues/Issue9946.hx
@@ -1,12 +1,14 @@
-#if cs
 package unit.issues;
 
+#if cs
 import cs.system.Attribute;
 import haxe.test.AttrWithNullType;
 import haxe.test.AttrWithNonNullType;
 import haxe.test.MyAttrAttribute;
+#end
 
 class Issue9946 extends unit.Test {
+	#if cs
 	function test() {
 		eq(hasNullArg(cs.Lib.toNativeType(AttrWithNullType)), true);
 		eq(hasNullArg(cs.Lib.toNativeType(AttrWithNonNullType)), false);
@@ -24,5 +26,5 @@ class Issue9946 extends unit.Test {
 
 		return null;
 	}
+	#end
 }
-#end

--- a/tests/unit/src/unit/issues/Issue9946.hx
+++ b/tests/unit/src/unit/issues/Issue9946.hx
@@ -2,12 +2,14 @@
 package unit.issues;
 
 import cs.system.Attribute;
+import haxe.test.AttrWithNullType;
+import haxe.test.AttrWithNonNullType;
 import haxe.test.MyAttrAttribute;
 
 class Issue9946 extends unit.Test {
 	function test() {
-		eq(hasNullArg(untyped __cs__('typeof(haxe.test.AttrWithNullType)')), true);
-		eq(hasNullArg(untyped __cs__('typeof(haxe.test.AttrWithNonNullType)')), false);
+		eq(hasNullArg(cs.Lib.toNativeType(AttrWithNullType)), true);
+		eq(hasNullArg(cs.Lib.toNativeType(AttrWithNonNullType)), false);
 	}
 
 	static function hasNullArg(cls:cs.system.Type):Null<Bool> {

--- a/tests/unit/src/unit/issues/Issue9946.hx
+++ b/tests/unit/src/unit/issues/Issue9946.hx
@@ -1,0 +1,26 @@
+#if cs
+package unit.issues;
+
+import cs.system.Attribute;
+import haxe.test.MyAttrAttribute;
+
+class Issue9946 extends unit.Test {
+	function test() {
+		eq(hasNullArg(untyped __cs__('typeof(haxe.test.AttrWithNullType)')), true);
+		eq(hasNullArg(untyped __cs__('typeof(haxe.test.AttrWithNonNullType)')), false);
+	}
+
+	static function hasNullArg(cls:cs.system.Type):Null<Bool> {
+		var attributes = @:privateAccess new Array(Attribute.GetCustomAttributes(cls));
+
+		for (attr in attributes) {
+			if (Std.isOfType(attr, MyAttrAttribute)) {
+				var a:MyAttrAttribute = cast attr;
+				return a.check;
+			}
+		}
+
+		return null;
+	}
+}
+#end


### PR DESCRIPTION
Checked with a haxe binary from before PR fixing #9946, test do fail with
```
PeReader.Error_message("Error reading compressed data. Invalid first byte: ff")
```

Works with latest.