### PR TITLE
Add methods to get Map and EReg sizes

### DIFF
--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -916,6 +916,12 @@ module StdEReg = struct
 			vfalse
 		end
 	)
+	
+	let matchedNum = vifun0 (fun vthis ->
+		let this = this vthis in
+		if Array.length this.r_groups = 0 then exc_string "Invalid regex operation because no match was made" else this.r_groups.(0) in
+		vint (num_of_subs substrings)
+	)
 
 	let replace = vifun2 (fun vthis s by ->
 		let this = this vthis in
@@ -1546,6 +1552,10 @@ module StdIntMap = struct
 		IntHashtbl.clear (this vthis);
 		vnull
 	)
+	
+	let get_size = vifun0 (fun vthis ->
+		vint (IntHashtbl.size (this vthis))
+	)
 end
 
 module StdStringMap = struct
@@ -1605,6 +1615,10 @@ module StdStringMap = struct
 		StringHashtbl.clear (this vthis);
 		vnull
 	)
+	
+	let get_size = vifun0 (fun vthis ->
+		vint (StringHashtbl.size (this vthis))
+	)
 end
 
 module StdObjectMap = struct
@@ -1662,6 +1676,10 @@ module StdObjectMap = struct
 	let clear = vifun0 (fun vthis ->
 		ValueHashtbl.reset (this vthis);
 		vnull
+	)
+	
+	let get_size = vifun0 (fun vthis ->
+		vint (ValueHashtbl.length (this vthis))
 	)
 end
 
@@ -3155,6 +3173,7 @@ let init_maps builtins =
 		"set",StdIntMap.set;
 		"toString",StdIntMap.toString;
 		"clear",StdIntMap.clear;
+		"get_size",StdIntMap.get_size;
 	];
 	init_fields builtins (["haxe";"ds"],"ObjectMap") [] [
 		"copy",StdObjectMap.copy;
@@ -3167,6 +3186,7 @@ let init_maps builtins =
 		"set",StdObjectMap.set;
 		"toString",StdObjectMap.toString;
 		"clear",StdObjectMap.clear;
+		"get_size",StdObjectMap.get_size;
 	];
 	init_fields builtins (["haxe";"ds"],"StringMap") [] [
 		"copy",StdStringMap.copy;
@@ -3179,6 +3199,7 @@ let init_maps builtins =
 		"set",StdStringMap.set;
 		"toString",StdStringMap.toString;
 		"clear",StdStringMap.clear;
+		"get_size",StdStringMap.get_size;
 	]
 
 let init_constructors builtins =
@@ -3450,6 +3471,7 @@ let init_standard_library builtins =
 		"matchedPos",StdEReg.matchedPos;
 		"matchedRight",StdEReg.matchedRight;
 		"matchSub",StdEReg.matchSub;
+		"matchedNum",StdEReg.matchedNum;
 		"replace",StdEReg.replace;
 		"split",StdEReg.split;
 	];

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -919,7 +919,7 @@ module StdEReg = struct
 	
 	let matchedNum = vifun0 (fun vthis ->
 		let this = this vthis in
-		if Array.length this.r_groups = 0 then exc_string "Invalid regex operation because no match was made" else this.r_groups.(0) in
+		let substrings = if Array.length this.r_groups = 0 then exc_string "Invalid regex operation because no match was made" else this.r_groups.(0) in
 		vint (num_of_subs substrings)
 	)
 

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -1553,7 +1553,7 @@ module StdIntMap = struct
 		vnull
 	)
 	
-	let get_size = vifun0 (fun vthis ->
+	let size = vifun0 (fun vthis ->
 		vint (IntHashtbl.size (this vthis))
 	)
 end
@@ -1616,7 +1616,7 @@ module StdStringMap = struct
 		vnull
 	)
 	
-	let get_size = vifun0 (fun vthis ->
+	let size = vifun0 (fun vthis ->
 		vint (StringHashtbl.size (this vthis))
 	)
 end
@@ -1678,7 +1678,7 @@ module StdObjectMap = struct
 		vnull
 	)
 	
-	let get_size = vifun0 (fun vthis ->
+	let size = vifun0 (fun vthis ->
 		vint (ValueHashtbl.length (this vthis))
 	)
 end
@@ -3173,7 +3173,7 @@ let init_maps builtins =
 		"set",StdIntMap.set;
 		"toString",StdIntMap.toString;
 		"clear",StdIntMap.clear;
-		"get_size",StdIntMap.get_size;
+		"size",StdIntMap.size;
 	];
 	init_fields builtins (["haxe";"ds"],"ObjectMap") [] [
 		"copy",StdObjectMap.copy;
@@ -3186,7 +3186,7 @@ let init_maps builtins =
 		"set",StdObjectMap.set;
 		"toString",StdObjectMap.toString;
 		"clear",StdObjectMap.clear;
-		"get_size",StdObjectMap.get_size;
+		"size",StdObjectMap.size;
 	];
 	init_fields builtins (["haxe";"ds"],"StringMap") [] [
 		"copy",StdStringMap.copy;
@@ -3199,7 +3199,7 @@ let init_maps builtins =
 		"set",StdStringMap.set;
 		"toString",StdStringMap.toString;
 		"clear",StdStringMap.clear;
-		"get_size",StdStringMap.get_size;
+		"size",StdStringMap.size;
 	]
 
 let init_constructors builtins =

--- a/src/macro/eval/evalValue.ml
+++ b/src/macro/eval/evalValue.ml
@@ -57,6 +57,7 @@ module StringHashtbl = struct
 	let mem this key = StringMap.mem key.sstring !this
 	let remove this key = this := StringMap.remove key.sstring !this
 	let clear this = this := StringMap.empty
+	let size this = StringMap.cardinal !this
 end
 
 module IntHashtbl = struct
@@ -72,6 +73,7 @@ module IntHashtbl = struct
 	let mem this key = Hashtbl.mem this key
 	let remove this key = Hashtbl.remove this key
 	let clear this = Hashtbl.clear this
