### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,6 @@ RUN add-apt-repository ppa:haxe/ocaml -y
 RUN apt-get update -qqy
 RUN apt-get install -qqy ocaml-nox camlp5 opam libpcre3-dev zlib1g-dev libgtk2.0-dev libmbedtls-dev ninja-build libstring-shellquote-perl libipc-system-simple-perl neko neko-dev
 
-RUN apt-get install -qqy sudo
 RUN useradd -ms /bin/bash haxe && echo "haxe:haxe" | chpasswd && adduser haxe sudo
 USER haxe
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -qqy
+RUN apt-get install -qqy sudo software-properties-common
+
+RUN add-apt-repository ppa:avsm/ppa -y
+RUN add-apt-repository ppa:haxe/ocaml -y
+RUN apt-get update -qqy
+RUN apt-get install -qqy ocaml-nox camlp5 opam libpcre3-dev zlib1g-dev libgtk2.0-dev libmbedtls-dev ninja-build libstring-shellquote-perl libipc-system-simple-perl neko neko-dev
+
+RUN apt-get install -qqy sudo
+RUN useradd -ms /bin/bash haxe && echo "haxe:haxe" | chpasswd && adduser haxe sudo
+USER haxe
+
+ENV OPAMYES=1
+RUN opam init --disable-sandboxing
+RUN opam update
+
+# The following has to run with the cwd mounted to the container, see "postCreateCommand" in devcontainer.json
+# RUN opam pin add haxe . --no-action
+# RUN opam install haxe --deps-only --assume-depexts

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"vshaxe.haxe-extension-pack"
+		"vshaxe.haxe-extension-pack",
+		"ocamllabs.ocaml-platform"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "Haxe",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		// "terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"vshaxe.haxe-extension-pack"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "opam pin add haxe . --no-action && opam install haxe --deps-only --assume-depexts && opam env > ~/.bashrc",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "haxe" // (pw: haxe)
+}


### PR DESCRIPTION
Setting up dev env for haxe has always been far from easy. Using devcontainer should make it simpler.

To use it, first install docker and this [vscode extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), then fire up the vscode command `Remote-Containers: Open Folder in Container...` and choose the haxe folder. First run will take quite some time to setup. On my macbook pro it took ~10minutes. But subsequent startup should be almost instant. Note that most of the steps are copied from the CI scripts.

Btw, I am not very sure what vscode extensions are used for ocaml dev. So, those educated please kindly add them to "extensions" in devcontainer.json.