### PR TITLE
[php] PDO::ATTR_DRIVER_NAME is an integer

### DIFF
--- a/std/php/db/PDO.hx
+++ b/std/php/db/PDO.hx
@@ -61,7 +61,7 @@ extern class PDO {
 	@:phpClassConst static final ATTR_CASE:Int;
 	@:phpClassConst static final ATTR_CURSOR_NAME:Int;
 	@:phpClassConst static final ATTR_CURSOR:Int;
-	@:phpClassConst static final ATTR_DRIVER_NAME:String;
+	@:phpClassConst static final ATTR_DRIVER_NAME:Int;
 	@:phpClassConst static final ATTR_ORACLE_NULLS:Int;
 	@:phpClassConst static final ATTR_PERSISTENT:Int;
 	@:phpClassConst static final ATTR_STATEMENT_CLASS:Int;


### PR DESCRIPTION
The official PHP documentation is invalid about the type of the `PDO::ATTR_DRIVER_NAME` constant.
It says: `PDO::ATTR_DRIVER_NAME (string)` but in fact, the value of this constant is an integer:

```
$ php -r "var_dump(PDO::ATTR_DRIVER_NAME);"
int(16)
```

And it also prevents the Haxe code from compiling:

```haxe
pdo.getAttribute(PDO.ATTR_DRIVER_NAME);
// Error: String should be Int
```