### PR TITLE
[php] Fix the return type of `PDOStatement.fetchColumn()` method

### DIFF
--- a/std/php/db/PDOStatement.hx
+++ b/std/php/db/PDOStatement.hx
@@ -37,7 +37,7 @@ extern class PDOStatement {
 	function execute(?input_parameters:NativeArray):Bool;
 	function fetch(?fetch_style:Int = 4, ?cursor_orientation:Int = 0, ?cursor_offset:Int = 0):Dynamic;
 	function fetchAll(?fetch_style:Int, ?fetch_argument:Dynamic, ?ctor_args:NativeArray):NativeArray;
-	function fetchColumn(?column_number:Int = 0):String;
+	function fetchColumn(?column_number:Int = 0):Dynamic;
 	function fetchObject(?class_name:String, ?ctor_args:NativeArray):Dynamic;
 	function getAttribute(attribute:Int):Dynamic;
 	function getColumnMeta(column:Int):NativeArray;


### PR DESCRIPTION
Cf. https://www.php.net/manual/fr/pdostatement.fetchcolumn.php

In the PHP documentation, the return type is `mixed`. And, depending on the PDO connection attributes, this method may return something other than strings.

```haxe
final statement = pdo.query("SELECT MAX(id) FROM table");
trace(Type.typeof(statement.fetchColumn()); // TInt
```