### PR TITLE
Rework Sys.exit for eval

### DIFF
--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -30,6 +30,7 @@ type communication = {
 	write_out : string -> unit;
 	write_err : string -> unit;
 	flush     : compilation_context -> unit;
+	exit      : int -> unit;
 	is_server : bool;
 }
 

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -191,37 +191,35 @@ module Communication = struct
 		is_server = false;
 	}
 
-	let create_pipe sctx write =
-		let rec comm = {
-			write_out = (fun s ->
-				write ("\x01" ^ String.concat "\x01" (ExtString.String.nsplit s "\n") ^ "\n")
-			);
-			write_err = (fun s ->
-				write s
-			);
-			flush = (fun ctx ->
-				check_display_flush ctx (fun () ->
-					List.iter
-						(fun msg ->
-							let s = compiler_message_string msg in
-							write (s ^ "\n");
-							ServerMessage.message s;
-						)
-						(List.rev ctx.messages);
-					sctx.was_compilation <- ctx.com.display.dms_full_typing;
-					if has_error ctx then begin
-						measure_times := false;
-						write "\x02\n"
-					end else
-						maybe_cache_context sctx ctx.com;
-				)
-			);
-			exit = (fun i ->
-				()
-			);
-			is_server = true;
-		} in
-		comm
+	let create_pipe sctx write = {
+		write_out = (fun s ->
+			write ("\x01" ^ String.concat "\x01" (ExtString.String.nsplit s "\n") ^ "\n")
+		);
+		write_err = (fun s ->
+			write s
+		);
+		flush = (fun ctx ->
+			check_display_flush ctx (fun () ->
+				List.iter
+					(fun msg ->
+						let s = compiler_message_string msg in
+						write (s ^ "\n");
+						ServerMessage.message s;
+					)
+					(List.rev ctx.messages);
+				sctx.was_compilation <- ctx.com.display.dms_full_typing;
+				if has_error ctx then begin
+					measure_times := false;
+					write "\x02\n"
+				end else
+					maybe_cache_context sctx ctx.com;
+			)
+		);
+		exit = (fun i ->
+			()
+		);
+		is_server = true;
+	}
 end
 
 let stat dir =

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2585,8 +2585,6 @@ module StdSys = struct
 	)
 
 	let exit = vfun1 (fun code ->
-		(* TODO: Borrowed from interp.ml *)
-		if (get_ctx()).curapi.use_cache() then raise (Error.Fatal_error ("",Globals.null_pos));
 		raise (Sys_exit(decode_int code));
 	)
 

--- a/tests/misc/compile.hxml
+++ b/tests/misc/compile.hxml
@@ -1,4 +1,4 @@
 -p src
-#-D MISC_TEST_FILTER=9619
+-D MISC_TEST_FILTER=sys-exit
 -main Main
 --interp

--- a/tests/misc/projects/sys-exit/SysExit0.hx
+++ b/tests/misc/projects/sys-exit/SysExit0.hx
@@ -1,0 +1,6 @@
+class SysExit0 {
+	static function main() {
+		Sys.stderr().writeString("Exiting with 0\n");
+		Sys.exit(0);
+	}
+}

--- a/tests/misc/projects/sys-exit/SysExit1.hx
+++ b/tests/misc/projects/sys-exit/SysExit1.hx
@@ -1,0 +1,6 @@
+class SysExit1 {
+	static function main() {
+		Sys.stderr().writeString("Exiting with 1\n");
+		Sys.exit(1);
+	}
+}

--- a/tests/misc/projects/sys-exit/compile00.hxml
+++ b/tests/misc/projects/sys-exit/compile00.hxml
@@ -1,0 +1,7 @@
+--main SysExit0
+--interp
+
+--next
+
+--main SysExit0
+--interp

--- a/tests/misc/projects/sys-exit/compile00.hxml.stderr
+++ b/tests/misc/projects/sys-exit/compile00.hxml.stderr
@@ -1,0 +1,2 @@
+Exiting with 0
+Exiting with 0

--- a/tests/misc/projects/sys-exit/compile01-fail.hxml
+++ b/tests/misc/projects/sys-exit/compile01-fail.hxml
@@ -1,0 +1,7 @@
+--main SysExit0
+--interp
+
+--next
+
+--main SysExit1
+--interp

--- a/tests/misc/projects/sys-exit/compile01-fail.hxml.stderr
+++ b/tests/misc/projects/sys-exit/compile01-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Exiting with 0
+Exiting with 1

--- a/tests/misc/projects/sys-exit/compile10-fail.hxml
+++ b/tests/misc/projects/sys-exit/compile10-fail.hxml
@@ -1,0 +1,7 @@
+--main SysExit1
+--interp
+
+--next
+
+--main SysExit0
+--interp

--- a/tests/misc/projects/sys-exit/compile10-fail.hxml.stderr
+++ b/tests/misc/projects/sys-exit/compile10-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Exiting with 1

--- a/tests/misc/projects/sys-exit/compile11-fail.hxml
+++ b/tests/misc/projects/sys-exit/compile11-fail.hxml
@@ -1,0 +1,7 @@
+--main SysExit1
+--interp
+
+--next
+
+--main SysExit1
+--interp

--- a/tests/misc/projects/sys-exit/compile11-fail.hxml.stderr
+++ b/tests/misc/projects/sys-exit/compile11-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Exiting with 1


### PR DESCRIPTION
I've always hated how a `Sys.exit(0)` when running the interpreter would cause an error on the compilation server. This change addresses this by always throwing the `Sys_exit` exception, but making sure to properly catch it in `compiler.ml`. `compile_ctx` now returns the exit code, and `HighLevel.entry` keeps going (in case of `--next`) as long as the exit code is 0. Finally, it calls `comm.exit`, which does a legit `exit` in the stdio version and nothing in the pipe version (context error state is set by `catch_completion_and_exit`).