### PR TITLE
[eval] Fix `haxe.Int64` to native `Int64` conversion

### DIFF
--- a/src/macro/eval/evalIntegers.ml
+++ b/src/macro/eval/evalIntegers.ml
@@ -29,7 +29,7 @@ let decode_haxe_i64 v =
 		let high = decode_i32 (vi.ifields.(get_instance_field_index_raise vi.iproto key_high))
 		and low = decode_i32 (vi.ifields.(get_instance_field_index_raise vi.iproto key_low)) in
 		let high64 = GInt64.shift_left (Int32.to_int64 high) 32
-		and low64 = Int32.to_int64 low in
+		and low64 = GInt64.logand (Int32.to_int64 low) 0xffffffffL in
 		GInt64.logor high64 low64
 	| _ ->
 		unexpected_value v "haxe.Int64"


### PR DESCRIPTION
The problem occurs when `low` is `>= 0x80000000`, because `Int32.to_int64` sign-extends the `low` number. The high 32 bits are then all set, so after `GInt64.logor` the `high` value is completely lost.

```
high (int32):   cafecafe
low (int32):    80000001
high (int64):   cafecafe00000000
low (int64):    ffffffff80000001
result:         ffffffff80000001
```

This fix bitmasks the sign-extended low value to only keep the low 32 bits again.