### PR TITLE
#5890 Method typeparameter constraints

### DIFF
--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -323,7 +323,7 @@ let duplicate t =
 exception ApplyParamsRecursion
 
 (* substitute parameters with other types *)
-let apply_params ?stack cparams params t =
+let apply_params ?stack ?substs cparams params t =
 	match cparams with
 	| [] -> t
 	| _ ->
@@ -334,7 +334,10 @@ let apply_params ?stack cparams params t =
 		| (_,t1) :: l1 , t2 :: l2 -> (t1,t2) :: loop l1 l2
 		| _ -> die "" __LOC__
 	in
-	let subst = loop cparams params in
+	let subst = match substs with 
+		| None -> loop cparams params 
+		| Some (s) -> s @ (loop cparams params)
+		in
 	let rec loop t =
 		try
 			List.assq t subst

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -350,17 +350,16 @@ module Inheritance = struct
 			end
 		| _ -> error "Should extend by using a class" p
 
-	let map_params substs from_p to_p =
-		List.iter2 
-			(fun (_, p1) p2 -> if p1 != p2 then (Hashtbl.add substs p1 p2))
-			from_p to_p
-
 	let map_constraints cl ipth substs =
-		let rec gather_super cl = match cl.cl_super with
+		let map_params substs from_p to_p =
+			List.iter2 
+				(fun (_, p1) p2 -> if p1 != p2 then (Hashtbl.add substs p1 p2))
+				from_p to_p in
+		let gather_super cl = match cl.cl_super with
 			| Some (scl, tparams) -> map_params substs scl.cl_params tparams
 			| None -> ()
 			in
-		let rec ifinder =
+		let ifinder =
 			try	Some (List.find (fun (ifc, _) -> ifc.cl_path = ipth) cl.cl_implements)
 			with Not_found -> 	None
 		in begin

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -77,8 +77,8 @@ let valid_redefinition ctx f1 t1 f2 t2 subst = (* child, parent *)
 									see more #5890 *)
 										| None -> t
 										| Some (from_p, to_p) -> find_subst to_p in
-									let t1 = find_subst ( apply_params l1 monos (apply_params c1.cl_params pl1 t1) ) in
-									let t2 = find_subst ( apply_params l2 monos (apply_params c2.cl_params pl2 t2) ) in
+									let t1 = find_subst ( apply_params ~substs:subst l1 monos (apply_params ~substs:subst c1.cl_params pl1 t1) ) in
+									let t2 = find_subst ( apply_params ~substs:subst l2 monos (apply_params ~substs:subst c2.cl_params pl2 t2) ) in
 									type_eq EqStrict t1 t2
 								with Unify_error l ->
 									raise (Unify_error (Unify_custom "Constraints differ" :: l))

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -46,7 +46,7 @@ let is_generic_parameter ctx c =
 	with Not_found ->
 		false
 
-let valid_redefinition ctx f1 t1 f2 t2 subst= (* child, parent *)
+let valid_redefinition ctx f1 t1 f2 t2 subst = (* child, parent *)
 	let valid t1 t2 =
 		Type.unify t1 t2;
 		if is_null t1 <> is_null t2 || ((follow t1) == t_dynamic && (follow t2) != t_dynamic) then raise (Unify_error [Cannot_unify (t1,t2)]);