+	let size this = Hashtbl.length this
 end
 
 type vregex = {

--- a/std/EReg.hx
+++ b/std/EReg.hx
@@ -133,6 +133,18 @@ class EReg {
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		return false;
 	}
+	
+	/**
+		Returns the total number of groups captures by the last matched substring.
+		
+		To stay consistent with `this.matched`, the matched substring is also
+		counted as a group.
+		
+		If no substring has been matched, an error is thrown.
+	**/
+	public function matchedNum():Int {
+		return 0;
+	}
 
 	/**
 		Splits String `s` at all substrings `this` EReg matches.

--- a/std/cpp/_std/EReg.hx
+++ b/std/cpp/_std/EReg.hx
@@ -70,6 +70,13 @@
 			last = null;
 		return p;
 	}
+	
+	public function matchedNum():Int {
+		var num = _hx_regexp_matched_num(r);
+		if (num == -1)
+			throw "No string matched!";
+		return num;
+	}
 
 	public function split(s:String):Array<String> {
 		var pos = 0;

--- a/std/cpp/_std/haxe/ds/IntMap.hx
+++ b/std/cpp/_std/haxe/ds/IntMap.hx
@@ -52,8 +52,6 @@ package haxe.ds;
   inline String get_string(int key) { return __int_hash_get_string(h,key); }
 ")
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never): Int;
-	
 	@:ifFeature("haxe.ds.IntMap.*")
 	private var h:Dynamic;
 
@@ -108,7 +106,7 @@ package haxe.ds;
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		return untyped __global__.__root_hash_size(h);
 	}
 

--- a/std/cpp/_std/haxe/ds/IntMap.hx
+++ b/std/cpp/_std/haxe/ds/IntMap.hx
@@ -52,6 +52,8 @@ package haxe.ds;
   inline String get_string(int key) { return __int_hash_get_string(h,key); }
 ")
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never): Int;
+	
 	@:ifFeature("haxe.ds.IntMap.*")
 	private var h:Dynamic;
 
@@ -104,6 +106,10 @@ package haxe.ds;
 		#else
 		h = null;
 		#end
+	}
+	
+	private function get_size():Int {
+		return untyped __global__.__root_hash_size(h);
 	}
 
 	#if (scriptable)

--- a/std/cpp/_std/haxe/ds/ObjectMap.hx
+++ b/std/cpp/_std/haxe/ds/ObjectMap.hx
@@ -52,6 +52,8 @@ package haxe.ds;
 ")
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never): Int;
+	
 	@:ifFeature("haxe.ds.ObjectMap.*")
 	private var h:Dynamic;
 
@@ -104,6 +106,10 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		#else
 		h = null;
 		#end
+	}
+	
+	private function get_size():Int {
+		return untyped __global__.__root_hash_size(h);
 	}
 
 	#if (scriptable)

--- a/std/cpp/_std/haxe/ds/ObjectMap.hx
+++ b/std/cpp/_std/haxe/ds/ObjectMap.hx
@@ -52,8 +52,6 @@ package haxe.ds;
 ")
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never): Int;
-	
 	@:ifFeature("haxe.ds.ObjectMap.*")
 	private var h:Dynamic;
 
@@ -108,7 +106,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		return untyped __global__.__root_hash_size(h);
 	}
 

--- a/std/cpp/_std/haxe/ds/StringMap.hx
+++ b/std/cpp/_std/haxe/ds/StringMap.hx
@@ -52,6 +52,8 @@ package haxe.ds;
   inline String get_string(String key) { return __string_hash_get_string(h,key); }
 ")
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never): Int;
+	
 	@:ifFeature("haxe.ds.StringMap.*")
 	private var h:Dynamic;
 
@@ -104,6 +106,10 @@ package haxe.ds;
 		#else
 		h = null;
 		#end
+	}
+	
+	private function get_size():Int {
+		return untyped __global__.__root_hash_size(h);
 	}
 
 	#if (scriptable)

--- a/std/cpp/_std/haxe/ds/StringMap.hx
+++ b/std/cpp/_std/haxe/ds/StringMap.hx
@@ -52,8 +52,6 @@ package haxe.ds;
   inline String get_string(String key) { return __string_hash_get_string(h,key); }
 ")
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never): Int;
-	
 	@:ifFeature("haxe.ds.StringMap.*")
 	private var h:Dynamic;
 
@@ -108,7 +106,7 @@ package haxe.ds;
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		return untyped __global__.__root_hash_size(h);
 	}
 

--- a/std/cpp/_std/haxe/ds/WeakMap.hx
+++ b/std/cpp/_std/haxe/ds/WeakMap.hx
@@ -45,8 +45,6 @@ package haxe.ds;
 ")
 @:coreApi
 class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never): Int;
-	
 	@:ifFeature("haxe.ds.WeakMap.*")
 	private var h:Dynamic;
 
@@ -101,7 +99,7 @@ class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		return untyped __global__.__root_hash_size(h);
 	}
 }

--- a/std/cpp/_std/haxe/ds/WeakMap.hx
+++ b/std/cpp/_std/haxe/ds/WeakMap.hx
@@ -45,6 +45,8 @@ package haxe.ds;
 ")
 @:coreApi
 class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never): Int;
+	
 	@:ifFeature("haxe.ds.WeakMap.*")
 	private var h:Dynamic;
 
@@ -97,5 +99,9 @@ class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		#else
 		h = null;
 		#end
+	}
+	
+	private function get_size():Int {
+		return untyped __global__.__root_hash_size(h);
 	}
 }

--- a/std/cs/_std/EReg.hx
+++ b/std/cs/_std/EReg.hx
@@ -77,6 +77,12 @@ import cs.system.text.regularexpressions.*;
 	public function matchedPos():{pos:Int, len:Int} {
 		return {pos: m.Index, len: m.Length};
 	}
+	
+	public function matchedNum():Int {
+		if (m == null)
+			throw "No string matched";
+		return m.Groups.Count;
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		m = if (len < 0) regex.Match(s, pos) else regex.Match(s, pos, len);

--- a/std/cs/_std/haxe/ds/IntMap.hx
+++ b/std/cs/_std/haxe/ds/IntMap.hx
@@ -39,7 +39,7 @@ import cs.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -389,6 +389,10 @@ import cs.NativeArray;
 		cachedKey = 0;
 		cachedIndex = -1;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	private static inline function assert(x:Bool):Void {

--- a/std/cs/_std/haxe/ds/IntMap.hx
+++ b/std/cs/_std/haxe/ds/IntMap.hx
@@ -39,7 +39,7 @@ import cs.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var _size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -57,7 +57,7 @@ import cs.NativeArray;
 	public function set(key:Int, value:T):Void {
 		var targetIndex:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1)) {
+			if (nBuckets > (_size << 1)) {
 				resize(nBuckets - 1); // clear "deleted" elements
 			} else {
 				resize(nBuckets + 1);
@@ -99,13 +99,13 @@ import cs.NativeArray;
 			_keys[targetIndex] = key;
 			vals[targetIndex] = value;
 			setIsBothFalse(flags, targetIndex);
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			_keys[targetIndex] = key;
 			vals[targetIndex] = value;
 			setIsBothFalse(flags, targetIndex);
-			size++;
+			_size++;
 		} else {
 			#if debug
 			assert(_keys[targetIndex] == key);
@@ -223,7 +223,7 @@ import cs.NativeArray;
 			#end
 			if (!isEither(getFlag(flags, idx))) {
 				setIsDelTrue(flags, idx);
-				--size;
+				--_size;
 
 				vals[idx] = null;
 				// we do NOT reset the keys here, as unlike StringMap, we check for keys equality
@@ -245,10 +245,10 @@ import cs.NativeArray;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = flagsSize(newNBuckets);
 				newFlags = new NativeArray(nfSize);
 				for (i in 0...nfSize) {
@@ -338,7 +338,7 @@ import cs.NativeArray;
 
 			this.flags = newFlags;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -382,7 +382,7 @@ import cs.NativeArray;
 		_keys = null;
 		vals = null;
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -391,8 +391,8 @@ import cs.NativeArray;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	private static inline function assert(x:Bool):Void {

--- a/std/cs/_std/haxe/ds/ObjectMap.hx
+++ b/std/cs/_std/haxe/ds/ObjectMap.hx
@@ -43,7 +43,7 @@ import cs.NativeArray;
 	private var vals:NativeArray<V>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -68,7 +68,7 @@ import cs.NativeArray;
 	public function set(key:K, value:V):Void {
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1))
+			if (nBuckets > (_size << 1))
 				resize(nBuckets - 1); // clear "deleted" elements
 			else
 				resize(nBuckets + 2);
@@ -117,13 +117,13 @@ import cs.NativeArray;
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 		} else {
 			assert(_keys[x] == key);
 			vals[x] = value;
@@ -171,10 +171,10 @@ import cs.NativeArray;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = newNBuckets;
 				newHash = new NativeArray(nfSize);
 				if (nBuckets < newNBuckets) // expand
@@ -263,7 +263,7 @@ import cs.NativeArray;
 
 			this.hashes = newHash;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -351,7 +351,7 @@ import cs.NativeArray;
 			hashes[idx] = FLAG_DEL;
 			_keys[idx] = null;
 			vals[idx] = null;
-			--size;
+			--_size;
 
 			return true;
 		}
@@ -396,7 +396,7 @@ import cs.NativeArray;
 		_keys = null;
 		vals = null;
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -411,8 +411,8 @@ import cs.NativeArray;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/cs/_std/haxe/ds/ObjectMap.hx
+++ b/std/cs/_std/haxe/ds/ObjectMap.hx
@@ -43,7 +43,7 @@ import cs.NativeArray;
 	private var vals:NativeArray<V>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -409,6 +409,10 @@ import cs.NativeArray;
 		sameHash = 0;
 		maxProbe = 0;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/cs/_std/haxe/ds/StringMap.hx
+++ b/std/cs/_std/haxe/ds/StringMap.hx
@@ -43,7 +43,7 @@ import cs.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -68,7 +68,7 @@ import cs.NativeArray;
 	public function set(key:String, value:T):Void {
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1)) {
+			if (nBuckets > (_size << 1)) {
 				resize(nBuckets - 1); // clear "deleted" elements
 			} else {
 				resize(nBuckets + 2);
@@ -119,13 +119,13 @@ import cs.NativeArray;
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 		} else {
 			assert(_keys[x] == key);
 			vals[x] = value;
@@ -173,10 +173,10 @@ import cs.NativeArray;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = newNBuckets;
 				newHash = new NativeArray(nfSize);
 				if (nBuckets < newNBuckets) // expand
@@ -265,7 +265,7 @@ import cs.NativeArray;
 
 			this.hashes = newHash;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -350,7 +350,7 @@ import cs.NativeArray;
 			hashes[idx] = FLAG_DEL;
 			_keys[idx] = null;
 			vals[idx] = null;
-			--size;
+			--_size;
 
 			return true;
 		}
@@ -395,7 +395,7 @@ import cs.NativeArray;
 		_keys = null;
 		vals = null;
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -410,8 +410,8 @@ import cs.NativeArray;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/cs/_std/haxe/ds/StringMap.hx
+++ b/std/cs/_std/haxe/ds/StringMap.hx
@@ -43,7 +43,7 @@ import cs.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -408,6 +408,10 @@ import cs.NativeArray;
 		sameHash = 0;
 		maxProbe = 0;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/eval/_std/EReg.hx
+++ b/std/eval/_std/EReg.hx
@@ -30,6 +30,7 @@ extern class EReg {
 	function matchedRight():String;
 	function matchedPos():{pos:Int, len:Int};
 	function matchSub(s:String, pos:Int, len:Int = -1):Bool;
+	function matchedNum():Int;
 	function split(s:String):Array<String>;
 	function replace(s:String, by:String):String;
 	function map(s:String, f:EReg->String):String;

--- a/std/flash/_std/EReg.hx
+++ b/std/flash/_std/EReg.hx
@@ -58,6 +58,12 @@
 			throw "No string matched";
 		return {pos: result.index, len: (result[0] : String).length};
 	}
+	
+	public function matchedNum():Int {
+		if (result == null)
+			throw "No string matched";
+		return result.length;
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		return if (r.global) {

--- a/std/flash/_std/haxe/ds/IntMap.hx
+++ b/std/flash/_std/haxe/ds/IntMap.hx
@@ -23,6 +23,7 @@
 package haxe.ds;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	private var h:flash.utils.Dictionary;
 
 	public function new():Void {
@@ -84,6 +85,12 @@ package haxe.ds;
 
 	public inline function clear():Void {
 		h = new flash.utils.Dictionary();
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		for(_ in keys()) s++;
+		return s;
 	}
 }
 

--- a/std/flash/_std/haxe/ds/IntMap.hx
+++ b/std/flash/_std/haxe/ds/IntMap.hx
@@ -23,7 +23,6 @@
 package haxe.ds;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	private var h:flash.utils.Dictionary;
 
 	public function new():Void {
@@ -87,7 +86,7 @@ package haxe.ds;
 		h = new flash.utils.Dictionary();
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		for(_ in keys()) s++;
 		return s;

--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -24,8 +24,6 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
-	
 	public function new() {
 		super(false);
 	}
@@ -83,7 +81,7 @@ class ObjectMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constrai
 			untyped __delete__(this, i);
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		for(_ in keys()) s++;
 		return s;

--- a/std/flash/_std/haxe/ds/ObjectMap.hx
+++ b/std/flash/_std/haxe/ds/ObjectMap.hx
@@ -24,6 +24,8 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
+	
 	public function new() {
 		super(false);
 	}
@@ -79,6 +81,12 @@ class ObjectMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constrai
 	public function clear():Void {
 		for (i in keys())
 			untyped __delete__(this, i);
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		for(_ in keys()) s++;
+		return s;
 	}
 }
 

--- a/std/flash/_std/haxe/ds/StringMap.hx
+++ b/std/flash/_std/haxe/ds/StringMap.hx
@@ -23,7 +23,6 @@
 package haxe.ds;
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	private var h:Dynamic;
 	private var rh:Dynamic;
 
@@ -126,7 +125,7 @@ package haxe.ds;
 		rh = null;
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		for(_ in keys()) s++;
 		return s;

--- a/std/flash/_std/haxe/ds/StringMap.hx
+++ b/std/flash/_std/haxe/ds/StringMap.hx
@@ -23,6 +23,7 @@
 package haxe.ds;
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	private var h:Dynamic;
 	private var rh:Dynamic;
 
@@ -123,6 +124,12 @@ package haxe.ds;
 	public inline function clear():Void {
 		h = {};
 		rh = null;
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		for(_ in keys()) s++;
+		return s;
 	}
 }
 

--- a/std/flash/_std/haxe/ds/UnsafeStringMap.hx
+++ b/std/flash/_std/haxe/ds/UnsafeStringMap.hx
@@ -28,7 +28,6 @@ package haxe.ds;
 	with some reserved keys such as `constructor` or `prototype`.
 **/
 class UnsafeStringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	private var h:flash.utils.Dictionary;
 
 	public function new():Void {
@@ -92,7 +91,7 @@ class UnsafeStringMap<T> implements haxe.Constraints.IMap<String, T> {
 		h = new flash.utils.Dictionary();
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		for(_ in keys()) s++;
 		return s;

--- a/std/flash/_std/haxe/ds/UnsafeStringMap.hx
+++ b/std/flash/_std/haxe/ds/UnsafeStringMap.hx
@@ -28,6 +28,7 @@ package haxe.ds;
 	with some reserved keys such as `constructor` or `prototype`.
 **/
 class UnsafeStringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	private var h:flash.utils.Dictionary;
 
 	public function new():Void {
@@ -89,6 +90,12 @@ class UnsafeStringMap<T> implements haxe.Constraints.IMap<String, T> {
 
 	public inline function clear():Void {
 		h = new flash.utils.Dictionary();
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		for(_ in keys()) s++;
+		return s;
 	}
 }
 

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -24,8 +24,6 @@ package haxe.ds;
 
 @:coreApi
 class WeakMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
-	
 	public function new() {
 		super(true);
 	}
@@ -83,7 +81,7 @@ class WeakMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraint
 			untyped __delete__(this, i);
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		for(_ in keys()) s++;
 		return s;

--- a/std/flash/_std/haxe/ds/WeakMap.hx
+++ b/std/flash/_std/haxe/ds/WeakMap.hx
@@ -24,6 +24,8 @@ package haxe.ds;
 
 @:coreApi
 class WeakMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
+	
 	public function new() {
 		super(true);
 	}
@@ -79,6 +81,12 @@ class WeakMap<K:{}, V> extends flash.utils.Dictionary implements haxe.Constraint
 	public function clear():Void {
 		for (i in keys())
 			untyped __delete__(this, i);
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		for(_ in keys()) s++;
+		return s;
 	}
 }
 

--- a/std/haxe/Constraints.hx
+++ b/std/haxe/Constraints.hx
@@ -65,6 +65,7 @@ abstract NotVoid(Dynamic) { }
 abstract Constructible<T>(Dynamic) {}
 
 interface IMap<K, V> {
+	var size(get, never):Int;
 	function get(k:K):Null<V>;
 	function set(k:K, v:V):Void;
 	function exists(k:K):Bool;

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -33,6 +33,7 @@ package haxe.ds;
 	are in-order.
 **/
 class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
 	var root:TreeNode<K, V>;
 
 	/**
@@ -184,6 +185,14 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 			keysLoop(node.right, acc);
 		}
 	}
+	
+	static function sizeLoop<K,V>(node:TreeNode<K, V>):Int {
+		if (node != null) {
+			return sizeLoop(node.left) + 1 + sizeLoop(node.right);
+		} else {
+			return 0;
+		}
+	}
 
 	function merge(t1, t2) {
 		if (t1 == null)
@@ -235,6 +244,10 @@ class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
 	**/
 	public function clear():Void {
 		root = null;
+	}
+	
+	function get_size():Int {
+		return sizeLoop(root);
 	}
 }
 

--- a/std/haxe/ds/BalancedTree.hx
+++ b/std/haxe/ds/BalancedTree.hx
@@ -33,7 +33,6 @@ package haxe.ds;
 	are in-order.
 **/
 class BalancedTree<K, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
 	var root:TreeNode<K, V>;
 
 	/**

--- a/std/haxe/ds/HashMap.hx
+++ b/std/haxe/ds/HashMap.hx
@@ -32,8 +32,6 @@ import haxe.iterators.HashMapKeyValueIterator;
 	@see https://haxe.org/manual/std-Map.html
 **/
 abstract HashMap<K:{function hashCode():Int;}, V>(HashMapData<K, V>) {
-	public var size(get, never):Int;
-	
 	/**
 		Creates a new HashMap.
 	**/

--- a/std/haxe/ds/HashMap.hx
+++ b/std/haxe/ds/HashMap.hx
@@ -32,6 +32,8 @@ import haxe.iterators.HashMapKeyValueIterator;
 	@see https://haxe.org/manual/std-Map.html
 **/
 abstract HashMap<K:{function hashCode():Int;}, V>(HashMapData<K, V>) {
+	public var size(get, never):Int;
+	
 	/**
 		Creates a new HashMap.
 	**/
@@ -106,6 +108,10 @@ abstract HashMap<K:{function hashCode():Int;}, V>(HashMapData<K, V>) {
 	public inline function clear():Void {
 		this.keys.clear();
 		this.values.clear();
+	}
+	
+	inline function get_size():Int {
+		return this.keys.size;
 	}
 }
 

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -99,5 +99,5 @@ extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	**/
 	function clear():Void;
 	
-	private function get_size();
+	private function get_size():Int;
 }

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -30,8 +30,6 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
-	
 	/**
 		Creates a new IntMap.
 	**/
@@ -99,5 +97,5 @@ extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	**/
 	function clear():Void;
 	
-	private function get_size():Int;
+	function size():Int;
 }

--- a/std/haxe/ds/IntMap.hx
+++ b/std/haxe/ds/IntMap.hx
@@ -30,6 +30,8 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
+	
 	/**
 		Creates a new IntMap.
 	**/
@@ -96,4 +98,6 @@ extern class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		See `Map.clear`
 	**/
 	function clear():Void;
+	
+	private function get_size();
 }

--- a/std/haxe/ds/Map.hx
+++ b/std/haxe/ds/Map.hx
@@ -50,6 +50,11 @@ import haxe.Constraints.IMap;
 @:multiType(@:followWithAbstracts K)
 abstract Map<K, V>(IMap<K, V>) {
 	/**
+		Contains the size of the map.
+	**/
+	var size(get, never):Int;
+	
+	/**
 		Creates a new Map.
 
 		This becomes a constructor call to one of the specialization types in
@@ -160,6 +165,10 @@ abstract Map<K, V>(IMap<K, V>) {
 	**/
 	public inline function clear():Void {
 		this.clear();
+	}
+	
+	inline function get_size():Int {
+		return this.size;
 	}
 
 	@:arrayAccess @:noCompletion public inline function arrayWrite(k:K, v:V):V {

--- a/std/haxe/ds/ObjectMap.hx
+++ b/std/haxe/ds/ObjectMap.hx
@@ -33,8 +33,6 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 extern class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
-	
 	/**
 		Creates a new ObjectMap.
 	**/
@@ -102,5 +100,5 @@ extern class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	**/
 	function clear():Void;
 	
-	private function get_size():Int;
+	public function size():Int;
 }

--- a/std/haxe/ds/ObjectMap.hx
+++ b/std/haxe/ds/ObjectMap.hx
@@ -33,6 +33,8 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 extern class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
+	
 	/**
 		Creates a new ObjectMap.
 	**/
@@ -99,4 +101,6 @@ extern class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		See `Map.clear`
 	**/
 	function clear():Void;
+	
+	private function get_size():Int;
 }

--- a/std/haxe/ds/StringMap.hx
+++ b/std/haxe/ds/StringMap.hx
@@ -30,6 +30,8 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 extern class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
+	
 	/**
 		Creates a new StringMap.
 	**/
@@ -96,4 +98,6 @@ extern class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		See `Map.clear`
 	**/
 	function clear():Void;
+	
+	private function get_size():Int;
 }

--- a/std/haxe/ds/StringMap.hx
+++ b/std/haxe/ds/StringMap.hx
@@ -30,8 +30,6 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 extern class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
-	
 	/**
 		Creates a new StringMap.
 	**/
@@ -99,5 +97,5 @@ extern class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 	**/
 	function clear():Void;
 	
-	private function get_size():Int;
+	public function size():Int;
 }

