### PR TITLE
[lua] Improve codegen for handling instance Var functions

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1318,6 +1318,13 @@ and gen_tbinop ctx op e1 e2 =
               spr ctx "_hx_funcToField(";
               gen_value ctx e2;
               spr ctx ")";
+          | TField(e3, (FInstance _ as lhs)), TField(e4, (FInstance _ as rhs)) when not (is_dot_access e3 lhs) && (is_dot_access e4 rhs) ->
+              gen_value ctx e1;
+              print ctx " %s " (Ast.s_binop op);
+              add_feature ctx "use._hx_funcToField";
+              spr ctx "_hx_funcToField(";
+              gen_value ctx e2;
+              spr ctx ")";
           | TField(e3, (FInstance _ as ci)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) when not (is_dot_access e3 ci) ->
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -352,7 +352,7 @@ let rec is_function_type t =
 
 and gen_argument ?(reflect=false) ctx e = begin
     match e.eexpr with
-    | TField (x,((FInstance (_,_,f)| FAnon(f) | FClosure(_,f))))  when (is_function_type e.etype) ->
+    | TField (x, ((FInstance (_, _, f) | FAnon(f) | FClosure(_,f)) as i)) when ((is_function_type e.etype) && (not(is_dot_access x i))) ->
             (
             if reflect then (
               add_feature ctx "use._hx_funcToField";
@@ -1469,7 +1469,7 @@ and gen_return ctx e eo =
          spr ctx "do return end"
      | Some e ->
          (match e.eexpr with
-          | TField (e2, ((FClosure (_, tcf) | FAnon tcf |FInstance (_,_,tcf)))) when (is_function_type tcf.cf_type) ->
+          | TField (e2, ((FAnon tcf | FInstance (_,_,tcf)) as t)) when ((is_function_type tcf.cf_type) && (not(is_dot_access e2 t)))->
               (* See issue #6259 *)
               add_feature ctx "use._hx_bind";
               spr ctx "do return ";

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -222,8 +222,15 @@ let this ctx = match ctx.in_value with None -> "self" | Some _ -> "self"
 
 let is_dot_access e cf =
     match follow(e.etype), cf with
-    | TInst (c,_), FInstance(_,_,icf)  when (Meta.has Meta.LuaDotMethod c.cl_meta || Meta.has Meta.LuaDotMethod icf.cf_meta)->
-        true;
+    | TInst (c, _), FInstance(_, _, icf) -> (match icf.cf_kind with
+        | Var _ ->
+            true
+        | Method _ when Meta.has Meta.LuaDotMethod c.cl_meta ->
+            true
+        | Method _ when Meta.has Meta.LuaDotMethod icf.cf_meta ->
+            true
+        | Method _ ->
+            false)
     | _ ->
         false
 

--- a/tests/unit/src/unit/issues/Issue10799.hx
+++ b/tests/unit/src/unit/issues/Issue10799.hx
@@ -17,6 +17,21 @@ class Issue10799 extends Test {
 		throw "not implemented";
 	}
 
+	private function returnsField():(Int) -> Int {
+		return this.myField;
+	}
+
+	private function returnsMethod():(Int) -> Int {
+		return this.bar;
+	}
+
+	private function returnsClosure():(Int) -> Int {
+		final obj = lua.Lua.assert({num: 7});
+		final fn:(Int) -> Int = x -> x * obj.num;
+		lua.Lua.assert(fn);
+		return fn;
+	}
+
 	public function test() {
 		this.myField = x -> x * 2;
 		eq(6, untyped __lua__("self.myField(3)"));
@@ -31,6 +46,21 @@ class Issue10799 extends Test {
 		eq(6, untyped __lua__("self:bar(3)"));
 		this.baz = this.bar;
 		eq(6, untyped __lua__("self:baz(3)"));
+
+		var localVar = this.myField;
+		lua.Lua.assert(localVar);
+		eq(6, untyped __lua__("localVar(3)"));
+
+		localVar = this.bar;
+		lua.Lua.assert(localVar);
+		eq(6, untyped __lua__("localVar(3)"));
+
+		final field = this.returnsField();
+		eq(6, untyped __lua__("field(3)"));
+		final method = this.returnsMethod();
+		eq(6, untyped __lua__("method(3)"));
+		final closure = this.returnsClosure();
+		eq(21, untyped __lua__("closure(3)"));
 
 		final anon = lua.Lua.assert({
 			fromField: this.myField,

--- a/tests/unit/src/unit/issues/Issue10799.hx
+++ b/tests/unit/src/unit/issues/Issue10799.hx
@@ -1,0 +1,49 @@
+package unit.issues;
+
+class Issue10799 extends Test {
+	#if lua
+	var myField:(Int) -> Int;
+
+	private static function foo(x:Int):Int
+		return x * 3;
+
+	private dynamic function bar(x:Int):Int {
+		eq("table", untyped __lua__("_G.type(self)"));
+		eq("number", untyped __lua__("_G.type(x)"));
+		return x * 4;
+	}
+
+	private dynamic function baz(x:Int):Int {
+		throw "not implemented";
+	}
+
+	public function test() {
+		this.myField = x -> x * 2;
+		eq(6, untyped __lua__("self.myField(3)"));
+		this.myField = Issue10799.foo;
+		eq(9, untyped __lua__("self.myField(3)"));
+		eq(9, untyped __lua__("__unit_issues_Issue10799.foo(3)"));
+		this.myField = this.bar;
+		eq(12, untyped __lua__("self.myField(3)"));
+		exc(() -> untyped __lua__("self.bar(3)"));
+		this.myField = x -> x * 2;
+		this.bar = this.myField;
+		eq(6, untyped __lua__("self:bar(3)"));
+		this.baz = this.bar;
+		eq(6, untyped __lua__("self:baz(3)"));
+
+		final anon = lua.Lua.assert({
+			fromField: this.myField,
+			fromStatic: Issue10799.foo,
+			fromMethod: this.bar,
+		});
+
+		exc(() -> untyped __lua__("anon.fromField(3)"));
+		eq(6, untyped __lua__("anon:fromField(3)"));
+		exc(() -> untyped __lua__("anon.fromStatic(3)"));
+		eq(9, untyped __lua__("anon:fromStatic(3)"));
+		exc(() -> untyped __lua__("anon.fromMethod(3)"));
+		eq(6, untyped __lua__("anon:fromMethod(3)"));
+	}
+	#end
+}


### PR DESCRIPTION
This PR changes how class instance fields are handled, improving interop with Lua APIs.

- Var fields that are functions should now behave as "dot methods"
- assignments to "dot methods" should no longer change their signatures
- passing as parameters and returning of "dot methods" should no longer wrap them in helper functions
- non-function members should be left as-is
- static methods should be left as-is
- instance methods should be left as-is
- anonymous structures' fields should be left as-is

Fixes #10799