### PR TITLE
[std] use direct from cast for Any

### DIFF
--- a/std/Any.hx
+++ b/std/Any.hx
@@ -32,12 +32,9 @@
 	to another type.
 **/
 @:forward.variance
-abstract Any(Dynamic) {
+abstract Any(Dynamic) from Dynamic {
 	@:noCompletion @:to extern inline function __promote<T>():T
 		return this;
-
-	@:noCompletion @:from extern inline static function __cast<T>(value:T):Any
-		return cast value;
 
 	@:noCompletion extern inline function toString():String
 		return Std.string(this);

--- a/tests/unit/src/unit/issues/Issue10148.hx
+++ b/tests/unit/src/unit/issues/Issue10148.hx
@@ -1,0 +1,17 @@
+package unit.issues;
+
+private enum FooBar {
+  Foo;
+  Bar(value: Any);
+}
+
+class Issue10148 extends Test {
+  function test() {
+    var bar: FooBar = Bar(0);
+    var matched = switch (bar) {
+      case Bar(0): true;
+      case _: false;
+    }
+    eq(true, matched);
+  }
+}


### PR DESCRIPTION
Revert [workaround](https://github.com/HaxeFoundation/haxe/commit/aa0e31381f8546df4648d70c99ae79e227caf6da) for #5506 since transitivity changes should have solved the underlying problem and it is now possible to use direct cast again instead of a field one.