### PR TITLE
Fix hxcpp tests by linking to latest version of utest

### DIFF
--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -7,6 +7,6 @@
 --resource serializedValues.txt
 --macro Macro.init()
 --dce full
--lib utest
+-lib utest:git:https://github.com/haxe-utest/utest#559b24c9a36533281ba7a2eed8aab83ed6b872b4
 -D analyzer-optimize
 -D analyzer-user-var-fusion


### PR DESCRIPTION
[hxcpp tests](https://dev.azure.com/HaxeFoundation/GitHubPublic/_build/results?buildId=7434&view=logs&j=8239a87a-2449-54dc-702d-47627111ebf5&t=ef0a5a8e-6c6a-5b7c-203b-bf45b584bee5&l=13) have been down for some weeks because `compile-cpp.hxml` fails with `TestBuilder.hx:408: characters 17-19 : Unmatched patterns: OpSpread`

utests has been updated with the fix but not pushed to haxelib yet

I think it makes sense to link to specific versions of utest to avoid random breaks in the future

This PR should get hxcpp tests green again