### PR TITLE
[CI] Enable sys tests for NodeJS

### DIFF
--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -110,6 +110,11 @@ class Js {
 		runCommand("haxe", ["build.hxml"]);
 		runCommand("node", ["test.js"]);
 
+		changeDirectory(sysDir);
+		runCommand("npm", ["install", "deasync"], true);
+		runCommand("haxe", ["compile-js.hxml"].concat(args));
+		runCommand("node", ["bin/js/sys.js"]);
+
 		changeDirectory(miscJsDir);
 		runCommand("haxe", ["run.hxml"]);
 	}

--- a/tests/sys/.gitignore
+++ b/tests/sys/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package.json
+package-lock.json

--- a/tests/sys/compile-js.hxml
+++ b/tests/sys/compile-js.hxml
@@ -1,0 +1,22 @@
+compile-each.hxml
+--main Main
+-js bin/js/sys.js
+-lib hxnodejs
+
+--next
+compile-each.hxml
+--main TestArguments
+-js bin/js/TestArguments.js
+-lib hxnodejs
+
+--next
+compile-each.hxml
+--main ExitCode
+-js bin/js/ExitCode.js
+-lib hxnodejs
+
+--next
+compile-each.hxml
+--main UtilityProcess
+-js bin/js/UtilityProcess.js
+-lib hxnodejs

--- a/tests/sys/compile.hxml
+++ b/tests/sys/compile.hxml
@@ -8,3 +8,4 @@
 --next compile-java.hxml
 --next compile-php.hxml
 --next compile-hl.hxml
+--next compile-js.hxml

--- a/tests/sys/genTestRes.py
+++ b/tests/sys/genTestRes.py
@@ -87,7 +87,8 @@ for data in allFilenames:
       ("../../bin/neko/UtilityProcess.n", "bin-neko"),
       ("../../bin/php/UtilityProcess/index.php", "bin-php"),
       ("../../bin/python/UtilityProcess.py", "bin-py"),
-      ("../../src/UtilityProcess.hx", "bin-eval")
+      ("../../src/UtilityProcess.hx", "bin-eval"),
+      ("../../bin/js/UtilityProcess.js", "bin-js")
     ]:
       os.symlink(target, os.path.join(TESTDIR, data, name), target_is_directory = False)
 

--- a/tests/sys/run.hxml
+++ b/tests/sys/run.hxml
@@ -11,6 +11,7 @@ compile.hxml
 -cmd echo CS     && mono bin/cs/bin/Main-Debug.exe
 -cmd echo Java   && java -jar bin/java/Main-Debug.jar
 -cmd echo Php    && php bin/php/Main/index.php
+--cmd echo Js     && node bin/js/sys.js
 
 # Windows
 # --next
@@ -20,6 +21,7 @@ compile.hxml
 # -cmd echo CS     && bin\cs\bin\Main-Debug.exe
 # -cmd echo Java   && java -jar bin\java\Main-Debug.jar
 # -cmd echo Php    && php bin\php\Main\index.php
+# --cmd echo Js     && node bin/js/sys.js
 
 # Macro has to be placed at the end since it would exit the compilation process.
 --next

--- a/tests/sys/run.hxml
+++ b/tests/sys/run.hxml
@@ -3,28 +3,35 @@
 # Compile everything first.
 compile.hxml
 
+# Install Dependencies
+# --next
+# --cmd luarocks install haxe-deps 0.0.1-6
+# --cmd npm install deasync
+
 # Mac/Linux
 --next
--cmd echo Neko   && neko bin/neko/sys.n
--cmd echo Python && python3 bin/python/sys.py
--cmd echo Cpp    && bin/cpp/Main-debug
--cmd echo CS     && mono bin/cs/bin/Main-Debug.exe
--cmd echo Java   && java -jar bin/java/Main-Debug.jar
--cmd echo Php    && php bin/php/Main/index.php
+--cmd echo Neko   && neko bin/neko/sys.n
+--cmd echo Python && python3 bin/python/sys.py
+--cmd echo Cpp    && bin/cpp/Main-debug
+--cmd echo CS     && mono bin/cs/bin/Main-Debug.exe
+--cmd echo Java   && java -jar bin/java/Main-Debug.jar
+--cmd echo Php    && php bin/php/Main/index.php
+--cmd echo Hl     && hl bin/hl/sys.hl
 --cmd echo Js     && node bin/js/sys.js
 
 # Windows
 # --next
