### PR TITLE
[sys] Make `getCwd()` consistent between targets 

### DIFF
--- a/std/cs/_std/Sys.hx
+++ b/std/cs/_std/Sys.hx
@@ -83,7 +83,7 @@ class Sys {
 	}
 
 	public static inline function getCwd():String {
-		return cs.system.io.Directory.GetCurrentDirectory();
+		return haxe.io.Path.addTrailingSlash(cs.system.io.Directory.GetCurrentDirectory());
 	}
 
 	public static inline function setCwd(s:String):Void {

--- a/std/lua/_std/Sys.hx
+++ b/std/lua/_std/Sys.hx
@@ -89,7 +89,7 @@ class Sys {
 	}
 
 	public inline static function getCwd():String
-		return Misc.cwd();
+		return haxe.io.Path.addTrailingSlash(Misc.cwd());
 
 	public inline static function setCwd(s:String):Void
 		Misc.chdir(s);

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -89,7 +89,7 @@ class Sys {
 	}
 
 	public static function getCwd():String {
-		return python.lib.Os.getcwd();
+		return haxe.io.Path.addTrailingSlash(python.lib.Os.getcwd());
 	}
 
 	public static function setCwd(s:String):Void {

--- a/tests/sys/src/TestSys.hx
+++ b/tests/sys/src/TestSys.hx
@@ -70,8 +70,14 @@ class TestSys extends TestCommandBase {
 		#end
 	}
 
+	function testGetCwd() {
+		final current = Sys.getCwd();
+		// ensure it has a trailing slash
+		Assert.notEquals(current, haxe.io.Path.removeTrailingSlashes(current));
+	}
+
 	#if !java
-	function testCwd() {
+	function testSetCwd() {
 		var cur = Sys.getCwd();
 		Sys.setCwd("../");
 		var newCwd = haxe.io.Path.join([cur, "../"]);


### PR DESCRIPTION
Fixes #10459

Adds a trailing slash to lua, python, and c# targets to match the others.

Includes a test for this.

This also requires a change to hxnodejs:
 - HaxeFoundation/hxnodejs/pull/183