--- a/std/haxe/ds/WeakMap.hx
+++ b/std/haxe/ds/WeakMap.hx
@@ -32,8 +32,6 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
-	
 	/**
 		Creates a new WeakMap.
 	**/

--- a/std/haxe/ds/WeakMap.hx
+++ b/std/haxe/ds/WeakMap.hx
@@ -32,6 +32,8 @@ package haxe.ds;
 	@see https://haxe.org/manual/std-Map.html
 **/
 class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
+	
 	/**
 		Creates a new WeakMap.
 	**/
@@ -104,4 +106,8 @@ class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		See `Map.clear`
 	**/
 	public function clear():Void {}
+	
+	function get_size():Int {
+		return 0;
+	}
 }

--- a/std/hl/_std/EReg.hx
+++ b/std/hl/_std/EReg.hx
@@ -68,6 +68,24 @@ private typedef ERegValue = hl.Abstract<"ereg">;
 			return null;
 		return {pos: p, len: len};
 	}
+	
+	public function matchedNum():Int {
+		if(last == null)
+			throw "No string matched";
+		#if (hl_ver >= version("1.12.0"))
+		return regexp_matched_num(r);
+		#else
+		var i = 0;
+		var num = 0;
+		try {
+			while (true) {
+				if (regexp_matched_pos(r, i, null) >= 0) num++;
+				i++;
+			}
+		} catch (_:String) {}
+		return num;
+		#end
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		var p = regexp_match(r, s.bytes, pos, len < 0 ? s.length - pos : len);
@@ -199,4 +217,10 @@ private typedef ERegValue = hl.Abstract<"ereg">;
 	@:hlNative("std", "regexp_matched_pos") static function regexp_matched_pos(r:ERegValue, n:Int, size:hl.Ref<Int>):Int {
 		return 0;
 	}
+	
+	#if (hl_ver >= version("1.12.0"))
+	@:hlNative("std", "regexp_matched_num") static function regexp_matched_num(r:ERegValue):Int {
+		return 0;
+	}
+	#end
 }

