### PR TITLE
More typeload refactoring

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -158,13 +158,13 @@ let load_display_module_in_macro tctx display_file_dot_path clear = match displa
 				display mode. This covers some cases like --macro typing it in non-display mode (issue #7017). *)
 			if clear then begin
 				begin try
-					let m = Hashtbl.find mctx.g.modules cpath in
-					Hashtbl.remove mctx.g.modules cpath;
-					Hashtbl.remove mctx.g.types_module cpath;
+					let m = Hashtbl.find mctx.com.module_lut cpath in
+					Hashtbl.remove mctx.com.module_lut cpath;
+					Hashtbl.remove mctx.com.type_to_module cpath;
 					List.iter (fun mt ->
 						let ti = t_infos mt in
-						Hashtbl.remove mctx.g.modules ti.mt_path;
-						Hashtbl.remove mctx.g.types_module ti.mt_path;
+						Hashtbl.remove mctx.com.module_lut ti.mt_path;
+						Hashtbl.remove mctx.com.type_to_module ti.mt_path;
 					) m.m_types
 				with Not_found ->
 					()

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -441,7 +441,7 @@ let add_modules sctx ctx m p =
 						a.a_meta <- List.filter (fun (m,_,_) -> m <> Meta.ValueUsed) a.a_meta
 					| _ -> ()
 				) m.m_types;
-				TypeloadModule.add_module ctx m p;
+				TypeloadModule.ModuleLevel.add_module ctx m p;
 				PMap.iter (Hashtbl.replace com.resources) m.m_extra.m_binded_res;
 				PMap.iter (fun _ m2 -> add_modules (tabs ^ "  ") m0 m2) m.m_extra.m_deps
 			)

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -339,6 +339,8 @@ type context = {
 	mutable flash_version : float;
 	mutable features : (string,bool) Hashtbl.t;
 	mutable modules : Type.module_def list;
+	module_lut : (path , module_def) Hashtbl.t;
+	type_to_module : (path, path) Hashtbl.t;
 	mutable main : Type.texpr option;
 	mutable types : Type.module_type list;
 	mutable resources : (string,string) Hashtbl.t;
@@ -745,6 +747,8 @@ let create compilation_step cs version args =
 		types = [];
 		callbacks = new compiler_callbacks;
 		modules = [];
+		module_lut = Hashtbl.create 0;
+		type_to_module = Hashtbl.create 0;
 		main = None;
 		flash_version = 10.;
 		resources = Hashtbl.create 0;
@@ -828,6 +832,8 @@ let clone com is_macro_context =
 		native_libs = create_native_libs();
 		overload_cache = Hashtbl.create 0;
 		is_macro_context = is_macro_context;
+		module_lut = Hashtbl.create 0;
+		type_to_module = Hashtbl.create 0;
 	}
 
 let file_time file = Extc.filetime file

--- a/src/context/display/displayFields.ml
+++ b/src/context/display/displayFields.ml
@@ -28,7 +28,7 @@ open DisplayTypes
 open Display
 
 let get_submodule_fields ctx path =
-	let m = Hashtbl.find ctx.g.modules path in
+	let m = Hashtbl.find ctx.com.module_lut path in
 	let tl = List.filter (fun t -> path <> (t_infos t).mt_path && not (t_infos t).mt_private) m.m_types in
 	let tl = List.map (fun mt ->
 		make_ci_type (CompletionItem.CompletionModuleType.of_module_type mt) ImportStatus.Imported None

--- a/src/context/display/displayTexpr.ml
+++ b/src/context/display/displayTexpr.ml
@@ -108,7 +108,7 @@ let check_display_enum ctx decls en =
 	PMap.iter (fun _ ef ->
 		if display_position#enclosed_in ef.ef_pos then begin
 			let sef = find_enum_field_by_position se ef.ef_name_pos in
-			ignore(TypeloadModule.load_enum_field ctx en (TEnum (en,extract_param_types en.e_params)) (ref false) (ref 0) sef)
+			ignore(TypeloadModule.TypeLevel.load_enum_field ctx en (TEnum (en,extract_param_types en.e_params)) (ref false) (ref 0) sef)
 		end
 	) en.e_constrs
 
@@ -143,7 +143,7 @@ let check_display_module ctx decls m =
 		| (EImport _ | EUsing _),_ -> true
 		| _ -> false
 	) decls in
