### PR TITLE
BufferSource: Align with TypedArray spec; don't modify ArrayBufferViews

### DIFF
--- a/std/js/lib/BufferSource.hx
+++ b/std/js/lib/BufferSource.hx
@@ -34,5 +34,13 @@ import haxe.extern.EitherType;
 
 	@see <https://developer.mozilla.org/en-US/docs/Web/API/BufferSource>
  */
-@:forward
-abstract BufferSource(Dynamic) from ArrayBuffer from ArrayBufferView { }
+abstract BufferSource(Dynamic) from ArrayBuffer from ArrayBufferView {
+	
+	public var byteLength(get, never): Int;
+
+	@:pure
+	inline function get_byteLength(): Int {
+		return this.byteLength;
+	}
+	
+}

--- a/std/js/lib/BufferSource.hx
+++ b/std/js/lib/BufferSource.hx
@@ -35,8 +35,4 @@ import haxe.extern.EitherType;
 	@see <https://developer.mozilla.org/en-US/docs/Web/API/BufferSource>
  */
 @:forward
-abstract BufferSource(ArrayBuffer) to ArrayBuffer from ArrayBuffer {
-	@:from public static inline function fromBufferView(view:ArrayBufferView) {
-		return cast view.buffer;
-	}
-}
+abstract BufferSource(Dynamic) from ArrayBuffer from ArrayBufferView { }


### PR DESCRIPTION
See #10474, current implementation was incorrect and likely to cause runtime errors

This PR corrects this

It is a breaking change however a compiler error will catch any cases that would affect runtime behavior
- BufferSource no longer auto casts to ArrayBuffer, generating a compiler error (which is the correct behavior)
- When an ArrayBufferView is auto cast to a BufferSource it no longer throws away the View information

(also adds byteLength field which is common to both ArrayBuffer and ArrayBufferView)

Closes #10474 