### PR TITLE
Move warning list to prebuild

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -1,0 +1,88 @@
+[
+	{
+		"name": "WInternal",
+		"code": 0,
+		"doc": "Reserved for internal use"
+	},
+	{
+		"name": "WTemp",
+		"code": 1,
+		"doc": "Reserved for internal use"
+	},
+	{
+		"name": "WInfo",
+		"code": 2,
+		"doc": "Generic information like $type"
+	},
+	{
+		"name": "WUser",
+		"code": 3,
+		"doc": "Custom user warnings, e.g. from Context.warning"
+	},
+	{
+		"name": "WCompiler",
+		"code": 1000,
+		"doc": "Warnings from the compiler frontend, e.g. argument parsing"
+	},
+	{
+		"name": "WParser",
+		"code": 2000,
+		"doc": "Warnings related to lexing and parsing"
+	},
+	{
+		"name": "WTyper",
+		"code": 3000,
+		"doc": "Warnings from the typer"
+	},
+	{
+		"name": "WMacro",
+		"code": 4000,
+		"doc": "Warning related to macros"
+	},
+	{
+		"name": "WOptimizer",
+		"code": 5000,
+		"doc": "Warnings related to optimization"
+	},
+	{
+		"name": "WGenerator",
+		"code": 6000,
+		"doc": "Warnings related to code generation"
+	},
+	{
+		"name": "WDeprecated",
+		"code": 3001,
+		"doc": "This is deprecated and should no longer be used"
+	},
+	{
+		"name": "WVarInit",
+		"code": 3002,
+		"doc": "A local variable might be used before being assigned a value"
+	},
+	{
+		"name": "WVarShadow",
+		"code": 3003,
+		"doc": "A local variable hides another by using the same name"
+	},
+	{
+		"name": "WExternWithExpr",
+		"code": 3004,
+		"doc": "A non-inline field marked as extern has an expression"
+	},
+	{
+		"name": "WStaticInitOrder",
+		"code": 3005,
+		"doc": "The compiler could not determine a type order due to mutually dependent static initializations"
+	},
+	{
+		"name": "WClosureCompare",
+		"code": 3006,
+		"doc": "Closures are being compared, which might be undefined"
+	},
+	{
+		"name": "WReservedTypePath",
+		"code": 3007,
+		"doc": "A type path is being used that is supposed to be reserved on the current target"
+	}
+
+]

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -1,108 +1,107 @@
 [
 	{
+		"name": "WAll",
+		"doc": "The mother of all warnings",
+		"generic": true
+	},
+	{
 		"name": "WInternal",
-		"code": 0,
 		"doc": "Reserved for internal use",
 		"generic": true
 	},
 	{
 		"name": "WTemp",
-		"code": 1,
 		"doc": "Reserved for internal use",
 		"generic": true
 	},
 	{
 		"name": "WInfo",
-		"code": 2,
 		"doc": "Generic information like $type",
 		"generic": true
 	},
 	{
 		"name": "WUser",
-		"code": 3,
 		"doc": "Custom user warnings, e.g. from Context.warning",
 		"generic": true
 	},
 	{
 		"name": "WCompiler",
-		"code": 1000,
 		"doc": "Warnings from the compiler frontend, e.g. argument parsing",
 		"generic": true
 	},
 	{
 		"name": "WParser",
-		"code": 2000,
 		"doc": "Warnings related to lexing and parsing",
 		"generic": true
 	},
 	{
 		"name": "WTyper",
-		"code": 3000,
 		"doc": "Warnings from the typer",
 		"generic": true
 	},
 	{
 		"name": "WMacro",
-		"code": 4000,
 		"doc": "Warning related to macros",
 		"generic": true
 	},
 	{
 		"name": "WOptimizer",
-		"code": 5000,
 		"doc": "Warnings related to optimization",
 		"generic": true
 	},
 	{
 		"name": "WGenerator",
-		"code": 6000,
 		"doc": "Warnings related to code generation",
 		"generic": true
 	},
 	{
 		"name": "WDeprecated",
-		"code": 3001,
 		"doc": "This is deprecated and should no longer be used"
 	},
 	{
 		"name": "WVarInit",
-		"code": 3002,
-		"doc": "A local variable might be used before being assigned a value"
+		"doc": "A local variable might be used before being assigned a value",
+		"parent": "WTyper"
 	},
 	{
 		"name": "WVarShadow",
-		"code": 3003,
-		"doc": "A local variable hides another by using the same name"
+		"doc": "A local variable hides another by using the same name",
+		"parent": "WTyper"
 	},
 	{
 		"name": "WExternWithExpr",
-		"code": 3004,
-		"doc": "A non-inline field marked as extern has an expression"
+		"doc": "A non-inline field marked as extern has an expression",
+		"parent": "WTyper"
 	},
 	{
 		"name": "WStaticInitOrder",
-		"code": 3005,
-		"doc": "The compiler could not determine a type order due to mutually dependent static initializations"
+		"doc": "The compiler could not determine a type order due to mutually dependent static initializations",
+		"parent": "WTyper"
 	},
 	{
 		"name": "WClosureCompare",
-		"code": 3006,
-		"doc": "Closures are being compared, which might be undefined"
+		"doc": "Closures are being compared, which might be undefined",
+		"parent": "WTyper"
 	},
 	{
 		"name": "WReservedTypePath",
-		"code": 3007,
-		"doc": "A type path is being used that is supposed to be reserved on the current target"
+		"doc": "A type path is being used that is supposed to be reserved on the current target",
+		"parent": "WTyper"
+	},
+	{
+		"name": "WPatternMatcher",
+		"doc": "Warnings related to the pattern matcher",
+		"parent": "WTyper"
 	},
 	{
 		"name": "WUnusedPattern",
-		"code": 3008,
-		"doc": "The pattern is not used because previous cases cover"
+		"doc": "The pattern is not used because previous cases cover",
+		"parent": "WPatternMatcher"
 	},
 	{
 		"name": "WConstructorInliningCancelled",
-		"code": 3009,
-		"doc": "Constructor call could not be inlined because a field is uninitialized"
+		"doc": "Constructor call could not be inlined because a field is uninitialized",
+		"parent": "WTyper"
 	}
 
 ]

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -93,6 +93,16 @@
 		"name": "WReservedTypePath",
 		"code": 3007,
 		"doc": "A type path is being used that is supposed to be reserved on the current target"
