### PR TITLE
Disable fusion for impure externs

### DIFF
--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -590,19 +590,11 @@ module Fusion = struct
 			let can_be_used_as_value = can_be_used_as_value com e in
 			let is_compiler_generated = match v.v_kind with VUser _ | VInlined -> false | _ -> true in
 			let has_type_params = match v.v_extra with Some ve when ve.v_params <> [] -> true | _ -> false in
-			let rec contains_pure_meta metadata = match metadata with
-				| [] -> false
-				| (Meta.Pure, [], _) :: _
-				| (Meta.Pure, [(EConst (Ident ("true")), _)], _) :: _  -> true
-				| _ :: rest -> contains_pure_meta rest
-			in
 			let rec is_impure_extern e = match e.eexpr with
 				| TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf))) when has_class_flag cl CExtern ->
 					not (
 						Meta.has Meta.CoreApi cl.cl_meta ||
-						Meta.has Meta.NoClosure cl.cl_meta ||
-						contains_pure_meta cf.cf_meta ||
-						contains_pure_meta cl.cl_meta
+						PurityState.is_pure cl cf
 					)
 				| _ -> check_expr is_impure_extern e
 			in

--- a/tests/optimization/src/issues/Issue9943.hx
+++ b/tests/optimization/src/issues/Issue9943.hx
@@ -16,23 +16,18 @@ private extern class CSSStyleDeclaration {
 }
 
 class Issue9943 {
-	static function main() new Issue9943();
-	final foo = Std.random(0);
-	public function new() {
-		test();
-		test2();
-	}
+	static final foo = Std.random(0);
 
 	@:js('
 		var el = issues._Issue9943.Element.get();
-		var a = el.offset + this.foo;
+		var a = el.offset + issues_Issue9943.foo;
 		el.style.verticalAlign = 1;
-		var b = el.offset + this.foo;
+		var b = el.offset + issues_Issue9943.foo;
 		el.style.verticalAlign = 2;
-		var c = el.offset + this.foo;
-		this.values(a,b,c);
+		var c = el.offset + issues_Issue9943.foo;
+		issues_Issue9943.values(a,b,c);
 	')
-	function test() {
+	static function test() {
 		final el = Element.get();
 		final a = (el.offset + foo);
 		el.style.verticalAlign = 1;
@@ -45,9 +40,9 @@ class Issue9943 {
 		var el = issues._Issue9943.PureElement.get();
 		el.style.verticalAlign = 1;
 		el.style.verticalAlign = 2;
-		this.values(el.offset + this.foo,el.offset + this.foo,el.offset + this.foo);
+		issues_Issue9943.values(el.offset + issues_Issue9943.foo,el.offset + issues_Issue9943.foo,el.offset + issues_Issue9943.foo);
 	')
-	function test2() {
+	static function test2() {
 		final el = PureElement.get();
 		final a = (el.offset + foo);
 		el.style.verticalAlign = 1;
@@ -56,5 +51,5 @@ class Issue9943 {
 		final c = (el.offset + foo);
 		values(a, b, c);
 	}
-	function values(a, b, c) trace(a, b, c);
+	static function values(a, b, c) trace(a, b, c);
 }

--- a/tests/optimization/src/issues/Issue9943.hx
+++ b/tests/optimization/src/issues/Issue9943.hx
@@ -1,0 +1,60 @@
+package issues;
+
+private extern class Element {
+	static function get():Element;
+	var offset(default,null) : Int;
+	var style(default,null) : CSSStyleDeclaration;
+}
+@:pure
+private extern class PureElement {
+	static function get():PureElement;
+	var offset(default,null) : Int;
+	var style(default,null) : CSSStyleDeclaration;
+}
+private extern class CSSStyleDeclaration {
+	var verticalAlign : Int;
+}
+
+class Issue9943 {
+	static function main() new Issue9943();
+	final foo = Std.random(0);
+	public function new() {
+		test();
+		test2();
+	}
+
+	@:js('
+		var el = issues._Issue9943.Element.get();
+		var a = el.offset + this.foo;
+		el.style.verticalAlign = 1;
+		var b = el.offset + this.foo;
+		el.style.verticalAlign = 2;
+		var c = el.offset + this.foo;
+		this.values(a,b,c);
+	')
+	function test() {
+		final el = Element.get();
+		final a = (el.offset + foo);
+		el.style.verticalAlign = 1;
+		final b = (el.offset + foo);
+		el.style.verticalAlign = 2;
+		final c = (el.offset + foo);
+		values(a, b, c);
+	}
+	@:js('
+		var el = issues._Issue9943.PureElement.get();
+		el.style.verticalAlign = 1;
+		el.style.verticalAlign = 2;
+		this.values(el.offset + this.foo,el.offset + this.foo,el.offset + this.foo);
+	')
+	function test2() {
+		final el = PureElement.get();
+		final a = (el.offset + foo);
+		el.style.verticalAlign = 1;
+		final b = (el.offset + foo);
+		el.style.verticalAlign = 2;
+		final c = (el.offset + foo);
+		values(a, b, c);
+	}
+	function values(a, b, c) trace(a, b, c);
+}


### PR DESCRIPTION
Pretty scary bug, i think.

There is 5 test failures:
```
unit.TestExceptions
  testExceptionStack: FAILURE .FFFFF.....
    line: 255, _without_ throws: {
	file : /home/runner/work/haxe/haxe/tests/unit/bin/js/-Dgithub-DLinux-Djs-classic/unit.js, 
	line : NaN, 
	method : stacksWithoutThrowLevel2
} is expected, but got {

}
    line: 255, _without_ throws: {
	file : /home/runner/work/haxe/haxe/tests/unit/bin/js/-Dgithub-DLinux-Djs-classic/unit.js, 
	line : NaN, 
	method : stacksWithoutThrowLevel2
} is expected, but got {

}
    line: 255, _without_ throws: {
	file : /home/runner/work/haxe/haxe/tests/unit/bin/js/-Dgithub-DLinux-Djs-classic/unit.js, 
	line : NaN, 
	method : stacksWithoutThrowLevel2
} is expected, but got {

}
    line: 255, _without_ throws: {
	file : /home/runner/work/haxe/haxe/tests/unit/bin/js/-Dgithub-DLinux-Djs-classic/unit.js, 
	line : NaN, 
	method : stacksWithoutThrowLevel2
} is expected, but got {

}
    line: 255, _without_ throws: {
	file : /home/runner/work/haxe/haxe/tests/unit/bin/js/-Dgithub-DLinux-Djs-classic/unit.js, 
	line : NaN, 
	method : stacksWithoutThrowLevel2
} is expected, but got {

}
```

Please review [this test](https://github.com/HaxeFoundation/haxe/blob/development/tests/unit/src/unit/TestExceptions.hx#L235) and tryHaxeStack js impl, because diff change seems like a fix for Haxe code:
[Haxe tryHaxeStack function](https://github.com/HaxeFoundation/haxe/blob/development/std/js/_std/haxe/NativeStackTrace.hx#L89)
And unit.js diff for her:
```diff
haxe_NativeStackTrace.tryHaxeStack = function(e) {
	if(e == null) {
		return [];
	}
	var oldValue = Error.prepareStackTrace;
	Error.prepareStackTrace = haxe_NativeStackTrace.prepareHxStackTrace;
+	var stack = e.stack;
	Error.prepareStackTrace = oldValue;
-	return e.stack;
+	return stack;
};
```

closes #9943