### PR TITLE
Allow passing `null` values to Std.string() when null-safety is enabled

### DIFF
--- a/std/Std.hx
+++ b/std/Std.hx
@@ -83,7 +83,7 @@ extern class Std {
 
 		If s is null, "null" is returned.
 	**/
-	static function string(s:Dynamic):String;
+	static function string(s:Null<Dynamic>):String;
 
 	/**
 		Converts a `Float` to an `Int`, rounded towards 0.

--- a/std/cpp/_std/Std.hx
+++ b/std/cpp/_std/Std.hx
@@ -39,7 +39,7 @@
 		return inline downcast(value, c);
 	}
 
-	@:keep public static function string(s:Dynamic):String {
+	@:keep public static function string(s:Null<Dynamic>):String {
 		return untyped s == null ? "null" : s.toString();
 	}
 

--- a/std/cs/_std/Std.hx
+++ b/std/cs/_std/Std.hx
@@ -66,7 +66,7 @@ import cs.Lib;
 		return false;
 	}
 
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		if (s == null)
 			return "null";
 		if (Std.isOfType(s, Bool))

--- a/std/flash/_std/Std.hx
+++ b/std/flash/_std/Std.hx
@@ -41,7 +41,7 @@ import flash.Boot;
 		return downcast(value, c);
 	}
 
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return flash.Boot.__string_rec(s, "");
 	}
 

--- a/std/hl/_std/Std.hx
+++ b/std/hl/_std/Std.hx
@@ -90,7 +90,7 @@ class Std {
 		return untyped $int(x);
 	}
 
-	@:keep public static function string(s:Dynamic):String {
+	@:keep public static function string(s:Null<Dynamic>):String {
 		var len = 0;
 		var bytes = hl.Bytes.fromValue(s, new hl.Ref(len));
 		return @:privateAccess String.__alloc__(bytes, len);

--- a/std/java/_std/Std.hx
+++ b/std/java/_std/Std.hx
@@ -55,7 +55,7 @@ import java.Lib;
 		return clt.isAssignableFrom(clv);
 	}
 
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return cast(s, String) + "";
 	}
 

--- a/std/js/_std/Std.hx
+++ b/std/js/_std/Std.hx
@@ -44,7 +44,7 @@ import js.Syntax;
 	}
 
 	@:pure
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return @:privateAccess js.Boot.__string_rec(s, "");
 	}
 

--- a/std/jvm/_std/Std.hx
+++ b/std/jvm/_std/Std.hx
@@ -55,7 +55,7 @@ class Std {
 		return clt.isAssignableFrom((v : java.lang.Object).getClass());
 	}
 
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return jvm.Jvm.toString(s);
 	}
 

--- a/std/lua/_std/Std.hx
+++ b/std/lua/_std/Std.hx
@@ -44,7 +44,7 @@ import lua.NativeStringTools;
 	}
 
 	@:keep
-	public static function string(s:Dynamic) : String {
+	public static function string(s:Null<Dynamic>): String {
 		return untyped _hx_tostring(s, 0);
 	}
 

--- a/std/neko/_std/Std.hx
+++ b/std/neko/_std/Std.hx
@@ -39,7 +39,7 @@
 		return inline downcast(value, c);
 	}
 
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return new String(untyped __dollar__string(s));
 	}
 

--- a/std/php/_std/Std.hx
+++ b/std/php/_std/Std.hx
@@ -43,7 +43,7 @@ import php.Syntax;
 		return Boot.isOfType(value, cast c) ? cast value : null;
 	}
 
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return Boot.stringify(s);
 	}
 

--- a/std/python/_std/Std.hx
+++ b/std/python/_std/Std.hx
@@ -118,7 +118,7 @@ import python.Syntax;
 	}
 
 	@:access(python.Boot)
-	public static function string(s:Dynamic):String {
+	public static function string(s:Null<Dynamic>):String {
 		return python.Boot.toString(s);
 	}
 

--- a/tests/display/src/cases/Issue7171.hx
+++ b/tests/display/src/cases/Issue7171.hx
@@ -9,6 +9,6 @@ class Issue7171 extends DisplayTestCase {
 		}
 	**/
 	function test() {
-		eq("(s : Dynamic) -> String", type(pos(1)));
+		eq("(s : Null<Dynamic>) -> String", type(pos(1)));
 	}
 }

--- a/tests/nullsafety/src/cases/TestLoose.hx
+++ b/tests/nullsafety/src/cases/TestLoose.hx
@@ -65,6 +65,10 @@ class TestLoose {
 		bar();
 	}
 
+	function stdString_assignNull_shouldPass() {
+		Std.string(null);
+	}
+
 	static var struct:Null<{foo:String}>;
 
 	static function checkAgainstNull_checkAndFieldAccess() {


### PR DESCRIPTION
This should solve #10272 