### PR TITLE
[std] fix Template.resolve when current context is not an object

### DIFF
--- a/std/haxe/Template.hx
+++ b/std/haxe/Template.hx
@@ -121,11 +121,13 @@ class Template {
 	function resolve(v:String):Dynamic {
 		if (v == "__current__")
 			return context;
-		var value = Reflect.getProperty(context, v);
-		if (value != null || Reflect.hasField(context, v))
-			return value;
+		if (Reflect.isObject(context)) {
+			var value = Reflect.getProperty(context, v);
+			if (value != null || Reflect.hasField(context, v))
+				return value;
+		}
 		for (ctx in stack) {
-			value = Reflect.getProperty(ctx, v);
+			var value = Reflect.getProperty(ctx, v);
 			if (value != null || Reflect.hasField(ctx, v))
 				return value;
 		}

--- a/tests/unit/src/unit/issues/Issue9372.hx
+++ b/tests/unit/src/unit/issues/Issue9372.hx
@@ -1,0 +1,10 @@
+package unit.issues;
+
+class Issue9372 extends unit.Test {
+  function test() {
+    var data = {foo: '!', bar: [0, 1]};
+    var template = new haxe.Template("::foreach bar:: ::foo:: ::__current__:: ::end::");
+    var output = template.execute(data);
+    eq(" ! 0  ! 1 ", output);
+  }
+}


### PR DESCRIPTION
Closes #9372.

Checks if current context is an object before trying to get a field.