### PR TITLE
[js] Added "-D js-global" to customizes the global object name

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -319,6 +319,12 @@
 		"platforms": ["js"]
 	},
 	{
+		"name": "JsGlobal",
+		"define": "js_global",
+		"doc": "Customizes the global object name.",
+		"platforms": ["js"]
+	},
+	{
 		"name": "JsUnflatten",
 		"define": "js_unflatten",
 		"doc": "Generate nested objects for packages and types.",

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1893,11 +1893,11 @@ let generate com =
 
 	let defined_global = defined_global_value <> "" in
 
-	let rec typeof_join l = (match l with
+	let rec typeof_join = function
 	| x :: [] -> x
 	| x :: l -> "typeof " ^ x ^ " != \"undefined\" ? " ^ x ^ " : " ^ (typeof_join l)
 	| _ -> ""
-	) in
+	in
 
 	let var_exports = (
 		"$hx_exports",

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1889,19 +1889,24 @@ let generate com =
 		| _ -> ()
 	) include_files;
 
-	let var_console = (
-		"console",
-		"typeof console != \"undefined\" ? console : {log:function(){}}"
+	let defined_global_value = Common.defined_value_safe com Define.JsGlobal in
+
+	let defined_global = defined_global_value <> "" in
+
+	let rec typeof_join l = (match l with
+	| x :: [] -> x
+	| x :: l -> "typeof " ^ x ^ " != \"undefined\" ? " ^ x ^ " : " ^ (typeof_join l)
+	| _ -> ""
 	) in
 
 	let var_exports = (
 		"$hx_exports",
-		"typeof exports != \"undefined\" ? exports : typeof window != \"undefined\" ? window : typeof self != \"undefined\" ? self : this"
+		typeof_join (if defined_global then ["exports"; defined_global_value] else ["exports"; "window"; "self"; "this"])
 	) in
 
 	let var_global = (
 		"$global",
-		"typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this"
+		typeof_join (if defined_global then [defined_global_value] else ["window"; "global"; "self"; "this"])
 	) in
 
 	let closureArgs = [var_global] in
@@ -1912,7 +1917,7 @@ let generate com =
 	in
 	(* Provide console for environments that may not have it. *)
 	let closureArgs = if ctx.es_version < 5 then
-		var_console :: closureArgs
+		("console", typeof_join ["console"; "{log:function(){}}"]) :: closureArgs
 	else
 		closureArgs
 	in
@@ -2067,7 +2072,7 @@ let generate com =
 	| Some e -> gen_expr ctx e; newline ctx);
 	if ctx.js_modern then begin
 		let closureArgs =
-			if has_feature ctx "js.Lib.global" then
+			if has_feature ctx "js.Lib.global" || defined_global then
 				closureArgs
 			else
 				(* no need for `typeof window != "undefined" ? window : typeof global != "undefined" ? <...>` *)


### PR DESCRIPTION
Related to #10258

It's used in some strange js environments, for example: You can use `-D js-global=GameGlobal` for WeChat mini-games,

And the one corresponding to AudioWorklet is `-D js-global=globalThis`

Even for nodejs, the code generated by `-D js-global=global` is more cleaner when you use `@:expose`

