### PR TITLE
[CI] Update ubuntu version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   cancel:
     name: "Cancel previous runs"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 3
     steps:
       - uses: styfle/cancel-workflow-action@0.3.1
@@ -232,7 +232,7 @@ jobs:
       
 
   linux-build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       OPAMYES: 1
@@ -640,7 +640,7 @@ jobs:
 
   linux-test:
     needs: linux-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       TEST: ${{matrix.target}}
@@ -833,7 +833,7 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     needs: [linux-test, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
       # maybe https://github.community/t/expose-commit-timestamp-in-the-github-context-data/16460/3
@@ -905,7 +905,7 @@ jobs:
   deploy_apidoc:
     if: github.event_name != 'pull_request' # TODO: also only when `GHP_REMOTE` is present
     needs: [linux-test, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Download Haxe
         uses: actions/download-artifact@v2

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -6,7 +6,7 @@ on: [push, pull_request]
 jobs:
   cancel:
     name: "Cancel previous runs"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 3
     steps:
       - uses: styfle/cancel-workflow-action@0.3.1
@@ -53,7 +53,7 @@ jobs:
       @import build-windows.yml
 
   linux-build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       OPAMYES: 1
@@ -132,7 +132,7 @@ jobs:
 
   linux-test:
     needs: linux-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       TEST: ${{matrix.target}}
@@ -193,7 +193,7 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     needs: [linux-test, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
       # maybe https://github.community/t/expose-commit-timestamp-in-the-github-context-data/16460/3
@@ -265,7 +265,7 @@ jobs:
   deploy_apidoc:
     if: github.event_name != 'pull_request' # TODO: also only when `GHP_REMOTE` is present
     needs: [linux-test, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Download Haxe
         uses: actions/download-artifact@v2


### PR DESCRIPTION
The version of ubuntu used to build haxe did not match the one that neko was built with, which resulted in a compatibility issue when attempting to build haxelib.

```
Uncaught exception - load.c(237) : Failed to load library : /home/runner/work/_temp/neko-2.3.1-linux64/std.ndll (/lib/x86_64-linux-gnu/libm.so.6:version `GLIBC_2.29' not found (required by /home/runner/work/_temp/neko-2.3.1-linux64/std.ndll))
```

This updates the version of ubuntu used from 18.04 to 20.04.