### PR TITLE
[php] fixed EReg.split when called with malformed utf8 input

### DIFF
--- a/std/php/_std/EReg.hx
+++ b/std/php/_std/EReg.hx
@@ -125,12 +125,12 @@ import php.*;
 	}
 
 	public function split(s:String):Array<String> {
-		var parts:NativeArray = Global.preg_split(reUnicode, s, (global ? -1 : 2));
-		if (parts == null) {
+		var parts:EitherType<Bool, NativeArray> = Global.preg_split(reUnicode, s, (global ? -1 : 2));
+		if (parts == false) {
 			handlePregError();
 			parts = Global.preg_split(re, s, (global ? -1 : 2));
 		}
-		return @:privateAccess Array.wrap(parts);
+		return @:privateAccess Array.wrap(cast parts);
 	}
 
 	public function replace(s:String, by:String):String {

--- a/tests/unit/src/unit/TestEReg.hx
+++ b/tests/unit/src/unit/TestEReg.hx
@@ -63,7 +63,7 @@ class TestEReg extends Test {
 		test = "g r u n";
 		var binary:haxe.io.Bytes = haxe.io.Bytes.ofString(test);
 		binary.set(4, 252);
-		test = binary.toString();
+		test = binary.getString(0, binary.length, RawNative);
 		block = ~/\s/gm;
 		eq( block.split(test).join(" "), test );
 

--- a/tests/unit/src/unit/TestEReg.hx
+++ b/tests/unit/src/unit/TestEReg.hx
@@ -59,6 +59,7 @@ class TestEReg extends Test {
 		eq( block.split(test).length, 5 );
 		eq( '"' + block.split(test).join('","') + '"', '"","test",".blah","something:someval",""' );
 
+		#if php
 		// test split with malformed utf8
 		test = "g r u n";
 		var binary:haxe.io.Bytes = haxe.io.Bytes.ofString(test);
@@ -66,6 +67,7 @@ class TestEReg extends Test {
 		test = binary.getString(0, binary.length, RawNative);
 		block = ~/\s/gm;
 		eq( block.split(test).join(" "), test );
+		#end
 
 		// test custom replace
 		eq( ~/a+/g.map("aaabacx", function(r) return "[" + r.matched(0).substr(1) + "]") , "[aa]b[]cx" );

--- a/tests/unit/src/unit/TestEReg.hx
+++ b/tests/unit/src/unit/TestEReg.hx
@@ -59,6 +59,14 @@ class TestEReg extends Test {
 		eq( block.split(test).length, 5 );
 		eq( '"' + block.split(test).join('","') + '"', '"","test",".blah","something:someval",""' );
 
+		// test split with malformed utf8
+		test = "g r u n";
+		var binary:haxe.io.Bytes = haxe.io.Bytes.ofString(test);
+		binary.set(4, 252);
+		test = binary.toString();
+		block = ~/\s/gm;
+		eq( block.split(test).join(" "), test );
+
 		// test custom replace
 		eq( ~/a+/g.map("aaabacx", function(r) return "[" + r.matched(0).substr(1) + "]") , "[aa]b[]cx" );
 		eq( ~/a+/.map("aaabacx", function(r) return "[" + r.matched(0).substr(1) + "]") , "[aa]bacx" ); // same without 'g'

--- a/tests/unit/src/unit/TestEReg.hx
+++ b/tests/unit/src/unit/TestEReg.hx
@@ -59,16 +59,6 @@ class TestEReg extends Test {
 		eq( block.split(test).length, 5 );
 		eq( '"' + block.split(test).join('","') + '"', '"","test",".blah","something:someval",""' );
 
-		#if php
-		// test split with malformed utf8
-		test = "g r u n";
-		var binary:haxe.io.Bytes = haxe.io.Bytes.ofString(test);
-		binary.set(4, 252);
-		test = binary.getString(0, binary.length, RawNative);
-		block = ~/\s/gm;
-		eq( block.split(test).join(" "), test );
-		#end
-
 		// test custom replace
 		eq( ~/a+/g.map("aaabacx", function(r) return "[" + r.matched(0).substr(1) + "]") , "[aa]b[]cx" );
 		eq( ~/a+/.map("aaabacx", function(r) return "[" + r.matched(0).substr(1) + "]") , "[aa]bacx" ); // same without 'g'


### PR DESCRIPTION
had a weird error after migrating an old PHP application to Haxe 4... turns out some database entries had malformed utf8 data