### PR TITLE
Make `display_error` typer-independent

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -1160,6 +1160,12 @@ let add_diagnostics_message com s p kind sev =
 	let di = com.shared.shared_display_information in
 	di.diagnostics_messages <- (s,p,kind,sev) :: di.diagnostics_messages
 
+let display_error com msg p =
+	if is_diagnostics com then
+		add_diagnostics_message com msg p DisplayTypes.DiagnosticsKind.DKCompilerError DisplayTypes.DiagnosticsSeverity.Error
+	else
+		com.error msg p
+
 open Printer
 
 let dump_path com =

--- a/src/context/display/importHandling.ml
+++ b/src/context/display/importHandling.ml
@@ -152,7 +152,7 @@ let init_import ctx context_init path mode p =
 							add_static_init tmain name tsub
 						with Not_found ->
 							(* TODO: mention module-level declarations in the error message? *)
-							display_error ctx (s_type_path (t_infos tmain).mt_path ^ " has no field or subtype " ^ tsub) p
+							display_error ctx.com (s_type_path (t_infos tmain).mt_path ^ " has no field or subtype " ^ tsub) p
 					in
 					context_init#add (fun() ->
 						match md.m_statics with
@@ -188,7 +188,7 @@ let init_import ctx context_init path mode p =
 					try
 						add_static_init tsub name fname
 					with Not_found ->
-						display_error ctx (s_type_path (t_infos tsub).mt_path ^ " has no field " ^ fname) (punion p p3)
+						display_error ctx.com (s_type_path (t_infos tsub).mt_path ^ " has no field " ^ fname) (punion p p3)
 				);
 			)
 		| IAll ->

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -71,7 +71,7 @@ module LocalStatic = struct
 		let name = Printf.sprintf "%s_%s" ctx.curfield.cf_name v.v_name in
 		begin try
 			let cf = PMap.find name ctx.curclass.cl_statics in
-			display_error ctx (Printf.sprintf "The expanded name of this local (%s) conflicts with another static field" name) v.v_pos;
+			display_error ctx.com (Printf.sprintf "The expanded name of this local (%s) conflicts with another static field" name) v.v_pos;
 			typing_error "Conflicting field was found here" cf.cf_name_pos;
 		with Not_found ->
 			let cf = mk_field name ~static:true v.v_type v.v_pos v.v_pos in

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -122,8 +122,8 @@ let inline_constructors ctx original_e =
 			| IOKCtor(ioc) ->
 				List.iter (fun v -> if v.v_id < 0 then cancel_v v p) io.io_dependent_vars;
 				if ioc.ioc_forced then begin
-					display_error ctx "Forced inline constructor could not be inlined" io.io_pos;
-					display_error ctx (compl_msg "Cancellation happened here") p;
+					display_error ctx.com "Forced inline constructor could not be inlined" io.io_pos;
+					display_error ctx.com (compl_msg "Cancellation happened here") p;
 				end
 			| _ -> ()
 		end
@@ -399,7 +399,7 @@ let inline_constructors ctx original_e =
 						Some iv
 					| _ ->
 						List.iter (fun v -> cancel_v v v.v_pos) argvs;
-						if is_extern_ctor c cf then display_error ctx "Extern constructor could not be inlined" e.epos;
+						if is_extern_ctor c cf then display_error ctx.com "Extern constructor could not be inlined" e.epos;
 						None
 				end
 			| TNew({ cl_constructor = Some ({cf_kind = Method MethInline; cf_expr = Some _} as cf)} as c,_,pl),_ when is_extern_ctor c cf ->

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -1,6 +1,7 @@
 open Globals
 open Ast
 open Type
+open Common
 open Typecore
 open Error
 open FieldAccess
@@ -384,10 +385,10 @@ let unify_field_call ctx fa el_typed el p inline =
 			| [_,msg,p] ->
 				typing_error msg p
 			| _ ->
-				display_error ctx "Could not find a suitable overload, reasons follow" p;
+				display_error ctx.com "Could not find a suitable overload, reasons follow" p;
 				List.iter (fun (cf,msg,p2) ->
-					display_error ctx ("Overload resolution failed for " ^ (s_type (print_context()) cf.cf_type)) p;
-					display_error ctx msg p2;
+					display_error ctx.com ("Overload resolution failed for " ^ (s_type (print_context()) cf.cf_type)) p;
+					display_error ctx.com msg p2;
 				) failures;
 				typing_error "End of overload failure reasons" p
 			end
@@ -398,10 +399,10 @@ let unify_field_call ctx fa el_typed el p inline =
 				maybe_check_access fcc.fc_field;
 				commit_delayed_display fcc
 			| fcc :: l ->
-				display_error ctx "Ambiguous overload, candidates follow" p;
+				display_error ctx.com "Ambiguous overload, candidates follow" p;
 				let st = s_type (print_context()) in
 				List.iter (fun fcc ->
-					display_error ctx (Printf.sprintf "... %s" (st fcc.fc_type)) fcc.fc_field.cf_name_pos;
+					display_error ctx.com (Printf.sprintf "... %s" (st fcc.fc_type)) fcc.fc_field.cf_name_pos;
 				) (fcc :: l);
 				commit_delayed_display fcc
 		end else begin match List.rev candidates with
@@ -426,7 +427,7 @@ object(self)
 			!type_generic_function_ref ctx fa fcc with_type p
 		end else begin
 			if has_class_field_flag fcc.fc_field CfAbstract then begin match fa.fa_on.eexpr with
-				| TConst TSuper -> display_error ctx (Printf.sprintf "abstract method %s cannot be accessed directly" fcc.fc_field.cf_name) p;
+				| TConst TSuper -> display_error ctx.com (Printf.sprintf "abstract method %s cannot be accessed directly" fcc.fc_field.cf_name) p;
 				| _ -> ()
 			end;
 			fcc.fc_data()
