### PR TITLE
Add CfPostProcessed flag

### DIFF
--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -211,8 +211,7 @@ module Communication = struct
 				if has_error ctx then begin
 					measure_times := false;
 					write "\x02\n"
-				end else
-					maybe_cache_context sctx ctx.com;
+				end
 			)
 		);
 		is_server = true;

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -204,6 +204,10 @@ let handler =
 				| [] ->
 					hctx.send_error [jstring "No such type"]
 				| mt :: mtl ->
+					begin match mt with
+					| TClassDecl c -> c.cl_restore()
+					| _ -> ()
+					end;
 					let infos = t_infos mt in
 					if snd infos.mt_path = typeName then begin
 						let ctx = Genjson.create_context GMMinimum in

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -231,7 +231,11 @@ let null_abstract = {
 }
 
 let add_dependency m mdep =
-	if m != null_module && m != mdep then m.m_extra.m_deps <- PMap.add mdep.m_id mdep m.m_extra.m_deps
+	if m != null_module && m != mdep then begin
+		m.m_extra.m_deps <- PMap.add mdep.m_id mdep m.m_extra.m_deps;
+		(* In case the module is cached, we'll have to run post-processing on it again (issue #10635) *)
+		m.m_extra.m_processed <- 0
+	end
 
 let arg_name (a,_) = a.v_name
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -420,6 +420,7 @@ type flag_tclass_field =
 	| CfEnum
 	| CfGeneric
 	| CfDefault (* Interface field with default implementation (only valid on Java) *)
+	| CfPostProcessed (* Marker to indicate the field has been post-processed *)
 
 (* Order has to match declaration for printing*)
 let flag_tclass_field_names = [

--- a/src/filters/defaultArguments.ml
+++ b/src/filters/defaultArguments.ml
@@ -61,6 +61,8 @@ let rec change_func com cl cf =
 	List.iter (change_func com cl) cf.cf_overloads;
 
 	match cf.cf_kind, follow cf.cf_type with
+	| _ when has_class_field_flag cf CfPostProcessed ->
+		()
 	| Var _, _ | Method MethDynamic, _ ->
 		()
 	| _, TFun(args, ret) ->

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -510,7 +510,9 @@ let add_field_inits cl_path locals com t =
 					die "" __LOC__
 			in
 			let config = AnalyzerConfig.get_field_config com c cf in
+			remove_class_field_flag cf CfPostProcessed;
 			Analyzer.Run.run_on_field com config c cf;
+			add_class_field_flag cf CfPostProcessed;
 			(match cf.cf_expr with
 			| Some e ->
 				(* This seems a bit expensive, but hopefully constructor expressions aren't that massive. *)

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -760,7 +760,6 @@ let destruction tctx detail_times main locals =
 	List.iter (fun f -> f()) (List.rev com.callbacks#get_after_filters);
 	com.stage <- CFilteringDone
 
-
 (* Saves a class state so it can be restored later, e.g. after DCE or native path rewrite *)
 let save_class_state ctx t = match t with
 | TClassDecl c ->

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -67,11 +67,13 @@ let run_expression_filters time_details ctx filters t =
 	| TClassDecl c ->
 		ctx.curclass <- c;
 		let rec process_field f =
-			ctx.curfield <- f;
-			(match f.cf_expr with
-			| Some e when not (is_removable_field ctx.com f) ->
-				f.cf_expr <- Some (rec_stack_loop AbstractCast.cast_stack f run e);
-			| _ -> ());
+			if not (has_class_field_flag f CfPostProcessed) then begin
+				ctx.curfield <- f;
+				(match f.cf_expr with
+				| Some e when not (is_removable_field ctx.com f) ->
+					f.cf_expr <- Some (rec_stack_loop AbstractCast.cast_stack f run e);
+				| _ -> ());
+			end;
 			List.iter process_field f.cf_overloads
 		in
 		List.iter process_field c.cl_ordered_fields;

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -48,7 +48,7 @@ let is_overridden cls field =
 	in
 	List.exists (fun d -> loop_inheritance d) cls.cl_descendants
 
-let run_expression_filters time_details ctx filters t =
+let run_expression_filters ?(ignore_processed_status=false) time_details ctx filters t =
 	let run e =
 		List.fold_left
 			(fun e (filter_name,f) ->
@@ -67,7 +67,7 @@ let run_expression_filters time_details ctx filters t =
 	| TClassDecl c ->
 		ctx.curclass <- c;
 		let rec process_field f =
-			if not (has_class_field_flag f CfPostProcessed) then begin
+			if ignore_processed_status || not (has_class_field_flag f CfPostProcessed) then begin
 				ctx.curfield <- f;
 				(match f.cf_expr with
 				| Some e when not (is_removable_field ctx.com f) ->

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -1058,7 +1058,7 @@ module Run = struct
 		Optimizer.reduce_control_flow com e
 
 	let run_on_field com config c cf = match cf.cf_expr with
-		| Some e when not (is_ignored cf.cf_meta) && not (Typecore.is_removable_field com cf) ->
+		| Some e when not (is_ignored cf.cf_meta) && not (Typecore.is_removable_field com cf) && not (has_class_field_flag cf CfPostProcessed) ->
 			let config = update_config_from_meta com config cf.cf_meta in
 			let actx = create_analyzer_context com config e in
 			let debug() =

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -204,7 +204,7 @@ let set_type_parameter_dependencies mg tl =
 	in
 	List.iter loop tl
 
-let rec build_generic ctx c p tl =
+let rec build_generic_class ctx c p tl =
 	let pack = fst c.cl_path in
 	let recurse = ref false in
 	let rec check_recursive t =
@@ -308,7 +308,7 @@ let rec build_generic ctx c p tl =
 				unify_raise t0 t p;
 				link_dynamic t0 t;
 				t
-			) "build_generic" in
+			) "build_generic_class" in
 			cf_new.cf_type <- TLazy r;
 			cf_new
 		in
@@ -324,7 +324,7 @@ let rec build_generic ctx c p tl =
 				let cs,pl = TypeloadCheck.Inheritance.check_extends ctx c ts p in
 				match cs.cl_kind with
 				| KGeneric ->
-					(match build_generic ctx cs p pl with
+					(match build_generic_class ctx cs p pl with
 					| TInst (cs,pl) -> Some (cs,pl)
 					| _ -> die "" __LOC__)
 				| _ -> Some(cs,pl)

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -274,6 +274,7 @@ let rec build_generic_class ctx c p tl =
 			) ([],[]) cf_old.cf_params in
 			let gctx = {gctx with subst = param_subst @ gctx.subst} in
 			let cf_new = {cf_old with cf_pos = cf_old.cf_pos} in (* copy *)
+			remove_class_field_flag cf_new CfPostProcessed;
 			(* Type parameter constraints are substituted here. *)
 			cf_new.cf_params <- List.rev_map (fun tp -> match follow tp.ttp_type with
 				| TInst({cl_kind = KTypeParameter tl1} as c,_) ->

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -91,7 +91,7 @@ let build_instance ctx mtype p =
 		let ft = (fun pl ->
 			match c.cl_kind with
 			| KGeneric ->
-				build (fun () -> Generic.build_generic ctx c p pl) "build_generic"
+				build (fun () -> Generic.build_generic_class ctx c p pl) "build_generic"
 			| KMacroType ->
 				build (fun () -> build_macro_type ctx pl p) "macro_type"
 			| KGenericBuild cfl ->

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -185,13 +185,10 @@ let add_constructor ctx c force_constructor p =
 	let constructor = try Some (Type.get_constructor_class c (extract_param_types c.cl_params)) with Not_found -> None in
 	match constructor with
 	| Some(cfsup,csup,cparams) when not (has_class_flag c CExtern) ->
-		let cf = {
-			cfsup with
-			cf_pos = p;
-			cf_meta = List.filter (fun (m,_,_) -> m = Meta.CompilerGenerated) cfsup.cf_meta;
-			cf_doc = None;
-			cf_expr = None;
-		} in
+		let cf = mk_field "new" cfsup.cf_type p null_pos in
+		cf.cf_kind <- cfsup.cf_kind;
+		cf.cf_params <- cfsup.cf_params;
+		cf.cf_meta <- List.filter (fun (m,_,_) -> m = Meta.CompilerGenerated) cfsup.cf_meta;
 		let r = exc_protect ctx (fun r ->
 			let t = mk_mono() in
 			r := lazy_processing (fun() -> t);

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -965,7 +965,7 @@ and type_new ctx path el with_type force_inline p =
 		ctx.call_argument_stack <- List.tl ctx.call_argument_stack;
 		(* Try to properly build @:generic classes here (issue #2016) *)
 		begin match t_follow with
-			| TInst({cl_kind = KGeneric } as c,tl) -> follow (Generic.build_generic ctx c p tl)
+			| TInst({cl_kind = KGeneric } as c,tl) -> follow (Generic.build_generic_class ctx c p tl)
 			| _ -> t
 		end
 	with
@@ -978,7 +978,7 @@ and type_new ctx path el with_type force_inline p =
 			no_abstract_constructor c p;
 			ignore (unify_constructor_call c fa);
 			begin try
-				Generic.build_generic ctx c p monos
+				Generic.build_generic_class ctx c p monos
 			with Generic.Generic_Exception _ as exc ->
 				(* If we have an expected type, just use that (issue #3804) *)
 				begin match with_type with

--- a/tests/server/.vscode/tasks.json
+++ b/tests/server/.vscode/tasks.json
@@ -3,7 +3,7 @@
 	"tasks": [
 		{
 			"type": "hxml",
-			"file": "build.hxml",
+			"file": "run.hxml",
 			"group": {
 				"kind": "build",
 				"isDefault": true

--- a/tests/server/src/cases/display/issues/Issue10635.hx
+++ b/tests/server/src/cases/display/issues/Issue10635.hx
@@ -1,5 +1,8 @@
 package cases.display.issues;
 
+import haxe.display.JsonModuleTypes;
+import haxe.Json;
+
 class Issue10635 extends DisplayTestCase {
 	/**
 		class C {
@@ -35,5 +38,24 @@ class Issue10635 extends DisplayTestCase {
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxe(args);
 		Assert.isTrue(lastResult.stderr.length == 2); // dumb, but we don't have a proper diagnostics structure in these tests
+	}
+
+	function testGenericAddition(_) {
+		var args = ["-main", "Main"];
+		vfs.putContent("GenericMethod.hx", getTemplate("GenericMethod.hx"));
+		vfs.putContent("Main.hx", getTemplate("issues/Issue10635/MainBefore.hx"));
+		runHaxe(args);
+		vfs.putContent("Main.hx", getTemplate("issues/Issue10635/MainAfter.hx"));
+		// Note: We only have to run this once to reproduce because ServerMethods.Type will call cl_restore anyway
+		runHaxe(args);
+		runHaxeJson(args, ServerMethods.Contexts, null);
+		var contexts:Array<HaxeServerContext> = Json.parse(lastResult.stderr).result.result;
+		utest.Assert.equals(1, contexts.length);
+		var sig = contexts[0].signature;
+		runHaxeJson(args, ServerMethods.Type, { signature: sig, modulePath: "GenericMethod", typeName: "GenericMethod"});
+		var type:JsonModuleType<JsonClass> = Json.parse(lastResult.stderr).result.result;
+		var statics = type.args.statics;
+		Assert.isTrue(statics.exists(cf -> cf.name == "f"));
+		Assert.isTrue(statics.exists(cf -> cf.name == "f_Class<Main>"));
 	}
 }

--- a/tests/server/src/cases/display/issues/Issue10635.hx
+++ b/tests/server/src/cases/display/issues/Issue10635.hx
@@ -46,6 +46,7 @@ class Issue10635 extends DisplayTestCase {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue10635/MainBefore.hx"));
 		runHaxe(args);
 		vfs.putContent("Main.hx", getTemplate("issues/Issue10635/MainAfter.hx"));
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		// Note: We only have to run this once to reproduce because ServerMethods.Type will call cl_restore anyway
 		runHaxe(args);
 		runHaxeJson(args, ServerMethods.Contexts, null);

--- a/tests/server/test/templates/GenericMethod.hx
+++ b/tests/server/test/templates/GenericMethod.hx
@@ -1,0 +1,3 @@
+class GenericMethod {
+	@:generic static public function f<T>(t:T) {}
+}

--- a/tests/server/test/templates/issues/Issue10635/MainAfter.hx
+++ b/tests/server/test/templates/issues/Issue10635/MainAfter.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		GenericMethod;
+		GenericMethod.f(Main);
+	}
+}

--- a/tests/server/test/templates/issues/Issue10635/MainBefore.hx
+++ b/tests/server/test/templates/issues/Issue10635/MainBefore.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main() {
+		GenericMethod;
+	}
+}


### PR DESCRIPTION
This adds a flag to mark fields which have been post-processed. We want to do this in cases where a cached type is being modified, so that any changes properly go through post-processing again. A good example of that is #10635.

Supporting this opens the door to in-cache modification of types and classes. 