### PR TITLE
Use plain method closure comparison for JS.

### DIFF
--- a/std/haxe/macro/ExampleJSGenerator.hx
+++ b/std/haxe/macro/ExampleJSGenerator.hx
@@ -231,7 +231,13 @@ class ExampleJSGenerator {
 	public function generate() {
 		print("var $_, $hxClasses = $hxClasses || {}, $estr = function() { return js.Boot.__string_rec(this,''); }");
 		newline();
-		print("function $bind(o,m) { var f = function(){ return f.method.apply(f.scope, arguments); }; f.scope = o; f.method = m; return f; };");
+		print(
+			#if (js_es < 5)
+				"function $bind(o,m) { if( m == null ) return null; if( m.__id__ == null ) m.__id__ = $global.$haxeUID++; var f; if( o.hx__closures__ == null ) o.hx__closures__ = {}; else f = o.hx__closures__[m.__id__]; if( f == null ) { f = function(){ return f.method.apply(f.scope, arguments); }; f.scope = o; f.method = m; o.hx__closures__[m.__id__] = f; } return f; }"
+			#else
+				"function $bind(o,m) { if( m == null ) return null; if( m.__id__ == null ) m.__id__ = $global.$haxeUID++; var f; if( o.hx__closures__ == null ) o.hx__closures__ = {}; else f = o.hx__closures__[m.__id__]; if( f == null ) { f = m.bind(o); o.hx__closures__[m.__id__] = f; } return f; }"
+			#end
+		);
 		newline();
 		for (t in api.types)
 			genType(t);

--- a/std/js/_std/Reflect.hx
+++ b/std/js/_std/Reflect.hx
@@ -79,12 +79,8 @@
 		return (a == b) ? 0 : (((cast a) > (cast b)) ? 1 : -1);
 	}
 
-	public static function compareMethods(f1:Dynamic, f2:Dynamic):Bool {
-		if (f1 == f2)
-			return true;
-		if (!isFunction(f1) || !isFunction(f2))
-			return false;
-		return f1.scope == f2.scope && f1.method == f2.method && f1.method != null;
+	public static inline function compareMethods(f1:Dynamic, f2:Dynamic):Bool {
+		return f1 == f2;
 	}
 
 	@:access(js.Boot)


### PR DESCRIPTION
Not too proud of duplicating the code from genjs. Perhaps it would be best to expose it via `JSGenApi`?

In any case, my main motivation is for `Reflect.compareMethods` not to use `Reflect.isFunction`, because that relies on `__define_feature__` quite a bit, thus increasing output. I ran into this, because `haxe.http.HttpBase` [uses `Reflect.compareMethods`](https://github.com/HaxeFoundation/haxe/blob/319f812ae04511274d17dd6e5f34747cf3c9c083/std/haxe/http/HttpBase.hx#L229) (could be avoided, but I'd rather fix the underlying issue).

If anyone feels strongly about having the `scope` and `method` check around for some weird compatibility reasons, I can instead make a PR that checks the `typeof` to be `"function"` (instead of the full `Reflect.isFunction`), which should be good enough, because per spec "If `f1` or `f2` are not functions, the result is unspecified".