### PR TITLE
Exclude private fields from import

### DIFF
--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -400,7 +400,8 @@ let collect ctx tk with_type sort =
 						| _ -> TClassDecl c,make_ci_class_field
 					in
 					let origin = StaticImport decl in
-					add (make (CompletionClassField.make cf CFSStatic origin is_qualified) (tpair ~values:(get_value_meta cf.cf_meta) cf.cf_type)) (Some name)
+					if not (has_class_field_flag cf CfPublic) || (Meta.has Meta.NoCompletion cf.cf_meta) then ()
+					else add (make (CompletionClassField.make cf CFSStatic origin is_qualified) (tpair ~values:(get_value_meta cf.cf_meta) cf.cf_type)) (Some name)
 				in
 				match resolve_typedef mt with
 					| TClassDecl c -> class_import c;

--- a/src/context/display/displayToplevel.ml
+++ b/src/context/display/displayToplevel.ml
@@ -400,8 +400,9 @@ let collect ctx tk with_type sort =
 						| _ -> TClassDecl c,make_ci_class_field
 					in
 					let origin = StaticImport decl in
-					if not (has_class_field_flag cf CfPublic) || (Meta.has Meta.NoCompletion cf.cf_meta) then ()
-					else add (make (CompletionClassField.make cf CFSStatic origin is_qualified) (tpair ~values:(get_value_meta cf.cf_meta) cf.cf_type)) (Some name)
+					if can_access ctx c cf true && not (Meta.has Meta.NoCompletion cf.cf_meta) then begin
+						add (make (CompletionClassField.make cf CFSStatic origin is_qualified) (tpair ~values:(get_value_meta cf.cf_meta) cf.cf_type)) (Some name)
+					end
 				in
 				match resolve_typedef mt with
 					| TClassDecl c -> class_import c;

--- a/tests/display/src/cases/Issue10704.hx
+++ b/tests/display/src/cases/Issue10704.hx
@@ -1,0 +1,17 @@
+package cases;
+
+class Issue10704 extends DisplayTestCase {
+	/**
+		import cases.Statics.*;
+		class Main {
+			static function main() {
+				foo{-1-}
+			}
+		}
+	**/
+	function test() {
+		eq(true, hasToplevel(toplevel(pos(1)), "static", "fooPublic"));
+		eq(false, hasToplevel(toplevel(pos(1)), "static", "fooNoCompletion"));
+		eq(false, hasToplevel(toplevel(pos(1)), "static", "fooPrivate"));
+	}
+}

--- a/tests/display/src/cases/Issue10704.hx
+++ b/tests/display/src/cases/Issue10704.hx
@@ -2,7 +2,7 @@ package cases;
 
 class Issue10704 extends DisplayTestCase {
 	/**
-		import cases.Statics.*;
+		import misc.issue10704.Statics.*;
 		class Main {
 			static function main() {
 				foo{-1-}

--- a/tests/display/src/cases/Statics.hx
+++ b/tests/display/src/cases/Statics.hx
@@ -1,0 +1,10 @@
+package cases;
+
+class Statics {
+	public static final fooPublic = 0;
+
+	@:noCompletion
+	public static final fooNoCompletion = 0;
+
+	static final fooPrivate = 0;
+}

--- a/tests/display/src/misc/issue10704/Statics.hx
+++ b/tests/display/src/misc/issue10704/Statics.hx
@@ -1,4 +1,4 @@
-package cases;
+package misc.issue10704;
 
 class Statics {
 	public static final fooPublic = 0;


### PR DESCRIPTION
Fix for things like:
```haxe
class Globals {
	static var foo = false;
}
...
import Globals.*;
foo; // available in completion, but error in diagnostic
```