### PR TITLE
Add ability to query adjacent entries of a BalancedTree

### DIFF
--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -73,6 +73,195 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 	}
 
 	/**
+		Returns the key and bound value of the largest key in this map less
+		than or equal to `key`.
+		
+		If `key` is present in this map, returns it and its bound value.
+		If `key` is not present, the key immediately _before_ this key is found,
+		and it and the corresponding bound value are returned.
+
+		If there is no such key in this map, both the returned key and value
+		will be `null`.
+
+		If `key` is omitted or `null`, returns the minimum key and its bound value
+		(equivalent to `min()`).
+
+		If the map is empty, both the returned key and value will be `null`.
+		
+		The returned struct is guaranteed non-null (only the fields may be null).
+	**/
+	public function floor(?key:K): {key:Null<K>, value:Null<V>} {
+		var node = root;
+		var floor = new TreeNode<K, V>(null, null, null, null, 0);
+
+		if (key == null) {
+			return min();
+		}
+
+		while (node != null) {
+			var c = compare(key, node.key);
+			if (c == 0)
+				return {key:node.key, value:node.value};
+			if (c < 0) {
+				node = node.left;
+			} else {
+				floor = node; // biggest node we've found that's smaller than the key
+				node = node.right;
+			}
+		}
+		return {key:floor.key, value:floor.value};
+	}
+
+	/**
+		Returns the key and bound value of the smallest key in this map greater
+		than or equal to `key`.
+		
+		If `key` is present in this map, returns it and its bound value.
+		If `key` is not present, the key immediately _after_ this key is found,
+		and it and the corresponding bound value are returned.
+
+		If there is no such key in this map, both the returned key and value
+		will be `null`.
+
+		If `key` is omitted or `null`, returns the maximum key and its bound value
+		(eqivalent to `max()`).
+
+		If the map is empty, both the returned key and value will be `null`.
+		
+		The returned struct is guaranteed non-null (only the fields may be null).
+	**/
+	public function ceil(?key:K): {key:Null<K>, value:Null<V>} {
+		var node = root;
+		var ceil = new TreeNode<K, V>(null, null, null, null, 0);
+
+		if (key == null) {
+			return max();
+		}
+
+		while (node != null) {
+			var c = compare(key, node.key);
+			if (c == 0)
+				return {key:node.key, value:node.value};
+			if (c < 0) {
+				ceil = node; // biggest node we've found that's smaller than the key
+				node = node.left;
+			} else {
+				node = node.right;
+			}
+		}
+		return {key:ceil.key, value:ceil.value};
+	}
+
+	/**
+		Returns the first / minimal key and the corresponding bound value.
+
+		If the map is empty, both the returned key and value will be `null`.
+		
+		The returned struct is guaranteed non-null (only the fields may be null).
+	**/
+	public function min(): {key:Null<K>, value:Null<V>} {
+		var node = minChild(root);
+		if (node == null) {
+			return {key:null, value:null};
+		} else {
+			return {key:node.key, value:node.value};
+		}
+	}
+
+	/**
+		Returns the last / maximal key and the corresponding bound value.
+		
+		If the map is empty, both the returned key and value will be `null`.
+		
+		The returned struct is guaranteed non-null (only the fields may be null).
+	**/
+	public function max(): {key:Null<K>, value:Null<V>} {
+		var node = maxChild(root);
+		if (node == null) {
+			return {key:null, value:null};
+		} else {
+			return {key:node.key, value:node.value};
+		}
+	}
+
+	/**
+		Returns the key and bound value of the specified key (if present)
+		and the keys and values that are immediately before and after it in
+		order (if there is another key in that direction).
+		
+		If `key` is present in this map, `ident` in the return struct is
+		that key and its value, otherwise both `ident.key` and `ident.value`
+		are `null`.
+
+		If there is a key in this map before `key`, `prev` in the return
+		struct is the key and value of the key immediately before `key`,
+		otherwise both `prev.key` and `prev.value` are `null`.
+		If `key` is omitted or `null`, `prev` is instead the minimum key
+		and bound value (equivalent to the value returned by `min()`).
+
+		If there is a key this map after `key`, `next` in the return
+		struct is the key and value of the key immediately after `key`,
+		otherwise both `next.key` and `next.value` are `null`.
+		If `key` is omitted or `null`, `next` is instead the minimum key
+		and bound value (equivalent to the value returned by `max()`).
+
+		Note that if the map is empty, all returned keys and values will
+		be `null`.
+		
+		The returned struct and the sub-structs `prev`, `ident`, and `next`
+		are guaranteed non-null (only the `key` and `value` fields may be null).
+	**/
+	public function neighborhood(?key:K): {prev:{key:Null<K>, value:Null<V>}, ident:{key:Null<K>, value:Null<V>}, next:{key:Null<K>, value:Null<V>}} {
+		var node = root;
+		var prev, ident, next;
+		prev = ident = next = new TreeNode<K, V>(null, null, null, null, 0);
+
+		if (key == null) {
+			prev = minChild(node);
+			next = maxChild(node);
+		} else {
+			while (node != null) {
+				var c = compare(key, node.key);
+				if (c == 0) {
+					ident = node;
+					prev = maxChild(node.left);
+					next = minChild(node.right);
+					break;
+				}
+				if (c < 0) {
+					next = node; // smallest node we've found that's bigger than the key
+					node = node.left;
+				} else {
+					prev = node; // biggest node we've found that's smaller than the key
+					node = node.right;
+				}
+			}
+		}
+		return {prev:{key:prev.key, value:prev.value}, ident:{key:ident.key, value:ident.value}, next:{key:next.key, value:next.value}};
+	}
+
+	/**
+		Seek along the right branch to the last non-null child.
+		Returns a `null` only if passed a `null`.
+	**/
+	function maxChild(node:TreeNode<K, V>): TreeNode<K, V> {
+		if (node != null)
+			while (node.right != null)
+				node = node.right;
+		return node;
+	}
+	/**
+		Seek along the left branch to the last non-null child.
+		Returns a `null` only if passed a `null`.
+	**/
+	function minChild(node:TreeNode<K, V>): TreeNode<K, V> {
+		if (node != null)
+			while (node.left != null)
+				node = node.left;
+		return node;
+	}
+
+	/**
 		Removes the current binding of `key`.
 
 		If `key` has no binding, `this` BalancedTree is unchanged and false is

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -35,6 +35,7 @@ package haxe.ds;
 class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 	var root:TreeNode<K, V>;
 
+
 	/**
 		Creates a new BalancedTree, which is initially empty.
 	**/
