### PR TITLE
Ignore EOF while attempting to read the HTTP header

### DIFF
--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -284,9 +284,13 @@ class Http extends haxe.http.HttpBase {
 		var s = haxe.io.Bytes.alloc(4);
 		sock.setTimeout(cnxTimeout);
 		while (true) {
-			var p = sock.input.readBytes(s, 0, k);
-			while (p != k)
-				p += sock.input.readBytes(s, p, k - p);
+			var p = 0;
+			while (p != k) {
+				try {
+					p += sock.input.readBytes(s, p, k - p);
+				}
+				catch (e:haxe.io.Eof) { }
+			}
 			b.addBytes(s, 0, k);
 			switch (k) {
 				case 1:


### PR DESCRIPTION
I was running haxe/hl on aws lambda and although it is usually really fast (just a few miliseconds) about 20% of the requests would run for several seconds and timeout and fail. I found that the problem was that when the lambda runtime tried to fetch the next request (using an http request) it would get and EOL and crash, hanging the lambda container.

This fixed it. It also was the only place in the Http class that reads from the socket without handling EOF.