### PR TITLE
add module for eval Int64 + UInt64

### DIFF
--- a/std/eval/integers/Int64.hx
+++ b/std/eval/integers/Int64.hx
@@ -100,6 +100,7 @@ package eval.integers;
 	@:op(A - B) inline function _sub(u:Int64):Int64 return this.sub(u);
 	@:op(A * B) inline function _mul(u:Int64):Int64 return this.mul(u);
 	@:op(A / B) inline function _div(u:Int64):Int64 return this.div(u);
+	@:op(A % B) inline function _mod(u:Int64):Int64 return this.remainder(u);
 	@:op(A & B) inline function _logand(u:Int64):Int64 return this.logand(u);
 	@:op(A | B) inline function _logor(u:Int64):Int64 return this.logor(u);
 	@:op(A ^ B) inline function _logxor(u:Int64):Int64 return this.logxor(u);

--- a/std/eval/integers/UInt64.hx
+++ b/std/eval/integers/UInt64.hx
@@ -89,6 +89,7 @@ package eval.integers;
 	@:op(A - B) inline function _sub(u:UInt64):UInt64 return this.sub(u);
 	@:op(A * B) inline function _mul(u:UInt64):UInt64 return this.mul(u);
 	@:op(A / B) inline function _div(u:UInt64):UInt64 return this.div(u);
+	@:op(A % B) inline function _mod(u:UInt64):UInt64 return this.remainder(u);
 	@:op(A & B) inline function _logand(u:UInt64):UInt64 return this.logand(u);
 	@:op(A | B) inline function _logor(u:UInt64):UInt64 return this.logor(u);
 	@:op(A ^ B) inline function _logxor(u:UInt64):UInt64 return this.logxor(u);


### PR DESCRIPTION
Uses the already included "remainder" function to add the operator overload functions.