### PR TITLE
[cpp] Support type parameters on extern classes

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -1666,11 +1666,13 @@ and tcpp_to_string tcpp =
     tcpp_to_string_suffix "" tcpp
 
 and cpp_class_path_of klass params =
-      let globalNamespace = if (get_meta_string klass.cl_meta Meta.Native)<>"" then " " else " ::" in
+   match (get_meta_string klass.cl_meta Meta.Native)<>"" with
+   | true -> 
       let typeParams = match params with
       | [] -> ""
       | _ -> "<" ^ String.concat "," (List.map tcpp_to_string params) ^ ">" in
-      globalNamespace ^ (join_class_path_remap klass.cl_path "::") ^ typeParams
+      (join_class_path_remap klass.cl_path "::") ^ typeParams
+   | false -> "::" ^ (join_class_path_remap klass.cl_path "::")
 ;;
 
 

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4833,7 +4833,9 @@ let find_referenced_types_flags ctx obj field_name super_deps constructor_deps h
             | (["cpp"],"Pointer") | (["cpp"],"ConstPointer") | (["cpp"],"Function")
             | (["cpp"],"RawPointer") | (["cpp"],"RawConstPointer") -> List.iter visit_type params
             | _ when is_native_gen_class klass -> add_native_gen_class klass
-            | _ when is_extern_class klass -> add_extern_class klass
+            | _ when is_extern_class klass ->
+               add_extern_class klass;
+               List.iter visit_type params;
             | _ -> (match klass.cl_kind with KTypeParameter _ -> () | _ -> add_type klass.cl_path);
             )
          | TAbstract (a,params) when is_scalar_abstract a ->

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -758,7 +758,8 @@ let rec class_string klass suffix params remap =
       | _ -> "<" ^ (String.concat "," (List.map type_string params)) ^ ">" in
       (join_class_path_remap klass.cl_path "::") ^ class_params
    | _ ->
-      (join_class_path_remap klass.cl_path "::") ^ suffix
+      let globalNamespace = if (get_meta_string klass.cl_meta Meta.Native)<>"" then "" else "::" in
+      globalNamespace ^ (join_class_path_remap klass.cl_path "::") ^ suffix
    )
 and type_string_suff suffix haxe_type remap =
    let type_string = type_string_remap remap in

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -753,7 +753,7 @@ let rec class_string klass suffix params remap =
             (join_class_path_remap klass.cl_path "::") ^ " *"
    (* Normal class *)
    | _ when is_native_class klass ->
-      join_class_path_remap klass.cl_path "::"
+      join_class_path_remap klass.cl_path "::" ^ "<" ^ (String.concat "," (List.map type_string params)) ^ ">"
    | _ ->
       let globalNamespace = if (get_meta_string klass.cl_meta Meta.Native)<>"" then "" else "::" in
       globalNamespace ^ (join_class_path_remap klass.cl_path "::") ^ suffix
@@ -1366,7 +1366,7 @@ type tcpp =
    | TCppNativePointer of tclass
    | TCppVariant
    | TCppCode of tcpp
-   | TCppInst of tclass
+   | TCppInst of tclass * tcpp list
    | TCppInterface of tclass
    | TCppProtocol of tclass
    | TCppClass
@@ -1634,10 +1634,10 @@ and tcpp_to_string_suffix suffix tcpp = match tcpp with
           name
        else
           "::hx::Native< " ^ name ^ "* >";
-   | TCppInst klass ->
-      (cpp_class_path_of klass) ^ (if is_native_class klass then "" else suffix)
+   | TCppInst (klass, p) ->
+      (cpp_class_path_of klass p) ^ (if is_native_class klass then "" else suffix)
    | TCppInterface klass when suffix="_obj" ->
-        (cpp_class_path_of klass) ^ suffix
+        (cpp_class_path_of klass []) ^ suffix
    | TCppInterface _ -> "::Dynamic"
    | TCppClass -> "::hx::Class" ^ suffix;
    | TCppGlobal -> "::Dynamic";
@@ -1663,9 +1663,12 @@ and tcpp_objc_block_struct argTypes retType =
 and tcpp_to_string tcpp =
     tcpp_to_string_suffix "" tcpp
 