+	},
+	{
+		"name": "WUnusedPattern",
+		"code": 3008,
+		"doc": "The pattern is not used because previous cases cover"
+	},
+	{
+		"name": "WConstructorInliningCancelled",
+		"code": 3009,
+		"doc": "Constructor call could not be inlined because a field is uninitialized"
 	}
 
 ]

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -2,52 +2,62 @@
 	{
 		"name": "WInternal",
 		"code": 0,
-		"doc": "Reserved for internal use"
+		"doc": "Reserved for internal use",
+		"generic": true
 	},
 	{
 		"name": "WTemp",
 		"code": 1,
-		"doc": "Reserved for internal use"
+		"doc": "Reserved for internal use",
+		"generic": true
 	},
 	{
 		"name": "WInfo",
 		"code": 2,
-		"doc": "Generic information like $type"
+		"doc": "Generic information like $type",
+		"generic": true
 	},
 	{
 		"name": "WUser",
 		"code": 3,
-		"doc": "Custom user warnings, e.g. from Context.warning"
+		"doc": "Custom user warnings, e.g. from Context.warning",
+		"generic": true
 	},
 	{
 		"name": "WCompiler",
 		"code": 1000,
-		"doc": "Warnings from the compiler frontend, e.g. argument parsing"
+		"doc": "Warnings from the compiler frontend, e.g. argument parsing",
+		"generic": true
 	},
 	{
 		"name": "WParser",
 		"code": 2000,
-		"doc": "Warnings related to lexing and parsing"
+		"doc": "Warnings related to lexing and parsing",
+		"generic": true
 	},
 	{
 		"name": "WTyper",
 		"code": 3000,
-		"doc": "Warnings from the typer"
+		"doc": "Warnings from the typer",
+		"generic": true
 	},
 	{
 		"name": "WMacro",
 		"code": 4000,
-		"doc": "Warning related to macros"
+		"doc": "Warning related to macros",
+		"generic": true
 	},
 	{
 		"name": "WOptimizer",
 		"code": 5000,
-		"doc": "Warnings related to optimization"
+		"doc": "Warnings related to optimization",
+		"generic": true
 	},
 	{
 		"name": "WGenerator",
 		"code": 6000,
-		"doc": "Warnings related to code generation"
+		"doc": "Warnings related to code generation",
+		"generic": true
 	},
 	{
 		"name": "WDeprecated",

--- a/src/codegen/gencommon/castDetect.ml
+++ b/src/codegen/gencommon/castDetect.ml
@@ -767,12 +767,12 @@ let handle_type_parameter gen e e1 ef ~clean_ef ~overloads_cast_to_base f elist 
 						| [Cannot_unify (b, TAbstract(a,params))] ->
 							let a = apply_params a.a_params params a.a_this in
 							if not (shallow_eq a b) then
-								gen.gwarning WGencommon ("This expression may be invalid") pos
+								gen.gwarning WGenerator ("This expression may be invalid") pos
 						| _ ->
-							gen.gwarning WGencommon ("This expression may be invalid") pos
+							gen.gwarning WGenerator ("This expression may be invalid") pos
 						)
 				| Invalid_argument _ ->
-						gen.gwarning WGencommon ("This expression may be invalid") pos
+						gen.gwarning WGenerator ("This expression may be invalid") pos
 			);
 
 			List.map (fun t ->
@@ -824,7 +824,7 @@ let handle_type_parameter gen e e1 ef ~clean_ef ~overloads_cast_to_base f elist 
 						(* f,f.cf_type, false *)
 						select_overload gen e1.etype ((f.cf_type,f) :: List.map (fun f -> f.cf_type,f) f.cf_overloads) [] [], true
 					| _ ->
-						gen.gwarning WGencommon "Overloaded classfield typed as anonymous" ecall.epos;
+						gen.gwarning WGenerator "Overloaded classfield typed as anonymous" ecall.epos;
 						(cf, actual_t, true), true
 				in
 
@@ -847,7 +847,7 @@ let handle_type_parameter gen e e1 ef ~clean_ef ~overloads_cast_to_base f elist 
 					end;
 					{ cf_orig with cf_name = cf.cf_name },actual_t,false
 				| None ->
-					gen.gwarning WGencommon "Cannot find matching overload" ecall.epos;
+					gen.gwarning WGenerator "Cannot find matching overload" ecall.epos;
 					cf, actual_t, true
 				else
 					cf,actual_t,error
@@ -929,7 +929,7 @@ let handle_type_parameter gen e e1 ef ~clean_ef ~overloads_cast_to_base f elist 
 							elist);
 					}, elist
 				with Invalid_argument _ ->
-					gen.gwarning WGencommon ("This expression may be invalid" ) ecall.epos;
+					gen.gwarning WGenerator ("This expression may be invalid" ) ecall.epos;
 					{ ecall with eexpr = TCall({ e1 with eexpr = TField(!ef, f) }, elist) }, elist
 				in
 				let new_ecall = if fparams <> [] then gen.gparam_func_call new_ecall { e1 with eexpr = TField(!ef, f) } fparams elist else new_ecall in
@@ -959,7 +959,7 @@ let handle_type_parameter gen e e1 ef ~clean_ef ~overloads_cast_to_base f elist 
 		*)
 			| _ ->
 				let pt = match e with | None -> real_type | Some _ -> snd (get_fun e1.etype) in
-				let _params = match follow pt with | TEnum(_, p) -> p | _ -> gen.gwarning WGencommon (debug_expr e1) e1.epos; die "" __LOC__ in
+				let _params = match follow pt with | TEnum(_, p) -> p | _ -> gen.gwarning WGenerator (debug_expr e1) e1.epos; die "" __LOC__ in
 				let args, ret = get_fun efield.ef_type in
 				let actual_t = TFun(List.map (fun (n,o,t) -> (n,o,gen.greal_type t)) args, gen.greal_type ret) in
 				(*
@@ -1143,7 +1143,7 @@ let configure gen ?(overloads_cast_to_base = false) maybe_empty_t calls_paramete
 				let base_type = match follow et with
 					| TInst({ cl_path = ([], "Array") } as cl, bt) -> gen.greal_type_param (TClassDecl cl) bt
 					| _ ->
-						gen.gwarning WGencommon (debug_type et) e.epos;
+						gen.gwarning WGenerator (debug_type et) e.epos;
 						(match gen.gcurrent_class with
 							| Some cl -> print_endline (s_type_path cl.cl_path)
 							| _ -> ());
@@ -1187,7 +1187,7 @@ let configure gen ?(overloads_cast_to_base = false) maybe_empty_t calls_paramete
 					) (wrap_rest_args gen (TFun (args,rt)) eparams e.epos) args in
 					{ e with eexpr = TCall(ef, eparams) }
 				with | Not_found ->
-					gen.gwarning WGencommon "No overload found for this constructor call" e.epos;
+					gen.gwarning WGenerator "No overload found for this constructor call" e.epos;
 					{ e with eexpr = TCall(ef, List.map run eparams) })
 			| TCall (ef, eparams) ->
 				(match ef.etype with
@@ -1215,7 +1215,7 @@ let configure gen ?(overloads_cast_to_base = false) maybe_empty_t calls_paramete
 				) (wrap_rest_args gen (TFun (args,rt)) eparams e.epos) args in
 				{ e with eexpr = TNew(cl, tparams, eparams) }
 			with | Not_found ->
-				gen.gwarning WGencommon "No overload found for this constructor call" e.epos;
+				gen.gwarning WGenerator "No overload found for this constructor call" e.epos;
 				{ e with eexpr = TNew(cl, tparams, List.map run eparams) })
 			| TUnop((Increment | Decrement) as op, flag, ({ eexpr = TArray (arr, idx) } as e2))
 				when (match follow arr.etype with TInst({ cl_path = ["cs"],"NativeArray" },_) -> true | _ -> false) ->

