### PR TITLE
Simplify binops involving Single, UInt, and haxe.Int64

### DIFF
--- a/tests/optimization/src/issues/Issue6229.hx
+++ b/tests/optimization/src/issues/Issue6229.hx
@@ -18,7 +18,7 @@ class Issue6229 {
 		}
 	}
 
-	@:js('var a = 1 + 1;')
+	@:js('var a = 2;')
 	@:analyzer(no_local_dce)
     static function test() {
         var v = mkVec(1);


### PR DESCRIPTION
While using the vector-math lib which has a flag for using `Single` instead of `Float` I noticed that binops weren't being simplified with the analyser when that flag was enabled. Looking into things it seems to be because `TCast`s aren't being looked at for simplication.

With these changes we look at the inner expression of casts for simplication. This allows stuff like `12 + (1234.5 : Single) * 2` to be properly simplified down and the overall `Single` type of the expression is preserved. I've enabled this for `Single`, `UInt`, and `haxe.Int64` but not any of the target specific numeric types. There is some target specific behaviour for `haxe.Int64`. For example, with the cpp target `(1000 : haxe.Int64) + 10` won't be simplified as operations are functions where as on js this will be properly simplified down to 1010.

I had to update one of the js tests to get it to pass with these changes. I don't think this is a regression, rather it seems to be the `1 + 1` is now simplified to 2. Hopefully someone with more knowledge will let me know if this is correct.