--- a/std/hl/_std/haxe/ds/IntMap.hx
+++ b/std/hl/_std/haxe/ds/IntMap.hx
@@ -24,7 +24,6 @@ package haxe.ds;
 
 @:coreApi
 class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	var h:hl.types.IntMap;
 
 	public function new():Void {
@@ -90,7 +89,7 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		#if (hl_ver >= version("1.12.0"))
 		return h.size();
 		#else

--- a/std/hl/_std/haxe/ds/IntMap.hx
+++ b/std/hl/_std/haxe/ds/IntMap.hx
@@ -24,6 +24,7 @@ package haxe.ds;
 
 @:coreApi
 class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	var h:hl.types.IntMap;
 
 	public function new():Void {
@@ -86,6 +87,14 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		@:privateAccess h.clear();
 		#else
 		h = new hl.types.IntMap();
+		#end
+	}
+	
+	private function get_size():Int {
+		#if (hl_ver >= version("1.12.0"))
+		return h.size();
+		#else
+		return h.keysArray().length;
 		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/ObjectMap.hx
+++ b/std/hl/_std/haxe/ds/ObjectMap.hx
@@ -24,6 +24,7 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
+	public var size(get, never):Int;
 	var h:hl.types.ObjectMap;
 
 	public function new():Void {
@@ -86,6 +87,14 @@ class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
 		@:privateAccess h.clear();
 		#else
 		h = new hl.types.ObjectMap();
+		#end
+	}
+	
+	private function get_size():Int {
+		#if (hl_ver >= version("1.12.0"))
+		return h.size();
+		#else
+		return h.keysArray().length;
 		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/ObjectMap.hx
+++ b/std/hl/_std/haxe/ds/ObjectMap.hx
@@ -24,7 +24,6 @@ package haxe.ds;
 
 @:coreApi
 class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
-	public var size(get, never):Int;
 	var h:hl.types.ObjectMap;
 
 	public function new():Void {
@@ -90,7 +89,7 @@ class ObjectMap<K:{}, T> implements haxe.Constraints.IMap<K, T> {
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		#if (hl_ver >= version("1.12.0"))
 		return h.size();
 		#else

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -45,6 +45,7 @@ private class StringMapKeysIterator {
 
 @:coreApi
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	var h:hl.types.BytesMap;
 
 	public function new():Void {
@@ -114,6 +115,14 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		@:privateAccess h.clear();
 		#else
 		h = new hl.types.BytesMap();
+		#end
+	}
+	
+	private function get_size():Int {
+		#if (hl_ver >= version("1.12.0"))
+		return h.size();
+		#else
+		return h.keysArray().length;
 		#end
 	}
 }

--- a/std/hl/_std/haxe/ds/StringMap.hx
+++ b/std/hl/_std/haxe/ds/StringMap.hx
@@ -45,7 +45,6 @@ private class StringMapKeysIterator {
 
 @:coreApi
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	var h:hl.types.BytesMap;
 
 	public function new():Void {
@@ -118,7 +117,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		#end
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		#if (hl_ver >= version("1.12.0"))
 		return h.size();
 		#else

--- a/std/hl/types/BytesMap.hx
+++ b/std/hl/types/BytesMap.hx
@@ -65,6 +65,13 @@ abstract BytesMap(BytesMapData) {
 	@:hlNative("std", "hbclear")
 	public function clear():Void {}
 	#end
+	
+	#if (hl_ver >= version("1.12.0"))
+	@:hlNative("std", "hbsize")
+	public function size():Int {
+		return 0;
+	}
+	#end
 
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());

--- a/std/hl/types/IntMap.hx
+++ b/std/hl/types/IntMap.hx
@@ -65,6 +65,13 @@ abstract IntMap(IntMapData) {
 	@:hlNative("std", "hiclear")
 	public function clear():Void {}
 	#end
+	
+	#if (hl_ver >= version("1.12.0"))
+	@:hlNative("std", "hisize")
+	public function size():Int {
+		return 0;
+	}
+	#end
 
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());

--- a/std/hl/types/ObjectMap.hx
+++ b/std/hl/types/ObjectMap.hx
@@ -65,6 +65,13 @@ abstract ObjectMap(ObjectMapData) {
 	@:hlNative("std", "hoclear")
 	public function clear():Void {}
 	#end
+	
+	#if (hl_ver >= version("1.12.0"))
+	@:hlNative("std", "hosize")
+	public function size():Int {
+		return 0;
+	}
+	#end
 
 	extern public inline function iterator() {
 		return new NativeArray.NativeArrayIterator<Dynamic>(valuesArray());

--- a/std/java/_std/EReg.hx
+++ b/std/java/_std/EReg.hx
@@ -106,6 +106,14 @@ using StringTools;
 		var start = matcher.start();
 		return {pos: start, len: matcher.end() - start};
 	}
+	
+	public function matchedNum():Int {
+		if(matcher.group() == null) {
+			return 0;
+		} else {
+			return matcher.groupCount() + 1;
+		}
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		matcher = matcher.reset(len < 0 ? s : s.substr(0, pos + len));

--- a/std/java/_std/haxe/ds/IntMap.hx
+++ b/std/java/_std/haxe/ds/IntMap.hx
@@ -39,7 +39,7 @@ import java.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var _size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -57,7 +57,7 @@ import java.NativeArray;
 	public function set(key:Int, value:T):Void {
 		var targetIndex:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1)) {
+			if (nBuckets > (_size << 1)) {
 				resize(nBuckets - 1); // clear "deleted" elements
 			} else {
 				resize(nBuckets + 1);
@@ -99,13 +99,13 @@ import java.NativeArray;
 			_keys[targetIndex] = key;
 			vals[targetIndex] = value;
 			setIsBothFalse(flags, targetIndex);
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			_keys[targetIndex] = key;
 			vals[targetIndex] = value;
 			setIsBothFalse(flags, targetIndex);
-			size++;
+			_size++;
 		} else {
 			#if debug
 			assert(_keys[targetIndex] == key);
@@ -223,7 +223,7 @@ import java.NativeArray;
 			#end
 			if (!isEither(getFlag(flags, idx))) {
 				setIsDelTrue(flags, idx);
-				--size;
+				--_size;
 
 				vals[idx] = null;
 				// we do NOT reset the keys here, as unlike StringMap, we check for keys equality
@@ -245,10 +245,10 @@ import java.NativeArray;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = flagsSize(newNBuckets);
 				newFlags = new NativeArray(nfSize);
 				for (i in 0...nfSize) {
@@ -338,7 +338,7 @@ import java.NativeArray;
 
 			this.flags = newFlags;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -382,7 +382,7 @@ import java.NativeArray;
 		_keys = null;
 		vals = null;
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -391,8 +391,8 @@ import java.NativeArray;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	private static inline function assert(x:Bool):Void {

--- a/std/java/_std/haxe/ds/IntMap.hx
+++ b/std/java/_std/haxe/ds/IntMap.hx
@@ -39,7 +39,7 @@ import java.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -389,6 +389,10 @@ import java.NativeArray;
 		cachedKey = 0;
 		cachedIndex = -1;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	private static inline function assert(x:Bool):Void {

--- a/std/java/_std/haxe/ds/ObjectMap.hx
+++ b/std/java/_std/haxe/ds/ObjectMap.hx
@@ -43,7 +43,7 @@ import java.NativeArray;
 	private var vals:NativeArray<V>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var _size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -68,7 +68,7 @@ import java.NativeArray;
 	public function set(key:K, value:V):Void {
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1))
+			if (nBuckets > (_size << 1))
 				resize(nBuckets - 1); // clear "deleted" elements
 			else
 				resize(nBuckets + 2);
@@ -117,13 +117,13 @@ import java.NativeArray;
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 		} else {
 			assert(keys[x] == key);
 			vals[x] = value;
@@ -171,10 +171,10 @@ import java.NativeArray;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = newNBuckets;
 				newHash = new NativeArray(nfSize);
 				if (nBuckets < newNBuckets) // expand
@@ -263,7 +263,7 @@ import java.NativeArray;
 
 			this.hashes = newHash;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -351,7 +351,7 @@ import java.NativeArray;
 			hashes[idx] = FLAG_DEL;
 			_keys[idx] = null;
 			vals[idx] = null;
-			--size;
+			--_size;
 
 			return true;
 		}
@@ -396,7 +396,7 @@ import java.NativeArray;
 		_keys = null;
 		vals = null;
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -411,8 +411,8 @@ import java.NativeArray;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/java/_std/haxe/ds/ObjectMap.hx
+++ b/std/java/_std/haxe/ds/ObjectMap.hx
@@ -43,7 +43,7 @@ import java.NativeArray;
 	private var vals:NativeArray<V>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -409,6 +409,10 @@ import java.NativeArray;
 		sameHash = 0;
 		maxProbe = 0;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/java/_std/haxe/ds/StringMap.hx
+++ b/std/java/_std/haxe/ds/StringMap.hx
@@ -43,7 +43,7 @@ import java.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -408,6 +408,10 @@ import java.NativeArray;
 		sameHash = 0;
 		maxProbe = 0;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/java/_std/haxe/ds/StringMap.hx
+++ b/std/java/_std/haxe/ds/StringMap.hx
@@ -43,7 +43,7 @@ import java.NativeArray;
 	private var vals:NativeArray<T>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var _size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -68,7 +68,7 @@ import java.NativeArray;
 	public function set(key:String, value:T):Void {
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1)) {
+			if (nBuckets > (_size << 1)) {
 				resize(nBuckets - 1); // clear "deleted" elements
 			} else {
 				resize(nBuckets + 2);
@@ -119,13 +119,13 @@ import java.NativeArray;
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			keys[x] = key;
 			vals[x] = value;
 			hashes[x] = k;
-			size++;
+			_size++;
 		} else {
 			assert(_keys[x] == key);
 			vals[x] = value;
@@ -173,10 +173,10 @@ import java.NativeArray;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = newNBuckets;
 				newHash = new NativeArray(nfSize);
 				if (nBuckets < newNBuckets) // expand
@@ -265,7 +265,7 @@ import java.NativeArray;
 
 			this.hashes = newHash;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -350,7 +350,7 @@ import java.NativeArray;
 			hashes[idx] = FLAG_DEL;
 			_keys[idx] = null;
 			vals[idx] = null;
-			--size;
+			--_size;
 
 			return true;
 		}
@@ -395,7 +395,7 @@ import java.NativeArray;
 		_keys = null;
 		vals = null;
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -410,8 +410,8 @@ import java.NativeArray;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/java/_std/haxe/ds/WeakMap.hx
+++ b/std/java/_std/haxe/ds/WeakMap.hx
@@ -47,7 +47,7 @@ import java.lang.ref.ReferenceQueue;
 	private var queue:ReferenceQueue<K>;
 
 	private var nBuckets:Int;
-	public var size(get, null):Int;
+	private var _size:Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -96,7 +96,7 @@ import java.lang.ref.ReferenceQueue;
 					#end
 					entries[i] = null;
 					hashes[i] = FLAG_DEL;
-					--size;
+					--_size;
 				}
 			}
 		}
@@ -106,7 +106,7 @@ import java.lang.ref.ReferenceQueue;
 		cleanupRefs();
 		var x:Int, k:Int;
 		if (nOccupied >= upperBound) {
-			if (nBuckets > (size << 1))
+			if (nBuckets > (_size << 1))
 				resize(nBuckets - 1); // clear "deleted" elements
 			else
 				resize(nBuckets + 2);
@@ -154,12 +154,12 @@ import java.lang.ref.ReferenceQueue;
 		if (isEmpty(flag)) {
 			entries[x] = entry;
 			hashes[x] = k;
-			size++;
+			_size++;
 			nOccupied++;
 		} else if (isDel(flag)) {
 			entries[x] = entry;
 			hashes[x] = k;
-			size++;
+			_size++;
 		} else {
 			assert(entries[x].keyEquals(key));
 			entries[x] = entry;
@@ -207,10 +207,10 @@ import java.lang.ref.ReferenceQueue;
 			newNBuckets = roundUp(newNBuckets);
 			if (newNBuckets < 4)
 				newNBuckets = 4;
-			if (size >= (newNBuckets * HASH_UPPER + 0.5))
-				/* requested size is too small */ {
+			if (_size >= (newNBuckets * HASH_UPPER + 0.5))
+				/* requested _size is too small */ {
 				j = 0;
-			} else { /* hash table size to be changed (shrink or expand); rehash */
+			} else { /* hash table _size to be changed (shrink or expand); rehash */
 				var nfSize = newNBuckets;
 				newHash = new NativeArray(nfSize);
 				if (nBuckets < newNBuckets) // expand
@@ -279,7 +279,7 @@ import java.lang.ref.ReferenceQueue;
 
 			this.hashes = newHash;
 			this.nBuckets = newNBuckets;
-			this.nOccupied = size;
+			this.nOccupied = _size;
 			this.upperBound = Std.int(newNBuckets * HASH_UPPER + .5);
 		}
 	}
@@ -375,7 +375,7 @@ import java.lang.ref.ReferenceQueue;
 
 			hashes[idx] = FLAG_DEL;
 			entries[idx] = null;
-			--size;
+			--_size;
 
 			return true;
 		}
@@ -422,7 +422,7 @@ import java.lang.ref.ReferenceQueue;
 		entries = null;
 		queue = new ReferenceQueue();
 		nBuckets = 0;
-		size = 0;
+		_size = 0;
 		nOccupied = 0;
 		upperBound = 0;
 		#if !no_map_cache
@@ -437,8 +437,8 @@ import java.lang.ref.ReferenceQueue;
 		#end
 	}
 	
-	private inline function get_size():Int {
-		return size;
+	public inline function size():Int {
+		return _size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/java/_std/haxe/ds/WeakMap.hx
+++ b/std/java/_std/haxe/ds/WeakMap.hx
@@ -47,7 +47,7 @@ import java.lang.ref.ReferenceQueue;
 	private var queue:ReferenceQueue<K>;
 
 	private var nBuckets:Int;
-	private var size:Int;
+	public var size(get, null):Int;
 	private var nOccupied:Int;
 	private var upperBound:Int;
 
@@ -435,6 +435,10 @@ import java.lang.ref.ReferenceQueue;
 		sameHash = 0;
 		maxProbe = 0;
 		#end
+	}
+	
+	private inline function get_size():Int {
+		return size;
 	}
 
 	extern private static inline function roundUp(x:Int):Int {

--- a/std/js/_std/EReg.hx
+++ b/std/js/_std/EReg.hx
@@ -60,7 +60,7 @@
 	public function matchedNum():Int {
 		if (r.m == null)
 			throw "No string matched";
-		return r.m.length - 1;
+		return r.m.length;
 	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {

--- a/std/js/_std/EReg.hx
+++ b/std/js/_std/EReg.hx
@@ -56,6 +56,12 @@
 			throw "No string matched";
 		return {pos: r.m.index, len: r.m[0].length};
 	}
+	
+	public function matchedNum():Int {
+		if (r.m == null)
+			throw "No string matched";
+		return r.m.length - 1;
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		return if (r.global) {

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -22,7 +22,74 @@
 
 package haxe.ds;
 
+#if (js_es >= 6)
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
+	private var m:js.lib.Map<Int, T>;
+	
+	public inline function new(map = new js.lib.Map()):Void {
+		m = map;
+	}
+	
+	public inline function set(key:Int, value:T): Void {
+		m.set(key, value);
+	}
+	
+	public inline function get(key:Int):Null<T> {
+		return m.get(key);
+	}
+	
+	public inline function exists(key:Int):Bool {
+		return m.has(key);
+	}
+	
+	public inline function remove(key:Int):Bool {
+		return m.delete(key);
+	}
+	
+	public inline function keys():Iterator<Int> {
+		return new js.lib.HaxeIterator(m.keys());
+	}
+	
+	public inline function iterator():Iterator<T> {
+		return m.iterator();
+	}
+	
+	public inline function keyValueIterator():KeyValueIterator<Int, T> {
+		return m.keyValueIterator();
+	}
+	
+	public inline function copy():IntMap<T> {
+		return new IntMap(new js.lib.Map(m));
+	}
+	
+	public function toString():String {
+		var s = new StringBuf();
+		s.add("{");
+		var it = keyValueIterator();
+		for (i in it) {
+			s.add(i.key);
+			s.add(" => ");
+			s.add(Std.string(i.value));
+			if (it.hasNext())
+				s.add(", ");
+		}
+		s.add("}");
+		return s.toString();
+	}
+	
+	public inline function clear():Void {
+		m.clear();
+	}
+	
+	private inline function get_size():Int {
+		return m.size;
+	}
+}
+
+#else
+@:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	private var h:Dynamic;
 
 	public inline function new():Void {
@@ -97,4 +164,11 @@ package haxe.ds;
 	public inline function clear():Void {
 		h = {};
 	}
+	
+	private inline function get_size():Int {
+		var s = 0;
+		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h, s);
+		return s;
+	}
 }
+#end

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -24,7 +24,6 @@ package haxe.ds;
 
 #if (js_es >= 6)
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	private var m:js.lib.Map<Int, T>;
 	
 	public inline function new(map = new js.lib.Map()):Void {
@@ -82,14 +81,13 @@ package haxe.ds;
 		m.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return m.size;
 	}
 }
 
 #else
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	private var h:Dynamic;
 
 	public inline function new():Void {
@@ -165,7 +163,7 @@ package haxe.ds;
 		h = {};
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		var s = 0;
 		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h, s);
 		return s;

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -25,9 +25,77 @@ package haxe.ds;
 import js.Syntax;
 import js.Lib;
 
+#if (js_es >= 6)
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
+	private var m:js.lib.Map<K, V>;
+	
+	public inline function new(map = new js.lib.Map()):Void {
+		m = map;
+	}
+	
+	public inline function set(key:K, value:V): Void {
+		m.set(key, value);
+	}
+	
+	public inline function get(key:K):Null<V> {
+		return m.get(key);
+	}
+	
+	public inline function exists(key:K):Bool {
+		return m.has(key);
+	}
+	
+	public inline function remove(key:K):Bool {
+		return m.delete(key);
+	}
+	
+	public inline function keys():Iterator<K> {
+		return new js.lib.HaxeIterator(m.keys());
+	}
+	
+	public inline function iterator():Iterator<V> {
+		return m.iterator();
+	}
+	
+	public inline function keyValueIterator():KeyValueIterator<K, V> {
+		return m.keyValueIterator();
+	}
+	
+	public inline function copy():ObjectMap<K, V> {
+		return new ObjectMap(new js.lib.Map(m));
+	}
+	
+	public function toString():String {
+		var s = new StringBuf();
+		s.add("{");
+		var it = keyValueIterator();
+		for (i in it) {
+			s.add(Std.string(i.key));
+			s.add(" => ");
+			s.add(Std.string(i.value));
+			if (it.hasNext())
+				s.add(", ");
+		}
+		s.add("}");
+		return s.toString();
+	}
+	
+	public inline function clear():Void {
+		m.clear();
+	}
+	
+	private inline function get_size():Int {
+		return m.size;
+	}
+}
 
+#else
+@:coreApi
+class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
+	
 	static inline function assignId(obj:{}):Int {
 		return Syntax.code('({0}.__id__ = {1})', obj, Lib.getNextHaxeUID());
 	}
@@ -122,4 +190,11 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	public inline function clear():Void {
 		h = {__keys__: {}};
 	}
+	
+	private inline function get_size():Int {
+		var s = 0;
+		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h.__keys__, s);
+		return s;
+	}
 }
+#end

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -28,7 +28,6 @@ import js.Lib;
 #if (js_es >= 6)
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
 	private var m:js.lib.Map<K, V>;
 	
 	public inline function new(map = new js.lib.Map()):Void {
@@ -86,7 +85,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		m.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return m.size;
 	}
 }
@@ -94,8 +93,6 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 #else
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
-	
 	static inline function assignId(obj:{}):Int {
 		return Syntax.code('({0}.__id__ = {1})', obj, Lib.getNextHaxeUID());
 	}
@@ -191,7 +188,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		h = {__keys__: {}};
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		var s = 0;
 		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h.__keys__, s);
 		return s;

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -26,8 +26,74 @@ import js.lib.Object;
 import haxe.Constraints.IMap;
 import haxe.DynamicAccess;
 
-#if (js_es >= 5)
+#if (js_es >= 6)
 @:coreApi class StringMap<T> implements IMap<String, T> {
+	public var size(get, never):Int;
+	private var m:js.lib.Map<String, T>;
+	
+	public inline function new(map = new js.lib.Map()):Void {
+		m = map;
+	}
+	
+	public inline function set(key:String, value:T): Void {
+		m.set(key, value);
+	}
+	
+	public inline function get(key:String):Null<T> {
+		return m.get(key);
+	}
+	
+	public inline function exists(key:String):Bool {
+		return m.has(key);
+	}
+	
+	public inline function remove(key:String):Bool {
+		return m.delete(key);
+	}
+	
+	public inline function keys():Iterator<String> {
+		return new js.lib.HaxeIterator(m.keys());
+	}
+	
+	public inline function iterator():Iterator<T> {
+		return m.iterator();
+	}
+	
+	public inline function keyValueIterator():KeyValueIterator<String, T> {
+		return m.keyValueIterator();
+	}
+	
+	public inline function copy():StringMap<T> {
+		return new StringMap(new js.lib.Map(m));
+	}
+	
+	public function toString():String {
+		var s = new StringBuf();
+		s.add("{");
+		var it = keyValueIterator();
+		for (i in it) {
+			s.add(i.key);
+			s.add(" => ");
+			s.add(Std.string(i.value));
+			if (it.hasNext())
+				s.add(", ");
+		}
+		s.add("}");
+		return s.toString();
+	}
+	
+	public inline function clear():Void {
+		m.clear();
+	}
+	
+	private inline function get_size():Int {
+		return m.size;
+	}
+}
+
+#elseif (js_es == 5)
+@:coreApi class StringMap<T> implements IMap<String, T> {
+	public var size(get, never):Int;
 	var h:Dynamic;
 
 	public inline function new() {
@@ -76,6 +142,12 @@ import haxe.DynamicAccess;
 
 	public inline function toString():String {
 		return stringify(h);
+	}
+	
+	private inline function get_size():Int {
+		var s = 0;
+		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h, s);
+		return s;
 	}
 
 	// impl
@@ -186,6 +258,7 @@ private class StringMapIterator<T> {
 }
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	private var h:Dynamic;
 	private var rh:Dynamic;
 
@@ -303,6 +376,12 @@ private class StringMapIterator<T> {
 	public inline function clear():Void {
 		h = {};
 		rh = null;
+	}
+	
+	private inline function get_size():Int {
+		var s = 0;
+		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h, s);
+		return s;
 	}
 
 	static function __init__():Void {

--- a/std/js/_std/haxe/ds/StringMap.hx
+++ b/std/js/_std/haxe/ds/StringMap.hx
@@ -28,7 +28,6 @@ import haxe.DynamicAccess;
 
 #if (js_es >= 6)
 @:coreApi class StringMap<T> implements IMap<String, T> {
-	public var size(get, never):Int;
 	private var m:js.lib.Map<String, T>;
 	
 	public inline function new(map = new js.lib.Map()):Void {
@@ -86,14 +85,13 @@ import haxe.DynamicAccess;
 		m.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return m.size;
 	}
 }
 
 #elseif (js_es == 5)
 @:coreApi class StringMap<T> implements IMap<String, T> {
-	public var size(get, never):Int;
 	var h:Dynamic;
 
 	public inline function new() {
@@ -144,7 +142,7 @@ import haxe.DynamicAccess;
 		return stringify(h);
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		var s = 0;
 		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h, s);
 		return s;
@@ -258,7 +256,6 @@ private class StringMapIterator<T> {
 }
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	private var h:Dynamic;
 	private var rh:Dynamic;
 
@@ -378,7 +375,7 @@ private class StringMapIterator<T> {
 		rh = null;
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		var s = 0;
 		js.Syntax.code("for( var key in {0} ) if({0}.hasOwnProperty(key)) {1}++", h, s);
 		return s;

--- a/std/jvm/_std/EReg.hx
+++ b/std/jvm/_std/EReg.hx
@@ -70,6 +70,14 @@ using StringTools;
 		var start = matcher.start();
 		return {pos: start, len: matcher.end() - start};
 	}
+	
+	public function matchedNum():Int {
+		if(matcher.group() == null) {
+			return 0;
+		} else {
+			return matcher.groupCount() + 1;
+		}
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		matcher = matcher.reset(len < 0 ? s : s.substr(0, pos + len));

--- a/std/jvm/_std/haxe/ds/StringMap.hx
+++ b/std/jvm/_std/haxe/ds/StringMap.hx
@@ -24,6 +24,7 @@ package haxe.ds;
 
 @:coreApi
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	var hashMap:java.util.HashMap<String, T>;
 
 	@:overload
@@ -87,5 +88,9 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 
 	public function clear():Void {
 		hashMap.clear();
+	}
+	
+	private inline function get_size():Int {
+		return hashMap.size();
 	}
 }

--- a/std/jvm/_std/haxe/ds/StringMap.hx
+++ b/std/jvm/_std/haxe/ds/StringMap.hx
@@ -24,7 +24,6 @@ package haxe.ds;
 
 @:coreApi
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	var hashMap:java.util.HashMap<String, T>;
 
 	@:overload
@@ -90,7 +89,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		hashMap.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return hashMap.size();
 	}
 }

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -110,6 +110,15 @@ class EReg {
 			len: matched.length
 		}
 	}
+	
+	public function matchedNum():Int {
+		if (m == null)
+			throw "No string matched";
+		else if (m[1] == null)
+			return 0;
+		else
+			return 1 + untyped __lua_length__(m[3]) / 2;
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		var ss = s.substr(0, len < 0 ? s.length : pos + len);

--- a/std/lua/_std/haxe/ds/IntMap.hx
+++ b/std/lua/_std/haxe/ds/IntMap.hx
@@ -25,6 +25,7 @@ package haxe.ds;
 import lua.Lua;
 
 class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	private var h:lua.Table<Int, T>;
 
 	static var tnull:Dynamic = lua.Table.create();
@@ -111,5 +112,11 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 
 	public inline function clear():Void {
 		h = lua.Table.create();
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
+		return s;
 	}
 }

--- a/std/lua/_std/haxe/ds/IntMap.hx
+++ b/std/lua/_std/haxe/ds/IntMap.hx
@@ -25,7 +25,6 @@ package haxe.ds;
 import lua.Lua;
 
 class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	private var h:lua.Table<Int, T>;
 
 	static var tnull:Dynamic = lua.Table.create();
@@ -114,7 +113,7 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		h = lua.Table.create();
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
 		return s;

--- a/std/lua/_std/haxe/ds/ObjectMap.hx
+++ b/std/lua/_std/haxe/ds/ObjectMap.hx
@@ -118,7 +118,7 @@ class ObjectMap<A, B> implements haxe.Constraints.IMap<A, B> {
 		k = lua.Table.create();
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
 		return s;

--- a/std/lua/_std/haxe/ds/ObjectMap.hx
+++ b/std/lua/_std/haxe/ds/ObjectMap.hx
@@ -117,4 +117,10 @@ class ObjectMap<A, B> implements haxe.Constraints.IMap<A, B> {
 		h = lua.Table.create();
 		k = lua.Table.create();
 	}
+	
+	private function get_size():Int {
+		var s = 0;
+		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
+		return s;
+	}
 }

--- a/std/lua/_std/haxe/ds/StringMap.hx
+++ b/std/lua/_std/haxe/ds/StringMap.hx
@@ -25,7 +25,6 @@ package haxe.ds;
 import lua.Lua;
 
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	private var h:lua.Table<String, T>;
 
 	static var tnull:Dynamic = lua.Table.create();
@@ -118,7 +117,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		h = lua.Table.create();
 	}
 	
-	private function get_size():Int {
+	public function size():Int {
 		var s = 0;
 		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
 		return s;

--- a/std/lua/_std/haxe/ds/StringMap.hx
+++ b/std/lua/_std/haxe/ds/StringMap.hx
@@ -25,6 +25,7 @@ package haxe.ds;
 import lua.Lua;
 
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	private var h:lua.Table<String, T>;
 
 	static var tnull:Dynamic = lua.Table.create();
@@ -115,5 +116,11 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 
 	public inline function clear():Void {
 		h = lua.Table.create();
+	}
+	
+	private function get_size():Int {
+		var s = 0;
+		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
+		return s;
 	}
 }

--- a/std/neko/_std/EReg.hx
+++ b/std/neko/_std/EReg.hx
@@ -217,9 +217,13 @@
 	
 	private static function fallback_matched_num(r:Dynamic):Int {
 		var i = 0;
+		var num = 0;
 		try {
-			while(regexp_matched(r, i) != null) i++;
+			while (true) {
+				if (regexp_matched(r, i) != null) num++;
+				i++;
+			}
 		} catch (_:Dynamic) {}
-		return i;
+		return num;
 	}
 }

--- a/std/neko/_std/EReg.hx
+++ b/std/neko/_std/EReg.hx
@@ -69,6 +69,13 @@
 			last = null;
 		return p;
 	}
+	
+	public function matchedNum():Int {
+		var num = regexp_matched_num(r);
+		if(last == null || num == -1)
+			throw "No string matched";
+		return num;
+	}
 
 	public function split(s:String):Array<String> {
 		var pos = 0;
@@ -206,4 +213,13 @@
 	static var regexp_match = neko.Lib.load("regexp", "regexp_match", 4);
 	static var regexp_matched = neko.Lib.load("regexp", "regexp_matched", 2);
 	static var regexp_matched_pos:Dynamic->Int->{pos: Int, len: Int} = neko.Lib.load("regexp", "regexp_matched_pos", 2);
+	static var regexp_matched_num = try neko.Lib.load("regexp", "regexp_matched_num", 1) catch (_:Dynamic) fallback_matched_num;
+	
+	private static function fallback_matched_num(r:Dynamic):Int {
+		var i = 0;
+		try {
+			while(regexp_matched(r, i) != null) i++;
+		} catch (_:Dynamic) {}
+		return i;
+	}
 }

--- a/std/neko/_std/haxe/ds/IntMap.hx
+++ b/std/neko/_std/haxe/ds/IntMap.hx
@@ -23,6 +23,7 @@
 package haxe.ds;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	private var h:Dynamic;
 
 	public function new():Void {
@@ -89,5 +90,9 @@ package haxe.ds;
 
 	public inline function clear():Void {
 		h = untyped __dollar__hnew(0);
+	}
+	
+	private inline function get_size():Int {
+		return untyped __dollar__hcount(h);
 	}
 }

--- a/std/neko/_std/haxe/ds/IntMap.hx
+++ b/std/neko/_std/haxe/ds/IntMap.hx
@@ -23,7 +23,6 @@
 package haxe.ds;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	private var h:Dynamic;
 
 	public function new():Void {
@@ -92,7 +91,7 @@ package haxe.ds;
 		h = untyped __dollar__hnew(0);
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return untyped __dollar__hcount(h);
 	}
 }

--- a/std/neko/_std/haxe/ds/ObjectMap.hx
+++ b/std/neko/_std/haxe/ds/ObjectMap.hx
@@ -36,7 +36,6 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		return untyped obj.__id__;
 	}
 
-	public var size(get, never):Int;
 	var h:{};
 	var k:{};
 
@@ -113,7 +112,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		k = untyped __dollar__hnew(0);
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return untyped __dollar__hcount(k);
 	}
 }

