### PR TITLE
upgrade camlp5 to 8.0.0 to allow building Haxe with OCaml 4.12

### DIFF
--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
   "dune" {>= "1.11"}
-  "camlp5" {build & = "8.00~alpha05"}
+  "camlp5" {build & = "8.00"}
   "sedlex" {>= "2.0"}
   "xml-light"
   "extlib" {>= "1.7.8"}


### PR DESCRIPTION
When trying to build Haxe with OCaml 4.12. The following error occurs due to [camlp5 8.0.0~alpha5](https://opam.ocaml.org/packages/camlp5/camlp5.8.00~alpha05/) is limited to `ocaml < 4.12`:

```
$ opam install haxe --deps-only

<><> Synchronising pinned packages ><><><><><><><><><><><><><><><><><><><><>  🐫
[haxe.4.2.0] synchronised from file:///Users/poga/projects/haxe
[haxe] Installing new package description from upstream file:///Users/poga/projects/haxe

The following dependencies couldn't be met:
  - haxe → camlp5 = 8.00~alpha05 → ocaml < 4.12.0
      base of this switch (use `--unlock-base' to force)

No solution found, exiting
```

This PR upgrade `camlp5` to [8.00](https://opam.ocaml.org/packages/camlp5/camlp5.8.00/) and makes OCaml 4.12.0 compiles Haxe successfully.