### PR TITLE
[java]fix Sys.programPath()

### DIFF
--- a/std/java/_std/Sys.hx
+++ b/std/java/_std/Sys.hx
@@ -143,7 +143,7 @@ using haxe.Int64;
 
 	public static function programPath():String {
 		final uri:URI = java.Lib.toNativeType(Sys).getProtectionDomain().getCodeSource().getLocation().toURI();
-		return Paths.get(uri).toString();
+		return Std.string(Paths.get(uri));
 	}
 
 	public static function getChar(echo:Bool):Int {

--- a/std/java/_std/Sys.hx
+++ b/std/java/_std/Sys.hx
@@ -21,6 +21,8 @@
  */
 
 import java.lang.System;
+import java.net.URI;
+import java.nio.file.Paths;
 import sys.io.Process;
 
 using haxe.Int64;
@@ -140,7 +142,8 @@ using haxe.Int64;
 	}
 
 	public static function programPath():String {
-		return java.Lib.toNativeType(Sys).getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
+		final uri:URI = java.Lib.toNativeType(Sys).getProtectionDomain().getCodeSource().getLocation().toURI();
+		return Paths.get(uri).toString();
 	}
 
 	public static function getChar(echo:Bool):Int {


### PR DESCRIPTION
`URI#getPath()` does not get a path that fits windows filesystem.
e.g. `/C:/tmp/main.jar`

Using `Paths.get` will work.
e.g. `C:\tmp\main.jar`

os: windows10
target: jvm
