### PR TITLE
UInt parse Float and String

### DIFF
--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -307,6 +307,48 @@ abstract UInt(Int) from Int to Int {
 		return this;
 	}
 
+	@:from private static #if (!js || analyzer) inline #end function parseFloat(x:Float):UInt {
+		var y = Math.floor(x);
+		if (x == y)
+			return y;
+		var z:UInt = y;
+		z += Std.int(x - y);
+		return z;
+	}
+
+	@:from private static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
+		var base:UInt = 10;
+		var current:UInt = 0;
+		var multiplier:UInt = 1;
+
+		var s = StringTools.trim(s);
+		if (s.charAt(0) == "-") {
+			throw "NumberFormatError: Negative";
+		}
+		var len = s.length;
+		var before:UInt = 0;
+
+		for (i in 0...len) {
+			var digitInt = s.charCodeAt(len - 1 - i) - '0'.code;
+
+			if (digitInt < 0 || digitInt > 9) {
+				throw "NumberFormatError";
+			}
+
+			if (digitInt != 0) {
+				var digit:UInt = digitInt;
+				before = current;
+				current = current + multiplier * digit;
+				if (lt(current,before)) {
+					throw "NumberFormatError: Overflow";
+				}
+			}
+
+			multiplier = multiplier * base;
+		}
+		return current;
+	}
+
 	@:to private #if (!js || analyzer) inline #end function toFloat():Float {
 		var int = toInt();
 		if (int < 0) {

--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -307,15 +307,6 @@ abstract UInt(Int) from Int to Int {
 		return this;
 	}
 
-	public static #if (!js || analyzer) inline #end function parseFloat(x:Float):UInt {
-		var y = Math.floor(x);
-		if (x == y)
-			return y;
-		var z:UInt = y;
-		z += Std.int(x - y);
-		return z;
-	}
-
 	public static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
 		var base:UInt = 10;
 		var current:UInt = 0;

--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -307,7 +307,7 @@ abstract UInt(Int) from Int to Int {
 		return this;
 	}
 
-	public static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
+	public static function parseString(s:String):UInt {
 		var base:UInt = 10;
 		var current:UInt = 0;
 		var multiplier:UInt = 1;

--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -307,7 +307,7 @@ abstract UInt(Int) from Int to Int {
 		return this;
 	}
 
-	private static #if (!js || analyzer) inline #end function parseFloat(x:Float):UInt {
+	public static #if (!js || analyzer) inline #end function parseFloat(x:Float):UInt {
 		var y = Math.floor(x);
 		if (x == y)
 			return y;
@@ -316,7 +316,7 @@ abstract UInt(Int) from Int to Int {
 		return z;
 	}
 
-	private static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
+	public static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
 		var base:UInt = 10;
 		var current:UInt = 0;
 		var multiplier:UInt = 1;

--- a/std/UInt.hx
+++ b/std/UInt.hx
@@ -307,7 +307,7 @@ abstract UInt(Int) from Int to Int {
 		return this;
 	}
 
-	@:from private static #if (!js || analyzer) inline #end function parseFloat(x:Float):UInt {
+	private static #if (!js || analyzer) inline #end function parseFloat(x:Float):UInt {
 		var y = Math.floor(x);
 		if (x == y)
 			return y;
@@ -316,7 +316,7 @@ abstract UInt(Int) from Int to Int {
 		return z;
 	}
 
-	@:from private static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
+	private static #if (!js || analyzer) inline #end function parseString(s:String):UInt {
 		var base:UInt = 10;
 		var current:UInt = 0;
 		var multiplier:UInt = 1;


### PR DESCRIPTION
Creates a String parser for UInt based upon Int64Helper and a Float parser created from scratch (not sure how sound it is) This is a pragmatic fix for #7535 at the current moment without support for larger max value integer literals.