### PR TITLE
Added API to haxe.Http for multiple response headers with same name.

### DIFF
--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -33,6 +33,8 @@ class Http extends haxe.http.HttpBase {
 	public var cnxTimeout:Float;
 	public var responseHeaders:Map<String, String>;
 
+	private var responseHeadersSameKey:Map<String, Array<String>>;
+
 	var chunk_size:Null<Int>;
 	var chunk_buf:haxe.io.Bytes;
 	var file:{
@@ -252,6 +254,23 @@ class Http extends haxe.http.HttpBase {
 		}
 	}
 
+	/**
+		Returns an array of values for a single response header or returns
+		null if no such header exists.
+		This method can be useful when you need to get a multiple headers with
+		the same name (e.g. `Set-Cookie`), that are unreachable via the
+		`responseHeaders` variable.
+	**/
+	public function getResponseHeaderValues(key:String):Null<Array<String>> {
+		var array = responseHeadersSameKey.get(key);
+		if (array == null) {
+			var singleValue = responseHeaders.get(key);
+			return (singleValue == null) ? null : [ singleValue ];
+		} else {
+			return array;
+		}
+	}
+
 	function writeBody(body:Null<BytesOutput>, fileInput:Null<Input>, fileSize:Int, boundary:Null<String>, sock:Socket) {
 		if (body != null) {
 			var bytes = body.getBytes();
@@ -366,6 +385,22 @@ class Http extends haxe.http.HttpBase {
 			var hname = a.shift();
 			var hval = if (a.length == 1) a[0] else a.join(": ");
 			hval = StringTools.ltrim(StringTools.rtrim(hval));
+
+			{
+				var previousValue = responseHeaders.get(hname);
+				if (previousValue != null) {
+					if (responseHeadersSameKey == null) {
+						responseHeadersSameKey = new haxe.ds.Map<String, Array<String>>();
+					}
+					var array = responseHeadersSameKey.get(hname);
+					if (array == null) {
+						array = new Array<String>();
+						array.push(previousValue);
+						responseHeadersSameKey.set(hname, array);
+					}
+					array.push(hval);
+				}
+			}
 			responseHeaders.set(hname, hval);
 			switch (hname.toLowerCase()) {
 				case "content-length":


### PR DESCRIPTION
As was reported here (#3550) there are situations when an endpoint returns multiple response headers with the same name (e.g. `Set-Cookie`) and these headers (except the last one) became unreachable.
So this PR adds a new method `getResponseHeaderValues` (suggested by @RealyUniqueName from https://github.com/HaxeFoundation/haxe/issues/9053#issuecomment-568907265) to a public API of the `haxe.Http` class.

This implementation of the method is trying to avoid an overhead allocation when it is possible: if an endpoint returns only single headers then `responseHeadersSameKey` will not be allocated and will keep a `null` state.

If you have any suggestions or remarks I would be happy to update my commit.