--- a/std/neko/_std/haxe/ds/ObjectMap.hx
+++ b/std/neko/_std/haxe/ds/ObjectMap.hx
@@ -36,6 +36,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		return untyped obj.__id__;
 	}
 
+	public var size(get, never):Int;
 	var h:{};
 	var k:{};
 
@@ -110,5 +111,9 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	public inline function clear():Void {
 		h = untyped __dollar__hnew(0);
 		k = untyped __dollar__hnew(0);
+	}
+	
+	private inline function get_size():Int {
+		return untyped __dollar__hcount(k);
 	}
 }

--- a/std/neko/_std/haxe/ds/StringMap.hx
+++ b/std/neko/_std/haxe/ds/StringMap.hx
@@ -23,6 +23,7 @@
 package haxe.ds;
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	private var h:Dynamic;
 
 	public function new():Void {
@@ -89,5 +90,9 @@ package haxe.ds;
 
 	public inline function clear():Void {
 		h = untyped __dollar__hnew(0);
+	}
+	
+	private inline function get_size():Int {
+		return untyped __dollar__hcount(h);
 	}
 }

--- a/std/neko/_std/haxe/ds/StringMap.hx
+++ b/std/neko/_std/haxe/ds/StringMap.hx
@@ -23,7 +23,6 @@
 package haxe.ds;
 
 @:coreApi class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	private var h:Dynamic;
 
 	public function new():Void {
@@ -92,7 +91,7 @@ package haxe.ds;
 		h = untyped __dollar__hnew(0);
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return untyped __dollar__hcount(h);
 	}
 }

