### PR TITLE
Keep reverse constraints list in `tmono`

### DIFF
--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -45,6 +45,7 @@ type t =
 and tmono = {
 	mutable tm_type : t option;
 	mutable tm_constraints : tmono_constraint list;
+	mutable tm_dependants : (tmono * string option) list; (* monomorphs which has this one as a constraint *)
 }
 
 and tmono_constraint =

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -52,7 +52,6 @@ let check_constraint name f =
 
 let unify_ref : (unification_context -> t -> t -> unit) ref = ref (fun _ _ _ -> ())
 let unify_min_ref : (unification_context -> t -> t list -> unify_min_result) ref = ref (fun _ _ _ -> assert false)
-let type_eq_ref : (unification_context -> t -> t -> unit) ref = ref (fun _ _ _ -> ())
 
 let default_unification_context = {
 	allow_transitive_cast = true;
@@ -70,11 +69,13 @@ module Monomorph = struct
 	}
 
 	(* constraining *)
+	let add_dependant m dep =
+		m.tm_dependants <- dep :: m.tm_dependants
 
 	let add_constraint m constr =
 		m.tm_constraints <- constr :: m.tm_constraints;
 		match constr with
-		| MMono (m2,s) -> m2.tm_dependants <- (m,s) :: m2.tm_dependants
+		| MMono (m2,s) -> add_dependant m2 (m,s)
 		| _ -> ()
 
 	let constraint_of_type name t = match follow t with
@@ -161,65 +162,24 @@ module Monomorph = struct
 		m.tm_dependants <- []
 
 	(**
-		Check this monomorph does not cause conflicts in constraints of its dependants.
+		Check `t` does not conflict with dependants of `m`.
 	*)
-	let rec validate_dependants m =
-		let t = TMono m in
-		let rec get_check m2 =
-			match m2.tm_type with
-			| Some t2 ->
-				(match follow t2 with
-				| TMono m2 ->
-					get_check m2
-				| _ ->
-					(fun() -> (!unify_ref) default_unification_context t t2)
-				)
-			| None ->
-				let check() =
-					let m2_copy = { m2 with tm_type = m2.tm_type } in
-					(!unify_ref) default_unification_context t (TMono m2_copy)
-				in
-				let check_anon own_fields dependant_fields () =
-					PMap.iter (fun name f ->
-						try
-							let f2 = PMap.find name dependant_fields in
-							(!type_eq_ref) default_unification_context f.cf_type f2.cf_type
-						with Not_found ->
-							error [Has_no_field (t,name)];
-					) own_fields
-				in
-				match classify_constraints m2 with
-				| CStructural (fields,_) ->
-					(match follow t with
-					| TAnon a ->
-						check_anon a.a_fields fields
-					| TMono _ ->
-						(match classify_constraints m with
-						| CStructural (own_fields,_) -> check_anon own_fields fields
-						| _ -> check
-						)
-					|_ ->
-						check
-					)
-				| _ ->
-					check
-		in
+	let rec validate_dependants m t =
 		List.iter (fun (m2,constraint_name) ->
-			let original_constraints = m2.tm_constraints in
-			m2.tm_constraints <- List.filter (function
-				| MMono (m',_) -> m' != m
-				| _ -> true
-			) m2.tm_constraints;
-			Std.finally
-				(fun() -> m2.tm_constraints <- original_constraints)
-				(fun() ->
-					let f = get_check m2 in
-					(match constraint_name with
-					| Some name -> check_constraint name f
-					| None -> f());
-					validate_dependants m2
-				)
-				()
+			(match m2.tm_type with
+			| None -> ()
+			| Some t2 ->
+				match follow t2 with
+				| TMono _ -> ()
+				| _ ->
+					let check() =
+						(!unify_ref) default_unification_context t t2
+					in
+					match constraint_name with
+					| Some name -> check_constraint name check
+					| None -> check()
+			);
+			validate_dependants m2 t
 		) m.tm_dependants
 
 	let rec bind m t =
@@ -233,6 +193,7 @@ module Monomorph = struct
 			if m != m2 then begin match m2.tm_type with
 			| None ->
 				List.iter (add_constraint m2) m.tm_constraints;
+				List.iter (add_dependant m2) m.tm_dependants;
 				do_bind m t;
 			| Some t ->
 				bind m t
@@ -242,13 +203,8 @@ module Monomorph = struct
 			   against before checking the constraints. *)
 			m.tm_type <- Some t;
 			let monos,kind = classify_constraints' m in
