### PR TITLE
tackle field inits in this-before-super situation

### DIFF
--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -502,7 +502,16 @@ let add_field_inits locals ctx t =
 				match cf.cf_expr with
 				| Some { eexpr = TFunction f } ->
 					let bl = match f.tf_expr with {eexpr = TBlock b } -> b | x -> [x] in
-					let ce = mk (TFunction {f with tf_expr = mk (TBlock (el @ bl)) ctx.com.basic.tvoid c.cl_pos }) cf.cf_type cf.cf_pos in
+					let bl =
+						if (not ctx.com.config.pf_this_before_super
+							&& Meta.has (Meta.Custom ":passThroughCtor") cf.cf_meta
+							&& Meta.has (Meta.Custom ":safe") cf.cf_meta
+						) then
+							bl @ el
+						else
+							el @ bl
+					in
+					let ce = mk (TFunction {f with tf_expr = mk (TBlock bl) ctx.com.basic.tvoid c.cl_pos }) cf.cf_type cf.cf_pos in
 					{cf with cf_expr = Some ce };
 				| _ ->
 					die "" __LOC__

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -186,10 +186,13 @@ let add_constructor ctx c force_constructor p =
 	let constructor = try Some (Type.get_constructor_class c (List.map snd c.cl_params)) with Not_found -> None in
 	match constructor with
 	| Some(cfsup,csup,cparams) when not (has_class_flag c CExtern) ->
+		let filter_meta (m,_,_) =
+			m = Meta.CompilerGenerated || m = Meta.Custom ":safe"
+		in
 		let cf = {
 			cfsup with
 			cf_pos = p;
-			cf_meta = List.filter (fun (m,_,_) -> m = Meta.CompilerGenerated) cfsup.cf_meta;
+			cf_meta = (Meta.Custom ":passThroughCtor",[],null_pos) :: (List.filter filter_meta cfsup.cf_meta);
 			cf_doc = None;
 			cf_expr = None;
 		} in


### PR DESCRIPTION
An experimental attempt to "deal" with https://github.com/HaxeFoundation/haxe/issues/10103#issuecomment-774503141:

1) when generating default inherited constructors, add `@:passThroughCtor` meta and inherit `@:safe` (will have to think of a better name) meta
2) when generating field inits, if it's a pass-through ctor for a safe one - generate field inits in the end (so they will appear after the generated `super` call)

This will allow ES6 inheritance without constructor redefinition but with added field inits, like this

```haxe
extern class ES6Class {
  @:safe function new();
}

class HaxeClass extends ES6Class {
  var field = 3;
}
```

```js
class HaxeClass extends ES6Class {
  constructor() {
    super();
    this.field = 3;
  }
}
```

I'm not sure how useful is this in practice though, because the moment you add an explicit constructor it will start complaining again, and I don't know if we should try to mess with user-defined constructor bodies and insert field inits between `super(...)` and other expressions that user has written explicitly.

I'd appreciate some input from @kLabz @elsassph @back2dos ;)