@@ -467,26 +468,26 @@ object(self)
 		in
 		ctx.macro_depth <- ctx.macro_depth - 1;
 		ctx.with_type_stack <- List.tl ctx.with_type_stack;
-		let old = ctx.on_error in
-		ctx.on_error <- (fun ctx msg ep ->
+		let old = ctx.com.error in
+		ctx.com.error <- (fun msg ep ->
 			(* display additional info in the case the error is not part of our original call *)
 			if ep.pfile <> p.pfile || ep.pmax < p.pmin || ep.pmin > p.pmax then begin
 				locate_macro_error := false;
-				old ctx msg ep;
+				old msg ep;
 				locate_macro_error := true;
 				ctx.com.error (compl_msg "Called from macro here") p;
 			end else
-				old ctx msg ep;
+				old msg ep;
 		);
 		let e = try
 			f()
 		with exc ->
-			ctx.on_error <- old;
+			ctx.com.error <- old;
 			!ethis_f();
 			raise exc
 		in
 		let e = Diagnostics.secure_generated_code ctx e in
-		ctx.on_error <- old;
+		ctx.com.error <- old;
 		!ethis_f();
 		e
 

--- a/src/typing/calls.ml
+++ b/src/typing/calls.ml
@@ -88,7 +88,7 @@ let make_call ctx e params t ?(force_inline=false) p =
 
 let mk_array_get_call ctx (cf,tf,r,e1,e2o) c ebase p = match cf.cf_expr with
 	| None when not (has_class_field_flag cf CfExtern) ->
-		if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx "Recursive array get method" p;
+		if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx.com "Recursive array get method" p;
 		mk (TArray(ebase,e1)) r p
 	| _ ->
 		let et = type_module_type ctx (TClassDecl c) None p in
@@ -99,7 +99,7 @@ let mk_array_set_call ctx (cf,tf,r,e1,e2o) c ebase p =
 	let evalue = match e2o with None -> die "" __LOC__ | Some e -> e in
 	match cf.cf_expr with
 		| None when not (has_class_field_flag cf CfExtern) ->
-			if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx "Recursive array set method" p;
+			if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx.com "Recursive array set method" p;
 			let ea = mk (TArray(ebase,e1)) r p in
 			mk (TBinop(OpAssign,ea,evalue)) r p
 		| _ ->
@@ -166,12 +166,12 @@ let rec acc_get ctx g p =
 			let e_def = FieldAccess.get_field_expr fa FRead in
 			begin match follow fa.fa_on.etype with
 				| TInst (c,_) when chk_class c ->
-					display_error ctx "Can't create closure on an extern inline member method" p;
+					display_error ctx.com "Can't create closure on an extern inline member method" p;
 					e_def
 				| TAnon a ->
 					begin match !(a.a_status) with
 						| Statics c when has_class_field_flag cf CfExtern ->
-							display_error ctx "Cannot create closure on @:extern inline method" p;
+							display_error ctx.com "Cannot create closure on @:extern inline method" p;
 							e_def
 						| Statics c when chk_class c -> wrap_extern c
 						| _ -> e_def

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -79,8 +79,8 @@ let no_abstract_constructor c p =
 	if has_class_flag c CAbstract then raise_typing_error (Abstract_class (TClassDecl c)) p
 
 let check_constructor_access ctx c f p =
-	if (Meta.has Meta.CompilerGenerated f.cf_meta) then display_error ctx (error_msg (No_constructor (TClassDecl c))) p;
-	if not (can_access ctx c f true || extends ctx.curclass c) && not ctx.untyped then display_error ctx (Printf.sprintf "Cannot access private constructor of %s" (s_class_path c)) p
+	if (Meta.has Meta.CompilerGenerated f.cf_meta) then display_error ctx.com (error_msg (No_constructor (TClassDecl c))) p;
+	if not (can_access ctx c f true || extends ctx.curclass c) && not ctx.untyped then display_error ctx.com (Printf.sprintf "Cannot access private constructor of %s" (s_class_path c)) p
 
 let check_no_closure_meta ctx cf fa mode p =
 	match mode with
@@ -133,9 +133,9 @@ let field_access ctx mode f fh e pfield =
 			| MethInline, _ when ctx.g.doinline ->
 				AKField (make_access true)
 			| MethMacro, MGet ->
-				display_error ctx "Macro functions must be called immediately" pfield; normal()
+				display_error ctx.com "Macro functions must be called immediately" pfield; normal()
 			| _ , MGet ->
-				if has_class_field_flag f CfGeneric then display_error ctx "Cannot create closure on generic function" pfield;
+				if has_class_field_flag f CfGeneric then display_error ctx.com "Cannot create closure on generic function" pfield;
 				normal()
 			| _ ->
 				normal()
@@ -144,7 +144,7 @@ let field_access ctx mode f fh e pfield =
 		| FHInstance(c,tl) ->
 			if e.eexpr = TConst TSuper then begin match mode with
 				| MSet _ | MGet ->
-					display_error ctx "Cannot create closure on super method" pfield
+					display_error ctx.com "Cannot create closure on super method" pfield
 				| MCall _ ->
 					()
 			end;
@@ -183,7 +183,7 @@ let field_access ctx mode f fh e pfield =
 				| MSet _ when v.v_write = AccCall ->
 					()
 				| _ ->
-					display_error ctx "Normal variables cannot be accessed with 'super', use 'this' instead" pfield;
+					display_error ctx.com "Normal variables cannot be accessed with 'super', use 'this' instead" pfield;
 			end;
 		| FHAnon ->
 			()
@@ -224,8 +224,8 @@ let field_access ctx mode f fh e pfield =
 			if bypass_accessor then (
 				(match e.eexpr with TLocal _ when Common.defined ctx.com Define.Haxe3Compat -> warning ctx WTemp "Field set has changed here in Haxe 4: call setter explicitly to keep Haxe 3.x behaviour" pfield | _ -> ());
 				if not (is_physical_field f) then begin
-					display_error ctx "This field cannot be accessed because it is not a real variable" pfield;
-					display_error ctx "Add @:isVar here to enable it" f.cf_pos;
+					display_error ctx.com "This field cannot be accessed because it is not a real variable" pfield;
+					display_error ctx.com "Add @:isVar here to enable it" f.cf_pos;
 				end;
 				normal false
 			)
@@ -332,7 +332,7 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 		| TAnon a ->
 			(try
 				let f = PMap.find i a.a_fields in
-				if has_class_field_flag f CfImpl && not (has_class_field_flag f CfEnum) then display_error ctx "Cannot access non-static abstract field statically" pfield;
+				if has_class_field_flag f CfImpl && not (has_class_field_flag f CfEnum) then display_error ctx.com "Cannot access non-static abstract field statically" pfield;
 				match !(a.a_status) with
 				| EnumStatics en ->
 					let c = try PMap.find f.cf_name en.e_constrs with Not_found -> die "" __LOC__ in
@@ -555,16 +555,16 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 			| TInst ({ cl_kind = KAbstractImpl a },_)
 			| TAbstract (a,_) when has_special_field a ->
 				(* the abstract field is not part of the field list, which is only true when it has no expression (issue #2344) *)
-				display_error ctx ("Field " ^ i ^ " cannot be called directly because it has no expression") pfield;
+				display_error ctx.com ("Field " ^ i ^ " cannot be called directly because it has no expression") pfield;
 			| TAnon { a_status = { contents = Statics c } } when PMap.mem i c.cl_fields ->
-				display_error ctx ("Static access to instance field " ^ i ^ " is not allowed") pfield;
+				display_error ctx.com ("Static access to instance field " ^ i ^ " is not allowed") pfield;
 			| _ ->
 				let tthis = e.etype in
 				try
 					if not (Diagnostics.error_in_diagnostics_run ctx.com pfield) then raise Exit;
 					DisplayFields.handle_missing_field_raise ctx tthis i mode with_type pfield
 				with Exit ->
-					display_error ctx (StringError.string_error i (string_source tthis) (s_type (print_context()) tthis ^ " has no field " ^ i)) pfield
+					display_error ctx.com (StringError.string_error i (string_source tthis) (s_type (print_context()) tthis ^ " has no field " ^ i)) pfield
 		end;
 		AKExpr (mk (TField (e,FDynamic i)) (spawn_monomorph ctx p) p)
 

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -115,8 +115,8 @@ module IterationKind = struct
 						| Some e -> e
 						| None ->
 							if resume then raise Not_found;
-							display_error ctx "Field iterator has an invalid type" acc_expr.epos;
-							display_error ctx (error_msg (Unify l)) p;
+							display_error ctx.com "Field iterator has an invalid type" acc_expr.epos;
+							display_error ctx.com (error_msg (Unify l)) p;
 							mk (TConst TNull) t_dynamic p
 					)
 			in
@@ -173,7 +173,7 @@ module IterationKind = struct
 
 	let of_texpr ?(resume=false) ctx e unroll p =
 		let dynamic_iterator e =
-			display_error ctx "You can't iterate on a Dynamic value, please specify Iterator or Iterable" e.epos;
+			display_error ctx.com "You can't iterate on a Dynamic value, please specify Iterator or Iterable" e.epos;
 			IteratorDynamic,e,t_dynamic
 		in
 		let check_iterator () =
@@ -504,7 +504,7 @@ let type_for_loop ctx handle_display it e2 p =
 	| IKKeyValue((ikey,pkey,dkokey),(ivalue,pvalue,dkovalue)) ->
 		(match follow e1.etype with
 		| TDynamic _ | TMono _ ->
-			display_error ctx "You can't iterate on a Dynamic value, please specify KeyValueIterator or KeyValueIterable" e1.epos;
+			display_error ctx.com "You can't iterate on a Dynamic value, please specify KeyValueIterator or KeyValueIterable" e1.epos;
 		| _ -> ()
 		);
 		let e1,pt = IterationKind.check_iterator ctx "keyValueIterator" e1 e1.epos in

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -32,7 +32,7 @@ let type_function_arg_value ctx t c do_display =
 				| TCast(e,None) -> loop e
 				| _ ->
 					if ctx.com.display.dms_kind = DMNone || Common.is_diagnostics ctx.com then
-						display_error ctx "Parameter default value should be constant" p;
+						Common.display_error ctx.com "Parameter default value should be constant" p;
 					None
 			in
 			loop e

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -290,8 +290,8 @@ let rec build_generic_class ctx c p tl =
 					| None ->
 						begin match cf_old.cf_kind with
 							| Method _ when not (has_class_flag c CInterface) && not (has_class_flag c CExtern) ->
-								display_error ctx (Printf.sprintf "Field %s has no expression (possible typing order issue)" cf_new.cf_name) cf_new.cf_pos;
-								display_error ctx (Printf.sprintf "While building %s" (s_type_path cg.cl_path)) p;
+								display_error ctx.com (Printf.sprintf "Field %s has no expression (possible typing order issue)" cf_new.cf_name) cf_new.cf_pos;
+								display_error ctx.com (Printf.sprintf "While building %s" (s_type_path cg.cl_path)) p;
 							| _ ->
 								()
 						end
@@ -382,8 +382,8 @@ let type_generic_function ctx fa fcc with_type p =
 		let unify_existing_field tcf pcf = try
 			unify_raise tcf fcc.fc_type p
 		with Error(Unify _,_) as err ->
-			display_error ctx ("Cannot create field " ^ name ^ " due to type mismatch") p;
-			display_error ctx (compl_msg "Conflicting field was defined here") pcf;
+			display_error ctx.com ("Cannot create field " ^ name ^ " due to type mismatch") p;
+			display_error ctx.com (compl_msg "Conflicting field was defined here") pcf;
 			raise err
 		in
 		let fa = try
@@ -410,14 +410,14 @@ let type_generic_function ctx fa fcc with_type p =
 				ignore(follow cf.cf_type);
 				let rec check e = match e.eexpr with
 					| TNew({cl_kind = KTypeParameter _} as c,_,_) when not (TypeloadCheck.is_generic_parameter ctx c) ->
-						display_error ctx "Only generic type parameters can be constructed" e.epos;
-						display_error ctx "While specializing this call" p;
+						display_error ctx.com "Only generic type parameters can be constructed" e.epos;
+						display_error ctx.com "While specializing this call" p;
 					| _ ->
 						Type.iter check e
 				in
 				cf2.cf_expr <- (match cf.cf_expr with
 					| None ->
-						display_error ctx "Recursive @:generic function" p; None;
+						display_error ctx.com "Recursive @:generic function" p; None;
 					| Some e ->
 						let e = generic_substitute_expr gctx e in
 						check e;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -391,7 +391,7 @@ let make_macro_api ctx p =
 		MacroApi.encode_expr = Interp.encode_expr;
 		MacroApi.encode_ctype = Interp.encode_ctype;
 		MacroApi.decode_type = Interp.decode_type;
-		MacroApi.display_error = Typecore.display_error ctx;
+		MacroApi.display_error = display_error ctx.com;
 		MacroApi.with_imports = (fun imports usings f ->
 			let old_globals = ctx.m.module_globals in
 			let old_imports = ctx.m.module_imports in
@@ -813,7 +813,7 @@ let call_init_macro ctx e =
 		| ParseError(_,(msg,p),_) -> (Parser.error msg p)
 		end
 	with err ->
-		display_error ctx ("Could not parse `" ^ e ^ "`") p;
+		display_error ctx.com ("Could not parse `" ^ e ^ "`") p;
 		raise err
 	in
 	match fst e with

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -269,14 +269,14 @@ module Pattern = struct
 			if pctx.is_postfix_match then DKMarked else DKPattern toplevel
 		in
 		let catch_errors () =
-			let old = ctx.on_error in
+			let old = ctx.com.error in
 			let restore_report_mode = disable_report_mode ctx.com in
-			ctx.on_error <- (fun _ _ _ ->
+			ctx.com.error <- (fun _ _ ->
 				raise Exit
 			);
 			(fun () ->
 				restore_report_mode();
-				ctx.on_error <- old
+				ctx.com.error <- old
 			)
 		in
 		let try_typing e =
@@ -314,7 +314,7 @@ module Pattern = struct
 				with _ ->
 					restore();
 					if not (is_lower_ident s) && (match s.[0] with '`' | '_' -> false | _ -> true) then begin
-						display_error ctx ("Unknown identifier : " ^ s ^ ", pattern variables must be lower-case or with `var ` prefix") p;
+						display_error ctx.com ("Unknown identifier : " ^ s ^ ", pattern variables must be lower-case or with `var ` prefix") p;
 					end;
 					begin match StringError.get_similar s (get_enumerable_idents()) with
 						| [] ->

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -399,7 +399,7 @@ let find_abstract_binop_overload ctx op e1 e2 a c tl left is_assign_op with_type
 	let map = apply_params a.a_params tl in
 	let make op_cf cf e1 e2 tret needs_assign swapped =
 		if cf.cf_expr = None && not (has_class_field_flag cf CfExtern) then begin
-			if not (Meta.has Meta.NoExpr cf.cf_meta) then display_error ctx "Recursive operator method" p;
+			if not (Meta.has Meta.NoExpr cf.cf_meta) then Common.display_error ctx.com "Recursive operator method" p;
 			if not (Meta.has Meta.CoreType a.a_meta) then begin
 				(* for non core-types we require that the return type is compatible to the native result type *)
 				let result = make_binop ctx op {e1 with etype = Abstract.follow_with_abstracts e1.etype} {e1 with etype = Abstract.follow_with_abstracts e2.etype} is_assign_op with_type p in

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -152,8 +152,8 @@ let get_native_name meta =
 
 let check_native_name_override ctx child base =
 	let error base_pos child_pos =
-		display_error ctx ("Field " ^ child.cf_name ^ " has different @:native value than in superclass") child_pos;
-		display_error ctx (compl_msg "Base field is defined here") base_pos
+		display_error ctx.com ("Field " ^ child.cf_name ^ " has different @:native value than in superclass") child_pos;
+		display_error ctx.com (compl_msg "Base field is defined here") base_pos
 	in
 	try
 		let child_name, child_pos = get_native_name child.cf_meta in
@@ -168,14 +168,14 @@ let check_native_name_override ctx child base =
 let check_overriding ctx c f =
 	match c.cl_super with
 	| None ->
-		if has_class_field_flag f CfOverride then display_error ctx ("Field " ^ f.cf_name ^ " is declared 'override' but doesn't override any field") f.cf_pos
+		if has_class_field_flag f CfOverride then display_error ctx.com ("Field " ^ f.cf_name ^ " is declared 'override' but doesn't override any field") f.cf_pos
 	| _ when (has_class_flag c CExtern) && Meta.has Meta.CsNative c.cl_meta -> () (* -net-lib specific: do not check overrides on extern CsNative classes *)
 	| Some (csup,params) ->
 		let p = f.cf_name_pos in
 		let i = f.cf_name in
 		let check_field f get_super_field is_overload = try
 			(if is_overload && not (has_class_field_flag f CfOverload) then
-				display_error ctx ("Missing overload declaration for field " ^ i) p);
+				display_error ctx.com ("Missing overload declaration for field " ^ i) p);
 			let f_has_override = has_class_field_flag f CfOverride in
 			let t, f2 = get_super_field csup i in
 			check_native_name_override ctx f f2;
@@ -185,35 +185,35 @@ let check_overriding ctx c f =
 			| _ -> ());
 			if has_class_field_flag f2 CfAbstract then begin
 				if f_has_override then
-					display_error ctx ("Field " ^ i ^ " is declared 'override' but parent field " ^ i ^ " is 'abstract' and does not provide any implementation to override") p
+					display_error ctx.com ("Field " ^ i ^ " is declared 'override' but parent field " ^ i ^ " is 'abstract' and does not provide any implementation to override") p
 				else
 					add_class_field_flag f CfOverride (* our spec requires users to not "override" abstract functions, but our implementation depends on implementations to be declared with "override" ¯\_(ツ)_/¯ *)
 			end;
 			if (has_class_field_flag f2 CfOverload && not (has_class_field_flag f CfOverload)) then
-				display_error ctx ("Field " ^ i ^ " should be declared with overload since it was already declared as overload in superclass") p
+				display_error ctx.com ("Field " ^ i ^ " should be declared with overload since it was already declared as overload in superclass") p
 			else if not f_has_override && not (has_class_field_flag f2 CfAbstract) then begin
 				if has_class_flag c CExtern then add_class_field_flag f CfOverride
-				else display_error ctx ("Field " ^ i ^ " should be declared with 'override' since it is inherited from superclass " ^ s_type_path csup.cl_path) p
+				else display_error ctx.com ("Field " ^ i ^ " should be declared with 'override' since it is inherited from superclass " ^ s_type_path csup.cl_path) p
 			end else if not (has_class_field_flag f CfPublic) && (has_class_field_flag f2 CfPublic) then
-				display_error ctx ("Field " ^ i ^ " has less visibility (public/private) than superclass one") p
+				display_error ctx.com ("Field " ^ i ^ " has less visibility (public/private) than superclass one") p
 			else (match f.cf_kind, f2.cf_kind with
 			| _, Method MethInline ->
-				display_error ctx ("Field " ^ i ^ " is inlined and cannot be overridden") p
+				display_error ctx.com ("Field " ^ i ^ " is inlined and cannot be overridden") p
 			| a, b when a = b -> ()
 			| Method MethInline, Method MethNormal ->
 				() (* allow to redefine a method as inlined *)
 			| _ ->
-				display_error ctx ("Field " ^ i ^ " has different property access than in superclass") p);
-			if (has_class_field_flag f2 CfFinal) then display_error ctx ("Cannot override final method " ^ i) p;
+				display_error ctx.com ("Field " ^ i ^ " has different property access than in superclass") p);
+			if (has_class_field_flag f2 CfFinal) then display_error ctx.com ("Cannot override final method " ^ i) p;
 			try
 				let t = apply_params csup.cl_params params t in
 				let map = TClass.get_map_function csup params in
 				valid_redefinition ctx map map f f.cf_type f2 t;
 			with
 				Unify_error l ->
-					display_error ctx ("Field " ^ i ^ " overrides parent class with different or incomplete type") p;
-					display_error ctx (compl_msg "Base field is defined here") f2.cf_name_pos;
-					display_error ctx (compl_msg (error_msg (Unify l))) p;
+					display_error ctx.com ("Field " ^ i ^ " overrides parent class with different or incomplete type") p;
+					display_error ctx.com (compl_msg "Base field is defined here") f2.cf_name_pos;
+					display_error ctx.com (compl_msg (error_msg (Unify l))) p;
 		with
 			Not_found ->
 				if has_class_field_flag f CfOverride then
@@ -227,7 +227,7 @@ let check_overriding ctx c f =
 						) fields [] in
 						StringError.string_error i fields ("Field " ^ i ^ " is declared 'override' but doesn't override any field")
 					end in
-					display_error ctx msg p
+					display_error ctx.com msg p
 		in
 		if has_class_field_flag f CfOverload then begin
 			let overloads = Overloads.get_overloads ctx.com csup i in
@@ -235,7 +235,7 @@ let check_overriding ctx c f =
 				(* check if any super class fields are vars *)
 				match f2.cf_kind with
 				| Var _ ->
-					display_error ctx ("A variable named '" ^ f2.cf_name ^ "' was already declared in a superclass") f.cf_pos
+					display_error ctx.com ("A variable named '" ^ f2.cf_name ^ "' was already declared in a superclass") f.cf_pos
 				| _ -> ()
 			) overloads;
 			List.iter (fun f ->
@@ -267,7 +267,7 @@ let class_field_no_interf c i =
 
 let rec return_flow ctx e =
 	let error() =
-		display_error ctx (Printf.sprintf "Missing return: %s" (s_type (print_context()) ctx.ret)) e.epos; raise Exit
+		display_error ctx.com (Printf.sprintf "Missing return: %s" (s_type (print_context()) ctx.ret)) e.epos; raise Exit
 	in
 	let return_flow = return_flow ctx in
 	let rec uncond e = match e.eexpr with
@@ -385,18 +385,18 @@ module Inheritance = struct
 						| MethMacro -> 2
 					in
 					if (has_class_field_flag f CfPublic) && not (has_class_field_flag f2 CfPublic) && not (Meta.has Meta.CompilerGenerated f.cf_meta) then
-						display_error ctx ("Field " ^ f.cf_name ^ " should be public as requested by " ^ s_type_path intf.cl_path) p
+						display_error ctx.com ("Field " ^ f.cf_name ^ " should be public as requested by " ^ s_type_path intf.cl_path) p
 					else if not (unify_kind f2.cf_kind f.cf_kind) || not (match f.cf_kind, f2.cf_kind with Var _ , Var _ -> true | Method m1, Method m2 -> mkind m1 = mkind m2 | _ -> false) then
-						display_error ctx ("Field " ^ f.cf_name ^ " has different property access than in " ^ s_type_path intf.cl_path ^ " (" ^ s_kind f2.cf_kind ^ " should be " ^ s_kind f.cf_kind ^ ")") p
+						display_error ctx.com ("Field " ^ f.cf_name ^ " has different property access than in " ^ s_type_path intf.cl_path ^ " (" ^ s_kind f2.cf_kind ^ " should be " ^ s_kind f.cf_kind ^ ")") p
 					else try
 						let map1 = TClass.get_map_function  intf params in
 						valid_redefinition ctx map1 map2 f2 t2 f (apply_params intf.cl_params params f.cf_type)
 					with
 						Unify_error l ->
 							if not (Meta.has Meta.CsNative c.cl_meta && (has_class_flag c CExtern)) then begin
-								display_error ctx ("Field " ^ f.cf_name ^ " has different type than in " ^ s_type_path intf.cl_path) p;
-								display_error ctx (compl_msg "Interface field is defined here") f.cf_pos;
-								display_error ctx (compl_msg (error_msg (Unify l))) p;
+								display_error ctx.com ("Field " ^ f.cf_name ^ " has different type than in " ^ s_type_path intf.cl_path) p;
+								display_error ctx.com (compl_msg "Interface field is defined here") f.cf_pos;
+								display_error ctx.com (compl_msg (error_msg (Unify l))) p;
 							end
 				)
 			with
@@ -419,7 +419,7 @@ module Inheritance = struct
 						else
 							("Field " ^ f.cf_name ^ " needed by " ^ s_type_path intf.cl_path ^ " is missing")
 						in
-						display_error ctx msg p
+						display_error ctx.com msg p
 					end
 				| Not_found -> ()
 		in
@@ -486,8 +486,8 @@ module Inheritance = struct
 			display.module_diagnostics <- MissingFields diag :: display.module_diagnostics
 		| l ->
 			let singular = match l with [_] -> true | _ -> false in
-			display_error ctx (Printf.sprintf "This class extends abstract class %s but doesn't implement the following method%s" (s_type_path csup.cl_path) (if singular then "" else "s")) c.cl_name_pos;
-			display_error ctx (Printf.sprintf "Implement %s or make %s abstract as well" (if singular then "it" else "them") (s_type_path c.cl_path)) c.cl_name_pos;
+			display_error ctx.com (Printf.sprintf "This class extends abstract class %s but doesn't implement the following method%s" (s_type_path csup.cl_path) (if singular then "" else "s")) c.cl_name_pos;
+			display_error ctx.com (Printf.sprintf "Implement %s or make %s abstract as well" (if singular then "it" else "them") (s_type_path c.cl_path)) c.cl_name_pos;
 			let pctx = print_context() in
 			List.iter (fun (cf,_) ->
 				let s = match follow cf.cf_type with
@@ -496,7 +496,7 @@ module Inheritance = struct
 					| t ->
 						s_type pctx t
 				in
-				display_error ctx (Printf.sprintf "... %s(%s)" cf.cf_name s) cf.cf_name_pos
+				display_error ctx.com (Printf.sprintf "... %s(%s)" cf.cf_name s) cf.cf_name_pos
 			) (List.rev !missing)
 
 	let set_heritance ctx c herits p =
@@ -589,7 +589,7 @@ module Inheritance = struct
 					)
 				| TDynamic t ->
 					if c.cl_dynamic <> None then typing_error "Cannot have several dynamics" p;
