### PR TITLE
Update depends in opam file

### DIFF
--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
   "dune" {>= "1.11"}
-  "camlp5" {build & = "8.00~alpha05"}
+  "camlp5" {build & = "8.00"}
   "sedlex" {>= "2.0"}
   "xml-light"
   "extlib" {>= "1.7.8"}


### PR DESCRIPTION
* Use `camlp` 8.00 (stable - bump from 8.00-alpha05)

This enables installation on m1 Macs. I've run through the unit tests, the sys tests, and the null safety tests on an m1 Mac and they pass. There are issues with other tests, but this is a good first step, and is usable for the managed code targets (i.e. anything except cpp, which fails due to inline assembly code in `hxcpp` library expecting to target x86 or x86_64 architecture.)

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>