-# -cmd echo Neko   && neko bin\neko\sys.n
-# -cmd echo Python && python3 bin\python\sys.py
-# -cmd echo Cpp    && bin\cpp\Main-debug.exe
-# -cmd echo CS     && bin\cs\bin\Main-Debug.exe
-# -cmd echo Java   && java -jar bin\java\Main-Debug.jar
-# -cmd echo Php    && php bin\php\Main\index.php
+# --cmd echo Neko   && neko bin\neko\sys.n
+# --cmd echo Python && python3 bin\python\sys.py
+# --cmd echo Cpp    && bin\cpp\Main-debug.exe
+# --cmd echo CS     && bin\cs\bin\Main-Debug.exe
+# --cmd echo Java   && java -jar bin\java\Main-Debug.jar
+# --cmd echo Php    && php bin\php\Main\index.php
+# --cmd echo Hl     && hl bin/hl/sys.hl
 # --cmd echo Js     && node bin/js/sys.js
 
 # Macro has to be placed at the end since it would exit the compilation process.
 --next
--cmd echo Macro
+--cmd echo Macro
 --next
 compile-macro.hxml

--- a/tests/sys/src/ExitCode.hx
+++ b/tests/sys/src/ExitCode.hx
@@ -39,6 +39,8 @@ class ExitCode {
 		"bin/php/ExitCode/index.php";
 	#elseif lua
 		"bin/lua/ExitCode.lua";
+	#elseif js
+		"bin/js/ExitCode.js";
 	#else
 		null;
 	#end

--- a/tests/sys/src/Main.hx
+++ b/tests/sys/src/Main.hx
@@ -10,8 +10,10 @@ class Main {
 		runner.addCase(new TestFileSystem());
 		runner.addCase(new io.TestFile());
 		runner.addCase(new io.TestFileInput());
+		#if !js
 		runner.addCase(new io.TestProcess());
-		#if !(java || cs || lua || python || eval) // Sqlite is not implemented for these targets
+		#end
+		#if !(java || cs || lua || python || eval || js) // Sqlite is not implemented for these targets
 		#if !hl // Idk how to resolve "FATAL ERROR : Failed to load library sqlite.hdll"
 		var testSqlite = #if php Sys.systemName() != 'Windows' #else true #end; //our CI doesn't have sqlite php module
 		if(testSqlite) {

--- a/tests/sys/src/TestArguments.hx
+++ b/tests/sys/src/TestArguments.hx
@@ -99,6 +99,8 @@ class TestArguments extends utest.Test {
 		"bin/php/TestArguments/index.php";
 	#elseif lua
 		"bin/lua/TestArguments.lua";
+	#elseif js
+		"bin/js/TestArguments.js";
 	#else
 		null;
 	#end

--- a/tests/sys/src/TestCommandBase.hx
+++ b/tests/sys/src/TestCommandBase.hx
@@ -42,6 +42,8 @@ class TestCommandBase extends utest.Test {
 				run(php.Global.defined('PHP_BINARY') ? php.Const.PHP_BINARY : 'php', [bin].concat(args));
 			#elseif lua
 				run("lua", [bin].concat(args));
+			#elseif js
+				run("node", [bin].concat(args));
 			#else
 				-1;
 			#end
@@ -133,6 +135,8 @@ class TestCommandBase extends utest.Test {
 					run(php.Global.defined('PHP_BINARY') ? php.Const.PHP_BINARY : 'php', [bin].concat(args));
 				#elseif lua
 					run("lua", [bin].concat(args));
+				#elseif js
+					run("node", [bin].concat(args));
 				#else
 					-1;
 				#end

--- a/tests/sys/src/TestFileSystem.hx
+++ b/tests/sys/src/TestFileSystem.hx
@@ -130,9 +130,7 @@ class TestFileSystem extends utest.Test {
 
 	function testAbsolutePath() {
 		var paths = [
-		#if !js // nodejs for some reason likes to unixify windows paths on linux
 			{ input: "c:\\nadako",   expected: "c:\\nadako" },
-		#end
 			{ input: "nadako.js",    expected: haxe.io.Path.join([Sys.getCwd(), "nadako.js"]) },
 			{ input: "./nadako.js",  expected: haxe.io.Path.join([Sys.getCwd(), "/./nadako.js"]) },
 			{ input: "/nadako",      expected: "/nadako" }

--- a/tests/sys/src/TestFileSystem.hx
+++ b/tests/sys/src/TestFileSystem.hx
@@ -130,7 +130,9 @@ class TestFileSystem extends utest.Test {
 
 	function testAbsolutePath() {
 		var paths = [
+		#if !js // nodejs for some reason likes to unixify windows paths on linux
 			{ input: "c:\\nadako",   expected: "c:\\nadako" },
+		#end
 			{ input: "nadako.js",    expected: haxe.io.Path.join([Sys.getCwd(), "nadako.js"]) },
 			{ input: "./nadako.js",  expected: haxe.io.Path.join([Sys.getCwd(), "/./nadako.js"]) },
 			{ input: "/nadako",      expected: "/nadako" }
@@ -141,8 +143,7 @@ class TestFileSystem extends utest.Test {
 	}
 
 	static function normPath(p:String, properCase = false):String {
-		if (Sys.systemName() == "Windows")
-		{
+		if (Sys.systemName() == "Windows") {
 			// on windows, haxe returns lowercase paths with backslashes, drive letter uppercased
 			p = p.substr(0, 1).toUpperCase() + p.substr(1);
 			p = p.replace("/", "\\");

--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -42,6 +42,8 @@ class TestUnicode extends utest.Test {
 		"bin-py";
 #elseif eval
 		"bin-eval";
+#elseif js
+		"bin-js";
 #else
 		null;
 #end

--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -391,13 +391,18 @@ class TestUnicode extends utest.Test {
 		assertBytesEqual(File.getBytes("temp-unicode/out.bin"), UnicodeSequences.validBytes);
 
 		// append
-		var out = File.append("temp-unicode/out.bin");
-		out.writeString(UnicodeSequences.validString);
-		out.close();
-		var repeated = Bytes.alloc(UnicodeSequences.validBytes.length * 2);
-		repeated.blit(0, UnicodeSequences.validBytes, 0, UnicodeSequences.validBytes.length);
-		repeated.blit(UnicodeSequences.validBytes.length, UnicodeSequences.validBytes, 0, UnicodeSequences.validBytes.length);
-		assertBytesEqual(File.getBytes("temp-unicode/out.bin"), repeated);
+#if js
+		if (Sys.systemName() != "Mac") // File.append() here is broken on mac
+#end
+		{
+			var out = File.append("temp-unicode/out.bin");
+			out.writeString(UnicodeSequences.validString);
+			out.close();
+			var repeated = Bytes.alloc(UnicodeSequences.validBytes.length * 2);
+			repeated.blit(0, UnicodeSequences.validBytes, 0, UnicodeSequences.validBytes.length);
+			repeated.blit(UnicodeSequences.validBytes.length, UnicodeSequences.validBytes, 0, UnicodeSequences.validBytes.length);
+			assertBytesEqual(File.getBytes("temp-unicode/out.bin"), repeated);
+		}
 
 		// readLine
 		var data = File.read("test-res/data.bin");

--- a/tests/sys/src/UtilityProcess.hx
+++ b/tests/sys/src/UtilityProcess.hx
@@ -28,6 +28,8 @@ class UtilityProcess {
 		Path.join(["bin", "python"]);
 #elseif eval
 		Path.join(["src"]);
+#elseif js
+		Path.join(["bin", "js"]);
 #else
 		null;
 #end
@@ -64,6 +66,8 @@ class UtilityProcess {
 		"UtilityProcess.py";
 #elseif eval
 		"UtilityProcess.hx";
+#elseif js
+		"UtilityProcess.js";
 #else
 		null;
 #end
@@ -118,7 +122,7 @@ class UtilityProcess {
 			stderr: stderr
 		};
 	}
-	
+
 	public static function main():Void {
 		var args = Sys.args();
 		function sequenceIndex(d:String, mode:String):String return (switch (UnicodeSequences.valid[Std.parseInt(d)]) {

--- a/tests/sys/src/net/TestSocket.hx
+++ b/tests/sys/src/net/TestSocket.hx
@@ -19,9 +19,11 @@ class TestSocket extends utest.Test {
 		registeredSockets = [];
 	}
 
+	#if !js // bind is not implemented on nodejs
 	public function testBind() {
 		var socket = register(new Socket());
 		socket.bind(new Host('localhost'), 34567);
 		Assert.pass();
 	}
+	#end
 }


### PR DESCRIPTION
Addresses #10436 partially.

Previously, the `sys` api tests for nodejs were not running. This PR enables most of them, apart from those that cannot be enabled currently because `sys.io.Process` and `sys.net.Socket.bind()` are not implemented in `hxnodejs`.

These hxnodejs PR need to be merged so that the tests run successfully:
- HaxeFoundation/hxnodejs/pull/180
- HaxeFoundation/hxnodejs/pull/181
- HaxeFoundation/hxnodejs/pull/182