### PR TITLE
Disabled debugchk for array get

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -1429,7 +1429,7 @@ and array_read ctx ra (at,vt) ridx p =
 		let harr = alloc_tmp ctx HArray in
 		op ctx (OField (harr,ra,1));
 		op ctx (OGetArray (tmp,harr,ridx));
-		op ctx (OMov (r,unsafe_cast_to ctx tmp vt p));
+		op ctx (OMov (r,unsafe_cast_to ~debugchk:false ctx tmp vt p));
 		jend();
 		r
 

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1060,7 +1060,8 @@ let generate_function ctx f =
 			(* insert end switch *)
 			output_at2 pend ([OODecreaseIndent;OODecreaseIndent;OOEndBlock] @ List.rev old);
 		| ONullCheck r ->
-			sexpr "if( %s == NULL ) hl_null_access()" (reg r)
+			(* sexpr "if( %s == NULL ) hl_null_access()" (reg r) *)
+			()
 		| OTrap (r,d) ->
 			sexpr "hl_trap(trap$%d,%s,%s)" !trap_depth (reg r) (label d);
 			incr trap_depth


### PR DESCRIPTION
Currently, the code is debug checking every array access for non basic types.  Most of the other calls in the code to unsafe_cast_to use '~debugchk:false` but array access did not.  This was a big hit for tight loops where a check on casting was evaluated in production code.