--- a/std/php/_std/EReg.hx
+++ b/std/php/_std/EReg.hx
@@ -108,6 +108,12 @@ import php.*;
 			len: Global.mb_strlen(matches[0][0])
 		};
 	}
+	
+	public function matchedNum():Int {
+		if(matches == null)
+			throw "No string matched";
+		return Global.count(matches);
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		var subject = len < 0 ? s : s.substr(0, pos + len);

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -28,7 +28,6 @@ import php.NativeArray;
 import php.NativeIndexedArray;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	var data:NativeIndexedArray<T>;
 
 	public function new():Void {
@@ -87,7 +86,7 @@ import php.NativeIndexedArray;
 		data = new NativeIndexedArray();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return Global.count(data);
 	}
 }

--- a/std/php/_std/haxe/ds/IntMap.hx
+++ b/std/php/_std/haxe/ds/IntMap.hx
@@ -28,6 +28,7 @@ import php.NativeArray;
 import php.NativeIndexedArray;
 
 @:coreApi class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	var data:NativeIndexedArray<T>;
 
 	public function new():Void {
@@ -84,5 +85,9 @@ import php.NativeIndexedArray;
 
 	public inline function clear():Void {
 		data = new NativeIndexedArray();
+	}
+	
+	private inline function get_size():Int {
+		return Global.count(data);
 	}
 }

