### PR TITLE
Null coalescing warning

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -102,6 +102,11 @@
 		"name": "WConstructorInliningCancelled",
 		"doc": "Constructor call could not be inlined because a field is uninitialized",
 		"parent": "WTyper"
+	},
+	{
+		"name": "WUnnecessaryNullCheck",
+		"doc": "Value can't be null, so comparison with null is excessive",
+		"parent": "WTyper"
 	}
 
 ]

--- a/tests/misc/projects/Issue10478/Main.hx
+++ b/tests/misc/projects/Issue10478/Main.hx
@@ -1,0 +1,27 @@
+class Main {
+	static function main() {
+		var a = 1;
+		var b = 2;
+		a = a ?? b;
+		a ??= b;
+
+		var a = 1;
+		var b:Null<Int> = 2;
+		a = a ?? b;
+		a ??= b;
+
+		var a:Null<Int> = 1;
+		var b = 2;
+		a = a ?? b;
+		a ??= b;
+
+		var a = 1;
+		var b = 2;
+		var c = 2;
+		a = a ?? b ?? c;
+
+		var a = null;
+		a = 1;
+		a ??= b;
+	}
+}

--- a/tests/misc/projects/Issue10478/compile.hxml
+++ b/tests/misc/projects/Issue10478/compile.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue10478/compile.hxml.stderr
+++ b/tests/misc/projects/Issue10478/compile.hxml.stderr
@@ -1,0 +1,6 @@
+Main.hx:5: characters 7-13 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:6: characters 3-10 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:10: characters 7-13 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:11: characters 3-10 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:21: characters 12-18 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:21: characters 7-18 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed

--- a/tests/misc/projects/Issue10478/compile2-fail.hxml
+++ b/tests/misc/projects/Issue10478/compile2-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--jvm bin/main.jar

--- a/tests/misc/projects/Issue10478/compile2-fail.hxml
+++ b/tests/misc/projects/Issue10478/compile2-fail.hxml
@@ -1,2 +1,2 @@
 --main Main
---jvm bin/main.jar
+--hl bin/main.hl

--- a/tests/misc/projects/Issue10478/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10478/compile2-fail.hxml.stderr
@@ -1,0 +1,10 @@
+Main.hx:5: characters 7-13 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:6: characters 3-10 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:10: characters 7-13 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:11: characters 3-10 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:21: characters 12-18 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:21: characters 7-18 : Warning : (WUnnecessaryNullCheck) The left operand is not nullable, so the right operand can be not executed
+Main.hx:6: characters 3-10 : On static platforms, null can't be used as basic type Int
+Main.hx:11: characters 3-10 : On static platforms, null can't be used as basic type Int
+Main.hx:6: characters 3-10 : On static platforms, null can't be used as basic type Int
+Main.hx:11: characters 3-10 : On static platforms, null can't be used as basic type Int


### PR DESCRIPTION
This adds warnings for `notNull ?? value` and `notNull ??= value`.
This also notifies users about hidden allocations on static targets, because `a ?? b` always converts `a` to `Null<T>` silently to make null check, which is bad for basic types here.
Not sure how to add `DKRemovableCode` diagnostic here for both cases.