-					if not (has_class_flag c CExtern) then display_error ctx "In haxe 4, implements Dynamic is only supported on externs" p;
+					if not (has_class_flag c CExtern) then display_error ctx.com "In haxe 4, implements Dynamic is only supported on externs" p;
 					c.cl_dynamic <- Some t;
 					(fun () -> ())
 				| _ ->
@@ -639,6 +639,6 @@ let check_final_vars ctx e =
 		in
 		find_inits e;
 		Hashtbl.iter (fun _ cf ->
-			display_error ctx ("final field " ^ cf.cf_name ^ " must be initialized immediately or in the constructor") cf.cf_pos;
+			display_error ctx.com ("final field " ^ cf.cf_name ^ " must be initialized immediately or in the constructor") cf.cf_pos;
 		) final_vars
 	end

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -136,7 +136,7 @@ let type_function ctx (args : function_arguments) ret fmode e do_display p =
 					let e_super_call = mk (TCall(e_super,[])) ctx.t.tvoid e.epos in
 					concat e_super_call e
 				else begin
-					display_error ctx "Missing super constructor call" p;
+					display_error ctx.com "Missing super constructor call" p;
 					e
 				end
 			with

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -304,9 +304,9 @@ let parse_module ctx m p =
 	if pack <> !remap then begin
 		let spack m = if m = [] then "`package;`" else "`package " ^ (String.concat "." m) ^ ";`" in
 		if p == null_pos then
