### PR TITLE
Implement js.lib.WeakRef

### DIFF
--- a/std/js/lib/WeakRef.hx
+++ b/std/js/lib/WeakRef.hx
@@ -26,7 +26,7 @@ package js.lib;
 	Documentation [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("WeakRef")
-extern class WeakRef<T> {
+extern class WeakRef<T:{}> {
 	/**
 		Creates a new WeakRef object.
 	**/

--- a/std/js/lib/WeakRef.hx
+++ b/std/js/lib/WeakRef.hx
@@ -26,13 +26,13 @@ package js.lib;
 	Documentation [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
 **/
 @:native("WeakRef")
-extern class WeakRef {
+extern class WeakRef<T> {
 	/**
 		Creates a new WeakRef object.
 	**/
-	@:pure function new(target:{});
+	@:pure function new(target:T);
 	/**
-		Returns the WeakRef object's target object, or undefined if the target object has been reclaimed.
+		Returns the WeakRef object's target object, or null if the target object has been reclaimed.
 	**/
-	@:pure function deref():{};
+	@:pure function deref():Null<T>;
 }

--- a/std/js/lib/WeakRef.hx
+++ b/std/js/lib/WeakRef.hx
@@ -1,0 +1,38 @@
+package js.lib;
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+	The `WeakRef` object lets you hold a weak reference to another object, without preventing that object from getting garbage-collected.
+	Documentation [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) by [Mozilla Contributors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef$history), licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/).
+**/
+@:native("WeakRef")
+extern class WeakRef {
+	/**
+		Creates a new WeakRef object.
+	**/
+	@:pure function new(target:{});
+	/**
+		Returns the WeakRef object's target object, or undefined if the target object has been reclaimed.
+	**/
+	@:pure function deref():{};
+}


### PR DESCRIPTION
WeakRef was introduced in ES2021 and is now supported on every major browser. I think it's time for Haxe to include it as well.