-			Std.finally
-				(fun () -> m.tm_type <- None)
-				(fun () ->
-					check_constraints kind t;
-					validate_dependants m
-				)
-				();
+			Std.finally (fun () -> m.tm_type <- None) (fun () -> check_constraints kind t) ();
+			validate_dependants m t;
 			(* If the monomorph we're binding to has other yet unbound monomorphs, constrain them to our target type (issue #9640) .*)
 			List.iter (fun m2 ->
 				constrain_to_type m2 None t;
@@ -1216,5 +1172,4 @@ end
 ;;
 unify_ref := unify_custom;;
 unify_min_ref := UnifyMinT.unify_min;;
-type_eq_ref := type_eq_custom;;
 monomorph_classify_constraints_ref := Monomorph.classify_constraints

--- a/tests/misc/projects/Issue10198/Main1.hx
+++ b/tests/misc/projects/Issue10198/Main1.hx
@@ -1,0 +1,12 @@
+function fn1<T1,R1:T1>(v:R1):T1
+	return null;
+
+function fn2<T2,R2:T2>(v:R2):T2
+	return null;
+
+function fn3<T3,R3:T3>(v:R3):T3
+	return null;
+
+function main() {
+	var b:Array<Int> = fn1(fn2(fn3(['s'])));
+}

--- a/tests/misc/projects/Issue10198/Main2.hx
+++ b/tests/misc/projects/Issue10198/Main2.hx
@@ -1,0 +1,31 @@
+class Main2 {
+	static function main() {
+		var foo:Vector<Foo> = null;
+		var bar:Vector<Bar> = Vector.fromIterable(foo);
+	}
+}
+
+typedef Foo = {
+	final id:String;
+	final ?project:String;
+}
+
+typedef Bar = {
+	final id:String;
+	final createDate:Date;
+}
+
+abstract Vector<T>(Array<T>) {
+
+	inline function new(a)
+		this = a;
+
+	@:from static function fromVector<T, R:T>(v:Vector<R>):Vector<T>
+		return cast v;
+
+	static public function fromIterable<T, R:T>(v:Iterable<R>):Vector<T>
+		return null;
+
+	@:to public function toArray()
+		return this.copy();
+}

--- a/tests/misc/projects/Issue10198/Main2.hx
+++ b/tests/misc/projects/Issue10198/Main2.hx
@@ -1,18 +1,8 @@
 class Main2 {
 	static function main() {
-		var foo:Vector<Foo> = null;
-		var bar:Vector<Bar> = Vector.fromIterable(foo);
+		var foo:Vector<String> = null;
+		var bar:Vector<Int> = Vector.fromIterable(foo);
 	}
-}
-
-typedef Foo = {
-	final id:String;
-	final ?project:String;
-}
-
-typedef Bar = {
-	final id:String;
-	final createDate:Date;
 }
 
 abstract Vector<T>(Array<T>) {

--- a/tests/misc/projects/Issue10198/compile1-fail.hxml
+++ b/tests/misc/projects/Issue10198/compile1-fail.hxml
@@ -1,0 +1,1 @@
+--main Main1

--- a/tests/misc/projects/Issue10198/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10198/compile1-fail.hxml.stderr
@@ -1,0 +1,3 @@
+Main1.hx:11: characters 2-42 : error: Int should be String
+Main1.hx:11: characters 2-42 : ... have: Array<Int>
+Main1.hx:11: characters 2-42 : ... want: Array<String>

--- a/tests/misc/projects/Issue10198/compile2-fail.hxml
+++ b/tests/misc/projects/Issue10198/compile2-fail.hxml
@@ -1,0 +1,1 @@
+--main Main2

--- a/tests/misc/projects/Issue10198/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10198/compile2-fail.hxml.stderr
@@ -1,0 +1,3 @@
+Main2.hx:4: characters 3-50 : error: { id : String, createDate : Date } has no field project
+Main2.hx:4: characters 3-50 : ... have: Vector<Bar>
+Main2.hx:4: characters 3-50 : ... want: Vector<{ ?project, id }>

--- a/tests/misc/projects/Issue10198/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10198/compile2-fail.hxml.stderr
@@ -1,3 +1,3 @@
-Main2.hx:4: characters 3-50 : error: { id : String, createDate : Date } has no field project
-Main2.hx:4: characters 3-50 : ... have: Vector<Bar>
-Main2.hx:4: characters 3-50 : ... want: Vector<{ ?project, id }>
+Main2.hx:4: characters 3-50 : error: Int should be String
+Main2.hx:4: characters 3-50 : ... have: Vector<Int>
+Main2.hx:4: characters 3-50 : ... want: Vector<String>


### PR DESCRIPTION
Fixes #10198

Field `tmono.tm_dependants` contains a list of monos constrained to the current one.

Upon binding a mono to a type we traverse back the constraints chain and check if all bound monos are compatible with that type.