--- a/std/php/_std/haxe/ds/ObjectMap.hx
+++ b/std/php/_std/haxe/ds/ObjectMap.hx
@@ -26,7 +26,6 @@ import php.*;
 
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
 	var _keys:NativeAssocArray<K>;
 	var _values:NativeAssocArray<V>;
 
@@ -96,7 +95,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		_values = new NativeAssocArray();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return Global.count(_keys);
 	}
 }

--- a/std/php/_std/haxe/ds/ObjectMap.hx
+++ b/std/php/_std/haxe/ds/ObjectMap.hx
@@ -26,6 +26,7 @@ import php.*;
 
 @:coreApi
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
 	var _keys:NativeAssocArray<K>;
 	var _values:NativeAssocArray<V>;
 
@@ -93,5 +94,9 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 	public inline function clear():Void {
 		_keys = new NativeAssocArray();
 		_values = new NativeAssocArray();
+	}
+	
+	private inline function get_size():Int {
+		return Global.count(_keys);
 	}
 }

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -29,7 +29,6 @@ import php.NativeAssocArray;
 import haxe.Constraints;
 
 @:coreApi class StringMap<T> implements IMap<String, T> {
-	public var size(get, never):Int;
 	private var data:NativeAssocArray<T>;
 
 	public inline function new():Void {
@@ -88,7 +87,7 @@ import haxe.Constraints;
 		data = new NativeAssocArray();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return Global.count(data);
 	}
 }

