### PR TITLE
Allow & Dynamic<T>

### DIFF
--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -420,7 +420,11 @@ let apply_params ?stack cparams params t =
 			TFun (List.map (fun (s,o,t) -> s, o, loop t) tl,loop r)
 		| TAnon a ->
 			let fields = PMap.map (fun f -> { f with cf_type = loop f.cf_type }) a.a_fields in
-			mk_anon ~fields a.a_status
+			let status = match !(a.a_status) with
+				| Extend tl -> ref (Extend (List.map loop tl))
+				| _ -> a.a_status
+			in
+			mk_anon ~fields status
 		| TLazy f ->
 			let ft = lazy_type f in
 			let ft2 = loop ft in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -271,7 +271,12 @@ let make_extension_type ctx tl =
 				else fields
 			) a.a_fields fields
 		| TDynamic _ ->
-			extends_dynamic := Some t;
+			begin match !extends_dynamic with
+			| None ->
+				extends_dynamic := Some t;
+			| Some _ ->
+				display_error ctx "Can only extend one Dynamic<T>" p
+			end;
 			fields
 		| _ ->
 			error "Can only extend structures" p

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -763,7 +763,13 @@ and type_object_decl ctx fl with_type p =
 	| WithType.WithType(t,_) ->
 		let rec loop seen t =
 			match follow t with
-			| TAnon a -> ODKWithStructure a
+			| TAnon a ->
+				begin try
+					dynamic_parameter := Some (extract_dynamic_parameter_from_anon a);
+				with Not_found ->
+					()
+				end;
+				ODKWithStructure a
 			| TAbstract (a,pl) as t
 				when not (Meta.has Meta.CoreType a.a_meta)
 					&& not (List.exists (fun t' -> shallow_eq t t') seen) ->

--- a/tests/unit/src/unit/issues/Issue9825.hx
+++ b/tests/unit/src/unit/issues/Issue9825.hx
@@ -1,0 +1,10 @@
+package unit.issues;
+
+typedef KnownDynamic<T> = {known:T} &
+	Dynamic<T>;
+
+class Issue9825 extends Test {
+	function test() {
+		var d:KnownDynamic<String> = {known: "foo", also: "bar"};
+	}
+}

--- a/tests/unit/src/unit/issues/Issue9825.hx
+++ b/tests/unit/src/unit/issues/Issue9825.hx
@@ -6,5 +6,10 @@ typedef KnownDynamic<T> = {known:T} &
 class Issue9825 extends Test {
 	function test() {
 		var d:KnownDynamic<String> = {known: "foo", also: "bar"};
+		eq("foo", d.known);
+		eq("bar", d.also);
+		d.even = "even";
+		eq("even", d.even);
+		t(HelperMacros.typeError(d.no = 12));
 	}
 }


### PR DESCRIPTION
Allows this:

```haxe
typedef KnownDynamic<T> = {known:T} & Dynamic<T>;

function main() {
	var d:KnownDynamic<Int> = { known: 12 };
	d.also = 12;
}
```

We have this `Extend` thing for `anon_status` which I'm using to implement this. In that context, I've noticed that `apply_params` doesn't recurse into it, which is likely a separate bug.

@RealyUniqueName Could you check this? I might have missed something.

CI failure is unrelated.

closes #9825