### PR TITLE
Clarify JSON docs.

### DIFF
--- a/std/haxe/Json.hx
+++ b/std/haxe/Json.hx
@@ -25,7 +25,7 @@ package haxe;
 /**
 	Cross-platform JSON API: it will automatically use the optimized native API if available.
 	Use `-D haxeJSON` to force usage of the Haxe implementation even if a native API is found:
-	This will provide extra encoding features such as enums (replaced by their index) and StringMaps.
+	This will provide extra encoding (but not decoding) features such as enums (replaced by their index) and StringMaps.
 
 	@see https://haxe.org/manual/std-Json.html
 **/


### PR DESCRIPTION
Make it clear that -D haxeJSON does not support decoding enums, maps, etc. Closes #10811.