### PR TITLE
Allow more attributes for generic instances

### DIFF
--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -315,7 +315,21 @@ let rec build_generic ctx c p tl =
 		TypeloadFunction.add_constructor ctx cg false p;
 		cg.cl_kind <- KGenericInstance (c,tl);
 		cg.cl_meta <- (Meta.NoDoc,[],null_pos) :: cg.cl_meta;
-		if has_meta Meta.Keep c.cl_meta then cg.cl_meta <- (Meta.Keep,[],null_pos) :: cg.cl_meta;
+		Meta.[
+			Access; Allow;
+			Final;
+			Hack;
+			Internal;
+			Keep;
+			NoClosure; NullSafety;
+			Pure;
+			Struct; StructInit;
+			Using
+		] |> List.iter (fun meta ->
+			if has_meta meta c.cl_meta then
+				let _,args,_ = get_meta meta c.cl_meta in
+				cg.cl_meta <- (meta,args,null_pos) :: cg.cl_meta
+		);
 		if (has_class_flag c CInterface) then add_class_flag cg CInterface;
 		cg.cl_constructor <- (match cg.cl_constructor, c.cl_constructor, c.cl_super with
 			| _, Some cf, _ -> Some (build_field cf)


### PR DESCRIPTION
This is hopefully a fix for #10550 and any other related issues.

These are the metadata that are now allowed on generic type instances:
- access
- allow
- final
- hack
- internal
- keep (this was already allowed)
- noClosure
- nullSafety
- pure
- struct
- structInit
- using

I'm not entirely sure if `using` will work as intended, but if it doesn't I guess I could change it.
I'm also not sure what to do with `autoBuild`, `build`, and `genericBuild` so I left them out, and I don't see much use for `keepInit` and `keepSub`.

(I probably missed some metadata, so those can be added if needed)