-			display_error ctx ("Invalid commandline class : " ^ s_type_path m ^ " should be " ^ s_type_path (pack,snd m)) p
+			display_error ctx.com ("Invalid commandline class : " ^ s_type_path m ^ " should be " ^ s_type_path (pack,snd m)) p
 		else
-			display_error ctx (spack pack ^ " in " ^ file ^ " should be " ^ spack (fst m)) {p with pmax = p.pmin}
+			display_error ctx.com (spack pack ^ " in " ^ file ^ " should be " ^ spack (fst m)) {p with pmax = p.pmin}
 	end;
 	file, if !remap <> fst m then
 		(* build typedefs to redirect to real package *)

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -122,7 +122,7 @@ let check_error ctx err p = match err with
 	| Module_not_found ([],name) when Diagnostics.error_in_diagnostics_run ctx.com p ->
 		DisplayToplevel.handle_unresolved_identifier ctx name p true
 	| _ ->
-		display_error ctx (error_msg err) p
+		display_error ctx.com (error_msg err) p
 
 (* ---------------------------------------------------------------------- *)
 (* PASS 3 : type expression & check structure *)
@@ -249,7 +249,7 @@ let rec unify_min_raise ctx (el:texpr list) : t =
 let unify_min ctx el =
 	try unify_min_raise ctx el
 	with Error (Unify l,p) ->