-and cpp_class_path_of klass =
+and cpp_class_path_of klass params =
       let globalNamespace = if (get_meta_string klass.cl_meta Meta.Native)<>"" then " " else " ::" in
-      globalNamespace ^ (join_class_path_remap klass.cl_path "::")
+      let typeParams = match params with
+      | [] -> ""
+      | _ -> "<" ^ String.concat "," (List.map tcpp_to_string params) ^ ">" in
+      globalNamespace ^ (join_class_path_remap klass.cl_path "::") ^ typeParams
 ;;
 
 
@@ -1688,7 +1691,7 @@ let is_cpp_scalar cpp_type =
 
 let is_cpp_array_implementer cppType =
    match cppType with
-   | TCppInst (klass)
+   | TCppInst (klass, _)
    | TCppInterface (klass) ->
       (match klass.cl_array_access with
       | Some _ -> true
@@ -1726,7 +1729,7 @@ let rec cpp_is_struct_access t =
    match t with
    | TCppFunction _ -> true
    | TCppStruct _-> false
-   | TCppInst (class_def) -> (has_meta_key class_def.cl_meta Meta.StructAccess)
+   | TCppInst (class_def, _) -> (has_meta_key class_def.cl_meta Meta.StructAccess)
    | TCppReference (r) -> cpp_is_struct_access r
    | _ -> false
 ;;
@@ -1930,9 +1933,9 @@ let rec cpp_type_of stack ctx haxe_type =
          else if (has_class_flag klass CInterface) then
             TCppInterface(klass)
          else if (has_class_flag klass CExtern) && (not (is_internal_class klass.cl_path) ) then
-            TCppInst(klass)
+            TCppInst(klass, List.map (cpp_type_of stack ctx) params)
          else
-            TCppInst(klass)
+            TCppInst(klass, List.map (cpp_type_of stack ctx) params)
        )
 
 let cpp_type_of ctx = cpp_type_of [] ctx
@@ -2206,8 +2209,8 @@ let cpp_no_debug_synbol ctx var =
    (ctx.ctx_debug_level<=1) || (match var.v_kind with VUser _ -> false | _ -> true) ||
       match cpp_type_of ctx var.v_type with
       | TCppStar _ | TCppReference _ -> true
-      | TCppInst (class_def) when (has_meta_key class_def.cl_meta Meta.StructAccess) -> true
-      | TCppInst (class_def) when (has_meta_key class_def.cl_meta Meta.Unreflective) -> true
+      | TCppInst (class_def, _) when (has_meta_key class_def.cl_meta Meta.StructAccess) -> true
+      | TCppInst (class_def, _) when (has_meta_key class_def.cl_meta Meta.Unreflective) -> true
       | _->
          let name = cpp_var_debug_name_of var in
          (String.length name) >4 && (String.sub name 0 4) = "_hx_"
@@ -2225,7 +2228,7 @@ let cpp_debug_var_visible ctx var =
 let only_stack_access ctx haxe_type =
    let tcpp = cpp_type_of ctx haxe_type in
    match tcpp with
-   | TCppInst(klass) -> has_meta_key klass.cl_meta Meta.StackOnly
+   | TCppInst(klass, _) -> has_meta_key klass.cl_meta Meta.StackOnly
    | _ -> false;
 ;;
 
@@ -2247,9 +2250,9 @@ let is_array_splice_call obj member =
 let is_map_get_call obj member =
    member.cf_name="get" &&
    (match obj.cpptype  with
-   | TCppInst({cl_path=(["haxe";"ds"],"IntMap")}) -> true
-   | TCppInst({cl_path=(["haxe";"ds"],"StringMap")}) -> true
-   | TCppInst({cl_path=(["haxe";"ds"],"ObjectMap")}) -> true
+   | TCppInst({cl_path=(["haxe";"ds"],"IntMap")}, _) -> true
+   | TCppInst({cl_path=(["haxe";"ds"],"StringMap")}, _) -> true
+   | TCppInst({cl_path=(["haxe";"ds"],"ObjectMap")}, _) -> true
    | _ -> false
    )
 ;;
