### PR TITLE
[WIP] [notxml] Be more forgiving in the lexer

### DIFF
--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -663,6 +663,12 @@ and not_xml ctx depth in_open =
 	| Plus (Compl ('<' | '/' | '>' | '\n' | '\r')) ->
 		store lexbuf;
 		not_xml ctx depth in_open
+	(* Incomplete opening tag, will raise an error later
+	   but we're allowing it to pass lex to allow completion. *)
+	| '<' ->
+		let s = lexeme lexbuf in
+		Buffer.add_string buf s;
+		not_xml ctx depth in_open
 	| _ ->
 		die "" __LOC__
 


### PR DESCRIPTION
This allows completion requests like
```
myMacro(<foo> <| </foo>);
myMacro(<| );
```
To reach the macro, which can they provide completion data.