### PR TITLE
[cpp,hl] disable lossy implicit cast of int 64 to 32

### DIFF
--- a/std/cpp/Int64.hx
+++ b/std/cpp/Int64.hx
@@ -22,7 +22,7 @@
 
 package cpp;
 
-@:coreType @:notNull @:runtimeValue abstract Int64 from Int to Int {
+@:coreType @:notNull @:runtimeValue abstract Int64 from Int {
 	@:to
 	#if !cppia inline #end function toInt64():haxe.Int64 {
 		return cast this;

--- a/std/cpp/Int64.hx
+++ b/std/cpp/Int64.hx
@@ -32,6 +32,12 @@ package cpp;
 	}
 
 	@:to
+	@:deprecated("Implicit cast from Int64 to Int (32 bits) is deprecated. Use .toInt() or explicitly cast instead.")
+	inline function implicitToInt(): Int {
+		return toInt();
+	}
+
+	@:to
 	#if !cppia inline #end function toInt64():haxe.Int64 {
 		return cast this;
 	}

--- a/std/cpp/Int64.hx
+++ b/std/cpp/Int64.hx
@@ -24,6 +24,9 @@ package cpp;
 
 @:coreType @:notNull @:runtimeValue abstract Int64 from Int {
 
+	/**
+		Destructively cast to Int
+	**/
 	public inline function toInt():Int {
 		return cast this;
 	}

--- a/std/cpp/Int64.hx
+++ b/std/cpp/Int64.hx
@@ -23,6 +23,11 @@
 package cpp;
 
 @:coreType @:notNull @:runtimeValue abstract Int64 from Int {
+
+	public inline function toInt():Int {
+		return cast this;
+	}
+
 	@:to
 	#if !cppia inline #end function toInt64():haxe.Int64 {
 		return cast this;

--- a/std/cpp/UInt64.hx
+++ b/std/cpp/UInt64.hx
@@ -24,6 +24,9 @@ package cpp;
 
 @:coreType @:notNull @:runtimeValue abstract UInt64 from Int {
 
+	/**
+		Destructively cast to Int
+	**/
 	public inline function toInt():Int {
 		return cast this;
 	}

--- a/std/cpp/UInt64.hx
+++ b/std/cpp/UInt64.hx
@@ -31,4 +31,10 @@ package cpp;
 		return cast this;
 	}
 
+	@:to
+	@:deprecated("Implicit cast from UInt64 to Int (32 bits) is deprecated. Use .toInt() or explicitly cast instead.")
+	inline function implicitToInt(): Int {
+		return toInt();
+	}
+
 }

--- a/std/cpp/UInt64.hx
+++ b/std/cpp/UInt64.hx
@@ -22,4 +22,10 @@
 
 package cpp;
 
-@:coreType @:notNull @:runtimeValue abstract UInt64 from Int {}
+@:coreType @:notNull @:runtimeValue abstract UInt64 from Int {
+
+	public inline function toInt():Int {
+		return cast this;
+	}
+
+}

--- a/std/cpp/UInt64.hx
+++ b/std/cpp/UInt64.hx
@@ -22,4 +22,4 @@
 
 package cpp;
 
-@:coreType @:notNull @:runtimeValue abstract UInt64 from Int to Int {}
+@:coreType @:notNull @:runtimeValue abstract UInt64 from Int {}

--- a/std/hl/I64.hx
+++ b/std/hl/I64.hx
@@ -31,4 +31,10 @@ package hl;
 		return cast this;
 	}
 
+	@:to
+	@:deprecated("Implicit cast from I64 to Int (32 bits) is deprecated. Use .toInt() or explicitly cast instead.")
+	inline function implicitToInt(): Int {
+		return toInt();
+	}
+
 }

--- a/std/hl/I64.hx
+++ b/std/hl/I64.hx
@@ -22,4 +22,10 @@
 
 package hl;
 
-@:coreType @:notNull @:runtimeValue abstract I64 from Int {}
+@:coreType @:notNull @:runtimeValue abstract I64 from Int {
+
+	public inline function toInt():Int {
+		return cast this;
+	}
+
+}

--- a/std/hl/I64.hx
+++ b/std/hl/I64.hx
@@ -22,4 +22,4 @@
 
 package hl;
 
-@:coreType @:notNull @:runtimeValue abstract I64 to Int from Int {}
+@:coreType @:notNull @:runtimeValue abstract I64 from Int {}

--- a/std/hl/I64.hx
+++ b/std/hl/I64.hx
@@ -24,6 +24,9 @@ package hl;
 
 @:coreType @:notNull @:runtimeValue abstract I64 from Int {
 
+	/**
+		Destructively cast to Int
+	**/
 	public inline function toInt():Int {
 		return cast this;
 	}


### PR DESCRIPTION
Remove implicit int32 cast for `cpp.Int64`, `cpp.UInt64` and `hl.I64` and add an explicit `toInt()` function

These types now match the explicit cast behavior of the other Int64 types for CS, Eval, Java and haxe.Int64

**Motivation**
Previously when handling Int64s on cpp they could become Int32s without the user realising (#10100, #9872). Generally if handling Int64s, the user explicitly requires the extra bits so losing them implicitly can often result in hard to debug runtime issues

**Impact**
- Does not affect any existing tests
- Will now generate an error for implicit `Int64` -> `Int` casts, which will hopefully be indicating potential bugs. The resolution is to use `.toInt()`

closes #10108 