-	let imports = TypeloadModule.handle_import_hx ctx m imports null_pos in
+	let imports = TypeloadModule.ModuleLevel.handle_import_hx ctx m imports null_pos in
 	let ctx = TypeloadModule.type_types_into_module ctx m imports null_pos in
 	List.iter (fun md ->
 		let infos = t_infos md in

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -68,8 +68,6 @@ type typer_module = {
 }
 
 type typer_globals = {
-	types_module : (path, path) Hashtbl.t;
-	modules : (path , module_def) Hashtbl.t;
 	mutable delayed : (typer_pass * (unit -> unit) list) list;
 	mutable debug_delayed : (typer_pass * ((unit -> unit) * string * typer) list) list;
 	doinline : bool;
@@ -441,7 +439,7 @@ let create_fake_module ctx file =
 		Hashtbl.add fake_modules key mdep;
 		mdep
 	) in
-	Hashtbl.replace ctx.g.modules mdep.m_path mdep;
+	Hashtbl.replace ctx.com.module_lut mdep.m_path mdep;
 	mdep
 
 let push_this ctx e = match e.eexpr with

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -380,7 +380,7 @@ let remove_extern_fields com t = match t with
 let check_private_path ctx t = match t with
 	| TClassDecl c when c.cl_private ->
 		let rpath = (fst c.cl_module.m_path,"_" ^ snd c.cl_module.m_path) in
-		if Hashtbl.mem ctx.g.types_module rpath then typing_error ("This private class name will clash with " ^ s_type_path rpath) c.cl_pos;
+		if Hashtbl.mem ctx.com.type_to_module rpath then typing_error ("This private class name will clash with " ^ s_type_path rpath) c.cl_pos;
 	| _ ->
 		()
 

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -112,7 +112,7 @@ let api_inline2 com c field params p =
 
 let api_inline ctx c field params p =
 	let mk_typeexpr path =
-		let m = (try Hashtbl.find ctx.g.modules path with Not_found -> die "" __LOC__) in
+		let m = (try Hashtbl.find ctx.com.module_lut path with Not_found -> die "" __LOC__) in
 		add_dependency ctx.m.curmod m;
 		Option.get (ExtList.List.find_map (function
 			| TClassDecl cl when cl.cl_path = path -> Some (make_static_this cl p)

--- a/src/typing/finalization.ml
+++ b/src/typing/finalization.ml
@@ -86,7 +86,7 @@ let finalize ctx =
 			()
 		| fl ->
 			let rec loop handled_types =
-				let all_types = Hashtbl.fold (fun _ m acc -> m.m_types @ acc) ctx.g.modules [] in
+				let all_types = Hashtbl.fold (fun _ m acc -> m.m_types @ acc) ctx.com.module_lut [] in
 				match (List.filter (fun mt -> not (List.memq mt handled_types)) all_types) with
 				| [] ->
 					()
@@ -198,5 +198,5 @@ let sort_types com modules =
 	List.rev !types, sorted_modules
 
 let generate ctx =
-	let types,modules = sort_types ctx.com ctx.g.modules in
+	let types,modules = sort_types ctx.com ctx.com.module_lut in
 	get_main ctx types,types,modules

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -157,7 +157,7 @@ let static_method_container gctx c cf p =
 		| TInst(cg,_) -> cg
 		| _ -> typing_error ("Cannot specialize @:generic static method because the generated type name is already used: " ^ name) p
 	with Error(Module_not_found path,_) when path = (pack,name) ->
-		let m = (try Hashtbl.find ctx.g.modules (Hashtbl.find ctx.g.types_module c.cl_path) with Not_found -> die "" __LOC__) in
+		let m = (try Hashtbl.find ctx.com.module_lut (Hashtbl.find ctx.com.type_to_module c.cl_path) with Not_found -> die "" __LOC__) in
 		let mg = {
 			m_id = alloc_mid();
 			m_path = (pack,name);
@@ -168,7 +168,7 @@ let static_method_container gctx c cf p =
 		gctx.mg <- Some mg;
 		let cg = mk_class mg (pack,name) c.cl_pos c.cl_name_pos in
 		mg.m_types <- [TClassDecl cg];
-		Hashtbl.add ctx.g.modules mg.m_path mg;
+		Hashtbl.add ctx.com.module_lut mg.m_path mg;
 		add_dependency mg m;
 		add_dependency ctx.m.curmod mg;
 		cg
@@ -232,7 +232,7 @@ let rec build_generic_class ctx c p tl =
 		| TInst({ cl_kind = KGenericInstance (csup,_) },_) when c == csup -> t
 		| _ -> typing_error ("Cannot specialize @:generic because the generated type name is already used: " ^ name) p
 	with Error(Module_not_found path,_) when path = (pack,name) ->
-		let m = (try Hashtbl.find ctx.g.modules (Hashtbl.find ctx.g.types_module c.cl_path) with Not_found -> die "" __LOC__) in
+		let m = (try Hashtbl.find ctx.com.module_lut (Hashtbl.find ctx.com.type_to_module c.cl_path) with Not_found -> die "" __LOC__) in
 		ignore(c.cl_build()); (* make sure the super class is already setup *)
 		let mg = {
 			m_id = alloc_mid();
@@ -259,7 +259,7 @@ let rec build_generic_class ctx c p tl =
 		) c.cl_meta;
 		cg.cl_meta <- (Meta.NoDoc,[],null_pos) :: cg.cl_meta;
 		mg.m_types <- [TClassDecl cg];
-		Hashtbl.add ctx.g.modules mg.m_path mg;
+		Hashtbl.add ctx.com.module_lut mg.m_path mg;
 		add_dependency mg m;
 		add_dependency ctx.m.curmod mg;
 		set_type_parameter_dependencies mg tl;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -318,7 +318,7 @@ let make_macro_api ctx p =
 			let types = imports @ usings @ types in
 			let mpath = Ast.parse_path m in
 			begin try
-				let m = Hashtbl.find ctx.g.modules mpath in
+				let m = Hashtbl.find ctx.com.module_lut mpath in
 				ignore(TypeloadModule.type_types_into_module ctx m types pos)
 			with Not_found ->
 				let mnew = TypeloadModule.type_module ctx mpath (Path.UniqueKey.lazy_path ctx.m.curmod.m_extra.m_file) types pos in
@@ -364,7 +364,7 @@ let make_macro_api ctx p =
 		MacroApi.add_module_check_policy = (fun sl il b i ->
 			let add ctx =
 				ctx.g.module_check_policies <- (List.fold_left (fun acc s -> (ExtString.String.nsplit s ".",List.map Obj.magic il,b) :: acc) ctx.g.module_check_policies sl);
-				Hashtbl.iter (fun _ m -> m.m_extra.m_check_policy <- TypeloadModule.get_policy ctx.g m.m_path) ctx.g.modules;
+				Hashtbl.iter (fun _ m -> m.m_extra.m_check_policy <- TypeloadModule.get_policy ctx.g m.m_path) ctx.com.module_lut;
 			in
 			let add_macro ctx = match ctx.g.macros with
 				| None -> ()
@@ -526,7 +526,7 @@ let get_macro_context ctx p =
 
 let load_macro_module ctx cpath display p =
 	let api, mctx = get_macro_context ctx p in
-	let m = (try Hashtbl.find ctx.g.types_module cpath with Not_found -> cpath) in
+	let m = (try Hashtbl.find ctx.com.type_to_module cpath with Not_found -> cpath) in
 	(* Temporarily enter display mode while typing the macro. *)
 	let old = mctx.com.display in
 	if display then mctx.com.display <- ctx.com.display;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -364,7 +364,7 @@ let make_macro_api ctx p =
 		MacroApi.add_module_check_policy = (fun sl il b i ->
 			let add ctx =
 				ctx.g.module_check_policies <- (List.fold_left (fun acc s -> (ExtString.String.nsplit s ".",List.map Obj.magic il,b) :: acc) ctx.g.module_check_policies sl);
-				Hashtbl.iter (fun _ m -> m.m_extra.m_check_policy <- TypeloadModule.get_policy ctx m.m_path) ctx.g.modules;
+				Hashtbl.iter (fun _ m -> m.m_extra.m_check_policy <- TypeloadModule.get_policy ctx.g m.m_path) ctx.g.modules;
 			in
 			let add_macro ctx = match ctx.g.macros with
 				| None -> ()

--- a/src/typing/strictMeta.ml
+++ b/src/typing/strictMeta.ml
@@ -1,0 +1,154 @@
+open Globals
+open Ast
+open Type
+open Common
+open Typecore
+
+let get_native_repr md pos =
+	let path, meta = match md with
+		| TClassDecl cl -> cl.cl_path, cl.cl_meta
+		| TEnumDecl e -> e.e_path, e.e_meta
+		| TTypeDecl t -> t.t_path, t.t_meta
+		| TAbstractDecl a -> a.a_path, a.a_meta
+	in
+	let rec loop acc = function
+		| (Meta.JavaCanonical,[EConst(String(pack,_)),_; EConst(String(name,_)),_],_) :: _ ->
+			ExtString.String.nsplit pack ".", name
+		| (Meta.Native,[EConst(String(name,_)),_],_) :: meta ->
+			loop (Ast.parse_path name) meta
+		| _ :: meta ->
+			loop acc meta
+		| [] ->
+			acc
+	in
+	let pack, name = loop path meta in
+	match pack with
+		| [] ->
+			(EConst(Ident(name)), pos)
+		| hd :: tl ->
+			let rec loop pack expr = match pack with
+				| hd :: tl ->
+					loop tl (efield(expr,hd),pos)
+				| [] ->
+					(efield(expr,name),pos)
+			in
+			loop tl (EConst(Ident(hd)),pos)
+
+let rec process_meta_argument ?(toplevel=true) ctx expr = match expr.eexpr with
+	| TField(e,f) ->
+		(efield(process_meta_argument ~toplevel:false ctx e,field_name f),expr.epos)
+	| TConst(TInt i) ->
+		(EConst(Int (Int32.to_string i, None)), expr.epos)
+	| TConst(TFloat f) ->
+		(EConst(Float (f, None)), expr.epos)
+	| TConst(TString s) ->
+		(EConst(String(s,SDoubleQuotes)), expr.epos)
+	| TConst TNull ->
+		(EConst(Ident "null"), expr.epos)
+	| TConst(TBool b) ->
+		(EConst(Ident (string_of_bool b)), expr.epos)
+	| TCast(e,_) | TMeta(_,e) | TParenthesis(e) ->
+		process_meta_argument ~toplevel ctx e
+	| TTypeExpr md when toplevel ->
+		let p = expr.epos in
+		if ctx.com.platform = Cs then
+			(ECall( (EConst(Ident "typeof"), p), [get_native_repr md expr.epos] ), p)
+		else
+			(efield(get_native_repr md expr.epos, "class"), p)
+	| TTypeExpr md ->
+		get_native_repr md expr.epos
+	| _ ->
+		display_error ctx.com "This expression is too complex to be a strict metadata argument" expr.epos;
+		(EConst(Ident "null"), expr.epos)
+
+let handle_fields ctx fields_to_check with_type_expr =
+	List.map (fun ((name,_,_),expr) ->
+		let pos = snd expr in
+		let field = (efield(with_type_expr,name), pos) in
+		let fieldexpr = (EConst(Ident name),pos) in
+		let left_side = match ctx.com.platform with
+			| Cs -> field
+			| Java -> (ECall(field,[]),pos)
+			| _ -> die "" __LOC__
+		in
+
+		let left = type_expr ctx left_side NoValue in
+		let right = type_expr ctx expr (WithType.with_type left.etype) in
+		unify ctx left.etype right.etype (snd expr);
+		(EBinop(Ast.OpAssign,fieldexpr,process_meta_argument ctx right), pos)
+	) fields_to_check
+
+let make_meta ctx texpr extra =
+	match texpr.eexpr with
+		| TNew(c,_,el) ->
+			ECall(get_native_repr (TClassDecl c) texpr.epos, (List.map (process_meta_argument ctx) el) @ extra), texpr.epos
+		| TTypeExpr(md) ->
+			ECall(get_native_repr md texpr.epos, extra), texpr.epos
+		| _ ->
+			display_error ctx.com "Unexpected expression" texpr.epos; die "" __LOC__
+
+let get_strict_meta ctx meta params pos =
+	let pf = ctx.com.platform in
+	let changed_expr, fields_to_check, ctype = match params with
+		| [ECall(ef, el),p] ->
+			let tpath = field_to_type_path ctx.com ef in
+			begin match pf with
+			| Cs ->
+				let el, fields = match List.rev el with
+					| (EObjectDecl(decl),_) :: el ->
+						List.rev el, decl
+					| _ ->
+						el, []
+				in
+				(ENew((tpath,snd ef), el), p), fields, CTPath tpath
+			| Java ->
+				let fields = match el with
+				| [EObjectDecl(fields),_] ->
+					fields
+				| [] ->
+					[]
+				| (_,p) :: _ ->
+					display_error ctx.com "Object declaration expected" p;
+					[]
+				in
+				ef, fields, CTPath tpath
+			| _ ->
+				Error.typing_error "@:strict is not supported on this target" p
+			end
+		| [EConst(Ident i),p as expr] ->
+			let tpath = { tpackage=[]; tname=i; tparams=[]; tsub=None } in
+			if pf = Cs then
+				(ENew((tpath,p), []), p), [], CTPath tpath
+			else
+				expr, [], CTPath tpath
+		| [ (EField(_),p as field) ] ->
+			let tpath = field_to_type_path ctx.com field in
+			if pf = Cs then
+				(ENew((tpath,p), []), p), [], CTPath tpath
+			else
+				field, [], CTPath tpath
+		| _ ->
+			display_error ctx.com "A @:strict metadata must contain exactly one parameter. Please check the documentation for more information" pos;
+			raise Exit
+	in
+	let texpr = type_expr ctx changed_expr NoValue in
+	let with_type_expr = (ECheckType( (EConst (Ident "null"), pos), (ctype,null_pos) ), pos) in
+	let extra = handle_fields ctx fields_to_check with_type_expr in
+	meta, [make_meta ctx texpr extra], pos
+
+let check_strict_meta ctx metas =
+	let pf = ctx.com.platform in
+	match pf with
+		| Cs | Java ->
+			let ret = ref [] in
+			List.iter (function
+				| Meta.AssemblyStrict,params,pos -> (try
+					ret := get_strict_meta ctx Meta.AssemblyMeta params pos :: !ret
+				with | Exit -> ())
+				| Meta.Strict,params,pos -> (try
+					ret := get_strict_meta ctx Meta.Meta params pos :: !ret
+				with | Exit -> ())
+				| _ -> ()
+			) metas;
+			!ret
+		| _ -> []

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -753,40 +753,6 @@ let load_type_hint ?(opt=false) ctx pcur t =
 (* ---------------------------------------------------------------------- *)
 (* PASS 1 & 2 : Module and Class Structure *)
 
-let field_to_type_path com e =
-	let rec loop e pack name = match e with
-		| EField(e,f,_),p when Char.lowercase (String.get f 0) <> String.get f 0 -> (match name with
-			| [] | _ :: [] ->
-				loop e pack (f :: name)
-			| _ -> (* too many name paths *)
-				display_error com ("Unexpected " ^ f) p;
-				raise Exit)
-		| EField(e,f,_),_ ->
-			loop e (f :: pack) name
-		| EConst(Ident f),_ ->
-			let pack, name, sub = match name with
-				| [] ->
-					let fchar = String.get f 0 in
-					if Char.uppercase fchar = fchar then
-						pack, f, None
-					else begin
-						display_error com "A class name must start with an uppercase letter" (snd e);
-						raise Exit
-					end
-				| [name] ->
-					f :: pack, name, None
-				| [name; sub] ->
-					f :: pack, name, Some sub
-				| _ ->
-					die "" __LOC__
-			in
-			{ tpackage=pack; tname=name; tparams=[]; tsub=sub }
-		| _,pos ->
-			display_error com "Unexpected expression when building strict meta" pos;
-			raise Exit
-	in
-	loop e [] []
-
 type type_param_host =
 	| TPHType
 	| TPHConstructor

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -323,12 +323,12 @@ let check_global_metadata ctx meta f_add mpath tpath so =
 let check_module_types ctx m p t =
 	let t = t_infos t in
 	try
-		let m2 = Hashtbl.find ctx.g.types_module t.mt_path in
+		let m2 = Hashtbl.find ctx.com.type_to_module t.mt_path in
 		if m.m_path <> m2 && String.lowercase (s_type_path m2) = String.lowercase (s_type_path m.m_path) then typing_error ("Module " ^ s_type_path m2 ^ " is loaded with a different case than " ^ s_type_path m.m_path) p;
 		typing_error ("Type name " ^ s_type_path t.mt_path ^ " is redefined from module " ^ s_type_path m2) p
 	with
 		Not_found ->
-			Hashtbl.add ctx.g.types_module t.mt_path m.m_path
+			Hashtbl.add ctx.com.type_to_module t.mt_path m.m_path
 
 module Inheritance = struct
 	let is_basic_class_path path = match path with

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -681,7 +681,7 @@ let transform_field (ctx,cctx) c f fields p =
 	in
 	if List.mem_assoc AMacro f.cff_access then
 		(match ctx.g.macros with
-		| Some (_,mctx) when Hashtbl.mem mctx.g.types_module c.cl_path ->
+		| Some (_,mctx) when Hashtbl.mem mctx.com.type_to_module c.cl_path ->
 			(* assume that if we had already a macro with the same name, it has not been changed during the @:build operation *)
 			if not (List.exists (fun f2 -> f2.cff_name = f.cff_name && List.mem_assoc AMacro f2.cff_access) (!fields)) then
 				typing_error "Class build macro cannot return a macro function when the class has already been compiled into the macro context" p

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -563,12 +563,6 @@ let create_typer_context_for_class ctx cctx p =
 				| TMono r when r.tm_type = None -> TAbstract (a,extract_param_types c.cl_params)
 				| t -> t)
 			| None -> TInst (c,extract_param_types c.cl_params));
-		on_error = (fun ctx msg ep ->
-			ctx.com.error msg ep;
-			(* macros expressions might reference other code, let's recall which class we are actually compiling *)
-			let open TFunctions in
-			if not (ExtString.String.starts_with msg "...") && !locate_macro_error && (is_pos_outside_class c ep) && not (is_module_fields_class c) then ctx.com.error (compl_msg "Defined in this class") c.cl_pos
-		);
 	} in
 	ctx
 

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -30,174 +30,9 @@ open Common
 open Typeload
 open Error
 
-let get_policy ctx mpath =
+let get_policy g mpath =
 	let sl1 = full_dot_path2 mpath mpath in
-	List.fold_left (fun acc (sl2,policy,recursive) -> if match_path recursive sl1 sl2 then policy @ acc else acc) [] ctx.g.module_check_policies
-
-let make_module ctx mpath file loadp =
-	let m = {
-		m_id = alloc_mid();
-		m_path = mpath;
-		m_types = [];
-		m_statics = None;
-		m_extra = module_extra (Path.get_full_path file) (Define.get_signature ctx.com.defines) (file_time file) (if ctx.com.is_macro_context then MMacro else MCode) (get_policy ctx mpath);
-	} in
-	m
-
-let add_module ctx m p =
-	List.iter (TypeloadCheck.check_module_types ctx m p) m.m_types;
-	Hashtbl.add ctx.g.modules m.m_path m
-
-module StrictMeta = struct
-	let get_native_repr md pos =
-		let path, meta = match md with
-			| TClassDecl cl -> cl.cl_path, cl.cl_meta
-			| TEnumDecl e -> e.e_path, e.e_meta
-			| TTypeDecl t -> t.t_path, t.t_meta
-			| TAbstractDecl a -> a.a_path, a.a_meta
-		in
-		let rec loop acc = function
-			| (Meta.JavaCanonical,[EConst(String(pack,_)),_; EConst(String(name,_)),_],_) :: _ ->
-				ExtString.String.nsplit pack ".", name
-			| (Meta.Native,[EConst(String(name,_)),_],_) :: meta ->
-				loop (Ast.parse_path name) meta
-			| _ :: meta ->
-				loop acc meta
-			| [] ->
-				acc
-		in
-		let pack, name = loop path meta in
-		match pack with
-			| [] ->
-				(EConst(Ident(name)), pos)
-			| hd :: tl ->
-				let rec loop pack expr = match pack with
-					| hd :: tl ->
-						loop tl (efield(expr,hd),pos)
-					| [] ->
-						(efield(expr,name),pos)
-				in
-				loop tl (EConst(Ident(hd)),pos)
-
-	let rec process_meta_argument ?(toplevel=true) ctx expr = match expr.eexpr with
-		| TField(e,f) ->
-			(efield(process_meta_argument ~toplevel:false ctx e,field_name f),expr.epos)
-		| TConst(TInt i) ->
-			(EConst(Int (Int32.to_string i, None)), expr.epos)
-		| TConst(TFloat f) ->
-			(EConst(Float (f, None)), expr.epos)
-		| TConst(TString s) ->
-			(EConst(String(s,SDoubleQuotes)), expr.epos)
-		| TConst TNull ->
-			(EConst(Ident "null"), expr.epos)
-		| TConst(TBool b) ->
-			(EConst(Ident (string_of_bool b)), expr.epos)
-		| TCast(e,_) | TMeta(_,e) | TParenthesis(e) ->
-			process_meta_argument ~toplevel ctx e
-		| TTypeExpr md when toplevel ->
-			let p = expr.epos in
-			if ctx.com.platform = Cs then
-				(ECall( (EConst(Ident "typeof"), p), [get_native_repr md expr.epos] ), p)
-			else
-				(efield(get_native_repr md expr.epos, "class"), p)
-		| TTypeExpr md ->
-			get_native_repr md expr.epos
-		| _ ->
-			display_error ctx.com "This expression is too complex to be a strict metadata argument" expr.epos;
-			(EConst(Ident "null"), expr.epos)
-
-	let handle_fields ctx fields_to_check with_type_expr =
-		List.map (fun ((name,_,_),expr) ->
-			let pos = snd expr in
-			let field = (efield(with_type_expr,name), pos) in
-			let fieldexpr = (EConst(Ident name),pos) in
-			let left_side = match ctx.com.platform with
-				| Cs -> field
-				| Java -> (ECall(field,[]),pos)
-				| _ -> die "" __LOC__
-			in
-
-			let left = type_expr ctx left_side NoValue in
-			let right = type_expr ctx expr (WithType.with_type left.etype) in
-			unify ctx left.etype right.etype (snd expr);
-			(EBinop(Ast.OpAssign,fieldexpr,process_meta_argument ctx right), pos)
-		) fields_to_check
-
-	let make_meta ctx texpr extra =
-		match texpr.eexpr with
-			| TNew(c,_,el) ->
-				ECall(get_native_repr (TClassDecl c) texpr.epos, (List.map (process_meta_argument ctx) el) @ extra), texpr.epos
-			| TTypeExpr(md) ->
-				ECall(get_native_repr md texpr.epos, extra), texpr.epos
-			| _ ->
-				display_error ctx.com "Unexpected expression" texpr.epos; die "" __LOC__
-
-	let get_strict_meta ctx meta params pos =
-		let pf = ctx.com.platform in
-		let changed_expr, fields_to_check, ctype = match params with
-			| [ECall(ef, el),p] ->
-				let tpath = field_to_type_path ctx.com ef in
-				begin match pf with
-				| Cs ->
-					let el, fields = match List.rev el with
-						| (EObjectDecl(decl),_) :: el ->
-							List.rev el, decl
-						| _ ->
-							el, []
-					in
-					(ENew((tpath,snd ef), el), p), fields, CTPath tpath
-				| Java ->
-					let fields = match el with
-					| [EObjectDecl(fields),_] ->
-						fields
-					| [] ->
-						[]
-					| (_,p) :: _ ->
-						display_error ctx.com "Object declaration expected" p;
-						[]
-					in
-					ef, fields, CTPath tpath
-				| _ ->
-					Error.typing_error "@:strict is not supported on this target" p
-				end
-			| [EConst(Ident i),p as expr] ->
-				let tpath = { tpackage=[]; tname=i; tparams=[]; tsub=None } in
-				if pf = Cs then
-					(ENew((tpath,p), []), p), [], CTPath tpath
-				else
-					expr, [], CTPath tpath
-			| [ (EField(_),p as field) ] ->
-				let tpath = field_to_type_path ctx.com field in
-				if pf = Cs then
-					(ENew((tpath,p), []), p), [], CTPath tpath
-				else
-					field, [], CTPath tpath
-			| _ ->
-				display_error ctx.com "A @:strict metadata must contain exactly one parameter. Please check the documentation for more information" pos;
-				raise Exit
-		in
-		let texpr = type_expr ctx changed_expr NoValue in
-		let with_type_expr = (ECheckType( (EConst (Ident "null"), pos), (ctype,null_pos) ), pos) in
-		let extra = handle_fields ctx fields_to_check with_type_expr in
-		meta, [make_meta ctx texpr extra], pos
-
-	let check_strict_meta ctx metas =
-		let pf = ctx.com.platform in
-		match pf with
-			| Cs | Java ->
-				let ret = ref [] in
-				List.iter (function
-					| Meta.AssemblyStrict,params,pos -> (try
-						ret := get_strict_meta ctx Meta.AssemblyMeta params pos :: !ret
-					with | Exit -> ())
-					| Meta.Strict,params,pos -> (try
-						ret := get_strict_meta ctx Meta.Meta params pos :: !ret
-					with | Exit -> ())
-					| _ -> ()
-				) metas;
-				!ret
-			| _ -> []
-end
+	List.fold_left (fun acc (sl2,policy,recursive) -> if match_path recursive sl1 sl2 then policy @ acc else acc) [] g.module_check_policies
 
 let field_of_static_definition d p =
 	{
@@ -209,602 +44,652 @@ let field_of_static_definition d p =
 		cff_kind = d.d_data;
 	}
 
-(*
-	Build module structure : should be atomic - no type loading is possible
-*)
-let module_pass_1 ctx m tdecls loadp =
-	let com = ctx.com in
-	let decls = ref [] in
-	let statics = ref [] in
-	let check_name name meta also_statics p =
-		DeprecationCheck.check_is com name meta p;
-		let error prev_pos =
-			display_error ctx.com ("Name " ^ name ^ " is already defined in this module") p;
-			typing_error (compl_msg "Previous declaration here") prev_pos;
+module ModuleLevel = struct
+	let make_module ctx mpath file loadp =
+		let m = {
+			m_id = alloc_mid();
+			m_path = mpath;
+			m_types = [];
+			m_statics = None;
+			m_extra = module_extra (Path.get_full_path file) (Define.get_signature ctx.com.defines) (file_time file) (if ctx.com.is_macro_context then MMacro else MCode) (get_policy ctx.g mpath);
+		} in
+		m
+
+	let add_module ctx m p =
+		List.iter (TypeloadCheck.check_module_types ctx m p) m.m_types;
+		Hashtbl.add ctx.g.modules m.m_path m
+
+	(*
+		Build module structure : should be atomic - no type loading is possible
+	*)
+	let create_module_types ctx m tdecls loadp =
+		let com = ctx.com in
+		let decls = ref [] in
+		let statics = ref [] in
+		let check_name name meta also_statics p =
+			DeprecationCheck.check_is com name meta p;
+			let error prev_pos =
+				display_error ctx.com ("Name " ^ name ^ " is already defined in this module") p;
+				typing_error (compl_msg "Previous declaration here") prev_pos;
+			in
+			List.iter (fun (t2,(_,p2)) ->
+				if snd (t_path t2) = name then error (t_infos t2).mt_name_pos
+			) !decls;
+			if also_statics then
+				List.iter (fun (d,_) ->
+					if fst d.d_name = name then error (snd d.d_name)
+				) !statics
 		in
-		List.iter (fun (t2,(_,p2)) ->
-			if snd (t_path t2) = name then error (t_infos t2).mt_name_pos
-		) !decls;
-		if also_statics then
-			List.iter (fun (d,_) ->
-				if fst d.d_name = name then error (snd d.d_name)
-			) !statics
-	in
-	let make_path name priv meta p =
-		check_name name meta true p;
-		if priv then (fst m.m_path @ ["_" ^ snd m.m_path], name) else (fst m.m_path, name)
-	in
-	let has_declaration = ref false in
-	let rec make_decl acc decl =
-		let p = snd decl in
-		let check_type_name type_name meta =
-			let module_name = snd m.m_path in
-			if type_name <> module_name && not (Meta.has Meta.Native meta) then Typecore.check_uppercase_identifier_name ctx type_name "type" p;
+		let make_path name priv meta p =
+			check_name name meta true p;
+			if priv then (fst m.m_path @ ["_" ^ snd m.m_path], name) else (fst m.m_path, name)
 		in
-		let acc = (match fst decl with
-		| EImport _ | EUsing _ ->
-			if !has_declaration then typing_error "import and using may not appear after a declaration" p;
-			acc
-		| EStatic d ->
-			check_name (fst d.d_name) d.d_meta false (snd d.d_name);
-			has_declaration := true;
-			statics := (d,p) :: !statics;
-			acc;
-		| EClass d ->
-			let name = fst d.d_name in
-			has_declaration := true;
-			let priv = List.mem HPrivate d.d_flags in
-			let path = make_path name priv d.d_meta (snd d.d_name) in
-			let c = mk_class m path p (pos d.d_name) in
-			(* we shouldn't load any other type until we propertly set cl_build *)
-			c.cl_build <- (fun() -> typing_error (s_type_path c.cl_path ^ " is not ready to be accessed, separate your type declarations in several files") p);
-			c.cl_module <- m;
-			c.cl_private <- priv;
-			c.cl_doc <- d.d_doc;
-			c.cl_meta <- d.d_meta;
-			if List.mem HAbstract d.d_flags then add_class_flag c CAbstract;
-			List.iter (function
-				| HExtern -> add_class_flag c CExtern
-				| HInterface -> add_class_flag c CInterface
-				| HFinal -> add_class_flag c CFinal
-				| _ -> ()
-			) d.d_flags;
-			if not (has_class_flag c CExtern) then check_type_name name d.d_meta;
-			if has_class_flag c CAbstract then begin
-				if has_class_flag c CInterface then display_error ctx.com "An interface may not be abstract" c.cl_name_pos;
-				if has_class_flag c CFinal then display_error ctx.com "An abstract class may not be final" c.cl_name_pos;
-			end;
-			decls := (TClassDecl c, decl) :: !decls;
-			acc
-		| EEnum d ->
-			let name = fst d.d_name in
-			has_declaration := true;
-			let priv = List.mem EPrivate d.d_flags in
-			let path = make_path name priv d.d_meta p in
-			if Meta.has (Meta.Custom ":fakeEnum") d.d_meta then typing_error "@:fakeEnum enums is no longer supported in Haxe 4, use extern enum abstract instead" p;
-			let e = {
-				e_path = path;
-				e_module = m;
-				e_pos = p;
-				e_name_pos = (pos d.d_name);
-				e_doc = d.d_doc;
-				e_meta = d.d_meta;
-				e_params = [];
-				e_using = [];
-				e_private = priv;
-				e_extern = List.mem EExtern d.d_flags;
-				e_constrs = PMap.empty;
-				e_names = [];
-				e_type = enum_module_type m path p;
-			} in
-			if not e.e_extern then check_type_name name d.d_meta;
-			decls := (TEnumDecl e, decl) :: !decls;
-			acc
-		| ETypedef d ->
-			let name = fst d.d_name in
-			check_type_name name d.d_meta;
-			has_declaration := true;
-			let priv = List.mem EPrivate d.d_flags in
-			let path = make_path name priv d.d_meta p in
-			let t = {(mk_typedef m path p (pos d.d_name) (mk_mono())) with
-				t_doc = d.d_doc;
-				t_private = priv;
-				t_meta = d.d_meta;
-			} in
-			(* failsafe in case the typedef is not initialized (see #3933) *)
-			delay ctx PBuildModule (fun () ->
-				match t.t_type with
-				| TMono r -> (match r.tm_type with None -> Monomorph.bind r com.basic.tvoid | _ -> ())
-				| _ -> ()
-			);
-			decls := (TTypeDecl t, decl) :: !decls;
-			acc
-		 | EAbstract d ->
-		 	let name = fst d.d_name in
-			check_type_name name d.d_meta;
-			let priv = List.mem AbPrivate d.d_flags in
-			let path = make_path name priv d.d_meta p in
-			let a = {
-				a_path = path;
-				a_private = priv;
-				a_module = m;
-				a_pos = p;
-				a_name_pos = pos d.d_name;
-				a_doc = d.d_doc;
-				a_params = [];
-				a_using = [];
-				a_meta = d.d_meta;
-				a_from = [];
-				a_to = [];
-				a_from_field = [];
-				a_to_field = [];
-				a_ops = [];
-				a_unops = [];
-				a_impl = None;
-				a_array = [];
-				a_this = mk_mono();
-				a_read = None;
-				a_write = None;
-				a_call = None;
-				a_enum = List.mem AbEnum d.d_flags || Meta.has Meta.Enum d.d_meta;
-			} in
-			if a.a_enum && not (Meta.has Meta.Enum a.a_meta) then a.a_meta <- (Meta.Enum,[],null_pos) :: a.a_meta;
-			decls := (TAbstractDecl a, decl) :: !decls;
-			match d.d_data with
-			| [] when Meta.has Meta.CoreType a.a_meta ->
-				a.a_this <- t_dynamic;
+		let has_declaration = ref false in
+		let rec make_decl acc decl =
+			let p = snd decl in
+			let check_type_name type_name meta =
+				let module_name = snd m.m_path in
+				if type_name <> module_name && not (Meta.has Meta.Native meta) then Typecore.check_uppercase_identifier_name ctx type_name "type" p;
+			in
+			let acc = (match fst decl with
+			| EImport _ | EUsing _ ->
+				if !has_declaration then typing_error "import and using may not appear after a declaration" p;
 				acc
-			| fields ->
-				let a_t =
-					let params = List.map (fun t -> TPType (CTPath (mk_type_path ([],fst t.tp_name)),null_pos)) d.d_params in
-					CTPath (mk_type_path ~params ([],fst d.d_name)),null_pos
-				in
-				let rec loop = function
-					| [] -> a_t
-					| AbOver t :: _ -> t
-					| _ :: l -> loop l
-				in
-				let this_t = loop d.d_flags in
-				let fields = List.map (TypeloadFields.transform_abstract_field com this_t a_t a) fields in
-				let meta = ref [] in
-				if has_meta Meta.Dce a.a_meta then meta := (Meta.Dce,[],null_pos) :: !meta;
-				let acc = make_decl acc (EClass { d_name = (fst d.d_name) ^ "_Impl_",snd d.d_name; d_flags = [HPrivate]; d_data = fields; d_doc = None; d_params = []; d_meta = !meta },p) in
+			| EStatic d ->
+				check_name (fst d.d_name) d.d_meta false (snd d.d_name);
+				has_declaration := true;
+				statics := (d,p) :: !statics;
+				acc;
+			| EClass d ->
+				let name = fst d.d_name in
+				has_declaration := true;
+				let priv = List.mem HPrivate d.d_flags in
+				let path = make_path name priv d.d_meta (snd d.d_name) in
+				let c = mk_class m path p (pos d.d_name) in
+				(* we shouldn't load any other type until we propertly set cl_build *)
+				c.cl_build <- (fun() -> typing_error (s_type_path c.cl_path ^ " is not ready to be accessed, separate your type declarations in several files") p);
+				c.cl_module <- m;
+				c.cl_private <- priv;
+				c.cl_doc <- d.d_doc;
+				c.cl_meta <- d.d_meta;
+				if List.mem HAbstract d.d_flags then add_class_flag c CAbstract;
+				List.iter (function
+					| HExtern -> add_class_flag c CExtern
+					| HInterface -> add_class_flag c CInterface
+					| HFinal -> add_class_flag c CFinal
+					| _ -> ()
+				) d.d_flags;
+				if not (has_class_flag c CExtern) then check_type_name name d.d_meta;
+				if has_class_flag c CAbstract then begin
+					if has_class_flag c CInterface then display_error ctx.com "An interface may not be abstract" c.cl_name_pos;
+					if has_class_flag c CFinal then display_error ctx.com "An abstract class may not be final" c.cl_name_pos;
+				end;
+				decls := (TClassDecl c, decl) :: !decls;
+				acc
+			| EEnum d ->
+				let name = fst d.d_name in
+				has_declaration := true;
+				let priv = List.mem EPrivate d.d_flags in
+				let path = make_path name priv d.d_meta p in
+				if Meta.has (Meta.Custom ":fakeEnum") d.d_meta then typing_error "@:fakeEnum enums is no longer supported in Haxe 4, use extern enum abstract instead" p;
+				let e = {
+					e_path = path;
+					e_module = m;
+					e_pos = p;
+					e_name_pos = (pos d.d_name);
+					e_doc = d.d_doc;
+					e_meta = d.d_meta;
+					e_params = [];
+					e_using = [];
+					e_private = priv;
+					e_extern = List.mem EExtern d.d_flags;
+					e_constrs = PMap.empty;
+					e_names = [];
+					e_type = enum_module_type m path p;
+				} in
+				if not e.e_extern then check_type_name name d.d_meta;
+				decls := (TEnumDecl e, decl) :: !decls;
+				acc
+			| ETypedef d ->
+				let name = fst d.d_name in
+				check_type_name name d.d_meta;
+				has_declaration := true;
+				let priv = List.mem EPrivate d.d_flags in
+				let path = make_path name priv d.d_meta p in
+				let t = {(mk_typedef m path p (pos d.d_name) (mk_mono())) with
+					t_doc = d.d_doc;
+					t_private = priv;
+					t_meta = d.d_meta;
+				} in
+				(* failsafe in case the typedef is not initialized (see #3933) *)
+				delay ctx PBuildModule (fun () ->
+					match t.t_type with
+					| TMono r -> (match r.tm_type with None -> Monomorph.bind r com.basic.tvoid | _ -> ())
+					| _ -> ()
+				);
+				decls := (TTypeDecl t, decl) :: !decls;
+				acc
+			| EAbstract d ->
+				let name = fst d.d_name in
+				check_type_name name d.d_meta;
+				let priv = List.mem AbPrivate d.d_flags in
+				let path = make_path name priv d.d_meta p in
+				let a = {
+					a_path = path;
+					a_private = priv;
+					a_module = m;
+					a_pos = p;
+					a_name_pos = pos d.d_name;
+					a_doc = d.d_doc;
+					a_params = [];
+					a_using = [];
+					a_meta = d.d_meta;
+					a_from = [];
+					a_to = [];
+					a_from_field = [];
+					a_to_field = [];
+					a_ops = [];
+					a_unops = [];
+					a_impl = None;
+					a_array = [];
+					a_this = mk_mono();
+					a_read = None;
+					a_write = None;
+					a_call = None;
+					a_enum = List.mem AbEnum d.d_flags || Meta.has Meta.Enum d.d_meta;
+				} in
+				if a.a_enum && not (Meta.has Meta.Enum a.a_meta) then a.a_meta <- (Meta.Enum,[],null_pos) :: a.a_meta;
+				decls := (TAbstractDecl a, decl) :: !decls;
+				match d.d_data with
+				| [] when Meta.has Meta.CoreType a.a_meta ->
+					a.a_this <- t_dynamic;
+					acc
+				| fields ->
+					let a_t =
+						let params = List.map (fun t -> TPType (CTPath (mk_type_path ([],fst t.tp_name)),null_pos)) d.d_params in
+						CTPath (mk_type_path ~params ([],fst d.d_name)),null_pos
+					in
+					let rec loop = function
+						| [] -> a_t
+						| AbOver t :: _ -> t
+						| _ :: l -> loop l
+					in
+					let this_t = loop d.d_flags in
+					let fields = List.map (TypeloadFields.transform_abstract_field com this_t a_t a) fields in
+					let meta = ref [] in
+					if has_meta Meta.Dce a.a_meta then meta := (Meta.Dce,[],null_pos) :: !meta;
+					let acc = make_decl acc (EClass { d_name = (fst d.d_name) ^ "_Impl_",snd d.d_name; d_flags = [HPrivate]; d_data = fields; d_doc = None; d_params = []; d_meta = !meta },p) in
+					(match !decls with
+					| (TClassDecl c,_) :: _ ->
+						List.iter (fun m -> match m with
+							| ((Meta.Using | Meta.Build | Meta.CoreApi | Meta.Allow | Meta.Access | Meta.Enum | Meta.Dce | Meta.Native | Meta.HlNative | Meta.JsRequire | Meta.PythonImport | Meta.Expose | Meta.Deprecated | Meta.PhpGlobal | Meta.PublicFields),_,_) ->
+								c.cl_meta <- m :: c.cl_meta;
+							| _ ->
+								()
+						) a.a_meta;
+						a.a_impl <- Some c;
+						c.cl_kind <- KAbstractImpl a;
+						add_class_flag c CFinal;
+					| _ -> die "" __LOC__);
+					acc
+			) in
+			decl :: acc
+		in
+		let tdecls = List.fold_left make_decl [] tdecls in
+		let tdecls =
+			match !statics with
+			| [] ->
+				tdecls
+			| statics ->
+				let first_pos = ref null_pos in
+				let fields = List.map (fun (d,p) ->
+					first_pos := p;
+					field_of_static_definition d p;
+				) statics in
+				let p = let p = !first_pos in { p with pmax = p.pmin } in
+				let c = EClass {
+					d_name = (snd m.m_path) ^ "_Fields_", null_pos;
+					d_flags = [HPrivate];
+					d_data = List.rev fields;
+					d_doc = None;
+					d_params = [];
+					d_meta = []
+				} in
+				let tdecls = make_decl tdecls (c,p) in
 				(match !decls with
 				| (TClassDecl c,_) :: _ ->
-					List.iter (fun m -> match m with
-						| ((Meta.Using | Meta.Build | Meta.CoreApi | Meta.Allow | Meta.Access | Meta.Enum | Meta.Dce | Meta.Native | Meta.HlNative | Meta.JsRequire | Meta.PythonImport | Meta.Expose | Meta.Deprecated | Meta.PhpGlobal | Meta.PublicFields),_,_) ->
-							c.cl_meta <- m :: c.cl_meta;
+					assert (m.m_statics = None);
+					m.m_statics <- Some c;
+					c.cl_kind <- KModuleFields m;
+					add_class_flag c CFinal;
+				| _ -> assert false);
+				tdecls
+
+		in
+		let decls = List.rev !decls in
+		decls, List.rev tdecls
+
+	let handle_import_hx ctx m decls p =
+		let com = ctx.com in
+		let path_split = match List.rev (Path.get_path_parts (Path.UniqueKey.lazy_path m.m_extra.m_file)) with
+			| [] -> []
+			| _ :: l -> l
+		in
+		let join l = String.concat Path.path_sep (List.rev ("import.hx" :: l)) in
+		let rec loop path pack = match path,pack with
+			| _,[] -> [join path]
+			| (p :: path),(_ :: pack) -> (join (p :: path)) :: (loop path pack)
+			| _ -> []
+		in
+		let candidates = loop path_split (fst m.m_path) in
+		let make_import_module path r =
+			Hashtbl.replace com.parser_cache path r;
+			(* We use the file path as module name to make it unique. This may or may not be a good idea... *)
+			let m_import = make_module ctx ([],path) path p in
+			m_import.m_extra.m_kind <- MImport;
+			add_module ctx m_import p;
+			m_import
+		in
+		List.fold_left (fun acc path ->
+			let decls = try
+				let r = Hashtbl.find com.parser_cache path in
+				let mimport = Hashtbl.find ctx.g.modules ([],path) in
+				if mimport.m_extra.m_kind <> MFake then add_dependency m mimport;
+				r
+			with Not_found ->
+				if Sys.file_exists path then begin
+					let _,r = match !TypeloadParse.parse_hook com path p with
+						| ParseSuccess(data,_,_) -> data
+						| ParseError(_,(msg,p),_) -> Parser.error msg p
+					in
+					List.iter (fun (d,p) -> match d with EImport _ | EUsing _ -> () | _ -> typing_error "Only import and using is allowed in import.hx files" p) r;
+					add_dependency m (make_import_module path r);
+					r
+				end else begin
+					let r = [] in
+					(* Add empty decls so we don't check the file system all the time. *)
+					(make_import_module path r).m_extra.m_kind <- MFake;
+					r
+				end
+			in
+			decls @ acc
+		) decls candidates
+
+	let init_type_params ctx decls =
+		(* here is an additional PASS 1 phase, which define the type parameters for all module types.
+		 Constraints are handled lazily (no other type is loaded) because they might be recursive anyway *)
+		 List.iter (fun d ->
+			match d with
+			| (TClassDecl c, (EClass d, p)) ->
+				c.cl_params <- type_type_params ctx TPHType c.cl_path (fun() -> c.cl_params) p d.d_params;
+				if Meta.has Meta.Generic c.cl_meta && c.cl_params <> [] then c.cl_kind <- KGeneric;
+				if Meta.has Meta.GenericBuild c.cl_meta then begin
+					if ctx.com.is_macro_context then typing_error "@:genericBuild cannot be used in macros" c.cl_pos;
+					c.cl_kind <- KGenericBuild d.d_data;
+				end;
+				if c.cl_path = (["haxe";"macro"],"MacroType") then c.cl_kind <- KMacroType;
+			| (TEnumDecl e, (EEnum d, p)) ->
+				e.e_params <- type_type_params ctx TPHType e.e_path (fun() -> e.e_params) p d.d_params;
+			| (TTypeDecl t, (ETypedef d, p)) ->
+				t.t_params <- type_type_params ctx TPHType t.t_path (fun() -> t.t_params) p d.d_params;
+			| (TAbstractDecl a, (EAbstract d, p)) ->
+				a.a_params <- type_type_params ctx TPHType a.a_path (fun() -> a.a_params) p d.d_params;
+			| _ ->
+				die "" __LOC__
+		) decls
+end
+
+module TypeLevel = struct
+	let load_enum_field ctx e et is_flat index c =
+		let p = c.ec_pos in
+		let params = ref [] in
+		params := type_type_params ctx TPHEnumConstructor ([],fst c.ec_name) (fun() -> !params) c.ec_pos c.ec_params;
+		let params = !params in
+		let ctx = { ctx with type_params = params @ ctx.type_params } in
+		let rt = (match c.ec_type with
+			| None -> et
+			| Some (t,pt) ->
+				let t = load_complex_type ctx true (t,pt) in
+				(match follow t with
+				| TEnum (te,_) when te == e ->
+					()
+				| _ ->
+					typing_error "Explicit enum type must be of the same enum type" pt);
+				t
+		) in
+		let t = (match c.ec_args with
+			| [] -> rt
+			| l ->
+				is_flat := false;
+				let pnames = ref PMap.empty in
+				TFun (List.map (fun (s,opt,(t,tp)) ->
+					(match t with CTPath({tpackage=[];tname="Void"}) -> typing_error "Arguments of type Void are not allowed in enum constructors" tp | _ -> ());
+					if PMap.mem s (!pnames) then typing_error ("Duplicate argument `" ^ s ^ "` in enum constructor " ^ fst c.ec_name) p;
+					pnames := PMap.add s () (!pnames);
+					s, opt, load_type_hint ~opt ctx p (Some (t,tp))
+				) l, rt)
+		) in
+		let f = {
+			ef_name = fst c.ec_name;
+			ef_type = t;
+			ef_pos = p;
+			ef_name_pos = snd c.ec_name;
+			ef_doc = c.ec_doc;
+			ef_index = !index;
+			ef_params = params;
+			ef_meta = c.ec_meta;
+		} in
+		DeprecationCheck.check_is ctx.com f.ef_name f.ef_meta f.ef_name_pos;
+		let cf = {
+			(mk_field f.ef_name f.ef_type p f.ef_name_pos) with
+			cf_kind = (match follow f.ef_type with
+				| TFun _ -> Method MethNormal
+				| _ -> Var { v_read = AccNormal; v_write = AccNo }
+			);
+			cf_doc = f.ef_doc;
+			cf_params = f.ef_params;
+		} in
+		if ctx.is_display_file && DisplayPosition.display_position#enclosed_in f.ef_name_pos then
+			DisplayEmitter.display_enum_field ctx e f p;
+		f,cf
+
+	(*
+		In this pass, we can access load and access other modules types, but we cannot follow them or access their structure
+		since they have not been setup. We also build a context_init list that will be evaluated the first time we evaluate
+		an expression into the context
+	*)
+	let init_module_type ctx context_init (decl,p) =
+		let get_type name =
+			try List.find (fun t -> snd (t_infos t).mt_path = name) ctx.m.curmod.m_types with Not_found -> die "" __LOC__
+		in
+		let check_path_display path p =
+			if DisplayPosition.display_position#is_in_file (ctx.com.file_keys#get p.pfile) then DisplayPath.handle_path_display ctx path p
+			in
+		match decl with
+		| EImport (path,mode) ->
+			begin try
+				check_path_display path p;
+				ImportHandling.init_import ctx context_init path mode p;
+				ImportHandling.commit_import ctx path mode p;
+			with Error(err,p) ->
+				display_error ctx.com (Error.error_msg err) p
+			end
+		| EUsing path ->
+			check_path_display path p;
+			ImportHandling.init_using ctx context_init path p
+		| EClass d ->
+			let c = (match get_type (fst d.d_name) with TClassDecl c -> c | _ -> die "" __LOC__) in
+			if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
+				DisplayEmitter.display_module_type ctx (match c.cl_kind with KAbstractImpl a -> TAbstractDecl a | _ -> TClassDecl c) (pos d.d_name);
+			TypeloadCheck.check_global_metadata ctx c.cl_meta (fun m -> c.cl_meta <- m :: c.cl_meta) c.cl_module.m_path c.cl_path None;
+			let herits = d.d_flags in
+			List.iter (fun (m,_,p) ->
+				if m = Meta.Final then begin
+					add_class_flag c CFinal;
+				end
+			) d.d_meta;
+			let prev_build_count = ref (!build_count - 1) in
+			let build() =
+				c.cl_build <- (fun()-> Building [c]);
+				let fl = TypeloadCheck.Inheritance.set_heritance ctx c herits p in
+				let rec build() =
+					c.cl_build <- (fun()-> Building [c]);
+					try
+						List.iter (fun f -> f()) fl;
+						TypeloadFields.init_class ctx c p context_init d.d_flags d.d_data;
+						c.cl_build <- (fun()-> Built);
+						incr build_count;
+						List.iter (fun tp -> ignore(follow tp.ttp_type)) c.cl_params;
+						Built;
+					with TypeloadCheck.Build_canceled state ->
+						c.cl_build <- make_pass ctx build;
+						let rebuild() =
+							delay_late ctx PBuildClass (fun() -> ignore(c.cl_build()));
+						in
+						(match state with
+						| Built -> die "" __LOC__
+						| Building cl ->
+							if !build_count = !prev_build_count then typing_error ("Loop in class building prevent compiler termination (" ^ String.concat "," (List.map (fun c -> s_type_path c.cl_path) cl) ^ ")") c.cl_pos;
+							prev_build_count := !build_count;
+							rebuild();
+							Building (c :: cl)
+						| BuildMacro f ->
+							f := rebuild :: !f;
+							state);
+					| exn ->
+						c.cl_build <- (fun()-> Built);
+						raise exn
+				in
+				build()
+			in
+			ctx.pass <- PBuildClass;
+			ctx.curclass <- c;
+			c.cl_build <- make_pass ctx build;
+			ctx.pass <- PBuildModule;
+			ctx.curclass <- null_class;
+			delay ctx PBuildClass (fun() -> ignore(c.cl_build()));
+			if Meta.has Meta.InheritDoc c.cl_meta then
+					delay ctx PConnectField (fun() -> InheritDoc.build_class_doc ctx c);
+			if (ctx.com.platform = Java || ctx.com.platform = Cs) && not (has_class_flag c CExtern) then
+				delay ctx PTypeField (fun () ->
+					let metas = StrictMeta.check_strict_meta ctx c.cl_meta in
+					if metas <> [] then c.cl_meta <- metas @ c.cl_meta;
+					let rec run_field cf =
+						let metas = StrictMeta.check_strict_meta ctx cf.cf_meta in
+						if metas <> [] then cf.cf_meta <- metas @ cf.cf_meta;
+						List.iter run_field cf.cf_overloads
+					in
+					List.iter run_field c.cl_ordered_statics;
+					List.iter run_field c.cl_ordered_fields;
+					match c.cl_constructor with
+						| Some f -> run_field f
+						| _ -> ()
+				);
+		| EEnum d ->
+			let e = (match get_type (fst d.d_name) with TEnumDecl e -> e | _ -> die "" __LOC__) in
+			if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
+				DisplayEmitter.display_module_type ctx (TEnumDecl e) (pos d.d_name);
+			let ctx = { ctx with type_params = e.e_params } in
+			let h = (try Some (Hashtbl.find ctx.g.type_patches e.e_path) with Not_found -> None) in
+			TypeloadCheck.check_global_metadata ctx e.e_meta (fun m -> e.e_meta <- m :: e.e_meta) e.e_module.m_path e.e_path None;
+			(match h with
+			| None -> ()
+			| Some (h,hcl) ->
+				Hashtbl.iter (fun _ _ -> typing_error "Field type patch not supported for enums" e.e_pos) h;
+				e.e_meta <- e.e_meta @ hcl.tp_meta);
+			let constructs = ref d.d_data in
+			let get_constructs() =
+				List.map (fun c ->
+					{
+						cff_name = c.ec_name;
+						cff_doc = c.ec_doc;
+						cff_meta = c.ec_meta;
+						cff_pos = c.ec_pos;
+						cff_access = [];
+						cff_kind = (match c.ec_args, c.ec_params with
+							| [], [] -> FVar (c.ec_type,None)
+							| _ -> FFun { f_params = c.ec_params; f_type = c.ec_type; f_expr = None; f_args = List.map (fun (n,o,t) -> (n,null_pos),o,[],Some t,None) c.ec_args });
+					}
+				) (!constructs)
+			in
+			TypeloadFields.build_module_def ctx (TEnumDecl e) e.e_meta get_constructs context_init (fun (e,p) ->
+				match e with
+				| EVars [{ ev_type = Some (CTAnonymous fields,p); ev_expr = None }] ->
+					constructs := List.map (fun f ->
+						let args, params, t = (match f.cff_kind with
+						| FVar (t,None) -> [], [], t
+						| FFun { f_params = pl; f_type = t; f_expr = (None|Some (EBlock [],_)); f_args = al } ->
+							let al = List.map (fun ((n,_),o,_,t,_) -> match t with None -> typing_error "Missing function parameter type" f.cff_pos | Some t -> n,o,t) al in
+							al, pl, t
+						| _ ->
+							typing_error "Invalid enum constructor in @:build result" p
+						) in
+						{
+							ec_name = f.cff_name;
+							ec_doc = f.cff_doc;
+							ec_meta = f.cff_meta;
+							ec_pos = f.cff_pos;
+							ec_args = args;
+							ec_params = params;
+							ec_type = t;
+						}
+					) fields
+				| _ -> typing_error "Enum build macro must return a single variable with anonymous object fields" p
+			);
+			let et = TEnum (e,extract_param_types e.e_params) in
+			let names = ref [] in
+			let index = ref 0 in
+			let is_flat = ref true in
+			let fields = ref PMap.empty in
+			List.iter (fun c ->
+				if PMap.mem (fst c.ec_name) e.e_constrs then typing_error ("Duplicate constructor " ^ fst c.ec_name) (pos c.ec_name);
+				let f,cf = load_enum_field ctx e et is_flat index c in
+				e.e_constrs <- PMap.add f.ef_name f e.e_constrs;
+				fields := PMap.add cf.cf_name cf !fields;
+				incr index;
+				names := (fst c.ec_name) :: !names;
+				if Meta.has Meta.InheritDoc f.ef_meta then
+					delay ctx PConnectField (fun() -> InheritDoc.build_enum_field_doc ctx f);
+			) (!constructs);
+			e.e_names <- List.rev !names;
+			e.e_extern <- e.e_extern;
+			e.e_type.t_params <- e.e_params;
+			e.e_type.t_type <- mk_anon ~fields:!fields (ref (EnumStatics e));
+			if !is_flat then e.e_meta <- (Meta.FlatEnum,[],null_pos) :: e.e_meta;
+			if Meta.has Meta.InheritDoc e.e_meta then
+				delay ctx PConnectField (fun() -> InheritDoc.build_enum_doc ctx e);
+			if (ctx.com.platform = Java || ctx.com.platform = Cs) && not e.e_extern then
+				delay ctx PTypeField (fun () ->
+					let metas = StrictMeta.check_strict_meta ctx e.e_meta in
+					e.e_meta <- metas @ e.e_meta;
+					PMap.iter (fun _ ef ->
+						let metas = StrictMeta.check_strict_meta ctx ef.ef_meta in
+						if metas <> [] then ef.ef_meta <- metas @ ef.ef_meta
+					) e.e_constrs
+				);
+		| ETypedef d ->
+			let t = (match get_type (fst d.d_name) with TTypeDecl t -> t | _ -> die "" __LOC__) in
+			if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
+				DisplayEmitter.display_module_type ctx (TTypeDecl t) (pos d.d_name);
+			TypeloadCheck.check_global_metadata ctx t.t_meta (fun m -> t.t_meta <- m :: t.t_meta) t.t_module.m_path t.t_path None;
+			let ctx = { ctx with type_params = t.t_params } in
+			let tt = load_complex_type ctx true d.d_data in
+			let tt = (match fst d.d_data with
+			| CTExtend _ -> tt
+			| CTPath { tpackage = ["haxe";"macro"]; tname = "MacroType" } ->
+				(* we need to follow MacroType immediately since it might define other module types that we will load afterwards *)
+				if t.t_type == follow tt then typing_error "Recursive typedef is not allowed" p;
+				tt
+			| _ ->
+				if (Meta.has Meta.Eager d.d_meta) then
+					follow tt
+				else begin
+					let rec check_rec tt =
+						if tt == t.t_type then typing_error "Recursive typedef is not allowed" p;
+						match tt with
+						| TMono r ->
+							(match r.tm_type with
+							| None -> ()
+							| Some t -> check_rec t)
+						| TLazy f ->
+							check_rec (lazy_type f);
+						| TType (td,tl) ->
+							if td == t then typing_error "Recursive typedef is not allowed" p;
+							check_rec (apply_typedef td tl)
 						| _ ->
 							()
-					) a.a_meta;
-					a.a_impl <- Some c;
-					c.cl_kind <- KAbstractImpl a;
-					add_class_flag c CFinal;
-				| _ -> die "" __LOC__);
-				acc
-		) in
-		decl :: acc
-	in
-	let tdecls = List.fold_left make_decl [] tdecls in
-	let tdecls =
-		match !statics with
-		| [] ->
-			tdecls
-		| statics ->
-			let first_pos = ref null_pos in
-			let fields = List.map (fun (d,p) ->
-				first_pos := p;
-				field_of_static_definition d p;
-			) statics in
-			let p = let p = !first_pos in { p with pmax = p.pmin } in
-			let c = EClass {
-				d_name = (snd m.m_path) ^ "_Fields_", null_pos;
-				d_flags = [HPrivate];
-				d_data = List.rev fields;
-				d_doc = None;
-				d_params = [];
-				d_meta = []
-			} in
-			let tdecls = make_decl tdecls (c,p) in
-			(match !decls with
-			| (TClassDecl c,_) :: _ ->
-				assert (m.m_statics = None);
-				m.m_statics <- Some c;
-				c.cl_kind <- KModuleFields m;
-				add_class_flag c CFinal;
-			| _ -> assert false);
-			tdecls
-
-	in
-	let decls = List.rev !decls in
-	decls, List.rev tdecls
-
-let load_enum_field ctx e et is_flat index c =
-	let p = c.ec_pos in
-	let params = ref [] in
-	params := type_type_params ctx TPHEnumConstructor ([],fst c.ec_name) (fun() -> !params) c.ec_pos c.ec_params;
-	let params = !params in
-	let ctx = { ctx with type_params = params @ ctx.type_params } in
-	let rt = (match c.ec_type with
-		| None -> et
-		| Some (t,pt) ->
-			let t = load_complex_type ctx true (t,pt) in
-			(match follow t with
-			| TEnum (te,_) when te == e ->
-				()
-			| _ ->
-				typing_error "Explicit enum type must be of the same enum type" pt);
-			t
-	) in
-	let t = (match c.ec_args with
-		| [] -> rt
-		| l ->
-			is_flat := false;
-			let pnames = ref PMap.empty in
-			TFun (List.map (fun (s,opt,(t,tp)) ->
-				(match t with CTPath({tpackage=[];tname="Void"}) -> typing_error "Arguments of type Void are not allowed in enum constructors" tp | _ -> ());
-				if PMap.mem s (!pnames) then typing_error ("Duplicate argument `" ^ s ^ "` in enum constructor " ^ fst c.ec_name) p;
-				pnames := PMap.add s () (!pnames);
-				s, opt, load_type_hint ~opt ctx p (Some (t,tp))
-			) l, rt)
-	) in
-	let f = {
-		ef_name = fst c.ec_name;
-		ef_type = t;
-		ef_pos = p;
-		ef_name_pos = snd c.ec_name;
-		ef_doc = c.ec_doc;
-		ef_index = !index;
-		ef_params = params;
-		ef_meta = c.ec_meta;
-	} in
-	DeprecationCheck.check_is ctx.com f.ef_name f.ef_meta f.ef_name_pos;
-	let cf = {
-		(mk_field f.ef_name f.ef_type p f.ef_name_pos) with
-		cf_kind = (match follow f.ef_type with
-			| TFun _ -> Method MethNormal
-			| _ -> Var { v_read = AccNormal; v_write = AccNo }
-		);
-		cf_doc = f.ef_doc;
-		cf_params = f.ef_params;
-	} in
-	if ctx.is_display_file && DisplayPosition.display_position#enclosed_in f.ef_name_pos then
-		DisplayEmitter.display_enum_field ctx e f p;
-	f,cf
-
-(*
-	In this pass, we can access load and access other modules types, but we cannot follow them or access their structure
-	since they have not been setup. We also build a context_init list that will be evaluated the first time we evaluate
-	an expression into the context
-*)
-let init_module_type ctx context_init (decl,p) =
-	let get_type name =
-		try List.find (fun t -> snd (t_infos t).mt_path = name) ctx.m.curmod.m_types with Not_found -> die "" __LOC__
-	in
-	let check_path_display path p =
-		if DisplayPosition.display_position#is_in_file (ctx.com.file_keys#get p.pfile) then DisplayPath.handle_path_display ctx path p
-		in
-	match decl with
-	| EImport (path,mode) ->
-		begin try
-			check_path_display path p;
-			ImportHandling.init_import ctx context_init path mode p;
-			ImportHandling.commit_import ctx path mode p;
-		with Error(err,p) ->
-			display_error ctx.com (Error.error_msg err) p
-		end
-	| EUsing path ->
-		check_path_display path p;
-		ImportHandling.init_using ctx context_init path p
-	| EClass d ->
-		let c = (match get_type (fst d.d_name) with TClassDecl c -> c | _ -> die "" __LOC__) in
-		if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
-			DisplayEmitter.display_module_type ctx (match c.cl_kind with KAbstractImpl a -> TAbstractDecl a | _ -> TClassDecl c) (pos d.d_name);
-		TypeloadCheck.check_global_metadata ctx c.cl_meta (fun m -> c.cl_meta <- m :: c.cl_meta) c.cl_module.m_path c.cl_path None;
-		let herits = d.d_flags in
-		List.iter (fun (m,_,p) ->
-			if m = Meta.Final then begin
-				add_class_flag c CFinal;
-			end
-		) d.d_meta;
-		let prev_build_count = ref (!build_count - 1) in
-		let build() =
-			c.cl_build <- (fun()-> Building [c]);
-			let fl = TypeloadCheck.Inheritance.set_heritance ctx c herits p in
-			let rec build() =
-				c.cl_build <- (fun()-> Building [c]);
-				try
-					List.iter (fun f -> f()) fl;
-					TypeloadFields.init_class ctx c p context_init d.d_flags d.d_data;
-					c.cl_build <- (fun()-> Built);
-					incr build_count;
-					List.iter (fun tp -> ignore(follow tp.ttp_type)) c.cl_params;
-					Built;
-				with TypeloadCheck.Build_canceled state ->
-					c.cl_build <- make_pass ctx build;
-					let rebuild() =
-						delay_late ctx PBuildClass (fun() -> ignore(c.cl_build()));
 					in
-					(match state with
-					| Built -> die "" __LOC__
-					| Building cl ->
-						if !build_count = !prev_build_count then typing_error ("Loop in class building prevent compiler termination (" ^ String.concat "," (List.map (fun c -> s_type_path c.cl_path) cl) ^ ")") c.cl_pos;
-						prev_build_count := !build_count;
-						rebuild();
-						Building (c :: cl)
-					| BuildMacro f ->
-						f := rebuild :: !f;
-						state);
-				| exn ->
-					c.cl_build <- (fun()-> Built);
-					raise exn
-			in
-			build()
-		in
-		ctx.pass <- PBuildClass;
-		ctx.curclass <- c;
-		c.cl_build <- make_pass ctx build;
-		ctx.pass <- PBuildModule;
-		ctx.curclass <- null_class;
-		delay ctx PBuildClass (fun() -> ignore(c.cl_build()));
-		if Meta.has Meta.InheritDoc c.cl_meta then
-				delay ctx PConnectField (fun() -> InheritDoc.build_class_doc ctx c);
-		if (ctx.com.platform = Java || ctx.com.platform = Cs) && not (has_class_flag c CExtern) then
-			delay ctx PTypeField (fun () ->
-				let metas = StrictMeta.check_strict_meta ctx c.cl_meta in
-				if metas <> [] then c.cl_meta <- metas @ c.cl_meta;
-				let rec run_field cf =
-					let metas = StrictMeta.check_strict_meta ctx cf.cf_meta in
-					if metas <> [] then cf.cf_meta <- metas @ cf.cf_meta;
-					List.iter run_field cf.cf_overloads
-				in
-				List.iter run_field c.cl_ordered_statics;
-				List.iter run_field c.cl_ordered_fields;
-				match c.cl_constructor with
-					| Some f -> run_field f
-					| _ -> ()
-			);
-	| EEnum d ->
-		let e = (match get_type (fst d.d_name) with TEnumDecl e -> e | _ -> die "" __LOC__) in
-		if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
-			DisplayEmitter.display_module_type ctx (TEnumDecl e) (pos d.d_name);
-		let ctx = { ctx with type_params = e.e_params } in
-		let h = (try Some (Hashtbl.find ctx.g.type_patches e.e_path) with Not_found -> None) in
-		TypeloadCheck.check_global_metadata ctx e.e_meta (fun m -> e.e_meta <- m :: e.e_meta) e.e_module.m_path e.e_path None;
-		(match h with
-		| None -> ()
-		| Some (h,hcl) ->
-			Hashtbl.iter (fun _ _ -> typing_error "Field type patch not supported for enums" e.e_pos) h;
-			e.e_meta <- e.e_meta @ hcl.tp_meta);
-		let constructs = ref d.d_data in
-		let get_constructs() =
-			List.map (fun c ->
-				{
-					cff_name = c.ec_name;
-					cff_doc = c.ec_doc;
-					cff_meta = c.ec_meta;
-					cff_pos = c.ec_pos;
-					cff_access = [];
-					cff_kind = (match c.ec_args, c.ec_params with
-						| [], [] -> FVar (c.ec_type,None)
-						| _ -> FFun { f_params = c.ec_params; f_type = c.ec_type; f_expr = None; f_args = List.map (fun (n,o,t) -> (n,null_pos),o,[],Some t,None) c.ec_args });
-				}
-			) (!constructs)
-		in
-		TypeloadFields.build_module_def ctx (TEnumDecl e) e.e_meta get_constructs context_init (fun (e,p) ->
-			match e with
-			| EVars [{ ev_type = Some (CTAnonymous fields,p); ev_expr = None }] ->
-				constructs := List.map (fun f ->
-					let args, params, t = (match f.cff_kind with
-					| FVar (t,None) -> [], [], t
-					| FFun { f_params = pl; f_type = t; f_expr = (None|Some (EBlock [],_)); f_args = al } ->
-						let al = List.map (fun ((n,_),o,_,t,_) -> match t with None -> typing_error "Missing function parameter type" f.cff_pos | Some t -> n,o,t) al in
-						al, pl, t
-					| _ ->
-						typing_error "Invalid enum constructor in @:build result" p
-					) in
-					{
-						ec_name = f.cff_name;
-						ec_doc = f.cff_doc;
-						ec_meta = f.cff_meta;
-						ec_pos = f.cff_pos;
-						ec_args = args;
-						ec_params = params;
-						ec_type = t;
-					}
-				) fields
-			| _ -> typing_error "Enum build macro must return a single variable with anonymous object fields" p
-		);
-		let et = TEnum (e,extract_param_types e.e_params) in
-		let names = ref [] in
-		let index = ref 0 in
-		let is_flat = ref true in
-		let fields = ref PMap.empty in
-		List.iter (fun c ->
-			if PMap.mem (fst c.ec_name) e.e_constrs then typing_error ("Duplicate constructor " ^ fst c.ec_name) (pos c.ec_name);
-			let f,cf = load_enum_field ctx e et is_flat index c in
-			e.e_constrs <- PMap.add f.ef_name f e.e_constrs;
-			fields := PMap.add cf.cf_name cf !fields;
-			incr index;
-			names := (fst c.ec_name) :: !names;
-			if Meta.has Meta.InheritDoc f.ef_meta then
-				delay ctx PConnectField (fun() -> InheritDoc.build_enum_field_doc ctx f);
-		) (!constructs);
-		e.e_names <- List.rev !names;
-		e.e_extern <- e.e_extern;
-		e.e_type.t_params <- e.e_params;
-		e.e_type.t_type <- mk_anon ~fields:!fields (ref (EnumStatics e));
-		if !is_flat then e.e_meta <- (Meta.FlatEnum,[],null_pos) :: e.e_meta;
-		if Meta.has Meta.InheritDoc e.e_meta then
-			delay ctx PConnectField (fun() -> InheritDoc.build_enum_doc ctx e);
-		if (ctx.com.platform = Java || ctx.com.platform = Cs) && not e.e_extern then
-			delay ctx PTypeField (fun () ->
-				let metas = StrictMeta.check_strict_meta ctx e.e_meta in
-				e.e_meta <- metas @ e.e_meta;
-				PMap.iter (fun _ ef ->
-					let metas = StrictMeta.check_strict_meta ctx ef.ef_meta in
-					if metas <> [] then ef.ef_meta <- metas @ ef.ef_meta
-				) e.e_constrs
-			);
-	| ETypedef d ->
-		let t = (match get_type (fst d.d_name) with TTypeDecl t -> t | _ -> die "" __LOC__) in
-		if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
-			DisplayEmitter.display_module_type ctx (TTypeDecl t) (pos d.d_name);
-		TypeloadCheck.check_global_metadata ctx t.t_meta (fun m -> t.t_meta <- m :: t.t_meta) t.t_module.m_path t.t_path None;
-		let ctx = { ctx with type_params = t.t_params } in
-		let tt = load_complex_type ctx true d.d_data in
-		let tt = (match fst d.d_data with
-		| CTExtend _ -> tt
-		| CTPath { tpackage = ["haxe";"macro"]; tname = "MacroType" } ->
-			(* we need to follow MacroType immediately since it might define other module types that we will load afterwards *)
-			if t.t_type == follow tt then typing_error "Recursive typedef is not allowed" p;
-			tt
-		| _ ->
-			if (Meta.has Meta.Eager d.d_meta) then
-				follow tt
-			else begin
-				let rec check_rec tt =
-					if tt == t.t_type then typing_error "Recursive typedef is not allowed" p;
-					match tt with
-					| TMono r ->
-						(match r.tm_type with
-						| None -> ()
-						| Some t -> check_rec t)
-					| TLazy f ->
-						check_rec (lazy_type f);
-					| TType (td,tl) ->
-						if td == t then typing_error "Recursive typedef is not allowed" p;
-						check_rec (apply_typedef td tl)
-					| _ ->
-						()
-				in
-				let r = exc_protect ctx (fun r ->
-					r := lazy_processing (fun() -> tt);
-					check_rec tt;
-					tt
-				) "typedef_rec_check" in
-				TLazy r
-			end
-		) in
-		(match t.t_type with
-		| TMono r ->
-			(match r.tm_type with
-			| None -> Monomorph.bind r tt;
-			| Some _ -> die "" __LOC__);
-		| _ -> die "" __LOC__);
-		TypeloadFields.build_module_def ctx (TTypeDecl t) t.t_meta (fun _ -> []) context_init (fun _ -> ());
-		if ctx.com.platform = Cs && t.t_meta <> [] then
-			delay ctx PTypeField (fun () ->
-				let metas = StrictMeta.check_strict_meta ctx t.t_meta in
-				if metas <> [] then t.t_meta <- metas @ t.t_meta;
-			);
-	| EAbstract d ->
-		let a = (match get_type (fst d.d_name) with TAbstractDecl a -> a | _ -> die "" __LOC__) in
-		if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
-			DisplayEmitter.display_module_type ctx (TAbstractDecl a) (pos d.d_name);
-		TypeloadCheck.check_global_metadata ctx a.a_meta (fun m -> a.a_meta <- m :: a.a_meta) a.a_module.m_path a.a_path None;
-		let ctx = { ctx with type_params = a.a_params } in
-		let is_type = ref false in
-		let load_type t from =
-			let _, pos = t in
-			let t = load_complex_type ctx true t in
-			let t = if not (Meta.has Meta.CoreType a.a_meta) then begin
-				if !is_type then begin
 					let r = exc_protect ctx (fun r ->
-						r := lazy_processing (fun() -> t);
-						(try (if from then Type.unify t a.a_this else Type.unify a.a_this t) with Unify_error _ -> typing_error "You can only declare from/to with compatible types" pos);
-						t
-					) "constraint" in
+						r := lazy_processing (fun() -> tt);
+						check_rec tt;
+						tt
+					) "typedef_rec_check" in
 					TLazy r
-				end else
-					typing_error "Missing underlying type declaration or @:coreType declaration" p;
-			end else begin
-				if Meta.has Meta.Callable a.a_meta then
-					typing_error "@:coreType abstracts cannot be @:callable" p;
-				t
-			end in
-			t
-		in
-		List.iter (function
-			| AbFrom t -> a.a_from <- (load_type t true) :: a.a_from
-			| AbTo t -> a.a_to <- (load_type t false) :: a.a_to
-			| AbOver t ->
-				if a.a_impl = None then typing_error "Abstracts with underlying type must have an implementation" a.a_pos;
-				if Meta.has Meta.CoreType a.a_meta then typing_error "@:coreType abstracts cannot have an underlying type" p;
-				let at = load_complex_type ctx true t in
-				delay ctx PForce (fun () ->
-					let rec loop stack t =
-						match follow t with
-						| TAbstract(a,_) when not (Meta.has Meta.CoreType a.a_meta) ->
-							if List.memq a stack then
-								typing_error "Abstract underlying type cannot be recursive" a.a_pos
-							else
-								loop (a :: stack) a.a_this
-						| _ -> ()
-					in
-					loop [] at
+				end
+			) in
+			(match t.t_type with
+			| TMono r ->
+				(match r.tm_type with
+				| None -> Monomorph.bind r tt;
+				| Some _ -> die "" __LOC__);
+			| _ -> die "" __LOC__);
+			TypeloadFields.build_module_def ctx (TTypeDecl t) t.t_meta (fun _ -> []) context_init (fun _ -> ());
+			if ctx.com.platform = Cs && t.t_meta <> [] then
+				delay ctx PTypeField (fun () ->
+					let metas = StrictMeta.check_strict_meta ctx t.t_meta in
+					if metas <> [] then t.t_meta <- metas @ t.t_meta;
 				);
-				a.a_this <- at;
-				is_type := true;
-			| AbExtern ->
-				(match a.a_impl with Some c -> add_class_flag c CExtern | None -> (* Hmmmm.... *) ())
-			| AbPrivate | AbEnum -> ()
-		) d.d_flags;
-		a.a_from <- List.rev a.a_from;
-		a.a_to <- List.rev a.a_to;
-		if not !is_type then begin
-			if Meta.has Meta.CoreType a.a_meta then
-				a.a_this <- TAbstract(a,extract_param_types a.a_params)
-			else
-				typing_error "Abstract is missing underlying type declaration" a.a_pos
-		end;
-		if Meta.has Meta.InheritDoc a.a_meta then
-			delay ctx PConnectField (fun() -> InheritDoc.build_abstract_doc ctx a);
-	| EStatic _ ->
-		(* nothing to do here as module fields are collected into a special EClass *)
-		()
-
-let module_pass_2 ctx m decls tdecls p =
-	(* here is an additional PASS 1 phase, which define the type parameters for all module types.
-		 Constraints are handled lazily (no other type is loaded) because they might be recursive anyway *)
-	List.iter (fun d ->
-		match d with
-		| (TClassDecl c, (EClass d, p)) ->
-			c.cl_params <- type_type_params ctx TPHType c.cl_path (fun() -> c.cl_params) p d.d_params;
-			if Meta.has Meta.Generic c.cl_meta && c.cl_params <> [] then c.cl_kind <- KGeneric;
-			if Meta.has Meta.GenericBuild c.cl_meta then begin
-				if ctx.com.is_macro_context then typing_error "@:genericBuild cannot be used in macros" c.cl_pos;
-				c.cl_kind <- KGenericBuild d.d_data;
+		| EAbstract d ->
+			let a = (match get_type (fst d.d_name) with TAbstractDecl a -> a | _ -> die "" __LOC__) in
+			if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
+				DisplayEmitter.display_module_type ctx (TAbstractDecl a) (pos d.d_name);
+			TypeloadCheck.check_global_metadata ctx a.a_meta (fun m -> a.a_meta <- m :: a.a_meta) a.a_module.m_path a.a_path None;
+			let ctx = { ctx with type_params = a.a_params } in
+			let is_type = ref false in
+			let load_type t from =
+				let _, pos = t in
+				let t = load_complex_type ctx true t in
+				let t = if not (Meta.has Meta.CoreType a.a_meta) then begin
+					if !is_type then begin
+						let r = exc_protect ctx (fun r ->
+							r := lazy_processing (fun() -> t);
+							(try (if from then Type.unify t a.a_this else Type.unify a.a_this t) with Unify_error _ -> typing_error "You can only declare from/to with compatible types" pos);
+							t
+						) "constraint" in
+						TLazy r
+					end else
+						typing_error "Missing underlying type declaration or @:coreType declaration" p;
+				end else begin
+					if Meta.has Meta.Callable a.a_meta then
+						typing_error "@:coreType abstracts cannot be @:callable" p;
+					t
+				end in
+				t
+			in
+			List.iter (function
+				| AbFrom t -> a.a_from <- (load_type t true) :: a.a_from
+				| AbTo t -> a.a_to <- (load_type t false) :: a.a_to
+				| AbOver t ->
+					if a.a_impl = None then typing_error "Abstracts with underlying type must have an implementation" a.a_pos;
+					if Meta.has Meta.CoreType a.a_meta then typing_error "@:coreType abstracts cannot have an underlying type" p;
+					let at = load_complex_type ctx true t in
+					delay ctx PForce (fun () ->
+						let rec loop stack t =
+							match follow t with
+							| TAbstract(a,_) when not (Meta.has Meta.CoreType a.a_meta) ->
+								if List.memq a stack then
+									typing_error "Abstract underlying type cannot be recursive" a.a_pos
+								else
+									loop (a :: stack) a.a_this
+							| _ -> ()
+						in
+						loop [] at
+					);
+					a.a_this <- at;
+					is_type := true;
+				| AbExtern ->
+					(match a.a_impl with Some c -> add_class_flag c CExtern | None -> (* Hmmmm.... *) ())
+				| AbPrivate | AbEnum -> ()
+			) d.d_flags;
+			a.a_from <- List.rev a.a_from;
+			a.a_to <- List.rev a.a_to;
+			if not !is_type then begin
+				if Meta.has Meta.CoreType a.a_meta then
+					a.a_this <- TAbstract(a,extract_param_types a.a_params)
+				else
+					typing_error "Abstract is missing underlying type declaration" a.a_pos
 			end;
-			if c.cl_path = (["haxe";"macro"],"MacroType") then c.cl_kind <- KMacroType;
-		| (TEnumDecl e, (EEnum d, p)) ->
-			e.e_params <- type_type_params ctx TPHType e.e_path (fun() -> e.e_params) p d.d_params;
-		| (TTypeDecl t, (ETypedef d, p)) ->
-			t.t_params <- type_type_params ctx TPHType t.t_path (fun() -> t.t_params) p d.d_params;
-		| (TAbstractDecl a, (EAbstract d, p)) ->
-			a.a_params <- type_type_params ctx TPHType a.a_path (fun() -> a.a_params) p d.d_params;
-		| _ ->
-			die "" __LOC__
-	) decls;
-	(* setup module types *)
-	let context_init = new TypeloadFields.context_init in
-	List.iter (init_module_type ctx context_init) tdecls;
-	(* Make sure that we actually init the context at some point (issue #9012) *)
-	delay ctx PConnectField (fun () -> context_init#run)
+			if Meta.has Meta.InheritDoc a.a_meta then
+				delay ctx PConnectField (fun() -> InheritDoc.build_abstract_doc ctx a);
+		| EStatic _ ->
+			(* nothing to do here as module fields are collected into a special EClass *)
+			()
+end
 
-(*
-	Creates a module context for [m] and types [tdecls] using it.
-*)
-let type_types_into_module ?(check=true) ctx m tdecls p =
-	let decls, tdecls = module_pass_1 ctx m tdecls p in
-	let types = List.map fst decls in
-	if check then List.iter (TypeloadCheck.check_module_types ctx m p) types;
-	m.m_types <- m.m_types @ types;
-	(* define the per-module context for the next pass *)
-	let ctx = {
+let create_typer_context_for_module ctx m = {
 		com = ctx.com;
 		g = ctx.g;
-		t = ctx.t;
+		t = ctx.com.basic;
 		m = {
 			curmod = m;
 			module_imports = List.map (fun t -> t,null_pos) ctx.g.std.m_types;
@@ -821,12 +706,11 @@ let type_types_into_module ?(check=true) ctx m tdecls p =
 		call_argument_stack = [];
 		pass = PBuildModule;
 		get_build_infos = (fun() -> None);
-		on_error = (fun ctx msg p -> ctx.com.error msg p);
-		macro_depth = ctx.macro_depth;
+		macro_depth = 0;
 		curclass = null_class;
 		curfield = null_field;
-		tthis = ctx.tthis;
-		ret = ctx.ret;
+		tthis = mk_mono();
+		ret = mk_mono();
 		locals = PMap.empty;
 		type_params = [];
 		curfun = FunStatic;
@@ -843,67 +727,38 @@ let type_types_into_module ?(check=true) ctx m tdecls p =
 		};
 		vthis = None;
 		memory_marker = Typecore.memory_marker;
-	} in
+	}
+
+(*
+	Creates a module context for [m] and types [tdecls] using it.
+*)
+let type_types_into_module ?(check=true) ctx m tdecls p =
+	let ctx = create_typer_context_for_module ctx m in
+	let decls,tdecls = ModuleLevel.create_module_types ctx m tdecls p in
+	let types = List.map fst decls in
+	if check then List.iter (TypeloadCheck.check_module_types ctx m p) types;
+	m.m_types <- m.m_types @ types;
+	(* define the per-module context for the next pass *)
 	if ctx.g.std != null_module then begin
 		add_dependency m ctx.g.std;
 		(* this will ensure both String and (indirectly) Array which are basic types which might be referenced *)
 		ignore(load_core_type ctx "String");
 	end;
-	module_pass_2 ctx m decls tdecls p;
+	ModuleLevel.init_type_params ctx decls;
+	(* setup module types *)
+	let context_init = new TypeloadFields.context_init in
+	List.iter (TypeLevel.init_module_type ctx context_init) tdecls;
+	(* Make sure that we actually init the context at some point (issue #9012) *)
+	delay ctx PConnectField (fun () -> context_init#run);
 	ctx
-
-let handle_import_hx ctx m decls p =
-	let path_split = match List.rev (Path.get_path_parts (Path.UniqueKey.lazy_path m.m_extra.m_file)) with
-		| [] -> []
-		| _ :: l -> l
-	in
-	let join l = String.concat Path.path_sep (List.rev ("import.hx" :: l)) in
-	let rec loop path pack = match path,pack with
-		| _,[] -> [join path]
-		| (p :: path),(_ :: pack) -> (join (p :: path)) :: (loop path pack)
-		| _ -> []
-	in
-	let candidates = loop path_split (fst m.m_path) in
-	let make_import_module path r =
-		Hashtbl.replace ctx.com.parser_cache path r;
-		(* We use the file path as module name to make it unique. This may or may not be a good idea... *)
-		let m_import = make_module ctx ([],path) path p in
-		m_import.m_extra.m_kind <- MImport;
-		add_module ctx m_import p;
-		m_import
-	in
-	List.fold_left (fun acc path ->
-		let decls = try
-			let r = Hashtbl.find ctx.com.parser_cache path in
-			let mimport = Hashtbl.find ctx.g.modules ([],path) in
-			if mimport.m_extra.m_kind <> MFake then add_dependency m mimport;
-			r
-		with Not_found ->
-			if Sys.file_exists path then begin
-				let _,r = match !TypeloadParse.parse_hook ctx.com path p with
-					| ParseSuccess(data,_,_) -> data
-					| ParseError(_,(msg,p),_) -> Parser.error msg p
-				in
-				List.iter (fun (d,p) -> match d with EImport _ | EUsing _ -> () | _ -> typing_error "Only import and using is allowed in import.hx files" p) r;
-				add_dependency m (make_import_module path r);
-				r
-			end else begin
-				let r = [] in
-				(* Add empty decls so we don't check the file system all the time. *)
-				(make_import_module path r).m_extra.m_kind <- MFake;
-				r
-			end
-		in
-		decls @ acc
-	) decls candidates
 
 (*
 	Creates a new module and types [tdecls] into it.
 *)
 let type_module ctx mpath file ?(dont_check_path=false) ?(is_extern=false) tdecls p =
-	let m = make_module ctx mpath file p in
+	let m = ModuleLevel.make_module ctx mpath file p in
 	Hashtbl.add ctx.g.modules m.m_path m;
-	let tdecls = handle_import_hx ctx m tdecls p in
+	let tdecls = ModuleLevel.handle_import_hx ctx m tdecls p in
 	let ctx = type_types_into_module ctx m tdecls p in
 	if is_extern then m.m_extra.m_kind <- MExtern else if not dont_check_path then Typecore.check_module_path ctx m.m_path p;
 	m
@@ -914,8 +769,8 @@ let type_module ctx mpath file ?(dont_check_path=false) ?(is_extern=false) tdecl
 
 let type_module_hook = ref (fun _ _ _ -> None)
 
-let load_module ctx m p =
-	let m2 = (try
+let load_module' ctx g m p =
+	try
 		Hashtbl.find ctx.g.modules m
 	with
 		Not_found ->
@@ -942,7 +797,9 @@ let load_module ctx m p =
 				type_module ctx m file ~is_extern decls p
 			with Forbid_package (inf,pl,pf) when p <> null_pos ->
 				raise (Forbid_package (inf,p::pl,pf))
-	) in
+
+let load_module ctx m p =
+	let m2 = load_module' ctx ctx.g m p in
 	add_dependency ctx.m.curmod m2;
 	if ctx.pass = PTypeField then flush_pass ctx PConnectField "load_module";
 	m2

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -57,7 +57,7 @@ module ModuleLevel = struct
 
 	let add_module ctx m p =
 		List.iter (TypeloadCheck.check_module_types ctx m p) m.m_types;
-		Hashtbl.add ctx.g.modules m.m_path m
+		Hashtbl.add ctx.com.module_lut m.m_path m
 
 	(*
 		Build module structure : should be atomic - no type loading is possible
@@ -293,7 +293,7 @@ module ModuleLevel = struct
 		List.fold_left (fun acc path ->
 			let decls = try
 				let r = Hashtbl.find com.parser_cache path in
-				let mimport = Hashtbl.find ctx.g.modules ([],path) in
+				let mimport = Hashtbl.find com.module_lut ([],path) in
 				if mimport.m_extra.m_kind <> MFake then add_dependency m mimport;
 				r
 			with Not_found ->
@@ -757,7 +757,7 @@ let type_types_into_module ?(check=true) ctx m tdecls p =
 *)
 let type_module ctx mpath file ?(dont_check_path=false) ?(is_extern=false) tdecls p =
 	let m = ModuleLevel.make_module ctx mpath file p in
-	Hashtbl.add ctx.g.modules m.m_path m;
+	Hashtbl.add ctx.com.module_lut m.m_path m;
 	let tdecls = ModuleLevel.handle_import_hx ctx m tdecls p in
 	let ctx = type_types_into_module ctx m tdecls p in
 	if is_extern then m.m_extra.m_kind <- MExtern else if not dont_check_path then Typecore.check_module_path ctx m.m_path p;
@@ -771,7 +771,7 @@ let type_module_hook = ref (fun _ _ _ -> None)
 
 let load_module' ctx g m p =
 	try
-		Hashtbl.find ctx.g.modules m
+		Hashtbl.find ctx.com.module_lut m
 	with
 		Not_found ->
 			match !type_module_hook ctx m p with

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2011,7 +2011,6 @@ let rec create com =
 		monomorphs = {
 			perfunction = [];
 		};
-		on_error = (fun ctx msg p -> ctx.com.error msg p);
 		memory_marker = Typecore.memory_marker;
 	} in
 	ctx.g.std <- (try

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -516,7 +516,7 @@ and handle_efield ctx e p0 mode with_type =
 							in
 							let pack,name,sub,p = loop [] None path in
 							let mpath = (pack,name) in
-							if Hashtbl.mem ctx.g.modules mpath then
+							if Hashtbl.mem ctx.com.module_lut mpath then
 								let tname = Option.default name sub in
 								raise (Error (Type_not_found (mpath,tname,Not_defined),p))
 							else
@@ -1949,8 +1949,6 @@ let rec create com =
 		g = {
 			core_api = None;
 			macros = None;
-			modules = Hashtbl.create 0;
-			types_module = Hashtbl.create 0;
 			type_patches = Hashtbl.create 0;
 			global_metadata = [];
 			module_check_policies = [];


### PR DESCRIPTION
This mostly just moves more things around. The main change is that we move two lookups from `typer_globals` to `Common.context`:

1. `g.modules` is now `com.module_lut`
2. `g.types_module` is now `com.type_to_module`

I don't see why these should live on the typer because it's global information, and I've been in various situations where I want these lookups to be available after typing anyway. We should also be able to remove the rogue `load_instance` I found in post-processing with this.

My vision is that we maintain one common context, and "work on it" with different typer contexts. If this is designed properly, we can attempt some typing and if that goes wrong, reset our global state to some extent. This is likely only possible at module-level due to type-inference, but that would already be a huge step towards a more modifiable cache.