### PR TITLE
[js] Use type parameters in all(), allSettled() and race()

### DIFF
--- a/std/js/lib/Promise.hx
+++ b/std/js/lib/Promise.hx
@@ -60,6 +60,7 @@ extern class Promise<T> {
 		useful for aggregating results of multiple promises.
 	**/
 	@:overload(function(iterable:Array<Dynamic>):Promise<Array<Dynamic>> {})
+	@:overload(function<T>(iterable:Array<T>):Promise<Array<T>> {})
 	static function all<T>(iterable:Array<Promise<T>>):Promise<Array<T>>;
 
 	/**
@@ -73,6 +74,7 @@ extern class Promise<T> {
 		on each other / if you'd like to immediately reject upon any of them rejecting.
 	**/
 	@:overload(function(iterable:Array<Dynamic>):Promise<Array<PromiseSettleOutcome<Dynamic>>> {})
+	@:overload(function<T>(iterable:Array<T>):Promise<Array<PromiseSettleOutcome<T>>> {})
 	static function allSettled<T>(iterable:Array<Promise<T>>):Promise<Array<PromiseSettleOutcome<T>>>;
 
 	/**
@@ -81,6 +83,7 @@ extern class Promise<T> {
 		from that promise.
 	**/
 	@:overload(function(iterable:Array<Dynamic>):Promise<Dynamic> {})
+	@:overload(function<T>(iterable:Array<T>):Promise<T> {})
 	static function race<T>(iterable:Array<Promise<T>>):Promise<T>;
 
 	/** @throws DOMError */

--- a/std/js/lib/Promise.hx
+++ b/std/js/lib/Promise.hx
@@ -59,6 +59,7 @@ extern class Promise<T> {
 		the first promise in the iterable that rejected. This method can be
 		useful for aggregating results of multiple promises.
 	**/
+	@:overload(function(iterable:Array<Dynamic>):Promise<Array<Dynamic>> {})
 	static function all<T>(iterable:Array<Promise<T>>):Promise<Array<T>>;
 
 	/**
@@ -71,6 +72,7 @@ extern class Promise<T> {
 		In comparison, the Promise returned by `Promise.all` may be more appropriate if the tasks are dependent
 		on each other / if you'd like to immediately reject upon any of them rejecting.
 	**/
+	@:overload(function(iterable:Array<Dynamic>):Promise<Array<PromiseSettleOutcome<Dynamic>>> {})
 	static function allSettled<T>(iterable:Array<Promise<T>>):Promise<Array<PromiseSettleOutcome<T>>>;
 
 	/**
@@ -78,6 +80,7 @@ extern class Promise<T> {
 		promises in the iterable fulfills or rejects, with the value or reason
 		from that promise.
 	**/
+	@:overload(function(iterable:Array<Dynamic>):Promise<Dynamic> {})
 	static function race<T>(iterable:Array<Promise<T>>):Promise<T>;
 
 	/** @throws DOMError */

--- a/std/js/lib/Promise.hx
+++ b/std/js/lib/Promise.hx
@@ -60,7 +60,6 @@ extern class Promise<T> {
 		useful for aggregating results of multiple promises.
 	**/
 	@:overload(function(iterable:Array<Dynamic>):Promise<Array<Dynamic>> {})
-	@:overload(function<T>(iterable:Array<T>):Promise<Array<T>> {})
 	static function all<T>(iterable:Array<Promise<T>>):Promise<Array<T>>;
 
 	/**
@@ -74,7 +73,6 @@ extern class Promise<T> {
 		on each other / if you'd like to immediately reject upon any of them rejecting.
 	**/
 	@:overload(function(iterable:Array<Dynamic>):Promise<Array<PromiseSettleOutcome<Dynamic>>> {})
-	@:overload(function<T>(iterable:Array<T>):Promise<Array<PromiseSettleOutcome<T>>> {})
 	static function allSettled<T>(iterable:Array<Promise<T>>):Promise<Array<PromiseSettleOutcome<T>>>;
 
 	/**
@@ -83,7 +81,6 @@ extern class Promise<T> {
 		from that promise.
 	**/
 	@:overload(function(iterable:Array<Dynamic>):Promise<Dynamic> {})
-	@:overload(function<T>(iterable:Array<T>):Promise<T> {})
 	static function race<T>(iterable:Array<Promise<T>>):Promise<T>;
 
 	/** @throws DOMError */

--- a/std/js/lib/Promise.hx
+++ b/std/js/lib/Promise.hx
@@ -59,7 +59,7 @@ extern class Promise<T> {
 		the first promise in the iterable that rejected. This method can be
 		useful for aggregating results of multiple promises.
 	**/
-	static function all(iterable:Array<Dynamic>):Promise<Array<Dynamic>>;
+	static function all<T>(iterable:Array<Promise<T>>):Promise<Array<T>>;
 
 	/**
 		Returns a promise that resolves after all of the given promises have either fulfilled or rejected,
@@ -71,14 +71,14 @@ extern class Promise<T> {
 		In comparison, the Promise returned by `Promise.all` may be more appropriate if the tasks are dependent
 		on each other / if you'd like to immediately reject upon any of them rejecting.
 	**/
-	static function allSettled(iterable:Array<Dynamic>):Promise<Array<PromiseSettleOutcome>>;
+	static function allSettled<T>(iterable:Array<Promise<T>>):Promise<Array<PromiseSettleOutcome<T>>>;
 
 	/**
 		Returns a promise that fulfills or rejects as soon as one of the
 		promises in the iterable fulfills or rejects, with the value or reason
 		from that promise.
 	**/
-	static function race(iterable:Array<Dynamic>):Promise<Dynamic>;
+	static function race<T>(iterable:Array<Promise<T>>):Promise<T>;
 
 	/** @throws DOMError */
 	function new(init:(resolve:(value:T) -> Void, reject:(reason:Dynamic) -> Void) -> Void):Void;
@@ -129,9 +129,9 @@ typedef ThenableStruct<T> = {
 	function then<TOut>(onFulfilled:Null<PromiseHandler<T, TOut>>, ?onRejected:PromiseHandler<Dynamic, TOut>):Thenable<TOut>;
 }
 
-typedef PromiseSettleOutcome = {
+typedef PromiseSettleOutcome<T> = {
 	var status:PromiseSettleStatus;
-	var ?value:Dynamic;
+	var ?value:T;
 	var ?reason:Dynamic;
 }
 


### PR DESCRIPTION
See #10246 

Shouldn't have any impact other than increasing type information

Before:

```haxe
Promise.all([Promise.resolve(4), Promise.resolve(5)]).then(a -> {
	$type(a); // Array<Dynamic>
});
```

After:

```haxe
Promise.all([Promise.resolve(4), Promise.resolve(5)]).then(a -> {
	$type(a); // Array<Int>
});
```