@@ -2257,9 +2260,9 @@ let is_map_get_call obj member =
 let is_map_set_call obj member =
    member.cf_name="set" &&
    (match obj.cpptype  with
-   | TCppInst({cl_path=(["haxe";"ds"],"IntMap")}) -> true
-   | TCppInst({cl_path=(["haxe";"ds"],"StringMap")}) -> true
-   | TCppInst({cl_path=(["haxe";"ds"],"ObjectMap")}) -> true
+   | TCppInst({cl_path=(["haxe";"ds"],"IntMap")}, _) -> true
+   | TCppInst({cl_path=(["haxe";"ds"],"StringMap")}, _) -> true
+   | TCppInst({cl_path=(["haxe";"ds"],"ObjectMap")}, _) -> true
    | _ -> false
    )
 ;;
@@ -2334,7 +2337,7 @@ let cpp_enum_name_of field =
 
 let is_object_element ctx member_type =
   match member_type with
-   | TCppInst x
+   | TCppInst (x, _)
    | TCppInterface x
        -> not (is_extern_class x)
    | TCppDynamic
@@ -2840,8 +2843,10 @@ let retype_expression ctx request_type function_args function_type expression_tr
             in
             let arg_types, _ = cpp_function_type_of_args_ret ctx constructor_type in
             let retypedArgs = retype_function_args args arg_types in
-            let created_type = cpp_type_of expr.etype in
-            gc_stack := !gc_stack || (match created_type with | TCppInst(t) -> not (is_native_class t) | _ -> false );
+            let created_type = (match cpp_type_of expr.etype with 
+            | TCppInst(klass, []) -> TCppInst(klass, List.map cpp_type_of params)
+            | other -> other ) in
+            gc_stack := !gc_stack || (match created_type with | TCppInst(t, _) -> not (is_native_class t) | _ -> false );
             CppCall( FuncNew(created_type), retypedArgs), created_type
 
          | TFunction func ->
@@ -2896,7 +2901,7 @@ let retype_expression ctx request_type function_args function_type expression_tr
                  CppArray( ArrayObject(retypedObj,retypedIdx,TCppDynamic) ), TCppDynamic
               | TCppObjectArray elem ->
                  CppArray( ArrayObject(retypedObj,retypedIdx,elem) ), elem
-              | TCppInst({cl_array_access = Some _ } as klass) ->
+              | TCppInst({cl_array_access = Some _ } as klass, _) ->
                  CppArray( ArrayImplements(klass, retypedObj,retypedIdx) ), cpp_type_of expr.etype
               | TCppDynamicArray ->
                  CppArray( ArrayVirtual(retypedObj, retypedIdx) ), TCppDynamic
@@ -3059,7 +3064,12 @@ let retype_expression ctx request_type function_args function_type expression_tr
 
          | TVar (v,eo) ->
             let varType = cpp_type_of v.v_type in
-            let init = match eo with None -> None | Some e -> Some (retype varType e) in
+            let init = match eo with
+            | None -> None
+            | Some e ->
+               (Printf.printf "# %s\n" (s_type_kind v.v_type));
+               (Printf.printf "# %s\n" (s_type_kind e.etype));
+               Some (retype varType e) in
             Hashtbl.add !declarations v.v_name ();
             CppVarDecl(v, init), varType
 
@@ -3175,10 +3185,10 @@ let retype_expression ctx request_type function_args function_type expression_tr
       end else if (cppExpr.cpptype=TCppVariant || cppExpr.cpptype=TCppDynamic || cppExpr.cpptype==TCppObject) then begin
          match return_type with
          | TCppUnchanged -> cppExpr
-         | TCppInst(t) when (has_meta_key t.cl_meta Meta.StructAccess) ->
-             let structType = TCppStruct( TCppInst(t) ) in
+         | TCppInst(t, _) when (has_meta_key t.cl_meta Meta.StructAccess) ->
+             let structType = TCppStruct( TCppInst(t, []) ) in
              let structCast =  mk_cppexpr (CppCast(cppExpr,structType)) structType in
-             mk_cppexpr (CppCast(structCast,(TCppInst t))) (TCppInst t)
+             mk_cppexpr (CppCast(structCast,(TCppInst (t, [])))) (TCppInst (t, []))
 
          | TCppObjectArray _
          | TCppScalarArray _
