### PR TITLE
[java] Respect interface methods with Code attributes

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -613,6 +613,14 @@
 		"targets": ["TClass", "TEnum"]
 	},
 	{
+		"name": "JavaDefault",
+		"metadata": ":java.default",
+		"doc": "Equivalent to the default modifier of the Java language",
+		"platforms": ["java"],
+		"params": [],
+		"targets": ["TClassField"]
+	},
+	{
 		"name": "JavaNative",
 		"metadata": ":javaNative",
 		"doc": "Automatically added by `--java-lib` on classes generated from JAR/class files.",

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -393,6 +393,7 @@ let convert_java_enum ctx p pe =
 					})
 				| _ -> error "Method signature was expected" p
 		in
+		if field.jf_code <> None && is_interface then cff_meta := (Meta.JavaDefault,[],cff_pos) :: !cff_meta;
 		let cff_name, cff_meta =
 			match String.get cff_name 0 with
 				| '%' ->

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -789,6 +789,8 @@ module Converter = struct
 						add_access (AOverride,null_pos);
 					| _ -> ()
 				) ann
+			| AttrCode _ when is_interface ->
+				add_meta (Meta.JavaDefault,[],p)
 			| _ -> ()
 		) jf.jf_attributes;
 		let add_native_meta () =

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -406,6 +406,7 @@ type flag_tclass_field =
 	| CfImpl
 	| CfEnum
 	| CfGeneric
+	| CfDefault (* Interface field with default implementation (only valid on Java) *)
 
 type flag_tvar =
 	| VCaptured

--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -2093,6 +2093,11 @@ let generate con =
 			newline w
 	in
 
+	let gen_class_field w ?(is_overload=false) is_static cl is_final cf =
+		(* This should probably be handled somewhere earlier in the unholy gencommon machinery, but whatever *)
+		if not (has_class_field_flag cf CfExtern) then gen_class_field w ~is_overload is_static cl is_final cf
+	in
+
 	let gen_class w cl =
 		let cf_filters = [ handle_throws ] in
 		List.iter (fun f -> List.iter (f gen) cl.cl_ordered_fields) cf_filters;

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -2505,7 +2505,7 @@ class tclass_to_jvm gctx c = object(self)
 		let field mtype cf = match cf.cf_kind with
 			| Method (MethNormal | MethInline) ->
 				List.iter (fun cf ->
-					self#generate_method gctx jc c mtype cf
+					if not (has_class_field_flag cf CfExtern) then self#generate_method gctx jc c mtype cf
 				) (cf :: List.filter (fun cf -> has_class_field_flag cf CfOverload) cf.cf_overloads)
 			| _ ->
 				if not (has_class_flag c CInterface) && is_physical_field cf then self#generate_field gctx jc c mtype cf

--- a/tests/unit/native_java/hxjava_build.txt
+++ b/tests/unit/native_java/hxjava_build.txt
@@ -22,4 +22,6 @@ M haxe.UpperCasePackage.SomeClass
 C haxe.UpperCasePackage.SomeClass
 M haxe.UpperCasePackage.lowercase
 C haxe.UpperCasePackage.lowercase
+M haxe.test.MyDefaultInterface
+C haxe.test.MyDefaultInterface
 end modules

--- a/tests/unit/native_java/hxjava_build.txt
+++ b/tests/unit/native_java/hxjava_build.txt
@@ -24,4 +24,6 @@ M haxe.UpperCasePackage.lowercase
 C haxe.UpperCasePackage.lowercase
 M haxe.test.MyDefaultInterface
 C haxe.test.MyDefaultInterface
+M haxe.test.MyDefaultSubInterface
+C haxe.test.MyDefaultSubInterface
 end modules

--- a/tests/unit/native_java/src/haxe/test/MyDefaultInterface.java
+++ b/tests/unit/native_java/src/haxe/test/MyDefaultInterface.java
@@ -1,0 +1,12 @@
+package haxe.test;
+import java.lang.annotation.*;
+
+public interface MyDefaultInterface
+{
+	default public String test(String a)
+	{
+		return a.toUpperCase();
+	}
+}
+
+class MyDefaultClass implements MyDefaultInterface {}

