### PR TITLE
[abstracts] fix operator overloading with external methods

### DIFF
--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -76,10 +76,10 @@ let make_call ctx e params t ?(force_inline=false) p =
 		mk (TCall (e,params)) t p
 
 let mk_array_get_call ctx (cf,tf,r,e1,e2o) c ebase p = match cf.cf_expr with
-	| None ->
+	| None when not (has_class_field_flag cf CfExtern) ->
 		if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx "Recursive array get method" p;
 		mk (TArray(ebase,e1)) r p
-	| Some _ ->
+	| _ ->
 		let et = type_module_type ctx (TClassDecl c) None p in
 		let ef = mk (TField(et,(FStatic(c,cf)))) tf p in
 		make_call ctx ef [ebase;e1] r p
@@ -87,11 +87,11 @@ let mk_array_get_call ctx (cf,tf,r,e1,e2o) c ebase p = match cf.cf_expr with
 let mk_array_set_call ctx (cf,tf,r,e1,e2o) c ebase p =
 	let evalue = match e2o with None -> die "" __LOC__ | Some e -> e in
 	match cf.cf_expr with
-		| None ->
+		| None when not (has_class_field_flag cf CfExtern) ->
 			if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx "Recursive array set method" p;
 			let ea = mk (TArray(ebase,e1)) r p in
 			mk (TBinop(OpAssign,ea,evalue)) r p
-		| Some _ ->
+		| _ ->
 			let et = type_module_type ctx (TClassDecl c) None p in
 			let ef = mk (TField(et,(FStatic(c,cf)))) tf p in
 			make_call ctx ef [ebase;e1;evalue] r p

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -451,7 +451,7 @@ let make_binop ctx op e1 e2 is_assign_op with_type p =
 let find_abstract_binop_overload ctx op e1 e2 a c tl left is_assign_op with_type p =
 	let map = apply_params a.a_params tl in
 	let make op_cf cf e1 e2 tret needs_assign swapped =
-		if cf.cf_expr = None then begin
+		if cf.cf_expr = None && not (has_class_field_flag cf CfExtern) then begin
 			if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx "Recursive operator method" p;
 			if not (Meta.has Meta.CoreType a.a_meta) then begin
 				(* for non core-types we require that the return type is compatible to the native result type *)

--- a/std/haxe/Int32.hx
+++ b/std/haxe/Int32.hx
@@ -68,7 +68,7 @@ abstract Int32(Int) from Int to Int {
 
 	@:op(A - B) private static function subFloat(a:Int32, b:Float):Float;
 
-	@:op(A - B) public static function floatSub(a:Float, b:Int32):Float;
+	@:op(A - B) private static function floatSub(a:Float, b:Int32):Float;
 
 	#if (js || php || python || lua)
 	#if js

--- a/tests/unit/src/unit/issues/Issue10073.hx
+++ b/tests/unit/src/unit/issues/Issue10073.hx
@@ -1,0 +1,41 @@
+package unit.issues;
+
+private abstract Foo(Array<Int>) from Array<Int> {
+  @:op([])
+  function get(index: Int): Int;
+
+  @:op([])
+  function set(index: Int, value: Int): Void;
+}
+
+#if eval
+abstract Bar(Int) from Int {
+  @:op(_ + _)
+  extern function add(other: Int): Int;
+
+  @:op([])
+  extern function get(index: Int): Int;
+
+  @:native('add')
+  function doAdd(other: Int): Int
+    return 39;
+
+  @:native('get')
+  function doGet(index: Int)
+    return (this + index) * 2;
+}
+#end
+
+class Issue10073 extends Test {
+  function test() {
+    var foo: Foo = [];
+    foo[0] = 3;
+    eq(3, foo[0]);
+
+    #if eval
+    var bar: Bar = 71;
+    eq(39, bar + 1);
+    eq(144, bar[1]);
+    #end
+  }
+}

--- a/tests/unit/src/unit/issues/Issue3345.hx
+++ b/tests/unit/src/unit/issues/Issue3345.hx
@@ -8,14 +8,14 @@ private abstract Meters(Float) from Float {
 		this = f;
 	}
 
-	@:op(-A) extern public static function neg(s:Meters):Meters;
-	@:op(A+B) extern public static function add(lhs:Meters, rhs:Meters):Meters;
-	@:op(A-B) extern public static function sub(lhs:Meters, rhs:Meters):Meters;
-	@:op(A>B) extern public static function gt(lhs:Meters, rhs:Meters):Bool;
-	@:op(A>=B) extern public static function gte(lhs:Meters, rhs:Meters):Bool;
-	@:op(A<B) extern public static function lt(lhs:Meters, rhs:Meters):Bool;
-	@:op(A<=B) extern public static function lte(lhs:Meters, rhs:Meters):Bool;
-	@:op(A==B) extern public static function eq(lhs:Meters, rhs:Meters):Bool;
+	@:op(-A) static private function neg(s:Meters):Meters;
+	@:op(A+B) static private function add(lhs:Meters, rhs:Meters):Meters;
+	@:op(A-B) static private function sub(lhs:Meters, rhs:Meters):Meters;
+	@:op(A>B) static private function gt(lhs:Meters, rhs:Meters):Bool;
+	@:op(A>=B) static private function gte(lhs:Meters, rhs:Meters):Bool;
+	@:op(A<B) static private function lt(lhs:Meters, rhs:Meters):Bool;
+	@:op(A<=B) static private function lte(lhs:Meters, rhs:Meters):Bool;
+	@:op(A==B) static private function eq(lhs:Meters, rhs:Meters):Bool;
 	extern inline public function float() return this;
 
 	@:to inline public function toString() {


### PR DESCRIPTION
Closes #10073.

Small bonuses:

- Seems like there was no way to forward array access to underlying type before: `allows_no_expr := true` was missing there.

- `haxe.Int32` was having `floatSub` as public, which is a typo since all others forwarding operators methods are private.

- Check that inline methods have bodies and that methods without bodies have a clear type for every abstract method and not only operator overloads ones. 