### PR TITLE
[hl] Int64 arrays

### DIFF
--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -821,7 +821,7 @@ let generate_function ctx f =
 			sexpr "%s = %s * %s" (reg r) (reg a) (reg b)
 		| OSDiv (r,a,b) ->
 			(match rtype r with
-			| HUI8 | HUI16 | HI32 ->
+			| HUI8 | HUI16 | HI32 | HI64 ->
 				sexpr "%s = %s == 0 ? 0 : %s / %s" (reg r) (reg b) (reg a) (reg b)
 			| _ ->
 				sexpr "%s = %s / %s" (reg r) (reg a) (reg b))
@@ -829,7 +829,7 @@ let generate_function ctx f =
 			sexpr "%s = %s == 0 ? 0 : ((unsigned)%s) / ((unsigned)%s)" (reg r) (reg b) (reg a) (reg b)
 		| OSMod (r,a,b) ->
 			(match rtype r with
-			| HUI8 | HUI16 | HI32 ->
+			| HUI8 | HUI16 | HI32 | HI64 ->
 				sexpr "%s = %s == 0 ? 0 : %s %% %s" (reg r) (reg b) (reg a) (reg b)
 			| HF32 ->
 				sexpr "%s = fmodf(%s,%s)" (reg r) (reg a) (reg b)

--- a/src/generators/hlinterp.ml
+++ b/src/generators/hlinterp.ml
@@ -538,6 +538,7 @@ let rec dyn_compare ctx a at b bt =
 	let fcompare (a:float) (b:float) = if a = b then 0 else if a > b then 1 else if a < b then -1 else invalid_comparison in
 	match a, b with
 	| VInt a, VInt b -> Int32.compare a b
+	| VInt64 a, VInt64 b -> Int64.compare a b
 	| VInt a, VFloat b -> fcompare (Int32.to_float a) b
 	| VFloat a, VInt b -> fcompare a (Int32.to_float b)
 	| VFloat a, VFloat b -> fcompare a b
@@ -799,6 +800,7 @@ let interp ctx f args =
 			(match get a, get b with
 			| VInt a, VInt b -> VInt (iop a b)
 			| _ -> Globals.die "" __LOC__)
+		| HI64 -> Globals.die "i64 operation via dynamic not yet implemented" __LOC__ (* todo *)
 		| HF32 | HF64 ->
 			(match get a, get b with
 			| VFloat a, VFloat b -> VFloat (fop a b)

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -358,3 +358,4 @@ typedef ArrayI32 = ArrayBytes<Int>;
 typedef ArrayUI16 = ArrayBytes<UI16>;
 typedef ArrayF32 = ArrayBytes<F32>;
 typedef ArrayF64 = ArrayBytes<Float>;
+typedef ArrayI64 = ArrayBytes<I64>;


### PR DESCRIPTION
@ncannasse 

I think the I64 operations should still be implemented in `hlinterp.ml`. This seems to work now with HL/JIT. For HL/C I get that `hl_dyn_casti64` is missing: this has to be added Hashlink-side but there seems more to the `dyn*` methods (get/set/…).