### PR TITLE
Sort out server module marks

### DIFF
--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -45,6 +45,7 @@ and compilation_context = {
 type server_accept = unit -> (bool * (bool -> string option) * (string -> unit) * (unit -> unit))
 
 type server_api = {
+	compilation_step : int;
 	cache : CompilationCache.t;
 	before_anything : compilation_context -> unit;
 	after_arg_parsing : compilation_context -> unit;

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -45,8 +45,8 @@ and compilation_context = {
 type server_accept = unit -> (bool * (bool -> string option) * (string -> unit) * (unit -> unit))
 
 type server_api = {
-	compilation_step : int;
 	cache : CompilationCache.t;
+	on_context_create : unit -> int;
 	before_anything : compilation_context -> unit;
 	after_arg_parsing : compilation_context -> unit;
 	after_compilation : compilation_context -> unit;

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -824,7 +824,7 @@ module HighLevel = struct
 		DynArray.to_list compilations
 
 	let entry server_api comm args =
-		let create = create_context server_api.compilation_step comm server_api.cache in
+		let create = create_context (server_api.on_context_create()) comm server_api.cache in
 		let ctxs = try
 			process_params server_api create args
 		with Arg.Bad msg ->

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -762,8 +762,8 @@ let compile_ctx server_api comm ctx =
 			error ctx ("Error: " ^ msg) null_pos;
 			false
 
-let create_context comm cs params = {
-	com = Common.create cs version params;
+let create_context compilation_step comm cs params = {
+	com = Common.create compilation_step cs version params;
 	on_exit = [];
 	messages = [];
 	has_next = false;
@@ -824,7 +824,7 @@ module HighLevel = struct
 		DynArray.to_list compilations
 
 	let entry server_api comm args =
-		let create = create_context comm server_api.cache in
+		let create = create_context server_api.compilation_step comm server_api.cache in
 		let ctxs = try
 			process_params server_api create args
 		with Arg.Bad msg ->

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -416,12 +416,12 @@ let add_modules sctx ctx m p =
 	let com = ctx.Typecore.com in
 	let rec add_modules tabs m0 m =
 		if m.m_extra.m_added < sctx.compilation_step then begin
-			m.m_extra.m_added <- sctx.compilation_step;
 			(match m0.m_extra.m_kind, m.m_extra.m_kind with
 			| MCode, MMacro | MMacro, MCode ->
 				(* this was just a dependency to check : do not add to the context *)
 				PMap.iter (Hashtbl.replace com.resources) m.m_extra.m_binded_res;
 			| _ ->
+				m.m_extra.m_added <- sctx.compilation_step;
 				ServerMessage.reusing com tabs m;
 				List.iter (fun t ->
 					match t with

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -292,6 +292,7 @@ type report_mode =
 	| RMStatistics
 
 type context = {
+	compilation_step : int;
 	mutable stage : compiler_stage;
 	mutable cache : CompilationCache.context_cache option;
 	(* config *)
@@ -706,9 +707,10 @@ let get_config com =
 
 let memory_marker = [|Unix.time()|]
 
-let create cs version args =
+let create compilation_step cs version args =
 	let m = Type.mk_mono() in
 	{
+		compilation_step = compilation_step;
 		cs = cs;
 		cache = None;
 		stage = CCreated;

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -160,7 +160,7 @@ let module_extra file sign time kind policy =
 		};
 		m_dirty = None;
 		m_added = 0;
-		m_mark = 0;
+		m_checked = 0;
 		m_time = time;
 		m_processed = 0;
 		m_deps = PMap.empty;

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -646,7 +646,7 @@ module Printer = struct
 			"m_time",string_of_float me.m_time;
 			"m_dirty",s_opt s_module_skip_reason me.m_dirty;
 			"m_added",string_of_int me.m_added;
-			"m_mark",string_of_int me.m_mark;
+			"m_checked",string_of_int me.m_checked;
 			"m_deps",s_pmap string_of_int (fun m -> snd m.m_path) me.m_deps;
 			"m_processed",string_of_int me.m_processed;
 			"m_kind",s_module_kind me.m_kind;

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -365,9 +365,9 @@ and module_def_extra = {
 	mutable m_time : float;
 	mutable m_dirty : module_skip_reason option;
 	mutable m_added : int;
-	mutable m_mark : int;
-	mutable m_deps : (int,module_def) PMap.t;
+	mutable m_checked : int;
 	mutable m_processed : int;
+	mutable m_deps : (int,module_def) PMap.t;
 	mutable m_kind : module_kind;
 	mutable m_binded_res : (string, string) PMap.t;
 	mutable m_if_feature : (string *(tclass * tclass_field * bool)) list;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -484,8 +484,7 @@ and flush_macro_context mint ctx =
 	in
 	(try Interp.add_types mint types ready
 	with Error (e,p) -> t(); raise (Fatal_error(error_msg e,p)));
-	t();
-	Filters.next_compilation()
+	t()
 
 let create_macro_interp ctx mctx =
 	let com2 = mctx.com in


### PR DESCRIPTION
Our marking looked weird to me because surely `m_dirty` has to be constant for a given compilation. This PR changes the handling accordingly, and does some other cleanup. We now have `m_added` (like before) and `m_checked` (was `m_mark`) which are handled exactly once per compilation by comparing them to `sctx.compilation_step`, which is increased for each new `compilation_context`.

The common context is now aware of its `compilation_step`, which replaces the global `pp_counter` when checking post-processing. 