-		if not ctx.untyped then display_error ctx (error_msg (Unify l)) p;
+		if not ctx.untyped then display_error ctx.com (error_msg (Unify l)) p;
 		(List.hd el).etype
 
 let unify_min_for_type_source ctx el src =
@@ -449,7 +449,7 @@ and type_ident ctx i p mode with_type =
 			end else begin
 				if ctx.curfun = FunStatic && PMap.mem i ctx.curclass.cl_fields then typing_error ("Cannot access " ^ i ^ " in static function") p;
 				if !resolved_to_type_parameter then begin
-					display_error ctx ("Only @:const type parameters on @:generic classes can be used as value") p;
+					display_error ctx.com ("Only @:const type parameters on @:generic classes can be used as value") p;
 					AKExpr (mk (TConst TNull) t_dynamic p)
 				end else begin
 					let err = Unknown_ident i in
@@ -465,7 +465,7 @@ and type_ident ctx i p mode with_type =
 						| DMNone ->
 							raise (Error(err,p))
 						| _ ->
-							display_error ctx (error_msg err) p;
+							display_error ctx.com (error_msg err) p;
 							let t = mk_mono() in
 							(* Add a fake local for #8751. *)
 							if !ServerConfig.legacy_completion then
@@ -1029,7 +1029,7 @@ and type_new ctx path el with_type force_inline p =
 	| _ ->
 		typing_error (s_type (print_context()) t ^ " cannot be constructed") p
 	end with Error(No_constructor _ as err,p) when ctx.com.display.dms_kind <> DMNone ->
-		display_error ctx (error_msg err) p;
+		display_error ctx.com (error_msg err) p;
 		Diagnostics.secure_generated_code ctx (mk (TConst TNull) t p)
 
 and type_try ctx e1 catches with_type p =
@@ -1037,9 +1037,9 @@ and type_try ctx e1 catches with_type p =
 	let rec check_unreachable cases t p = match cases with
 		| (v,e) :: cases ->
 			let unreachable () =
-				display_error ctx "This block is unreachable" p;
+				display_error ctx.com "This block is unreachable" p;
 				let st = s_type (print_context()) in
-				display_error ctx (Printf.sprintf "%s can be caught to %s, which is handled here" (st t) (st v.v_type)) e.epos
+				display_error ctx.com (Printf.sprintf "%s can be caught to %s, which is handled here" (st t) (st v.v_type)) e.epos
 			in
 			begin try
 				begin match follow t,follow v.v_type with
@@ -1127,7 +1127,7 @@ and type_map_declaration ctx e1 el with_type p =
 	let check_key e_key =
 		try
 			let p = Hashtbl.find keys e_key.eexpr in
-			display_error ctx "Duplicate key" e_key.epos;
+			display_error ctx.com "Duplicate key" e_key.epos;
 			typing_error (compl_msg "Previously defined here") p
 		with Not_found ->
 			begin match e_key.eexpr with
@@ -1184,7 +1184,7 @@ and type_local_function ctx kind f with_type p =
 	let name,inline = match kind with FKNamed (name,inline) -> Some name,inline | _ -> None,false in
 	let params = TypeloadFunction.type_function_params ctx f (match name with None -> "localfun" | Some (n,_) -> n) p in
 	if params <> [] then begin
-		if name = None then display_error ctx "Type parameters not supported in unnamed local functions" p;
+		if name = None then display_error ctx.com "Type parameters not supported in unnamed local functions" p;
 		if with_type <> WithType.NoValue then typing_error "Type parameters are not supported for rvalue functions" p
 	end;
 	let v,pname = (match name with
@@ -1266,7 +1266,7 @@ and type_local_function ctx kind f with_type p =
 		in
 		loop [] t
 	| WithType.NoValue ->
-		if name = None then display_error ctx "Unnamed lvalue functions are not supported" p
+		if name = None then display_error ctx.com "Unnamed lvalue functions are not supported" p
 	| _ ->
 		());
 	let ft = TFun (targs,rt) in
@@ -1312,7 +1312,7 @@ and type_local_function ctx kind f with_type p =
 		in
 		let exprs =
 			if is_rec then begin
-				if inline then display_error ctx "Inline function cannot be recursive" e.epos;
+				if inline then display_error ctx.com "Inline function cannot be recursive" e.epos;
 				(mk (TVar (v,Some (mk (TConst TNull) ft p))) ctx.t.tvoid p) ::
 				(mk (TBinop (OpAssign,mk (TLocal v) ft p,e)) ft p) ::
 				exprs
@@ -1378,7 +1378,7 @@ and type_array_decl ctx el with_type p =
 			if !allow_array_dynamic || ctx.untyped || ignore_error ctx.com then
 				t_dynamic
 			else begin
-				display_error ctx "Arrays of mixed types are only allowed if the type is forced to Array<Dynamic>" p;
+				display_error ctx.com "Arrays of mixed types are only allowed if the type is forced to Array<Dynamic>" p;
 				raise (Error (Unify l, p))
 			end
 		in
@@ -1443,7 +1443,7 @@ and type_return ?(implicit=false) ctx e with_type p =
 		if is_abstract_ctor then begin
 			match fst e with
 			| ECast((EConst(Ident "this"),_),None) -> ()
-			| _ -> display_error ctx "Cannot return a value from constructor" p
+			| _ -> display_error ctx.com "Cannot return a value from constructor" p
 		end;
 		try
 			let with_expected_type =
@@ -1581,7 +1581,7 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 			let old_counter = ctx.bypass_accessor in
 			ctx.bypass_accessor <- old_counter + 1;
 			let e = e () in
-			(if ctx.bypass_accessor > old_counter then display_error ctx "Field access expression expected after @:bypassAccessor metadata" p);
+			(if ctx.bypass_accessor > old_counter then display_error ctx.com "Field access expression expected after @:bypassAccessor metadata" p);
 			e
 		| (Meta.Inline,_,_) ->
 			begin match fst e1 with
@@ -1591,7 +1591,7 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 				let e = type_new ctx t el with_type true p in
 				{e with eexpr = TMeta((Meta.Inline,[],null_pos),e)}
 			| _ ->
-				display_error ctx "Call or function expected after inline keyword" p;
+				display_error ctx.com "Call or function expected after inline keyword" p;
 				e();
 			end
 		| (Meta.ImplicitReturn,_,_) ->
@@ -1607,7 +1607,7 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 and type_call_target ctx e el with_type inline p =
 	let e = maybe_type_against_enum ctx (fun () -> type_access ctx (fst e) (snd e) (MCall el) with_type) with_type true p in
 	let check_inline cf =
-		if (has_class_field_flag cf CfAbstract) then display_error ctx "Cannot force inline on abstract method" p
+		if (has_class_field_flag cf CfAbstract) then display_error ctx.com "Cannot force inline on abstract method" p
 	in
 	if not inline then
 		e
@@ -1619,7 +1619,7 @@ and type_call_target ctx e el with_type inline p =
 			check_inline sea.se_access.fa_field;
 			AKUsingField {sea with se_access = {sea.se_access with fa_inline = true}}
 		| AKExpr {eexpr = TLocal _} ->
-			display_error ctx "Cannot force inline on local functions" p;
+			display_error ctx.com "Cannot force inline on local functions" p;
 			e
 		| _ ->
 			e
@@ -1706,7 +1706,7 @@ and type_call ?(mode=MGet) ctx e el (with_type:WithType.t) inline p =
 			let cf = fa.fa_field in
 			let t = TInst (c,params) in
 			let e = mk (TConst TSuper) t sp in
-			if (Meta.has Meta.CompilerGenerated cf.cf_meta) then display_error ctx (error_msg (No_constructor (TClassDecl c))) p;
+			if (Meta.has Meta.CompilerGenerated cf.cf_meta) then display_error ctx.com (error_msg (No_constructor (TClassDecl c))) p;
 			let fa = FieldAccess.create e cf (FHInstance(c,params)) false p in
 			let fcc = unify_field_call ctx fa [] el p false in
 			let el = fcc.fc_args in
@@ -1856,7 +1856,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 		wrap e
 	| EReturn e ->
 		if not ctx.in_function then begin
-			display_error ctx "Return outside function" p;
+			display_error ctx.com "Return outside function" p;
 			match e with
 			| None ->
 				Texpr.Builder.make_null t_dynamic p
@@ -1868,10 +1868,10 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 		end else
 			type_return ctx e with_type p
 	| EBreak ->
-		if not ctx.in_loop then display_error ctx "Break outside loop" p;
+		if not ctx.in_loop then display_error ctx.com "Break outside loop" p;
 		mk TBreak t_dynamic p
 	| EContinue ->
-		if not ctx.in_loop then display_error ctx "Continue outside loop" p;
+		if not ctx.in_loop then display_error ctx.com "Continue outside loop" p;
 		mk TContinue t_dynamic p
 	| ETry (e1,[]) ->
 		type_expr ctx e1 with_type
@@ -1916,7 +1916,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 	| EIs (e,(t,p_t)) ->
 		match t with
 		| CTPath tp ->
-			if tp.tparams <> [] then display_error ctx "Type parameters are not supported for the `is` operator" p_t;
+			if tp.tparams <> [] then display_error ctx.com "Type parameters are not supported for the `is` operator" p_t;
 			let e = type_expr ctx e WithType.value in
 			let mt = Typeload.load_type_def ctx p_t tp in
 			if ctx.in_display && DisplayPosition.display_position#enclosed_in p_t then
@@ -1934,7 +1934,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 			in
 			mk (TCall (e_Std_isOfType, [e; e_t])) ctx.com.basic.tbool p
 		| _ ->
-			display_error ctx "Unsupported type for `is` operator" p_t;
+			display_error ctx.com "Unsupported type for `is` operator" p_t;
 			Texpr.Builder.make_bool ctx.com.basic false p
 
 (* ---------------------------------------------------------------------- *)


### PR DESCRIPTION
I've never liked how we need a full typer context in order to use `display_error`. The only reason this was done so that `ctx.on_error` could be checked, and that being a mutable record field was not very reliable anyway. I've changed it so that we're now using `com.error` instead, which I think is actually what we want.

My long-term goal here is to have less `typer` contexts around so there's less risk of misuse. For instance, I found some post-processing function using `load_instance`, which should not be allowed. I hope to be able to make the entire post-processing depend on `common` instead of `typer`.