@@ -3266,7 +3276,7 @@ let retype_expression ctx request_type function_args function_type expression_tr
          | TCppStar(t,const), TCppStruct _ ->
              mk_cppexpr (CppDereference(cppExpr)) return_type
 
-         | TCppInst(t), TCppStar _ when (is_native_class t) && (match cppExpr.cppexpr with
+         | TCppInst(t, _), TCppStar _ when (is_native_class t) && (match cppExpr.cppexpr with
             | CppCall(FuncNew(_), _) -> true
             | _ -> false) ->
             mk_cppexpr (CppNewNative(cppExpr)) return_type
@@ -3283,8 +3293,8 @@ let retype_expression ctx request_type function_args function_type expression_tr
          | t, TCppProtocol protocol ->
               mk_cppexpr (CppCastProtocol(cppExpr,protocol)) return_type
 
-         | TCppInst(t), TCppDynamic when (has_meta_key t.cl_meta Meta.StructAccess) ->
-             let structType = TCppStruct( TCppInst(t) ) in
+         | TCppInst(t, _), TCppDynamic when (has_meta_key t.cl_meta Meta.StructAccess) ->
+             let structType = TCppStruct( TCppInst(t, []) ) in
              let structCast =  mk_cppexpr (CppCast(cppExpr,structType)) structType in
              mk_cppexpr (CppCast(structCast,TCppDynamic)) TCppDynamic
 
@@ -3580,8 +3590,8 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
            expr.cpppos);
          out " ]"
 
-      | CppCall(FuncNew( TCppInst klass), args) when can_quick_alloc klass ->
-         out ((cpp_class_path_of klass) ^ "_obj::__alloc( HX_CTX ");
+      | CppCall(FuncNew( TCppInst (klass, p)), args) when can_quick_alloc klass ->
+         out ((cpp_class_path_of klass p) ^ "_obj::__alloc( HX_CTX ");
          List.iter (fun arg -> out ","; gen arg ) args;
          out (")")
 
@@ -3635,14 +3645,14 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
          | FuncEnumConstruct(enum,field) ->
             out ((string_of_path enum.e_path) ^ "::" ^ (cpp_enum_name_of field));
 
-         | FuncSuperConstruct(TCppInst klass) when is_native_class klass ->
+         | FuncSuperConstruct(TCppInst (klass, _)) when is_native_class klass ->
             doCall := false;
 
          | FuncSuperConstruct _ ->
             out ((if not ctx.ctx_real_this_ptr then "__this->" else "") ^  "super::__construct")
 
-         | FuncSuper(_,TCppInst(klass),field) when is_native_class klass ->
-            out ((cpp_class_path_of klass) ^ "::" ^ (cpp_member_name_of field));
+         | FuncSuper(_,TCppInst(klass, p),field) when is_native_class klass ->
+            out ((cpp_class_path_of klass p) ^ "::" ^ (cpp_member_name_of field));
 
          | FuncSuper(this,_,field) ->
             out ( (if this==ThisReal then "this->" else "__->") ^ "super::" ^ (cpp_member_name_of field) )
@@ -3653,10 +3663,10 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
             | TCppDynamicArray -> "::cpp::VirtualArray_obj::__new"
             | TCppObjectArray _ -> "::Array_obj< ::Dynamic>::__new"
             | TCppScalarArray(value) -> "::Array_obj< " ^ (tcpp_to_string value) ^ " >::__new"
-            | TCppObjC klass ->  (cpp_class_path_of klass) ^ "_obj::__new"
-            | TCppNativePointer klass -> "new " ^ (cpp_class_path_of klass);
-            | TCppInst klass when is_native_class klass -> cpp_class_path_of klass
-            | TCppInst klass -> (cpp_class_path_of klass) ^ "_obj::__new"
+            | TCppObjC klass ->  (cpp_class_path_of klass []) ^ "_obj::__new"
+            | TCppNativePointer klass -> "new " ^ (cpp_class_path_of klass []);
+            | TCppInst (klass, p) when is_native_class klass -> cpp_class_path_of klass p
+            | TCppInst (klass, p) -> (cpp_class_path_of klass p) ^ "_obj::__new"
             | TCppClass -> "::hx::Class_obj::__new";
             | TCppFunction _ -> tcpp_to_string newType
             | _ -> abort ("Unknown 'new' target " ^ (tcpp_to_string newType)) expr.cpppos
