### PR TITLE
[js] Added js.Lib.unbind to bypass the haxe `$bind`

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -402,6 +402,11 @@ let is_dynamic_iterator ctx e =
 	| _ ->
 		false
 
+let pass_tdynamic_in_tcast e t =
+	match t == t_dynamic, e.eexpr with
+	| true, TField(_,FClosure _) -> {e with etype = t}
+	| _ -> e
+
 let gen_constant ctx p = function
 	| TInt i -> print ctx "%ld" i
 	| TFloat s -> spr ctx s
@@ -656,7 +661,7 @@ and gen_expr ctx e =
 		print ctx "$bind(";
 		gen_value ctx x;
 		print ctx ",$arrayPush)"
-	| TField (x,FClosure (_,f)) ->
+	| TField (x,FClosure (_,f)) when e.etype != t_dynamic ->
 		add_feature ctx "use.$bind";
 		(match x.eexpr with
 		| TConst _ | TLocal _ ->
@@ -690,7 +695,8 @@ and gen_expr ctx e =
 		spr ctx (module_field m f)
 	| TField (x,f) ->
 		let rec skip e = match e.eexpr with
-			| TCast(e1,None) | TMeta(_,e1) -> skip e1
+			| TMeta(_,e1) -> skip e1
+			| TCast(e1,None) -> skip (pass_tdynamic_in_tcast e1 e.etype)
 			| TConst(TInt _ | TFloat _) | TObjectDecl _ -> {e with eexpr = TParenthesis e}
 			| _ -> e
 		in
@@ -878,8 +884,8 @@ and gen_expr ctx e =
 			newline ctx;
 		);
 		spr ctx "}"
-	| TCast (e,None) ->
-		gen_expr ctx e
+	| TCast (e1,None) ->
+		gen_expr ctx (pass_tdynamic_in_tcast e1 e.etype)
 	| TCast (e1,Some t) ->
 		print ctx "%s.__cast(" (ctx.type_accessor (TClassDecl { null_class with cl_path = ["js"],"Boot" }));
 		gen_value ctx e1;
@@ -1011,7 +1017,7 @@ and gen_value ctx e =
 	| TContinue ->
 		unsupported e.epos
 	| TCast (e1, None) ->
-		gen_value ctx e1
+		gen_value ctx (pass_tdynamic_in_tcast e1 e.etype)
 	| TCast (e1, Some t) ->
 		print ctx "%s.__cast(" (ctx.type_accessor (TClassDecl { null_class with cl_path = ["js"],"Boot" }));
 		gen_value ctx e1;

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -488,6 +488,14 @@ let rec gen_call ctx e el in_value =
 			| _ ->
 				abort "js.Lib.getOriginalException can only be called inside a catch block" e.epos
 		)
+	| TField (_, FStatic ({ cl_path = ["js"],"Lib" }, { cf_name = "unbind" })), [e] ->
+		(match e.eexpr with
+		| TField(x, FClosure(_,f)) ->
+			gen_value ctx x;
+			if not (Meta.has Meta.SelfCall f.cf_meta) then spr ctx (field f.cf_name)
+		| _ ->
+			gen_value ctx e
+		)
 	| TIdent "__new__", args ->
 		print_deprecation_message ctx.com "__new__ is deprecated, use js.Syntax.construct instead" e.epos;
 		gen_syntax ctx "construct" args e.epos

--- a/std/js/Lib.hx
+++ b/std/js/Lib.hx
@@ -144,6 +144,14 @@ class Lib {
 	}
 
 	/**
+		Avoid applying "$bind" to member functions
+	**/
+	@:noClosure
+	public static function unbind(fn:haxe.Constraints.Function):Dynamic {
+		return fn; // function is implemented in the compiler
+	}
+
+	/**
 		Generate next unique id
 	**/
 	@:allow(haxe.ds.ObjectMap.assignId)

--- a/tests/unit/src/unit/issues/Issue10420.hx
+++ b/tests/unit/src/unit/issues/Issue10420.hx
@@ -9,17 +9,19 @@ class Issue10420 extends Test {
 	function test() {
 		var obj = {count : 101};
 
-		eq((func :  Dynamic).apply(obj), obj.count);
+		eq(UNBIND(func).call(obj), obj.count);
 
-		var jsbind = (func :  Dynamic).bind(obj);
+		var jsbind = UNBIND(func).bind(obj);
 		eq(jsbind(), obj.count);
 
-		var jsv = js.Syntax.code("{0}.apply({1})", (func : Dynamic), obj);
+		var jsv = js.Syntax.code("{0}.apply({1})", UNBIND(func), obj);
 		eq(jsv, obj.count);
 
 		// .apply will not works on haxe $bind
 		var hxv = js.Syntax.code("{0}.apply({1})", func, obj);
 		eq(hxv, this.count);
 	}
+
+	static inline function UNBIND(fn) return js.Lib.unbind(fn);
 #end
 }

--- a/tests/unit/src/unit/issues/Issue10420.hx
+++ b/tests/unit/src/unit/issues/Issue10420.hx
@@ -1,0 +1,25 @@
+package unit.issues;
+
+class Issue10420 extends Test {
+#if js
+	var count = 0;
+
+	function func() return this.count;
+
+	function test() {
+		var obj = {count : 101};
+
+		eq((func :  Dynamic).apply(obj), obj.count);
+
+		var jsbind = (func :  Dynamic).bind(obj);
+		eq(jsbind(), obj.count);
+
+		var jsv = js.Syntax.code("{0}.apply({1})", (func : Dynamic), obj);
+		eq(jsv, obj.count);
+
+		// .apply will not works on haxe $bind
+		var hxv = js.Syntax.code("{0}.apply({1})", func, obj);
+		eq(hxv, this.count);
+	}
+#end
+}


### PR DESCRIPTION
The main motivation here is to make haxe have the ability to call the native `.apply` `.call` or `.bind` of js

<details>
<summary><del>Previous <code>(inst.func: Dynamic)</code></del></summary>

```haxe
class C {
	function new(){
	}
	function log(f) {
		return Math.log(f);
	}
	static function main(){
		var c = new C();
		var log = c.log;  // normal haxe $bind
		log(0);
		log(0);

		var log = (c.log : Dynamic);
		log(1);
		log(1);

		var log = (c.log : Dynamic).bind(c);
		log(2);
		log(2);

		(c.log : Dynamic).apply(c, [3]);
		(c.log : Dynamic).apply(c, [3]);
	}
}
```

</details>

UPDATES:
```haxe
import js.Lib.unbind;

class C {
	function new(){
	}
	function log(f) {
		return Math.log(f);
	}
	static function main(){
		var c = new C();
		var log = c.log;  // normal haxe $bind
		log(0);
		log(0);

		var log = unbind(c.log);
		log(1);
		log(1);

		var log = unbind(c.log).bind(c);
		log(2);
		log(2);

		unbind(c.log).apply(c, [3]);
		unbind(c.log).apply(c, [3]);
	}
}
```

output:

```js
C.main = function() {
	var c = new C();
	var log = $bind(c,c.log);
	log(0);
	log(0);
	var log = c.log;
	log(1);
	log(1);
	var log = c.log.bind(c);
	log(2);
	log(2);
	c.log.apply(c,[3]);
	c.log.apply(c,[3]);
};
```

### Alternatives

Using `(inst : Dynamic).func` also works, but its related fields may be eliminated by the optimizer.