### PR TITLE
Unify compiler messages and diagnostics

### DIFF
--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -36,7 +36,7 @@ type communication = {
 
 and compilation_context = {
 	com : Common.context;
-	mutable messages : Common.compiler_message list;
+	mutable messages : compiler_message list;
 	mutable has_next : bool;
 	mutable has_error : bool;
 	comm : communication;
@@ -65,5 +65,5 @@ let message ctx msg =
 	ctx.messages <- msg :: ctx.messages
 
 let error ctx msg p =
-	message ctx (CMError(msg,p));
+	message ctx (msg,p,DKCompilerMessage,Error);
 	ctx.has_error <- true

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -95,7 +95,7 @@ let process_display_configuration ctx =
 		com.warning <- (fun w options s p ->
 			match Warning.get_mode w (com.warning_options @ options) with
 			| WMEnable ->
-				add_diagnostics_message com s p DKCompilerError DisplayTypes.DiagnosticsSeverity.Warning
+				add_diagnostics_message com s p DKCompilerMessage Warning
 			| WMDisable ->
 				()
 		);

--- a/src/context/display/diagnostics.ml
+++ b/src/context/display/diagnostics.ml
@@ -43,10 +43,10 @@ let find_unused_variables com e =
 let check_other_things com e =
 	let had_effect = ref false in
 	let no_effect p =
-		add_diagnostics_message com "This code has no effect" p DKCompilerError DiagnosticsSeverity.Warning;
+		add_diagnostics_message com "This code has no effect" p DKCompilerMessage Warning;
 	in
 	let pointless_compound s p =
-		add_diagnostics_message com (Printf.sprintf "This %s has no effect, but some of its sub-expressions do" s) p DKCompilerError DiagnosticsSeverity.Warning;
+		add_diagnostics_message com (Printf.sprintf "This %s has no effect, but some of its sub-expressions do" s) p DKCompilerMessage Warning;
 	in
 	let rec compound s el p =
 		let old = !had_effect in
@@ -143,7 +143,7 @@ let prepare com =
 		unresolved_identifiers = [];
 		missing_fields = PMap.empty;
 	} in
-	if not (List.exists (fun (_,_,_,sev) -> sev = DiagnosticsSeverity.Error) com.shared.shared_display_information.diagnostics_messages) then
+	if not (List.exists (fun (_,_,_,sev) -> sev = MessageSeverity.Error) com.shared.shared_display_information.diagnostics_messages) then
 		collect_diagnostics dctx com;
 	let process_modules com =
 		List.iter (fun m ->

--- a/src/core/displayTypes.ml
+++ b/src/core/displayTypes.ml
@@ -63,42 +63,6 @@ module SymbolInformation = struct
 	}
 end
 
-module DiagnosticsSeverity = struct
-	type t =
-		| Error
-		| Warning
-		| Information
-		| Hint
-
-	let to_int = function
-		| Error -> 1
-		| Warning -> 2
-		| Information -> 3
-		| Hint -> 4
-end
-
-module DiagnosticsKind = struct
-	type t =
-		| DKUnusedImport
-		| DKUnresolvedIdentifier
-		| DKCompilerError
-		| DKRemovableCode
-		| DKParserError
-		| DKDeprecationWarning
-		| DKInactiveBlock
-		| DKMissingFields
-
-	let to_int = function
-		| DKUnusedImport -> 0
-		| DKUnresolvedIdentifier -> 1
-		| DKCompilerError -> 2
-		| DKRemovableCode -> 3
-		| DKParserError -> 4
-		| DKDeprecationWarning -> 5
-		| DKInactiveBlock -> 6
-		| DKMissingFields -> 7
-end
-
 module CompletionResultKind = struct
 	type expected_type_completion = {
 		expected_type : CompletionItem.CompletionType.t;
@@ -368,7 +332,7 @@ type diagnostics_context = {
 	mutable import_positions : (pos,bool ref) PMap.t;
 	mutable dead_blocks : (Path.UniqueKey.t,(pos * expr) list) Hashtbl.t;
 	mutable unresolved_identifiers : (string * pos * (string * CompletionItem.t * int) list) list;
-	mutable diagnostics_messages : (string * pos * DiagnosticsKind.t * DiagnosticsSeverity.t) list;
+	mutable diagnostics_messages : (string * pos * MessageKind.t * MessageSeverity.t) list;
 	mutable missing_fields : (pos,(module_type * (missing_fields_diagnostics list ref))) PMap.t;
 }
 

--- a/src/core/globals.ml
+++ b/src/core/globals.ml
@@ -115,3 +115,41 @@ let die ?p msg ml_loc =
 	and os_type = if Sys.unix then "unix" else "windows" in
 	Printf.eprintf "%s\nHaxe: %s; OS type: %s;\n%s\n%s" msg ver os_type ml_loc backtrace;
 	assert false
+
+module MessageSeverity = struct
+	type t =
+		| Error
+		| Warning
+		| Information
+		| Hint
+
+	let to_int = function
+		| Error -> 1
+		| Warning -> 2
+		| Information -> 3
+		| Hint -> 4
+end
+
+module MessageKind = struct
+	type t =
+		| DKUnusedImport
+		| DKUnresolvedIdentifier
+		| DKCompilerMessage
+		| DKRemovableCode
+		| DKParserError
+		| DKDeprecationWarning
+		| DKInactiveBlock
+		| DKMissingFields
+
+	let to_int = function
+		| DKUnusedImport -> 0
+		| DKUnresolvedIdentifier -> 1
+		| DKCompilerMessage -> 2
+		| DKRemovableCode -> 3
+		| DKParserError -> 4
+		| DKDeprecationWarning -> 5
+		| DKInactiveBlock -> 6
+		| DKMissingFields -> 7
+end
+
+type compiler_message = string * pos * MessageKind.t * MessageSeverity.t

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -375,11 +375,11 @@ and encode_display_kind dk =
 	in
 	encode_enum ~pos:None IDisplayKind tag pl
 
-and encode_message msg =
-	let tag, pl = match msg with
-		| CMInfo(msg,p) -> 0, [(encode_string msg); (encode_pos p)]
-		| CMWarning(msg,p) -> 1, [(encode_string msg); (encode_pos p)]
-		| CMError(_,_) -> Globals.die "" __LOC__
+and encode_message (msg,p,_,sev) =
+	let tag, pl = match sev with
+		| Globals.MessageSeverity.Information -> 0, [(encode_string msg); (encode_pos p)]
+		| Warning | Hint -> 1, [(encode_string msg); (encode_pos p)]
+		| Error -> Globals.die "" __LOC__
 	in
 	encode_enum ~pos:None IMessage tag pl
 

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -22,7 +22,6 @@
 open Globals
 open Ast
 open Parser
-open DisplayTypes.DiagnosticsSeverity
 open DisplayTypes.DisplayMode
 open Common
 open Type


### PR DESCRIPTION
With this change, `compiler_message` now lives on globals.ml and uses the ADTs that were previously used for diagnostics. This way we no longer need two separate message data structures. Also, `DKCompilerError` is now `DKCompilerMessage` because that's what it always has been anyway.

`CMError(msg,p)` -> `(msg,p,DKCompilerMessage,Error)`
`CMInfo(msg,p)` -> `(msg,p,DKCompilerMessage,Information)`
`CMWarning(msg,p)` -> `(msg,p,DKCompilerMessage,Warning)`

There shouldn't be any visible changes here to the exposed Context API.