### PR TITLE
[cpp] fix typing of cpp.Native.star

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -2716,7 +2716,8 @@ let retype_expression ctx request_type function_args function_type expression_tr
 
                | CppFunction( FuncStatic(obj, false, member), _ ) when member.cf_name = "::hx::Dereference" ->
                     let arg = retype TCppUnchanged (List.hd args) in
-                    CppDereference(arg), arg.cpptype
+                    let rawType = match arg.cpptype with | TCppStar(x,_) -> x | x -> x in
+                    CppDereference(arg), TCppReference(rawType)
 
                | CppFunction( FuncStatic(obj, false, member), _ ) when member.cf_name = "_hx_create_array_length" ->
                   let retypedArgs = List.map (retype TCppDynamic ) args in

--- a/tests/unit/src/unit/issues/Issue10057.hx
+++ b/tests/unit/src/unit/issues/Issue10057.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+class Issue10057 extends unit.Test {
+#if (cpp && !cppia)
+  function test() {
+    var i = 1;
+    var star = cpp.Native.addressOf(i);
+    var ref = cpp.Native.star(star);
+    ref = 2;
+    eq(2, i);
+  }
+#end
+}


### PR DESCRIPTION
Closes #10057.

Code by analogy with `::hx::AddressOf` and `::hx::StarOf`.