--- a/tests/unit/native_java/src/haxe/test/MyDefaultSubInterface.java
+++ b/tests/unit/native_java/src/haxe/test/MyDefaultSubInterface.java
@@ -1,0 +1,7 @@
+package haxe.test;
+import java.lang.annotation.*;
+
+public interface MyDefaultSubInterface extends MyDefaultInterface
+{
+
+}

--- a/tests/unit/src/unit/TestJava.hx
+++ b/tests/unit/src/unit/TestJava.hx
@@ -1,4 +1,5 @@
 package unit;
+
 import haxe.io.Bytes;
 import haxe.test.Base.Base_InnerClass;
 import haxe.test.Base.Base___InnerClass3__;
@@ -7,31 +8,33 @@ import haxe.test.Base;
 import haxe.test.LowerCaseClass;
 import haxe.test.MyClass;
 import haxe.test.MyDefaultInterface;
+import haxe.test.MyDefaultSubInterface;
 import haxe.test.TEnum;
 import java.util.EnumSet;
 import java.vm.*;
 
 #if java
-@:strict(haxe.test.MyClass.MyClass_MyAnnotation({ author:"John Doe", someEnum: TB }))
+@:strict(haxe.test.MyClass.MyClass_MyAnnotation({author: "John Doe", someEnum: TB}))
 @:strict(MyClass_ParameterLessAnnotation)