@@ -90,7 +91,7 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		
 		The returned struct is guaranteed non-null (only the fields may be null).
 	**/
-	public function floor(?key:K): {key:Null<K>, value:Null<V>} {
+	public function floor(?key:K): Entry<K,V> {
 		var node = root;
 		var floor = new TreeNode<K, V>(null, null, null, null, 0);
 
@@ -130,7 +131,7 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		
 		The returned struct is guaranteed non-null (only the fields may be null).
 	**/
-	public function ceil(?key:K): {key:Null<K>, value:Null<V>} {
+	public function ceil(?key:K): Entry<K,V> {
 		var node = root;
 		var ceil = new TreeNode<K, V>(null, null, null, null, 0);
 
@@ -159,7 +160,7 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		
 		The returned struct is guaranteed non-null (only the fields may be null).
 	**/
-	public function min(): {key:Null<K>, value:Null<V>} {
+	public function min(): Entry<K,V> {
 		var node = minChild(root);
 		if (node == null) {
 			return {key:null, value:null};
@@ -175,7 +176,7 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		
 		The returned struct is guaranteed non-null (only the fields may be null).
 	**/
-	public function max(): {key:Null<K>, value:Null<V>} {
+	public function max(): Entry<K,V> {
 		var node = maxChild(root);
 		if (node == null) {
 			return {key:null, value:null};
@@ -211,21 +212,24 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		The returned struct and the sub-structs `prev`, `ident`, and `next`
 		are guaranteed non-null (only the `key` and `value` fields may be null).
 	**/
-	public function neighborhood(?key:K): {prev:{key:Null<K>, value:Null<V>}, ident:{key:Null<K>, value:Null<V>}, next:{key:Null<K>, value:Null<V>}} {
+	public function neighborhood(?key:K): Neighborhood<K,V> {
 		var node = root;
 		var prev, ident, next;
-		prev = ident = next = new TreeNode<K, V>(null, null, null, null, 0);
+		var empty = new TreeNode<K, V>(null, null, null, null, 0);
+		prev = ident = next = empty;
 
 		if (key == null) {
-			prev = minChild(node);
-			next = maxChild(node);
+			if (node != null) {
+				prev = minChild(node);
+				next = maxChild(node);
+			}
 		} else {
 			while (node != null) {
 				var c = compare(key, node.key);
 				if (c == 0) {
 					ident = node;
-					prev = maxChild(node.left);
-					next = minChild(node.right);
+					if (node.left != null) prev = maxChild(node.left);
+					if (node.right != null) next = minChild(node.right);
 					break;
 				}
 				if (c < 0) {
@@ -426,6 +430,15 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 		root = null;
 	}
 }
+
+/**
+	A key and its associated value.
+**/
+typedef Entry<K,V> = {key:Null<K>, value:Null<V>};
+/**
+	The entry `ident` corresponding to the queried key, plus the entries immediately before and after it in the mapping.
+**/
+typedef Neighborhood<K,V> = {prev:Entry<K,V>, ident:Entry<K,V>, next:Entry<K,V>};
 
 /**
 	A tree node of `haxe.ds.BalancedTree`.

--- a/tests/unit/src/unitstd/haxe/ds/BalancedTree.unit.hx
+++ b/tests/unit/src/unitstd/haxe/ds/BalancedTree.unit.hx
@@ -102,3 +102,71 @@ test3.set(0, 1);
 test3.exists(0) == true;
 test3.exists(2) == false;
 test3.exists(4) == false;
+
+
+
+var entryEq = function(
+	a:haxe.ds.BalancedTree.Entry<Dynamic,Dynamic>,
+	b:haxe.ds.BalancedTree.Entry<Dynamic,Dynamic>,
+	?pos : haxe.PosInfos
+) {
+	eq(a.key, b.key, pos);
+	eq(a.value, b.value, pos);
+};
+var neighEq = function(
+	a:haxe.ds.BalancedTree.Neighborhood<Dynamic,Dynamic>,
+	b:haxe.ds.BalancedTree.Neighborhood<Dynamic,Dynamic>,
+	?pos : haxe.PosInfos
+) {
+	entryEq(a.prev, b.prev, pos);
+	entryEq(a.ident, b.ident, pos);
+	entryEq(a.next, b.next, pos);
+};
+var nullEntry = {key: null, value: null};
+var nullNeigh = {prev: nullEntry, ident: nullEntry, next: nullEntry};
+
+var nt = new haxe.ds.BalancedTree<Int, Int>();
+for (k in test.keys()) {
+	nt.set(k, test[k]);
+}
+// no-param versions, get info about whole tree
+entryEq({key: 1, value: 4}, nt.floor());
+entryEq({key: 1, value: 4}, nt.min());
+entryEq({key: 27, value: 10}, nt.ceil());
+entryEq({key: 27, value: 10}, nt.max());
+neighEq({prev: {key: 1, value: 4}, ident: nullEntry, next: {key: 27, value: 10}}, nt.neighborhood());
+// queried key is present, keys before and after
+entryEq({key: 11, value: 5}, nt.floor(11));
+entryEq({key: 11, value: 5}, nt.ceil(11));
+neighEq({prev: {key: 8, value: 2}, ident: {key: 11, value: 5}, next: {key: 13, value: 1}}, nt.neighborhood(11));
+// queried key not present, keys before and after
+entryEq({key: 17, value: 3}, nt.floor(18));
+entryEq({key: 22, value: 9}, nt.ceil(18));
+neighEq({prev: {key: 17, value: 3}, ident: nullEntry, next: {key: 22, value: 9}}, nt.neighborhood(18));
+// queried key is present, only keys after
+entryEq({key: 1, value: 4}, nt.floor(1));
+entryEq({key: 1, value: 4}, nt.ceil(1));
+neighEq({prev: nullEntry, ident: {key: 1, value: 4}, next: {key: 6, value: 8}}, nt.neighborhood(1));
+// queried key not present, only keys after
+entryEq(nullEntry, nt.floor(0));
+entryEq({key: 1, value: 4}, nt.ceil(0));
+neighEq({prev: nullEntry, ident: nullEntry, next: {key: 1, value: 4}}, nt.neighborhood(0));
+// queried key is present, only keys before
+entryEq({key: 27, value: 10}, nt.floor(27));
+entryEq({key: 27, value: 10}, nt.ceil(27));
+neighEq({prev: {key: 25, value: 7}, ident: {key: 27, value: 10}, next: nullEntry}, nt.neighborhood(27));
+// queried key not present, only keys before
+entryEq({key: 27, value: 10}, nt.floor(30));
+entryEq(nullEntry, nt.ceil(30));
+neighEq({prev: {key: 27, value: 10}, ident: nullEntry, next: nullEntry}, nt.neighborhood(30));
+
+var empty = new haxe.ds.BalancedTree<Int, Int>();
+// ensure queries behave properly on an empty tree
+entryEq(nullEntry, empty.floor(1));
+entryEq(nullEntry, empty.floor());
+entryEq(nullEntry, empty.min());
+entryEq(nullEntry, empty.ceil(1));
+entryEq(nullEntry, empty.ceil());
+entryEq(nullEntry, empty.max());
+neighEq(nullNeigh, empty.neighborhood(1));
+neighEq(nullNeigh, empty.neighborhood());


### PR DESCRIPTION
(Just a cleaned-up resubmission of #10104)

This PR adds the ability to query a `BalancedTree` for the entries immediately adjacent to a given key. The underlying data structure is one that already supports O(log(n)) performance for all of these operations; this simply adds implementations of these routines and makes them available as part of the public API.

Aside from simply providing increased functionality, the ability to query adjacent keys is important for the efficient performance of a number of application-specific sparse data structures that are normally implemented with an ordered map as one of their backing stores.

All of these added functions have analogues in other standard library implementations of ordered map types, however not all of the libraries I've compared with agree on the precise semantics or naming for the particular functions they provide.
I would appreciate any comments the developer community has here on how this proposal can be modified to put this API more in line with their vision for the Haxe standard library &mdash; I consider this pull request to be just a first attempt at a reasonable compromise between the different design considerations.

### Proposed Implementation

As proposed, the following public functions are added to `haxe.ds.BalancedTree`:
- `floor(key)` - retrieves the entry if it exists, or the one that would come right before if not.
- `ceil(key)` - retrieves the entry if it exists, or the one that would come right after if not.
- `min()` - retrieves the first entry.
- `max()` - retrieves the last entry.
- `neighborhood(key)` - retrieves more complete information about the keys both right before and after a given key.
 
All of these functions (with the exception of `neighborhood`) return a guaranteed-not-null struct containing the key and value of the retrieved entry.
This allows applications that need access to both the key and value to retrieve them while only walking the tree once, while applications that are only concerned with either the key or value but not both can idiomatically retrieve the field of interest without the need to null-check the struct as a whole:

```haxe
var need_both = my_tree.floor(3);
var just_need_key = my_tree.floor(3).key;
var just_need_value = my_tree.floor(3).value;
```

The `neighborhood` function likewise returns a struct containing multiple such non-null values:

```haxe
var full_info = my_tree.neighborhood(3);
var just_previous_key = my_tree.neighborhood(3).prev.key;
```

One other significant choice is how to define the behavior of these functions when given a null key. A lot of associative array implementations don't support actually _storing_ null keys. At present I've implemented `floor(null)` to act like `min()` based on a brief discussion [in chat](https://gitter.im/HaxeFoundation/haxe)`, just as a way to provide _some_ safe behavior when passed a null key (and enable that return value field access idiom earlier).

The three main options I can see for the behavior here are:
- `floor(null)` returns a null value, either just `null`, or `{key:null, value:null}` to make the earlier return-struct-field-access idiom null-safe. This is how Java `java.util.NavigableMap::floorEntry` is specified to behave.
- `floor(null)` returns the same thing as `min()`. This seems like an intuitive way to overload functionality if it's gonna be overloaded, although I'm not sure whether this would actually be more useful in practice.
- `floor(null)` returns the same thing as `max()`. This is probably less intuitive than returning `min()`, but at least in one set-theoretic interpretation of what it actually _means_ for a value to be the "floor" of nothing across a given set, this is actually the "correct" answer. I don't think it's a good idea to implement it this way, although I'm sure at least Wolfram Mathematica provides an option for it somewhere. The point is just to illustrate that returning `min()` isn't the only possible intuition one might have for this.
- Leave the behavior of `floor(null)` unspecified. This is consistent with the behavior of other functions in the class and probably better for performance, without preventing a later compatible implementation from providing full support for storing `null` keys.

A similar debate can be had for how (or whether) to specify `ceil(null)` and `neighborhood(null)`.

### Use Case

My specific use case (and the one that prompted me to make this PR) is to use it as a backing store for another data structure, a sparse range array, commonly used for representing address space maps to describe the locations of memory mapped peripherals and memory segments (e.g. for a retro console emulator), or for the layout of disk partitions and filesystems sections on various storage devices.
In order to implement a map like this efficiently, an ordered map is often used to store the information about the device being mapped _only_ at the low index of the range being, and then a null value stored at the address right after the high index being set. Then, when querying for a given intermediate index, you simply query for the floor entry of that index in the map.

There are a number of other application-specific sparse data structures that are implemented in a similar way, and rely on the ability to efficiently locate the nearest existing keys in the map to the indices they're trying to retrieve or modify.

(Note that other use cases certainly exist as well, this is just the main one I'm aware of.)

### Overview of Other Competing APIs
#### Java 8 Standard Utils
[`java.util.NavigableMap`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html) and its implementations (including [`java.util.TreeMap`](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html) and [`java.util.ConcurrentSkipListMap`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html))  provides the following analogous functions:

- [`floorEntry`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html#floorEntry-K-), equivalent to the proposed `floor()`
- [`ceilingEntry`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html#ceilingEntry-K-), equivalent to the proposed `ceil()`.
- [`lowerEntry`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html#lowerEntry-K-), provided by the proposed `neighborhood().prev` struct field. 
- [`higherEntry`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html#higherEntry-K-), provided by the proposed `neighborhood().next` struct field.
- [`firstEntry`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html#firstEntry--), equivalent to the proposed `min()`
- [`lastEntry`](https://docs.oracle.com/javase/8/docs/api/java/util/NavigableMap.html#lastEntry--), equivalent to the proposed `max()`

Java also provides equivalent `floorKey`, etc. functions for all of these to make null-safety easier, although that would be redundant in this library's case if we just ensure the immediate struct field access idiom described earlier works. (Although interestingly, Java doesn't provide `floorValue`, etc., functions.)

#### Judy Array
[Judy](http://judy.sourceforge.net/) is the current highest-performing in-order dynamic associative array data structure in the world. Originally a C library developed for Hewlett-Packard by Doug Baskin in the 2000, there are now a number of open-source implementations and bindings in several different languages. It's also used in the default implementation of the `bitset!` and `map!` types in the [Red](https://www.red-lang.org/p/documentation.html) programming language.
It is a _very_ complicated data structure with an API that's a little less friendly than many others, but one of its core design features it was built around was the ability to efficiently query for neighboring keys.

#### C++ STL
[`std::map`](https://en.cppreference.com/w/cpp/container/map) provides this type of access by allowing application code to directly create create iterators that start at the desired location, enabling application code to look even further forward or backward than just the immediate neighbors.

- [`std::map::lower_bound`](https://en.cppreference.com/w/cpp/container/map/lower_bound) provides a combined equivalent of `ceil()` and `neighborhood()`.
- [`std::map::upper_bound`](https://en.cppreference.com/w/cpp/container/map/upper_bound) provides the equivalent of `floor()` and `neighborhood()`.
- [`std::map::begin`](https://en.cppreference.com/w/cpp/container/map/begin) and the related functions `end`, `rbegin`, `rend`, etc., provide the equivalents for `min()` and `max()`.

#### Python
Curiously, python does not provide any sorted containers in its standard library. However, there are a number of very mature packages available in the public repositories that provide them, such as [`sortedcontainers`](https://pypi.org/project/sortedcontainers/) which implements what you'd expect, or [`judy`](https://pypi.org/project/judy/) that provides a python binding for the Judy Array library mentioned earlier.

### Future Work
For now, adding this to the existing `BalancedTree` will make it possible to use the existing structure to back application-specific data structures, but in the future it may be desirable to add other higher-performance ordered associative array structures.

Would it be desirable to define and add an "`INavigableMap`" abstract type similar to the existing `IMap`?