--- a/src/codegen/gencommon/closuresToClass.ml
+++ b/src/codegen/gencommon/closuresToClass.ml
@@ -627,7 +627,7 @@ let configure gen ft =
 		with
 			| Not_found ->
 				if in_tparam then begin
-					gen.gwarning WGencommon "This expression may be invalid" e.epos;
+					gen.gwarning WGenerator "This expression may be invalid" e.epos;
 					e
 				end else
 					(* It is possible that we are recursively calling a function
@@ -642,8 +642,8 @@ let configure gen ft =
 						(Meta.Custom(":tparamcall"), [], e.epos), e
 					) }
 			| Unify_error el ->
-				List.iter (fun el -> gen.gwarning WGencommon (Error.unify_error_msg (print_context()) el) e.epos) el;
-				gen.gwarning WGencommon "This expression may be invalid" e.epos;
+				List.iter (fun el -> gen.gwarning WGenerator (Error.unify_error_msg (print_context()) el) e.epos) el;
+				gen.gwarning WGenerator "This expression may be invalid" e.epos;
 				e
 		)
 		(* (handle_anon_func:texpr->tfunc->texpr) (dynamic_func_call:texpr->texpr->texpr list->texpr) *)

--- a/src/codegen/gencommon/gencommon.ml
+++ b/src/codegen/gencommon/gencommon.ml
@@ -619,7 +619,7 @@ let new_ctx con =
 
 		greal_field_types = Hashtbl.create 0;
 		ghandle_cast = (fun to_t from_t e -> mk_cast to_t e);
-		gon_unsafe_cast = (fun t t2 pos -> (gen.gwarning WGencommon ("Type " ^ (debug_type t2) ^ " is being cast to the unrelated type " ^ (s_type (print_context()) t)) pos));
+		gon_unsafe_cast = (fun t t2 pos -> (gen.gwarning WGenerator ("Type " ^ (debug_type t2) ^ " is being cast to the unrelated type " ^ (s_type (print_context()) t)) pos));
 		gneeds_box = (fun t -> false);
 		gspecial_needs_cast = (fun to_t from_t -> false);
 		gsupported_conversions = Hashtbl.create 0;

