### PR TITLE
Allow `ArrayAccess<T>` as a type constraint

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -679,6 +679,15 @@ let rec unify (uctx : unification_context) a b =
 		()
 	| TAbstract (ab,tl), TAbstract ({ a_path = ["haxe"],("FlatEnum" | "Function" | "Constructible") },_) ->
 		unify_to {uctx with allow_transitive_cast = false} a b ab tl
+	| TInst ({ cl_array_access=Some t1; cl_params=tp },tl), TInst ({ cl_path = [],"ArrayAccess" },[t2]) ->
+		begin try
+			let t1' = apply_params tp tl t1 in
+			unify uctx t1' t2
+		with Unify_error l ->
+			raise (cannot_unify a b :: l)
+		end
+	| _, TInst ({ cl_path = [],"ArrayAccess" },_) ->
+		error [cannot_unify a b]
 	| TAbstract (a1,tl1) , TAbstract (a2,tl2) ->
 		unify_abstracts uctx a b a1 tl1 a2 tl2
 	| TInst (c1,tl1) , TInst (c2,tl2) ->

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -684,7 +684,7 @@ let rec unify (uctx : unification_context) a b =
 			let t1' = apply_params tp tl t1 in
 			unify uctx t1' t2
 		with Unify_error l ->
-			raise (cannot_unify a b :: l)
+			error (cannot_unify a b :: l)
 		end
 	| _, TInst ({ cl_path = [],"ArrayAccess" },_) ->
 		error [cannot_unify a b]

--- a/tests/unit/src/unitstd/ArrayAccess.unit.hx
+++ b/tests/unit/src/unitstd/ArrayAccess.unit.hx
@@ -1,0 +1,83 @@
+package tests.unit.src.unitstd;
+
+extern inline overload function test1(access: ArrayAccess<Int>) return true;
+extern inline overload function test1(access: Any) return false;
+
+class Dummy1 implements ArrayAccess<Int> { public function new() {} }
+class Dummy2 extends Dummy2 {}
+
+class Dummy3<T> implements ArrayAccess<T> { public function new() {} }
+class Dummy4<T> extends Dummy3<T> {}
+class Dummy5 extends Dummy3<String> {}
+
+test1([]) == true;
+test1([1, 2, 3]) == true;
+test1([1.2]) == false;
+
+test1(new Dummy1()) == true;
+test1(new Dummy2()) == true;
+test1(new Dummy3<Int>()) == true;
+test1(new Dummy3<String>()) == false;
+test1(new Dummy4<Int>()) == true;
+test1(new Dummy4<Float>()) == false;
+test1(new Dummy5()) == false;
+
+test1("abc") == false;
+test1(null) == false;
+
+
+extern inline overload function test2<T>(access: ArrayAccess<T>) return true;
+extern inline overload function test2(access: Any) return false;
+
+test2([]) == true;
+test2([1, 2, 3]) == true;
+test2([1.2]) == true;
+
+test2(new Dummy1()) == true;
+test2(new Dummy2()) == true;
+test2(new Dummy3<Int>()) == true;
+test2(new Dummy3<String>()) == true;
+test2(new Dummy4<Int>()) == true;
+test2(new Dummy4<Float>()) == true;
+test2(new Dummy5()) == true;
+
+test2("abc") == false;
+test2(null) == false;
+
+
+extern inline overload function test3<T: ArrayAccess<Int>>(access: T) return true;
+extern inline overload function test3(access: Any) return false;
+
+test3([]) == true;
+test3([1, 2, 3]) == true;
+test3([1.2]) == false;
+
+test3(new Dummy1()) == true;
+test3(new Dummy2()) == true;
+test3(new Dummy3<Int>()) == true;
+test3(new Dummy3<String>()) == false;
+test3(new Dummy4<Int>()) == true;
+test3(new Dummy4<Float>()) == false;
+test3(new Dummy5()) == false;
+
+test3("abc") == false;
+test3(null) == false;
+
+
+extern inline overload function test4<T, U: ArrayAccess<T>>(access: U) return true;
+extern inline overload function test4(access: Any) return false;
+
+test4([]) == true;
+test4([1, 2, 3]) == true;
+test4([1.2]) == true;
+
+test4(new Dummy1()) == true;
+test4(new Dummy2()) == true;
+test4(new Dummy3<Int>()) == true;
+test4(new Dummy3<String>()) == true;
+test4(new Dummy4<Int>()) == true;
+test4(new Dummy4<Float>()) == true;
+test4(new Dummy5()) == true;
+
+test4("abc") == false;
+test4(null) == false;

--- a/tests/unit/src/unitstd/ArrayAccess.unit.hx
+++ b/tests/unit/src/unitstd/ArrayAccess.unit.hx
@@ -1,5 +1,3 @@
-package tests.unit.src.unitstd;
-
 extern inline overload function test1(access: ArrayAccess<Int>) return true;
 extern inline overload function test1(access: Any) return false;
 


### PR DESCRIPTION
Implements #10326 

This is my first time diving into the typer, so I'm not sure if I covered everything (although it should, given that I used the implementation of `haxe.Constructible` as reference)

Remaining questions:
- Should `ArrayAccess` only be allowed on type parameters (and otherwise be banned as a type annotation)?
- If so, should we at least allow it on dynamic targets like js and lua?