--- a/std/php/_std/haxe/ds/StringMap.hx
+++ b/std/php/_std/haxe/ds/StringMap.hx
@@ -29,6 +29,7 @@ import php.NativeAssocArray;
 import haxe.Constraints;
 
 @:coreApi class StringMap<T> implements IMap<String, T> {
+	public var size(get, never):Int;
 	private var data:NativeAssocArray<T>;
 
 	public inline function new():Void {
@@ -85,5 +86,9 @@ import haxe.Constraints;
 
 	public inline function clear():Void {
 		data = new NativeAssocArray();
+	}
+	
+	private inline function get_size():Int {
+		return Global.count(data);
 	}
 }

--- a/std/python/_std/EReg.hx
+++ b/std/python/_std/EReg.hx
@@ -70,6 +70,12 @@ class EReg {
 	public inline function matchedPos():{pos:Int, len:Int} {
 		return {pos: matchObj.start(), len: matchObj.end() - matchObj.start()};
 	}
+	
+	public function matchedNum():Int {
+		if (matchObj == null)
+			throw "No string matched";
+		return matchObj.lastindex + 1;
+	}
 
 	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
 		if (len != -1) {

--- a/std/python/_std/haxe/ds/IntMap.hx
+++ b/std/python/_std/haxe/ds/IntMap.hx
@@ -26,6 +26,7 @@ import python.Dict;
 import python.Syntax;
 
 class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
+	public var size(get, never):Int;
 	private var h:Dict<Int, T>;
 
 	public function new():Void {
@@ -87,5 +88,9 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 
 	public inline function clear():Void {
 		h.clear();
+	}
+	
+	private inline function get_size():Int {
+		return h.length;
 	}
 }

--- a/std/python/_std/haxe/ds/IntMap.hx
+++ b/std/python/_std/haxe/ds/IntMap.hx
@@ -26,7 +26,6 @@ import python.Dict;
 import python.Syntax;
 
 class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
-	public var size(get, never):Int;
 	private var h:Dict<Int, T>;
 
 	public function new():Void {
@@ -90,7 +89,7 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 		h.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return h.length;
 	}
 }

--- a/std/python/_std/haxe/ds/ObjectMap.hx
+++ b/std/python/_std/haxe/ds/ObjectMap.hx
@@ -25,7 +25,6 @@ package haxe.ds;
 import python.Dict;
 
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
-	public var size(get, never):Int;
 	var h:Dict<K, V>;
 
 	public function new():Void {
@@ -89,7 +88,7 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		h.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return h.length;
 	}
 }

--- a/std/python/_std/haxe/ds/ObjectMap.hx
+++ b/std/python/_std/haxe/ds/ObjectMap.hx
@@ -25,6 +25,7 @@ package haxe.ds;
 import python.Dict;
 
 class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	public var size(get, never):Int;
 	var h:Dict<K, V>;
 
 	public function new():Void {
@@ -86,5 +87,9 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 
 	public inline function clear():Void {
 		h.clear();
+	}
+	
+	private inline function get_size():Int {
+		return h.length;
 	}
 }

--- a/std/python/_std/haxe/ds/StringMap.hx
+++ b/std/python/_std/haxe/ds/StringMap.hx
@@ -26,6 +26,7 @@ import python.Syntax;
 import python.Dict;
 
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
+	public var size(get, never):Int;
 	private var h:Dict<String, T>;
 
 	public function new():Void {
@@ -88,5 +89,9 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 
 	public inline function clear():Void {
 		h.clear();
+	}
+	
+	private inline function get_size():Int {
+		return h.length;
 	}
 }

--- a/std/python/_std/haxe/ds/StringMap.hx
+++ b/std/python/_std/haxe/ds/StringMap.hx
@@ -26,7 +26,6 @@ import python.Syntax;
 import python.Dict;
 
 class StringMap<T> implements haxe.Constraints.IMap<String, T> {
-	public var size(get, never):Int;
 	private var h:Dict<String, T>;
 
 	public function new():Void {
@@ -91,7 +90,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		h.clear();
 	}
 	
-	private inline function get_size():Int {
+	public inline function size():Int {
 		return h.length;
 	}
 }

--- a/tests/unit/src/unitstd/EReg.unit.hx
+++ b/tests/unit/src/unitstd/EReg.unit.hx
@@ -43,6 +43,28 @@ var pos = rg2.matchedPos();
 pos.pos == 1;
 pos.len == 2;
 
+// matched num
+var rg3 = ~/a/;
+var rg4 = ~/a(b)/;
+var rg5 = ~/a(b)(c)?/;
+
+rg3.match("a") == true;
+rg3.matchedNum() == 1;
+rg3.match("b") == false;
+rg3.matchedNum() == 0;
+
+rg4.match("a") == false;
+rg4.matchedNum() == 0;
+rg4.match("ab") == true;
+rg4.matchedNum() == 2;
+
+rg5.match("a") == false;
+rg5.matchedNum() == 0;
+rg5.match("ab") == true;
+rg5.matchedNum() == 2;
+rg5.match("abc") == true;
+rg5.matchedNum() == 3;
+
 // split
 ~/a/.split("") == [""];
 ~/a/.split("a") == ["",""];

--- a/tests/unit/src/unitstd/Map.unit.hx
+++ b/tests/unit/src/unitstd/Map.unit.hx
@@ -347,5 +347,5 @@ new Map<{a: Int}, String>().size == 0;
 [{a: 1} => "a", {a: 3} => "c"].size == 2;
 
 new Map<unit.MyAbstract.ClassWithHashCode, Int>().size == 0;
-[new unit.MyAbstract.ClassWithHashCode(1) => 1].size == 1
-[new unit.MyAbstract.ClassWithHashCode(1) => 1, new unit.MyAbstract.ClassWithHashCode(3) => 3].size == 1
+[new unit.MyAbstract.ClassWithHashCode(1) => 1].size == 1;
+[new unit.MyAbstract.ClassWithHashCode(1) => 1, new unit.MyAbstract.ClassWithHashCode(3) => 3].size == 1;

--- a/tests/unit/src/unitstd/Map.unit.hx
+++ b/tests/unit/src/unitstd/Map.unit.hx
@@ -331,3 +331,21 @@ var it:KeyValueIterator<String,String> = cast it;
 var keys = [for(kv in it) kv.key];
 keys[0] in ["1a","1b"];
 keys[1] in ["1a","1b"];
+
+// Test size
+
+new Map<Int, String>().size == 0;
+[1 => "a"].size == 1;
+[1 => "a", 3 => "c"].size == 2;
+
+new Map<String, Int>().size == 0;
+["a" => 1].size == 1;
+["a" => 1, "b" => 3].size == 2;
+
+new Map<{a: Int}, String>().size == 0;
+[{a: 1} => "a"].size == 1;
+[{a: 1} => "a", {a: 3} => "c"].size == 2;
+
+new Map<unit.MyAbstract.ClassWithHashCode, Int>().size == 0;
+[new unit.MyAbstract.ClassWithHashCode(1) => 1].size == 1
+[new unit.MyAbstract.ClassWithHashCode(1) => 1, new unit.MyAbstract.ClassWithHashCode(3) => 3].size == 1

--- a/tests/unit/src/unitstd/Map.unit.hx
+++ b/tests/unit/src/unitstd/Map.unit.hx
@@ -334,18 +334,18 @@ keys[1] in ["1a","1b"];
 
 // Test size
 
-new Map<Int, String>().size == 0;
-[1 => "a"].size == 1;
-[1 => "a", 3 => "c"].size == 2;
+new Map<Int, String>().size() == 0;
+[1 => "a"].size() == 1;
+[1 => "a", 3 => "c"].size() == 2;
 
-new Map<String, Int>().size == 0;
-["a" => 1].size == 1;
-["a" => 1, "b" => 3].size == 2;
+new Map<String, Int>().size() == 0;
+["a" => 1].size() == 1;
+["a" => 1, "b" => 3].size() == 2;
 
-new Map<{a: Int}, String>().size == 0;
-[{a: 1} => "a"].size == 1;
-[{a: 1} => "a", {a: 3} => "c"].size == 2;
+new Map<{a: Int}, String>().size() == 0;
+[{a: 1} => "a"].size() == 1;
+[{a: 1} => "a", {a: 3} => "c"].size() == 2;
 
-new Map<unit.MyAbstract.ClassWithHashCode, Int>().size == 0;
-[new unit.MyAbstract.ClassWithHashCode(1) => 1].size == 1;
-[new unit.MyAbstract.ClassWithHashCode(1) => 1, new unit.MyAbstract.ClassWithHashCode(3) => 3].size == 1;
+new Map<unit.MyAbstract.ClassWithHashCode, Int>().size() == 0;
+[new unit.MyAbstract.ClassWithHashCode(1) => 1].size() == 1;
+[new unit.MyAbstract.ClassWithHashCode(1) => 1, new unit.MyAbstract.ClassWithHashCode(3) => 3].size() == 1;


### PR DESCRIPTION
This pr adds 2 things:
1) `size` property for `Map`, which returns the number of entries in the map.
2) `matchedNum()` method for `EReg`, which returns the number of captured groups from the match (or throws an error if it hasn't been matched).

There is a very good chance that the eval impl won't work at first because eval's code isn't documented very well.

Before this is merged:
- https://github.com/HaxeFoundation/neko/pull/223 needs to be merged (and then ideally, release a new version of Neko).
- new version of hxcpp needs to be released (relevant pr: https://github.com/HaxeFoundation/hxcpp/pull/956 was merged).
- new version of hashlink needs to be released (relevant pr: https://github.com/HaxeFoundation/hashlink/pull/437).