-class TestJava extends Test
-{
-  function testException()
-  {
-	var native = new NativeClass();
-	var hx:NativeClass = new HxClass();
+class TestJava extends Test {
+	function testException() {
+		var native = new NativeClass();
+		var hx:NativeClass = new HxClass();
 
-	exc(function() try native.excTest() catch (e:Dynamic) throw e);
-	var dyn:Dynamic = native;
-	exc(dyn.excTest);
+		exc(function() try
+			native.excTest()
+		catch (e:Dynamic)
+			throw e);
+		var dyn:Dynamic = native;
+		exc(dyn.excTest);
 
-	try
-	  hx.excTest()
-	catch(e:Dynamic) throw e; //shouldn't throw any exception
-  }
+		try
+			hx.excTest()
+		catch (e:Dynamic)
+			throw e; // shouldn't throw any exception
+	}
 
-	public function testIssue2964()
-	{
+	public function testIssue2964() {
 		var cl = new MyClass();
 		var bbool:java.lang.Boolean = null;
 		eq(cl.boolTest1(bbool), 100);
@@ -47,42 +50,40 @@ class TestJava extends Test
 
 		var i:java.lang.Integer = null;
 		eq(cl.intTest1(i), 100);
-		eq(cl.intTest1(cast(-1, java.lang.Integer)),-1);
-		eq(cl.intTest1(cast(1000, java.lang.Integer)),1000);
+		eq(cl.intTest1(cast(-1, java.lang.Integer)), -1);
+		eq(cl.intTest1(cast(1000, java.lang.Integer)), 1000);
 		i = -1;
 		eq(cl.intTest1(i), -1);
 		i = null;
 		eq(cl.intTest2(i), 100);
-		eq(cl.intTest2(-1),-1);
-		eq(cl.intTest2(1000),1000);
+		eq(cl.intTest2(-1), -1);
+		eq(cl.intTest2(1000), 1000);
 		i = -1;
 		eq(cl.intTest2(i), -1);
 
 		var i:java.lang.Long = null;
 		eq(cl.longTest(i), 100);
-		eq(cl.longTest(haxe.Int64.ofInt(-1)),-1);
-		eq(cl.longTest(haxe.Int64.ofInt(1000)),1000);
+		eq(cl.longTest(haxe.Int64.ofInt(-1)), -1);
+		eq(cl.longTest(haxe.Int64.ofInt(1000)), 1000);
 		i = 10;
 		eq(cl.longTest(i), 10);
 	}
 
-	public function testVarClash()
-	{
+	public function testVarClash() {
 		var ic = new Base_InnerClass2();
 		eq(ic.varNameClash2(), 1);
-		eq(ic.varNameClash2(2),2.2);
+		eq(ic.varNameClash2(2), 2.2);
 		var iface:Base_VarNameClash = ic;
 		eq(iface.varNameClash2(), 1);
-		eq(iface.varNameClash2(2),2.2);
+		eq(iface.varNameClash2(2), 2.2);
 		var base:Base = ic;
-		eq(base.varNameClash2,0);
+		eq(base.varNameClash2, 0);
 		base.varNameClash2 = 2;
-		eq(base.varNameClash2,2);
+		eq(base.varNameClash2, 2);
 	}
 
-	@:strict(MyClass_MyAnnotation({ author:"author", currentRevision: 2 }))
-	public function testAnnotations()
-	{
+	@:strict(MyClass_MyAnnotation({author: "author", currentRevision: 2}))
+	public function testAnnotations() {
 		var cl = java.Lib.toNativeType(TestJava);
 		var a = cl.getAnnotation(java.Lib.toNativeType(MyClass_MyAnnotation));
 		t(a != null);
@@ -98,20 +99,17 @@ class TestJava extends Test
 		eq(a.currentRevision(), 2);
 	}
 
-	function testLowerCase()
-	{
+	function testLowerCase() {
 		var l = new LowerCaseClass();
 		t(l.works);
 	}
 
-	function testNameCase()
-	{
+	function testNameCase() {
 		t(haxe.uppercasepackage.SomeClass.SomeClassFound);
 		t(haxe.uppercasepackage.Lowercase.lowercaseFound);
 	}
 
-	function testEnumSet()
-	{
+	function testEnumSet() {
 		var es1:EnumSet<TEnum> = EnumSet.noneOf(java.Lib.toNativeEnum(TEnum));
 		f(es1.contains(TA));
 		es1.add(TA);
@@ -122,8 +120,7 @@ class TestJava extends Test
 		// f(es2.contains(HC));
 	}
 
-	function testHaxeKeywords()
-	{
+	function testHaxeKeywords() {
 		eq(Base._inline, 42);
 		eq(Base.callback, 43);
 		eq(Base._cast, 44);
@@ -133,15 +130,12 @@ class TestJava extends Test
 		eq(Base._in, 40);
 	}
 
-	function testTypes()
-	{
+	function testTypes() {
 		eq(Base.charTest(cast 10), cast 10);
 		eq(Base.byteTest(cast 10), cast 10);
 	}
 
-
-	function testInnerClass()
-	{
+	function testInnerClass() {
 		//-java-lib should be able to detect inner classes on import
 		var i = new Base_InnerClass();
 		eq(i.nameClash(), 10);
@@ -159,13 +153,12 @@ class TestJava extends Test
 		eq("$$Inner$$Name8", haxe.test.MyClass.MyClass___Inner__Name7_____Inner__Name8.test());
 	}
 
-	function testGenerics()
-	{
+	function testGenerics() {
 		var jcl:java.lang.Class<Base_InnerClass_InnerInnerClass> = cast Base_InnerClass_InnerInnerClass;
 		t(haxe.test.GenericHelper.staticTypedGeneric(jcl) != null);
 
 		var helper = new haxe.test.GenericHelper();
-		//TODO use typedAs
+		// TODO use typedAs
 		eq(helper.getUntypedGeneric(), null);
 		eq(helper.typedGeneric, null);
 
@@ -173,21 +166,18 @@ class TestJava extends Test
 		var val3 = new Base___InnerClass3__();
 		var g1 = new haxe.test.Generic1(val);
 		g1.complexTypeParameterOfTypeParameter(new Base_InnerClass_InnerInnerClass());
-		//if no compile-time error, we're fine!
+		// if no compile-time error, we're fine!
 		t(true);
 	}
 
-	function testNameClash()
-	{
+	function testNameClash() {
 		eq(Base.nameClash(null), -1);
 		eq(new Base().nameClash(), 1);
 		eq(new Base().varNameClash(1), 1);
 		eq(Base.varNameClash(10.4), 10.4);
-
 	}
 
-	function testOverloadOverride()
-	{
+	function testOverloadOverride() {
 		var c = new TestMyClass();
 		c.normalOverload(true);
 		t(c.boolCalled);
@@ -215,8 +205,7 @@ class TestJava extends Test
 		t(c.dynamicCalled);
 	}
 
-	function testThrows1()
-	{
+	function testThrows1() {
 		// test 1: no @:throws / no catch
 		var b = new Base();
 		eq(Base.throwsTest(), 5);
@@ -225,49 +214,37 @@ class TestJava extends Test
 		eq(b.throwsMemberTest(true), 10);
 	}
 
-	function testThrows2()
-	{
+	function testThrows2() {
 		// test 2: catching only the IOException
-		try
-		{
+		try {
 			var b = new Base();
 			eq(Base.throwsTest(), 5);
 			eq(Base.throwsTest(42), 42);
 			eq(b.throwsMemberTest(), 6);
 			eq(b.throwsMemberTest(true), 10);
-		}
-		catch(e:java.io.IOException)
-		{
-		}
+		} catch (e:java.io.IOException) {}
 	}
 
-	function testThrows3()
-	{
+	function testThrows3() {
 		// test 3: catching all exceptions
-		try
-		{
+		try {
 			var b = new Base();
 			eq(Base.throwsTest(), 5);
 			eq(Base.throwsTest(42), 42);
 			eq(b.throwsMemberTest(), 6);
 			eq(b.throwsMemberTest(true), 10);
-		}
-		catch(e:java.lang.Throwable)
-		{
-		}
+		} catch (e:java.lang.Throwable) {}
 	}
 
 	// test 4: @:throws IOException and only use IOException
-	@:throws('java.io.IOException') function testThrows4()
-	{
+	@:throws('java.io.IOException') function testThrows4() {
 		var b = new Base();
 		eq(Base.throwsTest(), 5);
 		eq(b.throwsMemberTest(true), 10);
 	}
 
 	// test 5: @:throws IOException and use any
-	@:throws('java.io.IOException') function testThrows5()
-	{
+	@:throws('java.io.IOException') function testThrows5() {
 		var b = new Base();
 		eq(Base.throwsTest(), 5);
 		eq(Base.throwsTest(42), 42);
@@ -275,44 +252,42 @@ class TestJava extends Test
 		eq(b.throwsMemberTest(true), 10);
 	}
 
-	function testJavaLibEnum()
-	{
+	function testJavaLibEnum() {
 		var e = TEnum.TA;
-		switch(e)
-		{
+		switch (e) {
 			case TA:
 				t(true);
 			case _:
 				t(false);
 		}
-		eq("TA",Type.enumConstructor(e));
+		eq("TA", Type.enumConstructor(e));
 	}
 
-	function testMiscJavaLib()
-	{
-		//setting inline should be an error
+	function testMiscJavaLib() {
+		// setting inline should be an error
 		t(HelperMacros.typeError(Base.inlineNumber = 4));
 	}
 
-	//TODO:
-	//overload with functions + variable types
+	// TODO:
+	// overload with functions + variable types
 
 	function testDefaultInterface() {
 		var c = new MyDefaultInterfaceClass();
 		eq("FOO", c.test("foo"));
 	}
 
+	function testDefaultSubInterface() {
+		var c = new MyDefaultSubInterfaceClass();
+		eq("FOO", c.test("foo"));
+	}
 }
 
-private class TestMyClass extends haxe.test.MyClass
-{
-	@:overload public function new()
-	{
+private class TestMyClass extends haxe.test.MyClass {
+	@:overload public function new() {
 		super();
 	}
 
-	@:overload public function new(str:String)
-	{
+	@:overload public function new(str:String) {
 		super();
 		alternativeCtorCalled = true;
 	}
@@ -324,54 +299,39 @@ private class TestMyClass extends haxe.test.MyClass
 	public var stringCalled:Bool;
 	public var dynamicCalled:Bool;
 
-	@:overload override public function normalOverload(b:Bool):Void
-	{
+	@:overload override public function normalOverload(b:Bool):Void {
 		this.boolCalled = true;
 	}
 
-	@:overload override public function normalOverload(i:Int):Void
-	{
+	@:overload override public function normalOverload(i:Int):Void {
 		this.intCalled = true;
 	}
 
-	@:overload override public function normalOverload(i64:haxe.Int64):Void
-	{
+	@:overload override public function normalOverload(i64:haxe.Int64):Void {
 		this.int64Called = true;
 	}
 
-	@:overload override public function normalOverload(str:String):Void
-	{
+	@:overload override public function normalOverload(str:String):Void {
 		this.stringCalled = true;
 	}
 
-	@:overload override public function normalOverload(dyn:Dynamic):Void
-	{
+	@:overload override public function normalOverload(dyn:Dynamic):Void {
 		this.dynamicCalled = true;
 	}
 }
 
-@:nativeGen private class NativeClass
-{
-  public function new()
-  {
+@:nativeGen private class NativeClass {
+	public function new() {}
 
-  }
-
-  @:throws("java.lang.Throwable")
-  public function excTest():Void
-  {
-	throw new java.lang.Throwable("test", null);
-  }
+	@:throws("java.lang.Throwable")
+	public function excTest():Void {
+		throw new java.lang.Throwable("test", null);
+	}
 }
 
-private class HxClass extends NativeClass
-{
-
-  @:throws("java.lang.Throwable")
-  override public function excTest():Void
-  {
-
-  }
+private class HxClass extends NativeClass {
+	@:throws("java.lang.Throwable")
+	override public function excTest():Void {}
 }
 
 enum HaxeEnum {
@@ -384,4 +344,7 @@ class MyDefaultInterfaceClass implements MyDefaultInterface {
 	public function new() {}
 }
 
+class MyDefaultSubInterfaceClass implements MyDefaultSubInterface {
+	public function new() {}
+}
 #end

--- a/tests/unit/src/unit/TestJava.hx
+++ b/tests/unit/src/unit/TestJava.hx
@@ -1,12 +1,13 @@
 package unit;
 import haxe.io.Bytes;
-import haxe.test.Base;
-import haxe.test.MyClass;
 import haxe.test.Base.Base_InnerClass;
 import haxe.test.Base.Base___InnerClass3__;
 import haxe.test.Base.Base___InnerClass3___InnerClass4__;
-import haxe.test.TEnum;
+import haxe.test.Base;
 import haxe.test.LowerCaseClass;
+import haxe.test.MyClass;
+import haxe.test.MyDefaultInterface;
+import haxe.test.TEnum;
 import java.util.EnumSet;
 import java.vm.*;
 
@@ -296,6 +297,11 @@ class TestJava extends Test
 	//TODO:
 	//overload with functions + variable types
 
+	function testDefaultInterface() {
+		var c = new MyDefaultInterfaceClass();
+		eq("FOO", c.test("foo"));
+	}
+
 }
 
 private class TestMyClass extends haxe.test.MyClass
@@ -372,6 +378,10 @@ enum HaxeEnum {
 	HA;
 	HB;
 	HC;
+}
+
+class MyDefaultInterfaceClass implements MyDefaultInterface {
+	public function new() {}
 }
 
 #end


### PR DESCRIPTION
This consists of these steps:

* If while loading a jar we come across an interface method that has a `Code` attribute, add the `@:java.default` metadata to the field.
* If while typing a field we come across the `@:java.default` metadata, add the `CfDefault` flag to the class field.
* While checking interface implementations, if there's a missing interface method that has the `CfDefault` flag, create a copy of it on the implementing class the same way we would for abstract classes implementing interfaces. This step is necessary to satisfy the compiler's field resolution semantics.

Interestingly, I had to add a check to both the Java and the JVM generators to ignore methods with the `CfExtern` flag. That's probably because our post-processing doesn't touch interface fields.

TODO:

* Figure out if we have to do something special when interfaces extend each other. Also check the situation where a non-extern interface extends an extern interface with a default method.
* Write more tests I guess.