@@ -4457,7 +4467,7 @@ let gen_field ctx class_def class_name ptr_name dot_name is_static is_interface 
 
       let needsWrapper t = match t with
          | TCppStar _ -> true
-         | TCppInst(t) -> has_meta_key t.cl_meta Meta.StructAccess
+         | TCppInst(t, _) -> has_meta_key t.cl_meta Meta.StructAccess
          | _ -> false
       in
       let orig_debug = ctx.ctx_debug_level in
@@ -4503,7 +4513,7 @@ let gen_field ctx class_def class_name ptr_name dot_name is_static is_interface 
                   match return_type with
                     | TCppStar _ ->
                        output "return (cpp::Pointer<const void *>) "
-                    | TCppInst(t) when has_meta_key t.cl_meta Meta.StructAccess ->
+                    | TCppInst(t, _) when has_meta_key t.cl_meta Meta.StructAccess ->
                        output ("return (cpp::Struct< " ^ (tcpp_to_string return_type) ^ " >) ");
                     | _ -> output "return ";
                end;
@@ -4519,7 +4529,7 @@ let gen_field ctx class_def class_name ptr_name dot_name is_static is_interface 
                      (match arg with
                        | TCppStar (t,const) ->
                           output ("(cpp::" ^ (if const then "Const" else "") ^"Pointer<" ^ (tcpp_to_string t)^" >) ")
-                       | TCppInst(t) when has_meta_key t.cl_meta Meta.StructAccess ->
+                       | TCppInst(t, _) when has_meta_key t.cl_meta Meta.StructAccess ->
                           output ("(cpp::Struct< " ^ (tcpp_to_string arg) ^ " >) ");
                        | _ -> () );
                      output ("a" ^ (string_of_int i));
