### PR TITLE
Disallow case string interpolation

### DIFF
--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -335,6 +335,15 @@ module Pattern = struct
 				pctx.in_reification <- old;
 				e
 			| EConst((Ident ("false" | "true") | Int _ | String _ | Float _) as ct) ->
+				begin match ct with
+					| String (value,kind) when kind = Ast.SSingleQuotes ->
+						let e = ctx.g.do_format_string ctx value p in
+						begin match e with
+							| EBinop _, p -> typing_error "String interpolation is not allowed in case patterns" p;
+							| _ -> ()
+						end;
+					| _ -> ()
+				end;
 				let p = pos e in
 				let e = Texpr.type_constant ctx.com.basic ct p in
 				unify_expected e.etype;

--- a/tests/misc/projects/Issue9163/Main.hx
+++ b/tests/misc/projects/Issue9163/Main.hx
@@ -1,0 +1,12 @@
+class Main {
+	static function main() {
+		var foo = '5';
+		var bar = '5';
+		var isEqual = switch (bar) {
+			case 'foo$ foo': true;
+			case '\\ foo': true;
+			case '$foo': true;
+			default: false;
+		}
+	}
+}

--- a/tests/misc/projects/Issue9163/compile-fail.hxml
+++ b/tests/misc/projects/Issue9163/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue9163/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue9163/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:8: characters 10-14 : String interpolation is not allowed in case patterns


### PR DESCRIPTION
Maybe complex string interpolation expression should be generated [here](https://github.com/HaxeFoundation/haxe/blob/7b622ddd6484ac2d06aaf4d33cfec0e3b78c993f/src/core/texpr.ml#L576) with `do_format_string` call, but [typing](https://github.com/HaxeFoundation/haxe/blob/5e0a0299e3d502528f65e949407d14b573d7eae7/src/typing/typer.ml#L1675) cannot be called easily without refactoring (recursive dependency)?
Closes https://github.com/HaxeFoundation/haxe/issues/9163