### PR TITLE
Cleanup minor environment variable issues

### DIFF
--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -66,6 +66,15 @@ extern class Sys {
 	/**
 		Returns a map of the current environment variables and their values
 		as of the invocation of the function.
+
+		(python) On Windows, the variable names are always in upper case.
+
+		(cpp)(hl)(neko) On Windows, the variable names match the last capitalization used when modifying
+		the variable if the variable has been modified, otherwise they match their capitalization at
+		the start of the process.
+
+		On Windows on remaining targets, variable name capitalization matches however they were capitalized
+		at the start of the process or at the moment of their creation.
 	**/
 	static function environment():Map<String, String>;
 

--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -60,9 +60,6 @@ extern class Sys {
 		If `v` is `null`, the environment variable is removed.
 
 		(java) This functionality is not available on Java; calling this function will throw.
-
-		(python) When targeting python versions earlier than 3.9, passing `null` as the variable
-		value may not properly remove the variable depending on the platform.
 	**/
 	static function putEnv(s:String, v:Null<String>):Void;
 

--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -60,6 +60,9 @@ extern class Sys {
 		If `v` is `null`, the environment variable is removed.
 
 		(java) This functionality is not available on Java; calling this function will throw.
+
+		(python) When targeting python versions earlier than 3.9, passing `null` as the variable
+		value may not properly remove the variable depending on the platform.
 	**/
 	static function putEnv(s:String, v:Null<String>):Void;
 

--- a/std/cs/_std/Sys.hx
+++ b/std/cs/_std/Sys.hx
@@ -26,7 +26,6 @@ import cs.system.threading.Thread;
 
 @:coreApi
 class Sys {
-	private static var _env:haxe.ds.StringMap<String>;
 	private static var _args:Array<String>;
 
 	public static inline function print(v:Dynamic):Void {
@@ -52,25 +51,15 @@ class Sys {
 
 	public static function putEnv(s:String, v:Null<String>):Void {
 		Environment.SetEnvironmentVariable(s, v);
-		if (_env == null)
-			return;
-
-		if (v == null)
-			_env.remove(s);
-		else
-			_env.set(s, v);
 	}
 
 	public static function environment():Map<String, String> {
-		if (_env == null) {
-			var e = _env = new haxe.ds.StringMap();
-			var nenv = Environment.GetEnvironmentVariables().GetEnumerator();
-			while (nenv.MoveNext()) {
-				e.set(nenv.Key, nenv.Value);
-			}
+		final env = new haxe.ds.StringMap();
+		final nenv = Environment.GetEnvironmentVariables().GetEnumerator();
+		while (nenv.MoveNext()) {
+			env.set(nenv.Key, nenv.Value);
 		}
-
-		return _env.copy();
+		return env;
 	}
 
 	public static inline function sleep(seconds:Float):Void {

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -55,7 +55,11 @@ class Sys {
 
 	public static function putEnv(s:String, v:Null<String>):Void {
 		if (v == null) {
-			Os.environ.remove(s);
+			try {
+				Os.environ.remove(s);
+			} catch(e:python.Exceptions.KeyError) {
+				// the variable didn't exist
+			}
 			return;
 		}
 		Os.environ.set(s, v);

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -69,7 +69,10 @@ class Sys {
 
 	public static function putEnv(s:String, v:Null<String>):Void {
 		if (v == null) {
-			python.lib.Os.unsetenv(s);
+			try {
+				python.lib.Os.unsetenv(s);
+			} catch(e:python.Exceptions.AttributeError) {}
+			// in python versions earlier than 3.9, some platforms don't have the unsetenv function
 			environ.remove(s);
 			return;
 		}

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -69,6 +69,7 @@ class Sys {
 
 	public static function putEnv(s:String, v:Null<String>):Void {
 		if (v == null) {
+			python.lib.Os.unsetenv(s);
 			environ.remove(s);
 			return;
 		}

--- a/std/python/_std/Sys.hx
+++ b/std/python/_std/Sys.hx
@@ -28,20 +28,6 @@ import haxe.ds.StringMap;
 
 @:coreApi
 class Sys {
-	static var environ(get,default):StringMap<String>;
-	static function get_environ():StringMap<String> {
-		return switch environ {
-			case null:
-				var environ = new StringMap();
-				var env = Os.environ;
-				for (key in env.keys()) {
-					environ.set(key, env.get(key, null));
-				}
-				Sys.environ = environ;
-			case env: env;
-		}
-	}
-
 	public static inline function time():Float {
 		return Time.time();
 	}
@@ -64,24 +50,24 @@ class Sys {
 	}
 
 	public static function getEnv(s:String):String {
-		return environ.get(s);
+		return Os.environ.get(s, null);
 	}
 
 	public static function putEnv(s:String, v:Null<String>):Void {
 		if (v == null) {
-			try {
-				python.lib.Os.unsetenv(s);
-			} catch(e:python.Exceptions.AttributeError) {}
-			// in python versions earlier than 3.9, some platforms don't have the unsetenv function
-			environ.remove(s);
+			Os.environ.remove(s);
 			return;
 		}
-		python.lib.Os.putenv(s, v);
-		environ.set(s, v);
+		Os.environ.set(s, v);
 	}
 
 	public static function environment():Map<String, String> {
-		return environ.copy();
+		final environ = new StringMap();
+		final env = Os.environ;
+		for (key in env.keys()) {
+			environ.set(key, env.get(key, null));
+		}
+		return environ;
 	}
 
 	public static function sleep(seconds:Float):Void {

--- a/std/python/lib/Os.hx
+++ b/std/python/lib/Os.hx
@@ -57,6 +57,10 @@ extern class Os {
 
 	static function putenv(name:String, value:String):Void;
 
+	/** Removes the value for the environment variable `name`.
+
+		When targeting python versions prior to 3.9, this function may not exist on some platforms.
+	 **/
 	static function unsetenv(name:String):Void;
 
 	static function chdir(path:String):Void;

--- a/std/python/lib/Os.hx
+++ b/std/python/lib/Os.hx
@@ -57,6 +57,8 @@ extern class Os {
 
 	static function putenv(name:String, value:String):Void;
 
+	static function unsetenv(name:String):Void;
+
 	static function chdir(path:String):Void;
 
 	static function unlink(path:String):Void;

--- a/tests/sys/src/TestSys.hx
+++ b/tests/sys/src/TestSys.hx
@@ -59,39 +59,38 @@ class TestSys extends TestCommandBase {
 
 	#if !java
 	function testPutEnv() {
-		Sys.putEnv("foo", "value");
-		Assert.equals("value", Sys.getEnv("foo"));
+		Sys.putEnv("FOO", "value");
+		Assert.equals("value", Sys.getEnv("FOO"));
 
-		Assert.equals("value", Sys.environment().get("foo"));
+		Assert.equals("value", Sys.environment().get("FOO"));
 
-		Assert.isTrue(existsInSubProcess("foo", "value"));
+		Assert.isTrue(existsInSubProcess("FOO", "value"));
 
 		#if python
 		// the variable should also be visible through python's api
-		Assert.equals("value", python.lib.Os.environ.get("foo"));
+		Assert.equals("value", python.lib.Os.environ.get("FOO"));
 		#end
 
 		// null
-		Sys.putEnv("foo", null);
-		Assert.isNull(Sys.getEnv("foo"));
+		Sys.putEnv("FOO", null);
+		Assert.isNull(Sys.getEnv("FOO"));
 
-		Assert.isFalse(Sys.environment().exists("foo"));
+		Assert.isFalse(Sys.environment().exists("FOO"));
 
-		Assert.isFalse(existsInSubProcess("foo", "value"));
+		Assert.isFalse(existsInSubProcess("FOO", "value"));
 
 		#if python
 		// the variable should also be gone when checking through python's api
-		Assert.isFalse(python.lib.Os.environ.hasKey("foo"));
+		Assert.isFalse(python.lib.Os.environ.hasKey("FOO"));
 		#end
 
-		Assert.isTrue(
-			try {
-				Sys.putEnv("NON_EXISTENT", null);
-				true;
-			} catch (e) {
-				trace(e);
-				false;
-			});
+		Assert.isTrue(try {
+			Sys.putEnv("NON_EXISTENT", null);
+			true;
+		} catch (e) {
+			trace(e);
+			false;
+		});
 	}
 	#end
 

--- a/tests/sys/src/TestSys.hx
+++ b/tests/sys/src/TestSys.hx
@@ -83,6 +83,15 @@ class TestSys extends TestCommandBase {
 		// the variable should also be gone when checking through python's api
 		Assert.isFalse(python.lib.Os.environ.hasKey("foo"));
 		#end
+
+		Assert.isTrue(
+			try {
+				Sys.putEnv("NON_EXISTENT", null);
+				true;
+			} catch (e) {
+				trace(e);
+				false;
+			});
 	}
 	#end
 

--- a/tests/sys/src/TestSys.hx
+++ b/tests/sys/src/TestSys.hx
@@ -32,6 +32,10 @@ class TestSys extends TestCommandBase {
 		#end
 	}
 
+	function existsInSubProcess(variable:String, value:String) {
+		return UtilityProcess.runUtilityAsCommand(["checkEnv", variable, value]) == 0;
+	}
+
 	function testGetEnv() {
 		// EXISTS should be set manually via the command line
 		Assert.notNull(Sys.getEnv("EXISTS"));
@@ -45,11 +49,15 @@ class TestSys extends TestCommandBase {
 
 		Assert.equals("value", Sys.environment().get("foo"));
 
+		Assert.isTrue(existsInSubProcess("foo", "value"));
+
 		// null
 		Sys.putEnv("foo", null);
 		Assert.isNull(Sys.getEnv("foo"));
 
 		Assert.isFalse(Sys.environment().exists("foo"));
+
+		Assert.isFalse(existsInSubProcess("foo", "value"));
 	}
 	#end
 

--- a/tests/sys/src/TestSys.hx
+++ b/tests/sys/src/TestSys.hx
@@ -54,6 +54,11 @@ class TestSys extends TestCommandBase {
 	function testGetEnv() {
 		// EXISTS should be set manually via the command line
 		Assert.notNull(Sys.getEnv("EXISTS"));
+
+		// on windows, Sys.getEnv should be case insensitive
+		if (Sys.systemName() == "Windows")
+			Assert.notNull(Sys.getEnv("exists"));
+
 		Assert.isNull(Sys.getEnv("doesn't exist"));
 	}
 

--- a/tests/sys/src/UtilityProcess.hx
+++ b/tests/sys/src/UtilityProcess.hx
@@ -1,5 +1,5 @@
 /**
-	Used by TestUnicode.
+	Used by TestUnicode and TestSys.
 	Runs a given simple program based on the first argument.
  */
 
@@ -123,21 +123,67 @@ class UtilityProcess {
 		};
 	}
 
+	/** Runs the utility program via Sys.command rather than as a separate process,
+		for compatiblity with hxnodejs.
+
+		Returns the exit code of the command.
+	 **/
+	public static function runUtilityAsCommand(args:Array<String>, ?options:{?stdin:String, ?execPath:String, ?execName:String}):Int {
+		if (options == null) options = {};
+		if (options.execPath == null) options.execPath = BIN_PATH;
+		if (options.execName == null) options.execName = BIN_NAME;
+		final execFull = Path.join([options.execPath, options.execName]);
+		final exitCode =
+		#if (macro || interp)
+		Sys.command("haxe", ["compile-each.hxml", "-p", options.execPath, "--run", options.execName].concat(args));
+		#elseif cpp
+		Sys.command(execFull, args);
+		#elseif cs
+		(switch (Sys.systemName()) {
+			case "Windows":
+				Sys.command(execFull, args);
+			case _:
+				Sys.command("mono", [execFull].concat(args));
+		});
+		#elseif java
+		Sys.command(Path.join([java.lang.System.getProperty("java.home"), "bin", "java"]), ["-jar", execFull].concat(args));
+		#elseif python
+		Sys.command(python.lib.Sys.executable, [execFull].concat(args));
+		#elseif neko
+		Sys.command("neko", [execFull].concat(args));
+		#elseif hl
+		Sys.command("hl", [execFull].concat(args));
+		#elseif php
+		Sys.command(php.Global.defined('PHP_BINARY') ? php.Const.PHP_BINARY : 'php', [execFull].concat(args));
+		#elseif lua
+		Sys.command("lua", [execFull].concat(args));
+		#elseif js
+		Sys.command("node", [execFull].concat(args));
+		#else
+		1;
+		#end
+
+		return exitCode;
+	}
+
 	public static function main():Void {
 		var args = Sys.args();
-		function sequenceIndex(d:String, mode:String):String return (switch (UnicodeSequences.valid[Std.parseInt(d)]) {
+		function sequenceIndex(d:String, mode:String):String
+			return switch UnicodeSequences.valid[Std.parseInt(d)] {
 				case Only(ref): UnicodeSequences.codepointsToString(ref);
 				case Normal(nfc, nfd): UnicodeSequences.codepointsToString(mode == "nfc" ? nfc : nfd);
-			});
+			};
 		switch (args) {
 			case _.slice(0, 1) => ["putEnv"]:
-			// ["putEnv", var name, index, nfc mode, next args...]
-			Sys.putEnv(args[1], sequenceIndex(args[2], args[3]));
-			var out = runUtility(args.slice(4));
-			Sys.print(out.stdout);
-			Sys.exit(out.exitCode);
+				// ["putEnv", var name, index, nfc mode, next args...]
+				Sys.putEnv(args[1], sequenceIndex(args[2], args[3]));
+				var out = runUtility(args.slice(4));
+				Sys.print(out.stdout);
+				Sys.exit(out.exitCode);
 			case ["getCwd"]: Sys.println(Sys.getCwd());
 			case ["getEnv", name]: Sys.println(Sys.getEnv(name));
+			case ["checkEnv", name, value]:
+				Sys.exit(value == Sys.getEnv(name) ? 0 : 1);
 			case ["environment", name]: Sys.println(Sys.environment().get(name));
 			case ["exitCode", Std.parseInt(_) => code]: Sys.exit(code);
 			case ["args", data]: Sys.println(data);
@@ -148,9 +194,9 @@ class UtilityProcess {
 			case ["stdin.readString", Std.parseInt(_) => len]: Sys.println(Sys.stdin().readString(len, UTF8));
 			case ["stdin.readUntil", Std.parseInt(_) => end]: Sys.println(Sys.stdin().readUntil(end));
 			case ["stderr.writeString", d, mode]:
-			var stream = Sys.stderr(); stream.writeString(sequenceIndex(d, mode)); stream.flush();
+				var stream = Sys.stderr(); stream.writeString(sequenceIndex(d, mode)); stream.flush();
 			case ["stdout.writeString", d, mode]:
-			var stream = Sys.stdout(); stream.writeString(sequenceIndex(d, mode)); stream.flush();
+				var stream = Sys.stdout(); stream.writeString(sequenceIndex(d, mode)); stream.flush();
 			case ["programPath"]: Sys.println(Sys.programPath());
 			case _: // no-op
 		}


### PR DESCRIPTION
This was an oversight in #10402. Running `Sys.putEnv("var", null)` would remove the variable from the internal map used to keep track of environment variables, so it would appear that the variable was gone (`Sys.getEnv()` calls would also suggest that). However, the variable would not actually be removed, and would still exist in child processes for example.This fixes that issue on python and adds a `python.lib.Os.unsetenv()` extern which is needed to properly remove environment variables.

Also I added a test to ensure everywhere that removed variables are gone for good (by checking if they exist in child processes).

Fixes #10469 - Changes made via the Haxe API are visible when using the native Python/C# apis and vice versa.
Fixes #10471 - Sys.environment() returns only valid variables on php and python.