@@ -5830,7 +5840,7 @@ let generate_class_files baseCtx super_deps constructor_deps class_def inScripta
                   in
                   (match find_super_args [function_def.tf_expr.eexpr] with
                   | Some args ->
-                     out ("\n:" ^ (cpp_class_path_of klass) ^ "(");
+                     out ("\n:" ^ (cpp_class_path_of klass []) ^ "(");
                      let sep = ref "" in
                      List.iter (fun arg ->
                         out !sep; sep := ",";
@@ -6138,7 +6148,7 @@ let generate_class_files baseCtx super_deps constructor_deps class_def inScripta
 
       let toCommon t f value =
          t ^ "( " ^ ( match cpp_type_of ctx f.cf_type with
-           | TCppInst(t) as inst when (has_meta_key t.cl_meta Meta.StructAccess)
+           | TCppInst(t, _) as inst when (has_meta_key t.cl_meta Meta.StructAccess)
               -> "cpp::Struct< " ^ (tcpp_to_string inst) ^ " >( " ^ value ^ " )"
            | TCppStar(t,_) -> "cpp::Pointer<void *>( " ^ value ^ " )"
            | _ -> value
@@ -6186,7 +6196,7 @@ let generate_class_files baseCtx super_deps constructor_deps class_def inScripta
 
       let castable f =
          match cpp_type_of ctx f.cf_type with
-           | TCppInst(t) as inst when (has_meta_key t.cl_meta Meta.StructAccess)
+           | TCppInst(t, _) as inst when (has_meta_key t.cl_meta Meta.StructAccess)
               -> "cpp::Struct< " ^ (tcpp_to_string inst) ^ " > "
            | TCppStar(t,_) -> "cpp::Pointer< " ^ ( tcpp_to_string t ) ^ " >"
            | _ -> ctx_type_string ctx f.cf_type
@@ -7086,7 +7096,7 @@ let rec script_cpptype_string cppType = match cppType with
    | TCppProtocol _ -> "cpp.ObjC.Protocol"
    | TCppNativePointer klass -> "cpp.Pointer." ^ (join_class_path klass.cl_path ".")
    | TCppInterface klass -> (join_class_path klass.cl_path ".")
-   | TCppInst klass -> (join_class_path klass.cl_path ".")
+   | TCppInst (klass, _) -> (join_class_path klass.cl_path ".")
    | TCppClass -> "Class"
    | TCppGlobal -> "?global";
    | TCppNull -> "null";
@@ -7982,11 +7992,11 @@ class script_writer ctx filename asciiOut =
             | FuncEnumConstruct(enum,field) ->
                this#write ((this#op IaCreateEnum) ^ (this#enumText enum) ^ " " ^ (this#stringText field.ef_name) ^ argN ^
                    (this#commentOf field.ef_name) ^ "\n");
-            | FuncSuperConstruct(TCppInst klass) when (is_native_gen_class klass) && (is_native_class klass) ->
+            | FuncSuperConstruct(TCppInst (klass, _)) when (is_native_gen_class klass) && (is_native_class klass) ->
                abort "Unsupported super for native class constructor" expression.cpppos;
             | FuncSuperConstruct childType ->
                this#write ((this#op IaCallSuperNew) ^ (this#astType childType) ^ " " ^ argN ^ "\n");
-            | FuncSuper(_,TCppInst(klass),_) when (is_native_gen_class klass) && (is_native_class klass) ->
+            | FuncSuper(_,TCppInst(klass, _),_) when (is_native_gen_class klass) && (is_native_class klass) ->
                abort "Unsupported super for native class method" expression.cpppos;
             | FuncSuper(_,objType,field) ->
                this#write ( (this#op IaCallSuper) ^ (this#astType objType) ^ " " ^ (this#stringText field.cf_name) ^

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -2790,6 +2790,17 @@ let retype_expression ctx request_type function_args function_type expression_tr
                   *)
 
                (* Other functions ... *)
+               | CppFunction( FuncInstance(_, InstStruct, {cf_type=TFun(arg_types,_)}) as func, return_type) ->
+                  (* For struct access classes use the types of the arguments instead of the function argument types *)
+                  (* In the case of generic extern classes a TFun arg type could be `MyClass.T` instead of the real type *)
+                  let map_args func_arg passed_arg =
+                     let (name, opt, _) = func_arg in
+                     name, opt, passed_arg.etype in
+                  let real_types = List.map2 map_args arg_types args in
+                  let arg_types = List.map (fun (_,opt,t) -> cpp_tfun_arg_type_of ctx opt t) real_types in
+                  let retypedArgs = retype_function_args args arg_types in
+                  CppCall(func,retypedArgs), return_type
+
                | CppFunction( FuncInstance(_,_,{cf_type=TFun(arg_types,_)} ) as func, returnType )
                | CppFunction( FuncStatic(_,_,{cf_type=TFun(arg_types,_)} ) as func, returnType )
                | CppFunction( FuncThis({cf_type=TFun(arg_types,_)},_ ) as func, returnType ) ->


### PR DESCRIPTION
Hello,
I've added support for type parameters / generic extern classes for cpp. Main change is that `TCppInst` now carries a list of `tcpp` type parameters around with it which are used if the class is extern. This allows you to write externs like in the following example, where previously you'd need to write externs for each type of the native templated type (or do stuff like have a generic extern but then extern it with another extern specifying the type).

```haxe
function main() {
	final ivec = new StdVector();
	ivec.push_back(1);

	final fvec = new StdVector();
	fvec.push_back(1.4685);
}

@:keep
@:unreflective
@:structAccess
@:include('vector')
@:native('std::vector')
extern class StdVector<T> {
	function new();

	function size() : Int;

	function push_back(_v : T) : Void;

	function data() : cpp.RawPointer<T>;

	function at(_idx : Int) : T;
}
```

which generates cpp code looking like this.

```cpp
void Main_Fields__obj::main(){
            	HX_STACKFRAME(&_hx_pos_195033e4c87195a0_1_main)
HXLINE(   2)		std::vector<int> ivec = std::vector<int>();
HXLINE(   3)		ivec.push_back(1);
HXLINE(   5)		std::vector<Float> fvec = std::vector<Float>();
HXLINE(   6)		fvec.push_back(((Float)1.4685));
            	}
```

One thing you can't do with generic externs is something like `@:native('::cpp::Struct<std::vector>')` for templated classes like you can with non templated classes as the parameters are simply appened to the end (maybe we need a new meta like `@:structWrap` to auto wrap the type in a `cpp.Struct`?).