### PR TITLE
hl.UI.chooseFile multiple select support

### DIFF
--- a/std/hl/UI.hx
+++ b/std/hl/UI.hx
@@ -238,22 +238,17 @@ class UI {
 		var path = null;
 		var files = [];
 		var idx = 0;
-		var len = 0;
+		var len = bytes.ucs2Length(idx);
 
-		do {
-			len = bytes.ucs2Length(idx);
-			if( len == 0 )
-				break;
-
+		while( len > 0 ) {
 			var str = String.fromUCS2( bytes.sub(idx, len * 2 + 2 ) );
 			if( path == null )
 				path = str;
 			else
 				files.push( str );
-
 			idx += len * 2 + 2;
 			len = bytes.ucs2Length(idx);
-		} while ( idx < 2048 );
+		}
 
 		// Special case: If only one file is returned, it will be added to path. Separate it out
 		// here for API consistency

--- a/std/hl/UI.hx
+++ b/std/hl/UI.hx
@@ -238,25 +238,22 @@ class UI {
 		var path = null;
 		var files = [];
 		var idx = 0;
-		var start = 0;
-		var c: Int;
+		var len = 0;
+
 		do {
-			c = bytes.getUI16(idx);
-			idx+=2;
-			if( c == 0 ) {
-				var len = idx - start;
-				// Double null means end of list
-				if( len == 2 )
-					break;
+			len = bytes.ucs2Length(idx);
+			if( len == 0 )
+				break;
 
-				if( path == null )
-					path = String.fromUCS2( bytes.sub(start, idx - start ) );
-				else
-					files.push( String.fromUCS2( bytes.sub(start, idx - start ) ) );
+			var str = String.fromUCS2( bytes.sub(idx, len * 2 + 2 ) );
+			if( path == null )
+				path = str;
+			else
+				files.push( str );
 
-				start = idx;
-			}
-		} while( idx < 2048 );
+			idx += len * 2 + 2;
+			len = bytes.ucs2Length(idx);
+		} while ( idx < 2048 );
 
 		// Special case: If only one file is returned, it will be added to path. Separate it out
 		// here for API consistency


### PR DESCRIPTION
This is the haxe side change for https://github.com/HaxeFoundation/hashlink/pull/559 

This moves a bit of code around, and adds a new function `hl.UI.chooseFileMultiple`, which is a version of `chooseFile` that is always a load, and returns a path plus array of files.

The return format was chosen largely due to how the windows API works, so I'm not married to it if someone wants a different return format. I also would prefer a `@:structInit` class here (especially in hl) but I wanted to maintain consistency with the existing code.

Relevant API docs: https://docs.microsoft.com/en-us/windows/win32/api/commdlg/ns-commdlg-openfilenamea

Essentially this function takes the result from the hl-side chooseFile wrapper and breaks it up into a consistent haxe return. The code is fairly straightforward; we need to dig out each string in the return value, looking for the end marker (two nulls). We then handle the special case for a single file by breaking it out to keep the haxe side API consistent.

If this commit is accepted before the hashlink pull, the function will still function correctly, but not allow multiple file selections in the ui dialogue (making it basically useless, but not crashy/dangerous)