### PR TITLE
Restore macOS 10.13 (High Sierra) support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -428,13 +428,16 @@ jobs:
           cd zlib-$ZLIB_VERSION
           ./configure
           make && make install
+          cd ..
           curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
           cd mbedtls-$MBEDTLS_VERSION
           make && make install
+          cd ..
           curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz
           cd pcre2-$PCRE2_VERSION
           ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
           make && make install
+          cd ..
 
 
       - name: Install OCaml libraries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,7 +411,7 @@ jobs:
           # For compatibility with macOS 10.13
           ZLIB_VERSION: 1.2.13
           MBEDTLS_VERSION: 2.25.0
-          PCRE_VERSION: 10.39
+          PCRE2_VERSION: 10.39
         run: |
           set -ex
           brew uninstall openssl@1.0.2t || echo
@@ -431,8 +431,8 @@ jobs:
           curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
           cd mbedtls-$MBEDTLS_VERSION
           make && make install
-          curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-$PCRE_VERSION.tar.gz | tar xz
-          cd pcre2-$PCRE_VERSION
+          curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz
+          cd pcre2-$PCRE2_VERSION
           ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
           make && make install
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,7 +434,7 @@ jobs:
           cd mbedtls-$MBEDTLS_VERSION
           make && make install
           cd ..
-          curl -L https://ftp.pcre.org/pub/pcre/pcre-$PCRE_VERSION.tar.gz | tar xz
+          curl -L https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VERSION/pcre-$PCRE_VERSION.tar.gz | tar xz
           cd pcre-$PCRE_VERSION
           ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
           make && make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -412,7 +412,6 @@ jobs:
           ZLIB_VERSION: 1.2.13
           MBEDTLS_VERSION: 2.25.0
           PCRE_VERSION: 8.44
-          PCRE2_VERSION: 10.39
         run: |
           set -ex
           brew uninstall openssl@1.0.2t || echo
@@ -437,11 +436,6 @@ jobs:
           curl -L https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VERSION/pcre-$PCRE_VERSION.tar.gz | tar xz
           cd pcre-$PCRE_VERSION
           ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
-          make && make install
-          cd ..
-          curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz
-          cd pcre2-$PCRE2_VERSION
-          ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
           make && make install
           cd ..
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -411,6 +411,7 @@ jobs:
           # For compatibility with macOS 10.13
           ZLIB_VERSION: 1.2.13
           MBEDTLS_VERSION: 2.25.0
+          PCRE_VERSION: 8.44
           PCRE2_VERSION: 10.39
         run: |
           set -ex
@@ -431,6 +432,11 @@ jobs:
           cd ..
           curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
           cd mbedtls-$MBEDTLS_VERSION
+          make && make install
+          cd ..
+          curl -L https://ftp.pcre.org/pub/pcre/pcre-$PCRE_VERSION.tar.gz | tar xz
+          cd pcre-$PCRE_VERSION
+          ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
           make && make install
           cd ..
           curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -20,13 +20,16 @@
     cd zlib-$ZLIB_VERSION
     ./configure
     make && make install
+    cd ..
     curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
     cd mbedtls-$MBEDTLS_VERSION
     make && make install
+    cd ..
     curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz
     cd pcre2-$PCRE2_VERSION
     ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
     make && make install
+    cd ..
 
 
 - name: Install OCaml libraries

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -3,7 +3,7 @@
     # For compatibility with macOS 10.13
     ZLIB_VERSION: 1.2.13
     MBEDTLS_VERSION: 2.25.0
-    PCRE_VERSION: 10.39
+    PCRE2_VERSION: 10.39
   run: |
     set -ex
     brew uninstall openssl@1.0.2t || echo
@@ -23,8 +23,8 @@
     curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
     cd mbedtls-$MBEDTLS_VERSION
     make && make install
-    curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-$PCRE_VERSION.tar.gz | tar xz
-    cd pcre2-$PCRE_VERSION
+    curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz
+    cd pcre2-$PCRE2_VERSION
     ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
     make && make install
 

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -26,7 +26,7 @@
     cd mbedtls-$MBEDTLS_VERSION
     make && make install
     cd ..
-    curl -L https://ftp.pcre.org/pub/pcre/pcre-$PCRE_VERSION.tar.gz | tar xz
+    curl -L https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VERSION/pcre-$PCRE_VERSION.tar.gz | tar xz
     cd pcre-$PCRE_VERSION
     ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
     make && make install

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -4,7 +4,6 @@
     ZLIB_VERSION: 1.2.13
     MBEDTLS_VERSION: 2.25.0
     PCRE_VERSION: 8.44
-    PCRE2_VERSION: 10.39
   run: |
     set -ex
     brew uninstall openssl@1.0.2t || echo
@@ -29,11 +28,6 @@
     curl -L https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VERSION/pcre-$PCRE_VERSION.tar.gz | tar xz
     cd pcre-$PCRE_VERSION
     ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
-    make && make install
-    cd ..
-    curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz
-    cd pcre2-$PCRE2_VERSION
-    ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
     make && make install
     cd ..
 

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -3,6 +3,7 @@
     # For compatibility with macOS 10.13
     ZLIB_VERSION: 1.2.13
     MBEDTLS_VERSION: 2.25.0
+    PCRE_VERSION: 8.44
     PCRE2_VERSION: 10.39
   run: |
     set -ex
@@ -23,6 +24,11 @@
     cd ..
     curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
     cd mbedtls-$MBEDTLS_VERSION
+    make && make install
+    cd ..
+    curl -L https://ftp.pcre.org/pub/pcre/pcre-$PCRE_VERSION.tar.gz | tar xz
+    cd pcre-$PCRE_VERSION
+    ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
     make && make install
     cd ..
     curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-$PCRE2_VERSION/pcre2-$PCRE2_VERSION.tar.gz | tar xz


### PR DESCRIPTION
This restores macOS 10.13 support by ensuring that the pcre code that's linked into Haxe is built from source with the 10.13 deployment target.

This fixes https://github.com/HaxeFoundation/haxe/issues/10723