### PR TITLE
Fixed the number of complements in Base64 encoding

### DIFF
--- a/std/haxe/crypto/Base64.hx
+++ b/std/haxe/crypto/Base64.hx
@@ -35,10 +35,10 @@ class Base64 {
 	public static function encode(bytes:haxe.io.Bytes, complement = true):String {
 		var str = new BaseCode(BYTES).encodeBytes(bytes).toString();
 		if (complement)
-			switch (bytes.length % 3) {
-				case 1:
-					str += "==";
+			switch (bytes.length % 4) {
 				case 2:
+					str += "==";
+				case 3:
 					str += "=";
 				default:
 			}
@@ -55,10 +55,10 @@ class Base64 {
 	public static function urlEncode(bytes:haxe.io.Bytes, complement = false):String {
 		var str = new BaseCode(URL_BYTES).encodeBytes(bytes).toString();
 		if (complement)
-			switch (bytes.length % 3) {
-				case 1:
-					str += "==";
+			switch (bytes.length % 4) {
 				case 2:
+					str += "==";
+				case 3:
 					str += "=";
 				default:
 			}

--- a/std/haxe/crypto/Base64.hx
+++ b/std/haxe/crypto/Base64.hx
@@ -35,10 +35,10 @@ class Base64 {
 	public static function encode(bytes:haxe.io.Bytes, complement = true):String {
 		var str = new BaseCode(BYTES).encodeBytes(bytes).toString();
 		if (complement)
-			switch (bytes.length % 4) {
-				case 2:
+			switch (bytes.length % 3) {
+				case 1:
 					str += "==";
-				case 3:
+				case 2:
 					str += "=";
 				default:
 			}
@@ -55,10 +55,10 @@ class Base64 {
 	public static function urlEncode(bytes:haxe.io.Bytes, complement = false):String {
 		var str = new BaseCode(URL_BYTES).encodeBytes(bytes).toString();
 		if (complement)
-			switch (bytes.length % 4) {
-				case 2:
+			switch (bytes.length % 3) {
+				case 1:
 					str += "==";
-				case 3:
+				case 2:
 					str += "=";
 				default:
 			}

--- a/std/php/_std/haxe/crypto/Base64.hx
+++ b/std/php/_std/haxe/crypto/Base64.hx
@@ -44,10 +44,10 @@ class Base64 {
 
 	public static inline function decode(str:String, complement = true):Bytes {
 		if (!complement) {
-			switch (strlen(str) % 3) {
-				case 1:
-					str += "==";
+			switch (strlen(str) % 4) {
 				case 2:
+					str += "==";
+				case 3:
 					str += "=";
 				default:
 			}
@@ -65,10 +65,10 @@ class Base64 {
 
 	public static inline function urlDecode(str:String, complement = false):Bytes {
 		if (complement) {
-			switch (strlen(str) % 3) {
-				case 1:
-					str += "==";
+			switch (strlen(str) % 4) {
 				case 2:
+					str += "==";
+				case 3:
 					str += "=";
 				default:
 			}

--- a/tests/unit/src/unitstd/haxe/crypto/Base64.unit.hx
+++ b/tests/unit/src/unitstd/haxe/crypto/Base64.unit.hx
@@ -1,0 +1,45 @@
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("The quick brown fox jumps over the lazy dog"), true) == "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("The quick brown fox jumps over the lazy dog"), false) == "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("The quick brown fox jumps over the lazy dog"), true) == "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("The quick brown fox jumps over the lazy dog"), false) == "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw";
+
+haxe.crypto.Base64.decode("VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==", true).toString() == "The quick brown fox jumps over the lazy dog";
+haxe.crypto.Base64.decode("VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw", false).toString() == "The quick brown fox jumps over the lazy dog";
+haxe.crypto.Base64.urlDecode("VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==", true).toString() == "The quick brown fox jumps over the lazy dog";
+haxe.crypto.Base64.urlDecode("VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw", false).toString() == "The quick brown fox jumps over the lazy dog";
+
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("a"), true) == "YQ==";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("ab"), true) == "YWI=";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("ab?"), true) == "YWI/";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("ab~c"), true) == "YWJ+Yw==";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("a"), false) == "YQ";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("ab"), false) == "YWI";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("ab?"), false) == "YWI/";
+haxe.crypto.Base64.encode(haxe.io.Bytes.ofString("ab~c"), false) == "YWJ+Yw";
+
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("a"), true) == "YQ==";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("ab"), true) == "YWI=";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("ab?"), true) == "YWI_";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("ab~c"), true) == "YWJ-Yw==";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("a"), false) == "YQ";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("ab"), false) == "YWI";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("ab?"), false) == "YWI_";
+haxe.crypto.Base64.urlEncode(haxe.io.Bytes.ofString("ab~c"), false) == "YWJ-Yw";
+
+haxe.crypto.Base64.decode("YQ==", true).toString() == "a";
+haxe.crypto.Base64.decode("YWI=", true).toString() == "ab";
+haxe.crypto.Base64.decode("YWI/", true).toString() == "ab?";
+haxe.crypto.Base64.decode("YWJ+Yw==", true).toString() == "ab~c";
+haxe.crypto.Base64.decode("YQ", false).toString() == "a";
+haxe.crypto.Base64.decode("YWI", false).toString() == "ab";
+haxe.crypto.Base64.decode("YWI/", false).toString() == "ab?";
+haxe.crypto.Base64.decode("YWJ+Yw", false).toString() == "ab~c";
+
+haxe.crypto.Base64.urlDecode("YQ==", true).toString() == "a";
+haxe.crypto.Base64.urlDecode("YWI=", true).toString() == "ab";
+haxe.crypto.Base64.urlDecode("YWI_", true).toString() == "ab?";
+haxe.crypto.Base64.urlDecode("YWJ-Yw==", true).toString() == "ab~c";
+haxe.crypto.Base64.urlDecode("YQ", false).toString() == "a";
+haxe.crypto.Base64.urlDecode("YWI", false).toString() == "ab";
+haxe.crypto.Base64.urlDecode("YWI_", false).toString() == "ab?";
+haxe.crypto.Base64.urlDecode("YWJ-Yw", false).toString() == "ab~c";


### PR DESCRIPTION
I found that the standard library `haxe.crypto.Base64` tries to add complements `=` to an encoded string so that the length of the string is a multiple of **three**. However, this is not correct; complements actually should be added so that the length of an encoded string is a multiple of **four**.
I fix this problem in the pull request. Also please note that the number of complements can never be three for any Base64-encoded strings.

I hope this helps!