### PR TITLE
fix typo. –(U+2013) to -(U+002D).

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -204,7 +204,7 @@
 		"devcomment": "force-lib-check is only here as a debug facility - compiler checking allows errors to be found more easily",
 		"name": "ForceLibCheck",
 		"define": "force-lib-check",
-		"doc": "Force the compiler to check `--net-lib` and `–-java-lib` added classes (internal).",
+		"doc": "Force the compiler to check `--net-lib` and `--java-lib` added classes (internal).",
 		"platforms": ["cs", "java"]
 	},
 	{


### PR DESCRIPTION
Fix typo in `src-json/define.json`.
Replace en-dash to hyphen.

en-dash char cause breaking display of `haxe --help-defines` in some case.

![image](https://user-images.githubusercontent.com/1529486/173213847-0894a61a-2118-4248-928a-f955797c3a50.png)