--- a/src/codegen/gencommon/initFunction.ml
+++ b/src/codegen/gencommon/initFunction.ml
@@ -79,9 +79,9 @@ let handle_class gen cl =
 	let init = List.fold_left (fun acc cf ->
 		match cf.cf_kind with
 			| Var v when Meta.has Meta.ReadOnly cf.cf_meta ->
-					if v.v_write <> AccNever && not (Meta.has Meta.CoreApi cl.cl_meta) then gen.gwarning WGencommon "@:readOnly variable declared without `never` setter modifier" cf.cf_pos;
+					if v.v_write <> AccNever && not (Meta.has Meta.CoreApi cl.cl_meta) then gen.gwarning WGenerator "@:readOnly variable declared without `never` setter modifier" cf.cf_pos;
 					(match cf.cf_expr with
-					| None -> gen.gwarning WGencommon "Uninitialized readonly variable" cf.cf_pos
+					| None -> gen.gwarning WGenerator "Uninitialized readonly variable" cf.cf_pos
 					| Some e -> ensure_simple_expr gen.gcon e);
 					acc
 			| Var _
@@ -116,7 +116,7 @@ let handle_class gen cl =
 	let vars, funs = List.fold_left (fun (acc_vars,acc_funs) cf ->
 		match cf.cf_kind with
 		| Var v when Meta.has Meta.ReadOnly cf.cf_meta ->
-				if v.v_write <> AccNever && not (Meta.has Meta.CoreApi cl.cl_meta) then gen.gwarning WGencommon "@:readOnly variable declared without `never` setter modifier" cf.cf_pos;
+				if v.v_write <> AccNever && not (Meta.has Meta.CoreApi cl.cl_meta) then gen.gwarning WGenerator "@:readOnly variable declared without `never` setter modifier" cf.cf_pos;
 				Option.may (ensure_simple_expr com) cf.cf_expr;
 				(acc_vars,acc_funs)
 		| Var _

--- a/src/codegen/gencommon/unreachableCodeEliminationSynf.ml
+++ b/src/codegen/gencommon/unreachableCodeEliminationSynf.ml
@@ -67,7 +67,7 @@ let init gen java_mode =
 	let should_warn = false in
 
 	let do_warn =
-		if should_warn then gen.gwarning WGencommon "Unreachable code" else (fun pos -> ())
+		if should_warn then gen.gwarning WGenerator "Unreachable code" else (fun pos -> ())
 	in
 
 	let return_loop expr kind =

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -215,6 +215,11 @@ module Setup = struct
 		com.warning <- (fun w options msg p ->
 			match Warning.get_mode w (com.warning_options @ options) with
 			| WMEnable ->
+				let msg = if Warning.is_generic w then
+					msg
+				else
+					Printf.sprintf "(%s) %s" (Warning.to_string w) msg
+				in
 				message ctx (msg,p,DKCompilerMessage,Warning)
 			| WMDisable ->
 				()

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -215,10 +215,11 @@ module Setup = struct
 		com.warning <- (fun w options msg p ->
 			match Warning.get_mode w (com.warning_options @ options) with
 			| WMEnable ->
-				let msg = if Warning.is_generic w then
+				let wobj = Warning.warning_obj w in
+				let msg = if wobj.w_generic then
 					msg
 				else
-					Printf.sprintf "(%s) %s" (Warning.to_string w) msg
+					Printf.sprintf "(%s) %s" wobj.w_name msg
 				in
 				message ctx (msg,p,DKCompilerMessage,Warning)
 			| WMDisable ->

--- a/src/core/dune
+++ b/src/core/dune
@@ -9,3 +9,9 @@
 	(deps ../../src-json/define.json)
 	(action (with-stdout-to defineList.ml (run %{bin:haxe_prebuild} define ../../src-json/define.json)))
 )
+
+(rule
+	(targets warningList.ml)
+	(deps ../../src-json/warning.json)
+	(action (with-stdout-to warningList.ml (run %{bin:haxe_prebuild} warning ../../src-json/warning.json)))
+)

--- a/src/core/warning.ml
+++ b/src/core/warning.ml
@@ -1,28 +1,6 @@
 open Globals
 open Error
-
-type warning =
-	(* general *)
-	| WInternal
-	| WInfo
-	| WUser
-	| WTemp
-	(* subsystem *)
-	| WTyper
-	| WMatcher
-	| WMacro
-	| WAnalyzer
-	| WInliner
-	| WGencommon
-	| WGenerator
-	(* specific *)
-	| WDeprecated
-	| WVarShadow
-	| WExternInit
-	| WStaticInitOrder
-	| WClosureCompare
-	| WVarInit
-	| WReservedTypePath
+include WarningList
 
 type warning_range =
 	| WRExact of int
@@ -36,28 +14,6 @@ type warning_option = {
 	wo_range : warning_range;
 	wo_mode  : warning_mode;
 }
-
-let warning_id = function
-	| WInternal -> 0
-	| WInfo -> 1
-	| WUser -> 2
-	| WTemp -> 3
-	(* subsystem *)
-	| WTyper -> 100
-	| WMacro -> 200
-	| WMatcher -> 300
-	| WInliner -> 400
-	| WAnalyzer -> 500
-	| WGencommon -> 600
-	| WGenerator -> 700
-	(* specific *)
-	| WDeprecated -> 101
-	| WVarInit -> 102
-	| WVarShadow -> 103
-	| WExternInit -> 104
-	| WStaticInitOrder -> 105
-	| WClosureCompare -> 106
-	| WReservedTypePath -> 107
 
 let parse_options s ps lexbuf =
 	let fail msg p =

--- a/src/core/warning.ml
+++ b/src/core/warning.ml
@@ -19,9 +19,18 @@ let parse_options s ps lexbuf =
 	let fail msg p =
 		Error.typing_error msg {p with pmin = ps.pmin + p.pmin; pmax = ps.pmin + p.pmax}
 	in
+	let parse_string s p =
+		begin try
+			warning_id (from_string s)
+		with Exit ->
+			fail (Printf.sprintf "Unknown warning: %s" s) p
+		end
+	in
 	let parse_range () = match Lexer.token lexbuf with
 		| Const (Int(i,_)),_ ->
 			WRExact (int_of_string i)
+		| Const (Ident s),p ->
+			WRExact (parse_string s p)
 		| IntInterval i1,_ ->
 			begin match Lexer.token lexbuf with
 			| Const (Int(i2,_)),_ ->
@@ -30,7 +39,7 @@ let parse_options s ps lexbuf =
 				fail "Expected number" p
 			end
 		| (_,p) ->
-			fail "Expected number" p
+			fail "Expected number or identifier" p
 	in
 	let add acc mode range =
 		{ wo_range = range; wo_mode = mode } :: acc

--- a/src/optimization/analyzerConfig.ml
+++ b/src/optimization/analyzerConfig.ml
@@ -100,13 +100,13 @@ let update_config_from_meta com config ml =
 						| "as_var" -> config
 						| _ ->
 							let options = Warning.from_meta ml in
-							com.warning WAnalyzer options (StringError.string_error s all_flags ("Unrecognized analyzer option: " ^ s)) (pos e);
+							com.warning WOptimizer options (StringError.string_error s all_flags ("Unrecognized analyzer option: " ^ s)) (pos e);
 							config
 					end
 				| _ ->
 					let s = Ast.Printer.s_expr e in
 					let options = Warning.from_meta ml in
-					com.warning WAnalyzer options (StringError.string_error s all_flags ("Unrecognized analyzer option: " ^ s)) (pos e);
+					com.warning WOptimizer options (StringError.string_error s all_flags ("Unrecognized analyzer option: " ^ s)) (pos e);
 					config
 			) config el
 		| (Meta.HasUntyped,_,_) ->

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -317,7 +317,7 @@ let inline_constructors ctx original_e =
 						if is_lvalue && iv_is_const fiv then raise Not_found;
 						if fiv.iv_closed then raise Not_found;
 						if not is_lvalue && fiv.iv_state == IVSUnassigned then (
-							warning ctx WTyper ("Constructor inlining cancelled because of use of uninitialized member field " ^ fname) ethis.epos;
+							warning ctx WConstructorInliningCancelled ("Constructor inlining cancelled because of use of uninitialized member field " ^ fname) ethis.epos;
 							raise Not_found
 						);
 						if not captured then cancel_iv fiv efield.epos;

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -317,7 +317,7 @@ let inline_constructors ctx original_e =
 						if is_lvalue && iv_is_const fiv then raise Not_found;
 						if fiv.iv_closed then raise Not_found;
 						if not is_lvalue && fiv.iv_state == IVSUnassigned then (
-							warning ctx WInliner ("Constructor inlining cancelled because of use of uninitialized member field " ^ fname) ethis.epos;
+							warning ctx WTyper ("Constructor inlining cancelled because of use of uninitialized member field " ^ fname) ethis.epos;
 							raise Not_found
 						);
 						if not captured then cancel_iv fiv efield.epos;

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -935,8 +935,8 @@ module Useless = struct
 	let check_case ctx p (case,bindings,patterns) =
 		let p = List.map (fun (_,_,patterns) -> patterns) p in
 		match u' p (copy p) (copy p) patterns [] [] with
-			| False -> Typecore.warning ctx WTyper "This case is unused" case.case_pos
-			| Pos p -> Typecore.warning ctx WTyper "This pattern is unused" p
+			| False -> Typecore.warning ctx WUnusedPattern "This case is unused" case.case_pos
+			| Pos p -> Typecore.warning ctx WUnusedPattern "This pattern is unused" p
 			| True -> ()
 
 	let check ctx cases =

--- a/src/typing/matcher.ml
+++ b/src/typing/matcher.ml
@@ -252,7 +252,7 @@ module Pattern = struct
 								| _ -> ""
 							in
 							let fields = List.map (fun (el) -> tpath ^ el) l in
-							warning pctx.ctx WMatcher ("Potential typo detected (expected similar values are " ^ (String.concat ", " fields) ^ ")") p
+							warning pctx.ctx WTyper ("Potential typo detected (expected similar values are " ^ (String.concat ", " fields) ^ ")") p
 					end;
 					raise (Bad_pattern "Only inline or read-only (default, never) fields can be used as a pattern")
 				| TTypeExpr mt ->
@@ -321,7 +321,7 @@ module Pattern = struct
 							()
 							(* if toplevel then
 								warning pctx.ctx (Printf.sprintf "`case %s` has been deprecated, use `case var %s` instead" s s) p *)
-						| l -> warning pctx.ctx WMatcher ("Potential typo detected (expected similar values are " ^ (String.concat ", " l) ^ "). Consider using `var " ^ s ^ "` instead") p
+						| l -> warning pctx.ctx WTyper ("Potential typo detected (expected similar values are " ^ (String.concat ", " l) ^ "). Consider using `var " ^ s ^ "` instead") p
 					end;
 					let v = add_local false s p in
 					PatVariable v
@@ -935,8 +935,8 @@ module Useless = struct
 	let check_case ctx p (case,bindings,patterns) =
 		let p = List.map (fun (_,_,patterns) -> patterns) p in
 		match u' p (copy p) (copy p) patterns [] [] with
-			| False -> Typecore.warning ctx WMatcher "This case is unused" case.case_pos
-			| Pos p -> Typecore.warning ctx WMatcher "This pattern is unused" p
+			| False -> Typecore.warning ctx WTyper "This case is unused" case.case_pos
+			| Pos p -> Typecore.warning ctx WTyper "This pattern is unused" p
 			| True -> ()
 
 	let check ctx cases =

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1400,7 +1400,7 @@ let create_method (ctx,cctx,fctx) c f fd p =
 			delay ctx PTypeField (fun () -> args#verify_extern);
 		if fd.f_expr <> None then begin
 			if fctx.is_abstract then display_error ctx.com "Abstract methods may not have an expression" p
-			else if not (fctx.is_inline || fctx.is_macro) then warning ctx WExternInit "Extern non-inline function may not have an expression" p;
+			else if not (fctx.is_inline || fctx.is_macro) then warning ctx WExternWithExpr "Extern non-inline function may not have an expression" p;
 		end;
 	end;
 	cf

--- a/tests/misc/projects/Issue10184/check-warning.hxml.stderr
+++ b/tests/misc/projects/Issue10184/check-warning.hxml.stderr
@@ -1,1 +1,1 @@
-Deprecated.hx:3: characters 2-8 : Warning : Std.is is deprecated. Use Std.isOfType instead.
+Deprecated.hx:3: characters 2-8 : Warning : (WDeprecated) Std.is is deprecated. Use Std.isOfType instead.

--- a/tests/misc/projects/Issue2508/compile.hxml.stderr
+++ b/tests/misc/projects/Issue2508/compile.hxml.stderr
@@ -1,10 +1,10 @@
-Main.hx:15: characters 4-15 : Warning : This case is unused
-Main.hx:20: characters 4-14 : Warning : This case is unused
-Main.hx:21: characters 4-15 : Warning : This case is unused
-Main.hx:26: characters 6-11 : Warning : This pattern is unused
-Main.hx:32: characters 7-18 : Warning : This pattern is unused
-Main.hx:44: characters 4-32 : Warning : This case is unused
-Main.hx:50: characters 4-19 : Warning : This case is unused
-Main.hx:55: characters 4-15 : Warning : This case is unused
-Main.hx:60: characters 4-16 : Warning : This case is unused
-Main.hx:66: characters 9-15 : Warning : This pattern is unused
+Main.hx:15: characters 4-15 : Warning : (WUnusedPattern) This case is unused
+Main.hx:20: characters 4-14 : Warning : (WUnusedPattern) This case is unused
+Main.hx:21: characters 4-15 : Warning : (WUnusedPattern) This case is unused
+Main.hx:26: characters 6-11 : Warning : (WUnusedPattern) This pattern is unused
+Main.hx:32: characters 7-18 : Warning : (WUnusedPattern) This pattern is unused
+Main.hx:44: characters 4-32 : Warning : (WUnusedPattern) This case is unused
+Main.hx:50: characters 4-19 : Warning : (WUnusedPattern) This case is unused
+Main.hx:55: characters 4-15 : Warning : (WUnusedPattern) This case is unused
+Main.hx:60: characters 4-16 : Warning : (WUnusedPattern) This case is unused
+Main.hx:66: characters 9-15 : Warning : (WUnusedPattern) This pattern is unused

--- a/tests/misc/projects/Issue4720/compile.hxml.stderr
+++ b/tests/misc/projects/Issue4720/compile.hxml.stderr
@@ -1,24 +1,24 @@
-Main.hx:8: characters 9-15 : Warning : Usage of this typedef is deprecated
-Main.hx:9: characters 9-19 : Warning : Usage of this typedef is deprecated
-Main.hx:10: characters 9-14 : Warning : Usage of this typedef is deprecated
-Main.hx:18: characters 13-19 : Warning : This typedef is deprecated in favor of MyClass
-Main.hx:19: characters 9-14 : Warning : Usage of this typedef is deprecated
-Main.hx:20: characters 13-22 : Warning : This typedef is deprecated in favor of MyAbstract
-Main.hx:32: characters 9-13 : Warning : Usage of this enum is deprecated
-Main.hx:36: characters 9-14 : Warning : Usage of this enum field is deprecated
-Main.hx:4: characters 9-16 : Warning : Usage of this class is deprecated
-Main.hx:5: characters 9-20 : Warning : Usage of this class is deprecated
-Main.hx:6: characters 9-15 : Warning : Usage of this enum is deprecated
-Main.hx:15: characters 9-22 : Warning : Usage of this class is deprecated
-Main.hx:16: characters 9-15 : Warning : Usage of this enum is deprecated
-Main.hx:17: characters 9-29 : Warning : Usage of this class is deprecated
-Main.hx:18: characters 9-21 : Warning : Usage of this class is deprecated
-Main.hx:20: characters 9-28 : Warning : Usage of this class is deprecated
-Main.hx:23: characters 9-24 : Warning : Usage of this field is deprecated
-Main.hx:24: characters 9-23 : Warning : Usage of this field is deprecated
-Main.hx:25: characters 9-27 : Warning : Usage of this field is deprecated
-Main.hx:26: characters 17-35 : Warning : Usage of this field is deprecated
-Main.hx:27: characters 9-25 : Warning : Usage of this field is deprecated
-Main.hx:28: characters 17-33 : Warning : Usage of this field is deprecated
-Main.hx:31: characters 11-15 : Warning : Usage of this enum is deprecated
-Main.hx:35: characters 11-16 : Warning : Usage of this enum field is deprecated
+Main.hx:8: characters 9-15 : Warning : (WDeprecated) Usage of this typedef is deprecated
+Main.hx:9: characters 9-19 : Warning : (WDeprecated) Usage of this typedef is deprecated
+Main.hx:10: characters 9-14 : Warning : (WDeprecated) Usage of this typedef is deprecated
+Main.hx:18: characters 13-19 : Warning : (WDeprecated) This typedef is deprecated in favor of MyClass
+Main.hx:19: characters 9-14 : Warning : (WDeprecated) Usage of this typedef is deprecated
+Main.hx:20: characters 13-22 : Warning : (WDeprecated) This typedef is deprecated in favor of MyAbstract
+Main.hx:32: characters 9-13 : Warning : (WDeprecated) Usage of this enum is deprecated
+Main.hx:36: characters 9-14 : Warning : (WDeprecated) Usage of this enum field is deprecated
+Main.hx:4: characters 9-16 : Warning : (WDeprecated) Usage of this class is deprecated
+Main.hx:5: characters 9-20 : Warning : (WDeprecated) Usage of this class is deprecated
+Main.hx:6: characters 9-15 : Warning : (WDeprecated) Usage of this enum is deprecated
+Main.hx:15: characters 9-22 : Warning : (WDeprecated) Usage of this class is deprecated
+Main.hx:16: characters 9-15 : Warning : (WDeprecated) Usage of this enum is deprecated
+Main.hx:17: characters 9-29 : Warning : (WDeprecated) Usage of this class is deprecated
+Main.hx:18: characters 9-21 : Warning : (WDeprecated) Usage of this class is deprecated
+Main.hx:20: characters 9-28 : Warning : (WDeprecated) Usage of this class is deprecated
+Main.hx:23: characters 9-24 : Warning : (WDeprecated) Usage of this field is deprecated
+Main.hx:24: characters 9-23 : Warning : (WDeprecated) Usage of this field is deprecated
+Main.hx:25: characters 9-27 : Warning : (WDeprecated) Usage of this field is deprecated
+Main.hx:26: characters 17-35 : Warning : (WDeprecated) Usage of this field is deprecated
+Main.hx:27: characters 9-25 : Warning : (WDeprecated) Usage of this field is deprecated
+Main.hx:28: characters 17-33 : Warning : (WDeprecated) Usage of this field is deprecated
+Main.hx:31: characters 11-15 : Warning : (WDeprecated) Usage of this enum is deprecated
+Main.hx:35: characters 11-16 : Warning : (WDeprecated) Usage of this enum field is deprecated

--- a/tests/misc/projects/Issue6226/compile.hxml.stderr
+++ b/tests/misc/projects/Issue6226/compile.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:7: characters 3-4 : Warning : Usage of this field is deprecated
+Main.hx:7: characters 3-4 : Warning : (WDeprecated) Usage of this field is deprecated

--- a/tests/misc/projects/Issue7096/compile.hxml.stderr
+++ b/tests/misc/projects/Issue7096/compile.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:5: characters 9-10 : Warning : Usage of this field is deprecated
+Main.hx:5: characters 9-10 : Warning : (WDeprecated) Usage of this field is deprecated

--- a/tests/misc/projects/Issue7447/compile.hxml.stderr
+++ b/tests/misc/projects/Issue7447/compile.hxml.stderr
@@ -1,2 +1,2 @@
-Main.hx:4: characters 15-16 : Warning : Local variable v might be used before being initialized
-Main.hx:10: characters 15-19 : Warning : this might be used before assigning a value to it
+Main.hx:4: characters 15-16 : Warning : (WVarInit) Local variable v might be used before being initialized
+Main.hx:10: characters 15-19 : Warning : (WVarInit) this might be used before assigning a value to it

--- a/tests/misc/projects/Issue7669/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7669/compile-fail.hxml.stderr
@@ -1,5 +1,5 @@
 Main.hx:4: characters 9-23 : Unknown identifier : NumpadSubtract, pattern variables must be lower-case or with `var ` prefix
 Main.hx:5: characters 9-22 : Unknown identifier : NumpadDecimal, pattern variables must be lower-case or with `var ` prefix
-Main.hx:5: characters 4-23 : Warning : This case is unused
+Main.hx:5: characters 4-23 : Warning : (WUnusedPattern) This case is unused
 Main.hx:8: characters 15-29 : Unknown identifier : NumpadSubtract, pattern variables must be lower-case or with `var ` prefix
 Main.hx:8: characters 15-29 : Variable NumpadSubtract must appear exactly once in each sub-pattern

--- a/tests/misc/projects/Issue8471/compile2.hxml.stderr
+++ b/tests/misc/projects/Issue8471/compile2.hxml.stderr
@@ -1,4 +1,4 @@
-Macro2.hx:12: characters 25-39 : Warning : This typedef is deprecated in favor of String
+Macro2.hx:12: characters 25-39 : Warning : (WDeprecated) This typedef is deprecated in favor of String
 Warning : 1
 Warning : 2
 Warning : 3

--- a/tests/misc/projects/Issue9192/compile.hxml.stderr
+++ b/tests/misc/projects/Issue9192/compile.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:3: characters 3-4 : Warning : Usage of this class is deprecated
+Main.hx:3: characters 3-4 : Warning : (WDeprecated) Usage of this class is deprecated

--- a/tests/misc/projects/Issue9204/compile.hxml.stderr
+++ b/tests/misc/projects/Issue9204/compile.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:7: characters 9-13 : Warning : Usage of this field is deprecated
+Main.hx:7: characters 9-13 : Warning : (WDeprecated) Usage of this field is deprecated

--- a/tests/misc/projects/Issue9425/compile-success.hxml.stderr
+++ b/tests/misc/projects/Issue9425/compile-success.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:10: characters 3-14 : Warning : Usage of this field is deprecated
+Main.hx:10: characters 3-14 : Warning : (WDeprecated) Usage of this field is deprecated

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -10,4 +10,3 @@
 -lib utest:git:https://github.com/haxe-utest/utest#559b24c9a36533281ba7a2eed8aab83ed6b872b4
 -D analyzer-optimize
 -D analyzer-user-var-fusion
--w -400-102

--- a/tests/unit/src/unit/TestGADT.hx
+++ b/tests/unit/src/unit/TestGADT.hx
@@ -42,7 +42,7 @@ class TestGADT extends Test {
 		eq(s, true);
 	}
 
-	@:haxe.warning("-600")
+	@:haxe.warning("-WGenerator")
 	static function evalConst<T>(c:Constant<T>):T {
 		return switch (c) {
 			case CString(s): s;
@@ -51,7 +51,7 @@ class TestGADT extends Test {
 		}
 	}
 
-	@:haxe.warning("-600")
+	@:haxe.warning("-WGenerator")
 	static function evalBinop<T, C>(op:Binop<C, T>, e1:Expr<C>, e2:Expr<C>):T {
 		return switch (op) {
 			case OpAdd: eval(e1) + eval(e2);

--- a/tests/unit/src/unit/TestGeneric.hx
+++ b/tests/unit/src/unit/TestGeneric.hx
@@ -8,6 +8,7 @@ private typedef MyAnon = {
 @:generic
 class MyGeneric<T> {
 	public var t:T;
+
 	public function new(t:T) {
 		this.t = t;
 	}
@@ -15,25 +16,28 @@ class MyGeneric<T> {
 
 class MyRandomClass {
 	public var s:String;
+
 	public function new(s:String) {
 		this.s = s;
 	}
 }
 
-class MyRandomEmptyClass { }
+class MyRandomEmptyClass {}
 
 @:generic class RBNode<T:RBNode<T>> {
-	public var rbLeft : T;
-	public var rbRight : T;
+	public var rbLeft:T;
+	public var rbRight:T;
 }
 
 @:generic class RBTree<T:RBNode<T>> {
-	public var root : T;
-	public function new() {	}
+	public var root:T;
+
+	public function new() {}
 }
 
 class MyData extends RBNode<MyData> {
-	var id : Int;
+	var id:Int;
+
 	public function new(id:Int) {
 		this.id = id;
 	}
@@ -46,7 +50,7 @@ class TestGeneric extends Test {
 		t((mg.t is Int));
 
 		var mg = new MyGeneric<String>("12");
-		eq(mg.t,"12");
+		eq(mg.t, "12");
 		t((mg.t is String));
 	}
 
@@ -64,6 +68,7 @@ class TestGeneric extends Test {
 		eq(a.t.b, null);
 	}
 
+	@:haxe.warning("-WGenerator")
 	function testGenericFn() {
 		var a = new MyGeneric<Int->Int>(function(i:Int):Int return i * i);
 		eq(4, a.t(2));

--- a/tests/unit/src/unit/TestRest.hx
+++ b/tests/unit/src/unit/TestRest.hx
@@ -20,7 +20,7 @@ class TestRest extends Test {
 	function testToArray() {
 		function rest(...r:Int):Array<Int> {
 			var a = r.toArray();
-			a[0] = 999; //make sure array modification doesn't affect rest arguments object
+			a[0] = 999; // make sure array modification doesn't affect rest arguments object
 			return r.toArray();
 		}
 		aeq([1, 2, 3, 4], rest(1, 2, 3, 4));
@@ -36,7 +36,7 @@ class TestRest extends Test {
 
 	function testIterator() {
 		function rest(...r:Int):Array<Int> {
-			return [for(i in r) i];
+			return [for (i in r) i];
 		}
 		aeq([3, 2, 1], rest(3, 2, 1));
 	}
@@ -45,11 +45,11 @@ class TestRest extends Test {
 		function rest(...r:Int):{keys:Array<Int>, values:Array<Int>} {
 			var keys = [];
 			var values = [];
-			for(k => v in r) {
+			for (k => v in r) {
 				keys.push(k);
 				values.push(v);
 			}
-			return {keys:keys, values:values}
+			return {keys: keys, values: values}
 		}
 		var r = rest(3, 2, 1, 0);
 		aeq([0, 1, 2, 3], r.keys);
@@ -57,10 +57,11 @@ class TestRest extends Test {
 	}
 
 	@:depends(testToArray)
+	@:haxe.warning("-WGenerator")
 	function testAppend() {
 		function rest(...r:Int) {
 			var appended = r.append(9);
-			return {initial:r.toArray(), appended:appended.toArray()}
+			return {initial: r.toArray(), appended: appended.toArray()}
 		}
 		var result = rest(1, 2);
 		aeq([1, 2], result.initial);
@@ -71,7 +72,7 @@ class TestRest extends Test {
 	function testPrepend() {
 		function rest(...r:Int) {
 			var prepended = r.prepend(9);
-			return {initial:r.toArray(), prepended:prepended.toArray()}
+			return {initial: r.toArray(), prepended: prepended.toArray()}
 		}
 		var result = rest(1, 2);
 		aeq([1, 2], result.initial);
@@ -112,7 +113,7 @@ class TestRest extends Test {
 
 	@:depends(testToArray)
 	function testClosure() {
-		var fn:(...r:Int)->Array<Int>;
+		var fn:(...r:Int) -> Array<Int>;
 		fn = staticRest;
 		aeq([1, 2, 3], fn(1, 2, 3));
 		aeq([1, 2, 3], fn(...[1, 2, 3]));
@@ -120,9 +121,11 @@ class TestRest extends Test {
 		aeq([3, 2, 1], fn(3, 2, 1));
 		aeq([3, 2, 1], fn(...[3, 2, 1]));
 	}
+
 	function instanceRest(...r:Int):Array<Int> {
 		return r.toArray();
 	}
+
 	static function staticRest(...r:Int):Array<Int> {
 		return r.toArray();
 	}
@@ -140,14 +143,14 @@ class TestRest extends Test {
 		function rest(...r:{f:Int}) {
 			return r.toArray();
 		}
-		aeq([{f:2}, {f:1}], rest({f:2}, {f:1}));
+		aeq([{f: 2}, {f: 1}], rest({f: 2}, {f: 1}));
 	}
 
 	function testInferred() {
 		function rest(...r) {
 			(r[0] : Int);
 		}
-		HelperMacros.typedAs(rest, (null : (r : Rest<Int>)->Void));
+		HelperMacros.typedAs(rest, (null : (r:Rest<Int>) -> Void));
 	}
 
 	function testToString() {

--- a/tests/unit/src/unit/UnitBuilder.hx
+++ b/tests/unit/src/unit/UnitBuilder.hx
@@ -25,10 +25,10 @@ package unit;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
+
 using StringTools;
 
 class UnitBuilder {
-
 	static public macro function generateSpec(basePath:String) {
 		var ret = [];
 		var numFiles = 0;
@@ -46,34 +46,43 @@ class UnitBuilder {
 						params: [],
 						expr: read(filePath)
 					}
-					var p = Context.makePosition( { min:0, max:0, file:filePath + file } );
+					var p = Context.makePosition({min: 0, max: 0, file: filePath + file});
 					var field = {
 						name: "test",
 						kind: FFun(func),
 						pos: p,
 						access: [APublic],
 						doc: null,
-						meta: []
+						meta: file.endsWith("Utf8.unit.hx") ? [{name: ":haxe.warning", params: [macro "-WDeprecated"], pos: p}] : []
 					};
 					var pack = ["unit", "spec"].concat(pack);
 					var typeName = "Test" + file.substr(0, file.indexOf("."));
-					Context.defineModule(pack.join(".") + "." + typeName, [{
-						pack: pack,
-						name: typeName,
-						pos: p,
-						kind: TDClass({
-							pack: ["unit"],
-							name: "Test"
-						}),
-						fields: [field]
-					}], [{
-						path: [{pos: p, name: "unit"}, {pos: p, name: "spec"}, {pos: p, name: "TestSpecification"}],
-						mode: INormal
-					}, {
-						// TODO: import.hx doesn't work for this?
-						path: [{pos: p, name: "haxe"}, {pos: p, name: "macro"}, {pos: p, name: "Expr"}],
-						mode: INormal
-					}]);
+					Context.defineModule(pack.join(".") + "." + typeName, [
+						{
+							pack: pack,
+							name: typeName,
+							pos: p,
+							kind: TDClass({
+								pack: ["unit"],
+								name: "Test"
+							}),
+							fields: [field]
+						}
+					], [
+						{
+							path: [
+								{pos: p, name: "unit"},
+								{pos: p, name: "spec"},
+								{pos: p, name: "TestSpecification"}
+							],
+							mode: INormal
+						},
+						{
+							// TODO: import.hx doesn't work for this?
+							path: [{pos: p, name: "haxe"}, {pos: p, name: "macro"}, {pos: p, name: "Expr"}],
+							mode: INormal
+						}
+					]);
 					var tp:TypePath = {
 						pack: pack,
 						name: typeName
@@ -81,7 +90,7 @@ class UnitBuilder {
 					ret.push(macro new $tp());
 				} else if (sys.FileSystem.isDirectory(filePath)) {
 					readDir(filePath, pack.concat([file]));
-				} else if(filePath.endsWith('.hx')) {
+				} else if (filePath.endsWith('.hx')) {
 					Context.error('$filePath: specification tests filenames should end with ".unit.hx"', Context.currentPos());
 				}
 			}
@@ -93,28 +102,32 @@ class UnitBuilder {
 
 	#if macro
 	static function collapseToOrExpr(el:Array<Expr>) {
-		return switch(el) {
+		return switch (el) {
 			case []: throw "";
 			case [e]: e;
-		case _:
-			var e = el.pop();
-			{ expr: EBinop(OpBoolOr, e, collapseToOrExpr(el)), pos: e.pos }
+			case _:
+				var e = el.pop();
+				{expr: EBinop(OpBoolOr, e, collapseToOrExpr(el)), pos: e.pos}
 		}
 	}
 
 	static function mkEq(e1, e2, p:Position) {
 		function isFloat(e) {
-			try return switch(Context.follow(Context.typeof(e))) {
-				case TAbstract(tr, _):
-					tr.get().name == "Float";
-				case _:
-					false;
-			} catch (e:Dynamic) {
+			try
+				return switch (Context.follow(Context.typeof(e))) {
+					case TAbstract(tr, _):
+						tr.get().name == "Float";
+					case _:
+						false;
+				} catch (e:Dynamic) {
 				return false;
 			}
 		}
 		var e = switch [isFloat(e1) || isFloat(e2), e2.expr] {
-			case [_, EField( { expr:EConst(CIdent("Math" | "math")) }, "POSITIVE_INFINITY" | "NEGATIVE_INFINITY")] if (Context.defined("cpp") || Context.defined("php")):
+			case [
+				_,
+				EField({expr: EConst(CIdent("Math" | "math"))}, "POSITIVE_INFINITY" | "NEGATIVE_INFINITY")
+			] if (Context.defined("cpp") || Context.defined("php")):
 				macro t($e1 == $e2);
 			case [true, _]:
 				macro feq($e1, $e2);
@@ -126,12 +139,13 @@ class UnitBuilder {
 			pos: p
 		}
 	}
+
 	static public function read(path:String) {
-		var p = Context.makePosition( { min:0, max:0, file:path } );
+		var p = Context.makePosition({min: 0, max: 0, file: path});
 		var file = sys.io.File.getContent(path);
 		var code = Context.parseInlineString("{" + file + "\n}", p);
 		function mkBlock(e:Expr) {
-			return switch(e.expr) {
+			return switch (e.expr) {
 				case EBlock(b): b;
 				case _: [e];
 			}
@@ -139,30 +153,24 @@ class UnitBuilder {
 		function bl(block:Array<Expr>):Array<Expr> {
 			var ret = [];
 			for (e in block) {
-				var e = switch(e.expr) {
-					case EBinop(OpEq, e1, { expr: EConst(CIdent("false")) } )
-					| EBinop(OpEq, { expr: EConst(CIdent("false")) }, e1):
+				var e = switch (e.expr) {
+					case EBinop(OpEq, e1, {expr: EConst(CIdent("false"))}) | EBinop(OpEq, {expr: EConst(CIdent("false"))}, e1):
 						{
 							expr: (macro f($e1)).expr,
 							pos: e.pos
 						}
-					case EBinop(OpEq, e1, { expr: EConst(CIdent("true")) } )
-					| EBinop(OpEq, { expr: EConst(CIdent("true")) }, e1):
+					case EBinop(OpEq, e1, {expr: EConst(CIdent("true"))}) | EBinop(OpEq, {expr: EConst(CIdent("true"))}, e1):
 						{
 							expr: (macro t($e1)).expr,
 							pos: e.pos
 						}
-					case EBinop(OpEq, e1, { expr: EArrayDecl(el) } )
-					| EBinop(OpEq, { expr: EArrayDecl(el) }, e1 ):
+					case EBinop(OpEq, e1, {expr: EArrayDecl(el)}) | EBinop(OpEq, {expr: EArrayDecl(el)}, e1):
 						var el2 = [];
 						for (i in 0...el.length) {
 							var e2 = el[i];
 							el2.push(mkEq((macro $e1[$v{i}]), e2, e.pos));
 						}
-						if (el2.length == 0)
-							mkEq((macro @:pos(e1.pos) $e1.length), (macro 0), e.pos);
-						else
-							macro { $a{el2}; };
+						if (el2.length == 0) mkEq((macro @:pos(e1.pos) $e1.length), (macro 0), e.pos); else macro {$a{el2};};
 					case EBinop(OpEq, e1, e2):
 						mkEq(e1, e2, e.pos);
 					case EBinop(OpNotEq, e1, e2):
@@ -174,18 +182,18 @@ class UnitBuilder {
 						}
 					case EThrow(e):
 						macro exc(function() $e);
-					case EBinop(OpIn, e1, {expr:EArrayDecl(el) }):
+					case EBinop(OpIn, e1, {expr: EArrayDecl(el)}):
 						var el2 = [];
 						for (e in el)
 							el2.push(macro $e1 == $e);
-						macro @:pos(e.pos) t(${ collapseToOrExpr(el2) } );
+						macro @:pos(e.pos) t(${collapseToOrExpr(el2)});
 					case EVars(vl):
 						for (v in vl)
 							if (v.name == "t" || v.name == "f" || v.name == "eq" || v.name == "neq")
 								Context.error('${v.name} is reserved for unit testing', e.pos);
-							e;
+						e;
 					case EFor(it, {expr: EBlock(el), pos: p}):
-						{ expr: EFor(it, {expr:EBlock(bl(el)), pos: p}), pos: e.pos };
+						{expr: EFor(it, {expr: EBlock(bl(el)), pos: p}), pos: e.pos};
 					case _:
 						e;
 				}

--- a/tests/unit/src/unit/issues/Issue10073.hx
+++ b/tests/unit/src/unit/issues/Issue10073.hx
@@ -26,7 +26,7 @@ abstract Bar(Int) from Int {
 }
 #end
 
-@:haxe.warning("-600")
+@:haxe.warning("-WGenerator")
 class Issue10073 extends Test {
 	function test() {
 		var foo:Foo = [];

--- a/tests/unit/src/unit/issues/Issue10304.hx
+++ b/tests/unit/src/unit/issues/Issue10304.hx
@@ -24,6 +24,7 @@ private class PairIter<T> {
 }
 
 class Issue10304 extends Test {
+	@:haxe.warning("-WConstructorInliningCancelled")
 	function test() {
 		var buf = new StringBuf();
 		for (p in new PairIter(["1", "2", "3"])) {

--- a/tests/unit/src/unit/issues/Issue2778.hx
+++ b/tests/unit/src/unit/issues/Issue2778.hx
@@ -16,7 +16,7 @@ class Issue2778 extends Test {
 		t(unit.HelperMacros.typeError(sameType(BoolLit(true), IntLit(1))));
 	}
 
-	@:haxe.warning("-600")
+	@:haxe.warning("-WGenerator")
 	static function sameType<S>(o1:E<S>, o2:E<S>):S {
 		return switch [o1, o2] {
 			case [BoolLit(b1), BoolLit(b2)]: b1 && b2;

--- a/tests/unit/src/unit/issues/Issue3861.hx
+++ b/tests/unit/src/unit/issues/Issue3861.hx
@@ -1,6 +1,7 @@
 package unit.issues;
 
 class Issue3861 extends unit.Test {
+	@:haxe.warning("-WVarInit")
 	function test() {
 		var a;
 		var b = function() return a;

--- a/tests/unit/src/unit/issues/Issue4578.hx
+++ b/tests/unit/src/unit/issues/Issue4578.hx
@@ -29,7 +29,7 @@ private class IUnOp<X, Y, S:TList> implements Instr<TCons<X, S>, TCons<Y, S>> {
 	}
 }
 
-@:haxe.warning("-600")
+@:haxe.warning("-WGenerator")
 class Issue4578 extends Test {
 	function test() {
 		var i = new IUnOp(function(x) return x * 2);

--- a/tests/unit/src/unit/issues/Issue6561.hx
+++ b/tests/unit/src/unit/issues/Issue6561.hx
@@ -9,7 +9,7 @@ class Issue6561 extends unit.Test {
 		eq("hello", apply(NotLog("hello")));
 	}
 
-	@:haxe.warning("-600")
+	@:haxe.warning("-WGenerator")
 	static function apply<A>(f:Log<A>):A {
 		return switch f {
 			case NotLog(msg):


### PR DESCRIPTION
This uses a nice JSON file for warnings and generates the required OCaml types and functions from it. Also, we now support identifiers for enabling and disabling warnings, so you can do `haxe -w -WDeprecated` and `@:haxe.warning("-WDeprecated")`. I figured that this is nicer to work with than random numbers.

In that context, I've also changed the warning output to include that identifier, so now we get something like `Warning : (WDeprecated) Usage of this typedef is deprecated`. This makes it easy to figure out how to disable a warning. If anyone has a particular preference for how to format this message, let me know.