@@ -71,12 +71,12 @@ let valid_redefinition ctx f1 t1 f2 t2 subst= (* child, parent *)
 						let check monos =
 							List.iter2 (fun t1 t2  -> 
 								try
-									let rec find_subst t = match List.assq_opt t subst  with
+									let rec find_subst t = match List.find_opt (fun (key, value) -> (shallow_eq key t)) subst  with
 									(* subst is compatibility mapping of type parameters
 									between class and interfaces/base classes it implements
 									see more #5890 *)
 										| None -> t
-										| Some to_p -> find_subst to_p in
+										| Some (from_p, to_p) -> find_subst to_p in
 									let t1 = find_subst ( apply_params l1 monos (apply_params c1.cl_params pl1 t1) ) in
 									let t2 = find_subst ( apply_params l2 monos (apply_params c2.cl_params pl2 t2) ) in
 									type_eq EqStrict t1 t2
@@ -210,7 +210,7 @@ let check_overriding ctx c f =
 				display_error ctx ("Field " ^ i ^ " has different property access than in superclass") p);
 			if (has_class_field_flag f2 CfFinal) then display_error ctx ("Cannot override final method " ^ i) p;
 			try
-				let substs = ref [] in
+				let substs = ref [] in 
 				let t = apply_params csup.cl_params params t in
 				valid_redefinition ctx f f.cf_type f2 t !substs
 			with

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -377,7 +377,6 @@ module Inheritance = struct
 			check_interface ctx missing c i2 (List.map (apply_params intf.cl_params params) p2) substs;
 		) intf.cl_implements;
 		let p = c.cl_name_pos in
-		(* let vrbs = true in *)
 		let rec check_field i f =
 			let t = (apply_params intf.cl_params params f.cf_type) in
 			let is_overload = ref false in

--- a/tests/unit/src/unit/issues/Issue5890.hx
+++ b/tests/unit/src/unit/issues/Issue5890.hx
@@ -1,0 +1,43 @@
+package unit.issues;
+
+class Issue5890 extends unit.Test {
+	function test() {
+		new ReporterImplSuc2();
+		noAssert();
+	}
+}
+
+interface Reporter<TDef> {
+	public function shoot<T:TDef>(ctx:T):Void;
+}
+
+class ReporterImpl<A, TDef> implements Reporter<TDef> {
+	public function shoot<T:TDef>(ctx:T):Void {}
+}
+
+class Impl2 implements Reporter<Int> {
+	public function shoot<T:Int>(a:T) {}
+}
+
+class ReporterImplSuc<TDef, A> extends ReporterImpl<A, TDef> implements Reporter<TDef> {}
+
+class ReporterImplSuc2 extends ReporterImpl<Int, String> implements Reporter<String> {
+	public function new() {}
+}
+
+class HierarchyImpl implements ISuc<Float> {
+	public function shoot<A:Float>(a:A) {
+		trace(a + 5);
+	}
+}
+
+class HierarchyImpl2<T> implements ISuc<T> {
+	public function shoot<A:T>(a:A) {}
+}
+
+interface IBase2<T> {
+	function shoot<A:T>(a:A):Void;
+}
+
+interface OtherBase {}
+interface ISuc<T> extends IBase2<T> extends OtherBase {}

--- a/tests/unit/src/unit/issues/Issue5890.hx
+++ b/tests/unit/src/unit/issues/Issue5890.hx
@@ -41,3 +41,13 @@ interface IBase2<T> {
 
 interface OtherBase {}
 interface ISuc<T> extends IBase2<T> extends OtherBase {}
+class StatBase<T:{}> {}
+class ShotContext<TDef:{}, T:StatBase<TDef>> {}
+
+interface WeaponReporter<TDef:{}> {
+	public function shoot<T:StatBase<TDef>>(ctx:ShotContext<TDef, T>):Void;
+}
+
+class StatWeaponReporterImpl<TDef:{}> implements WeaponReporter<TDef> {
+	public function shoot<T:StatBase<TDef>>(ctx:ShotContext<TDef, T>):Void {}
+}


### PR DESCRIPTION
resolves #5890

Hi guys, I made this working. The implementation based on hashtable with mapping Foo.T → Bar.T all the way through inheritance chain (Naming from #5890 description). I’m pretty not sure in performance impact so pls look closely if this solution suitable.

BTW How do you use the debugger from VSCode? I’ve found it very useful to inspect complex structures but it very annoying to unfold a tons of folded items so i’d patched VSCode to be able configure “unfold depth” for the debugger popup. I’m not sure if it would be handy for anyone else so should I try to PR it to VSCode or so. Also I'd spend a damn lot of time to set up the working env, where do you discuss such kind of things?