### PR TITLE
Fix cpp.Int64 <-> haxe.Int64 roundtrip

### DIFF
--- a/std/cpp/_std/haxe/Int64.hx
+++ b/std/cpp/_std/haxe/Int64.hx
@@ -27,6 +27,7 @@ import haxe.Int64Helper;
 @:notNull
 @:include("cpp/Int64.h")
 @:native("cpp::Int64Struct")
+@:structAccess
 private extern class ___Int64 {
 	function get():cpp.Int64;
 
@@ -143,6 +144,16 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 
 	public static #if !cppia inline #end function make(high:Int32, low:Int32):Int64 {
 		return __Int64.make(high, low);
+	}
+
+	@:to
+	#if !cppia inline #end function toInt64():cpp.Int64 {
+		return this.get();
+	}
+
+	@:from
+	static #if !cppia inline #end function ofInt64(x:cpp.Int64):Int64 {
+		return cast x;
 	}
 
 	@:from

--- a/std/cpp/_std/haxe/Int64.hx
+++ b/std/cpp/_std/haxe/Int64.hx
@@ -27,9 +27,7 @@ import haxe.Int64Helper;
 @:notNull
 @:include("cpp/Int64.h")
 @:native("cpp::Int64Struct")
-@:structAccess
 private extern class ___Int64 {
-	function get():cpp.Int64;
 
 	@:native("_hx_int64_make")
 	static function make(high:Int32, low:Int32):__Int64;
@@ -148,7 +146,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 
 	@:to
 	#if !cppia inline #end function toInt64():cpp.Int64 {
-		return this.get();
+		return cast this;
 	}
 
 	@:from

--- a/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
+++ b/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
@@ -1,0 +1,24 @@
+package unit.hxcpp_issues;
+
+class Issue10100 extends Test {
+
+	@:analyzer(no_optimize)
+	function test() {
+		var cpp64: cpp.Int64 = untyped __cpp__('12345678944444');
+		// https://repl.it/join/wtqnxkxc-haxiomic
+		// low 1942935740
+		// high 2874
+		var hx64: haxe.Int64 = cpp64;
+		eq(hx64.low, 1942935740);
+		eq(hx64.high, 2874);
+
+		// there and back again
+		var cpp64: cpp.Int64 = hx64;
+		eq(Std.string(cpp64), '12345678944444');
+
+		var hx64: haxe.Int64 = cpp64;
+		eq(hx64.low, 1942935740);
+		eq(hx64.high, 2874);
+	}
+
+}

--- a/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
+++ b/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
@@ -1,7 +1,7 @@
 package unit.hxcpp_issues;
 
 class Issue10100 extends Test {
-	#if (cpp || cppia)
+	#if cpp
 	@:analyzer(no_optimize)
 	function test() {
 		var cpp64:cpp.Int64 = untyped __cpp__('12345678944444');

--- a/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
+++ b/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
@@ -1,7 +1,7 @@
 package unit.hxcpp_issues;
 
 class Issue10100 extends Test {
-	#if cpp
+	#if (cpp && !cppia)
 	@:analyzer(no_optimize)
 	function test() {
 		var cpp64:cpp.Int64 = untyped __cpp__('12345678944444');

--- a/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
+++ b/tests/unit/src/unit/hxcpp_issues/Issue10100.hx
@@ -1,24 +1,24 @@
 package unit.hxcpp_issues;
 
 class Issue10100 extends Test {
-
+	#if (cpp || cppia)
 	@:analyzer(no_optimize)
 	function test() {
-		var cpp64: cpp.Int64 = untyped __cpp__('12345678944444');
+		var cpp64:cpp.Int64 = untyped __cpp__('12345678944444');
 		// https://repl.it/join/wtqnxkxc-haxiomic
 		// low 1942935740
 		// high 2874
-		var hx64: haxe.Int64 = cpp64;
+		var hx64:haxe.Int64 = cpp64;
 		eq(hx64.low, 1942935740);
 		eq(hx64.high, 2874);
 
 		// there and back again
-		var cpp64: cpp.Int64 = hx64;
+		var cpp64:cpp.Int64 = hx64;
 		eq(Std.string(cpp64), '12345678944444');
 
-		var hx64: haxe.Int64 = cpp64;
+		var hx64:haxe.Int64 = cpp64;
 		eq(hx64.low, 1942935740);
 		eq(hx64.high, 2874);
 	}
-
+	#end
 }


### PR DESCRIPTION
**Changes**

- Added private auto-casts for **haxe.Int64**: `@:to toInt64(): cpp.Int64` and `@:from ofInt64(x: cpp.Int64)`
- Removed unused `get()` method from `___Int64` as it cannot be used without `@:structAccess` anyway
- Added regression test for roundtrip

closes #10100 