### PR TITLE
Add missing python threading apis.

### DIFF
--- a/std/python/_std/sys/thread/Deque.hx
+++ b/std/python/_std/sys/thread/Deque.hx
@@ -22,15 +22,17 @@
 
 package sys.thread;
 
+import python.lib.threading.Condition;
+
 using python.internal.UBuiltins;
 
 class Deque<T> {
 	var deque:NativeDeque<T>;
-	var lock:NativeCondition;
+	var lock:Condition;
 
 	public function new() {
 		deque = new NativeDeque<T>();
-		lock = new NativeCondition();
+		lock = new Condition();
 	}
 
 	public function add(i:T) {
@@ -68,16 +70,4 @@ private extern class NativeDeque<T> {
 	function append(x:T):Void;
 	function appendleft(x:T):Void;
 	function popleft():T;
-}
-
-@:pythonImport("threading", "Condition")
-@:native("Condition")
-private extern class NativeCondition {
-	function new(?lock:Dynamic);
-	function acquire(blocking:Bool = true, timeout:Float = -1):Bool;
-	function release():Void;
-	function wait(?timeout:Float):Bool;
-	function wait_for(predicate:()->Bool, ?timeout:Float):Bool;
-	function notify(n:Int = 1):Void;
-	function notify_all():Void;
 }

--- a/std/python/_std/sys/thread/Lock.hx
+++ b/std/python/_std/sys/thread/Lock.hx
@@ -22,12 +22,14 @@
 
 package sys.thread;
 
+import python.lib.threading.Semaphore;
+
 @:coreApi
 class Lock {
-	final semaphore:NativeSemaphore;
+	final semaphore:Semaphore;
 
 	public inline function new() {
-		semaphore = new NativeSemaphore(0);
+		semaphore = new Semaphore(0);
 	}
 
 	public inline function wait(?timeout:Float):Bool {
@@ -37,12 +39,4 @@ class Lock {
 	public inline function release():Void {
 		semaphore.release();
 	}
-}
-
-@:pythonImport("threading", "Semaphore")
-@:native("Lock")
-private extern class NativeSemaphore {
-	function new(value:Int);
-	function acquire(blocking:Bool = true, ?timeout:Float):Bool;
-	function release():Void;
 }

--- a/std/python/_std/sys/thread/Mutex.hx
+++ b/std/python/_std/sys/thread/Mutex.hx
@@ -22,12 +22,14 @@
 
 package sys.thread;
 
+import python.lib.threading.RLock;
+
 @:coreApi
 class Mutex {
-	final lock:NativeRLock;
+	final lock:RLock;
 
 	inline public function new():Void {
-		lock = new NativeRLock();
+		lock = new RLock();
 	}
 
 	inline public function acquire():Void {
@@ -41,11 +43,4 @@ class Mutex {
 	inline public function release():Void {
 		lock.release();
 	}
-}
-
-@:pythonImport("threading", "RLock")
-private extern class NativeRLock {
-	function new():Void;
-	function acquire(blocking:Bool):Bool;
-	function release():Void;
 }

--- a/std/python/_std/sys/thread/Thread.hx
+++ b/std/python/_std/sys/thread/Thread.hx
@@ -22,6 +22,9 @@
 
 package sys.thread;
 
+import python.lib.threading.Thread as NativeThread;
+import python.lib.Threading;
+
 import haxe.ds.ObjectMap;
 
 private typedef ThreadImpl = HxThread;
@@ -78,7 +81,7 @@ private class HxThread {
 	static function __init__() {
 		threads = new ObjectMap();
 		threadsMutex = new Mutex();
-		mainThread = new HxThread(PyThreadingAPI.current_thread());
+		mainThread = new HxThread(Threading.current_thread());
 		mainThread.events = new EventLoop();
 	}
 
@@ -92,8 +95,8 @@ private class HxThread {
 
 	public static function current():HxThread {
 		threadsMutex.acquire();
-		var ct = PyThreadingAPI.current_thread();
-		if (ct == PyThreadingAPI.main_thread()) {
+		var ct = Threading.current_thread();
+		if (ct == Threading.main_thread()) {
 			threadsMutex.release();
 			return mainThread;
 		}
@@ -158,18 +161,4 @@ private class HxThread {
 	public static function readMessage(block:Bool):Dynamic {
 		return current().messages.pop(block);
 	}
-}
-
-@:pythonImport("threading", "Thread")
-@:native("Thread")
-private extern class NativeThread {
-	function new(group:Dynamic, target:Void->Void);
-	function start():Void;
-}
-
-@:pythonImport("threading")
-@:native("threading")
-private extern class PyThreadingAPI {
-	static function current_thread():NativeThread;
-	static function main_thread():NativeThread;
 }

--- a/std/python/lib/threading/Condition.hx
+++ b/std/python/lib/threading/Condition.hx
@@ -1,0 +1,12 @@
+package python.lib.threading;
+
+@:pythonImport("threading", "Condition")
+extern class Condition {
+	function new(?lock:haxe.extern.EitherType<Lock, RLock>):Void;
+	function acquire(?blocking:Bool, ?timeout:Float):Bool;
+	function release():Void;
+	function wait(?timeout:Float):Bool;
+	function wait_for(predicate:()->Bool, ?timeout:Float):Bool;
+	function notify(n:Int = 1):Void;
+	function notify_all():Void;
+}

--- a/std/python/lib/threading/Semaphore.hx
+++ b/std/python/lib/threading/Semaphore.hx
@@ -1,0 +1,8 @@
+package python.lib.threading;
+
+@:pythonImport("threading", "Semaphore")
+extern class Semaphore {
+	function new(value:Int);
+	function acquire(blocking:Bool = true, ?timeout:Float):Bool;
+	function release(n:Int = 1):Void;
+}


### PR DESCRIPTION
Add `threading.Condition` and `threading.Semaphore`.
Make the python `sys.thread` implementation use the existing python externs.