### PR TITLE
Fix anonymous functions in operator expressions regression

### DIFF
--- a/tests/misc/projects/Issue10782/ImmediatelyInvoked.hx
+++ b/tests/misc/projects/Issue10782/ImmediatelyInvoked.hx
@@ -1,5 +1,5 @@
 class ImmediatelyInvoked {
 	static function main() {
-        var test:String = function(str) { return str; }("hello");
-    }
+		var test:String = function(str) { return str; }("hello");
+	}
 }

--- a/tests/misc/projects/Issue10782/ImmediatelyInvoked.hx
+++ b/tests/misc/projects/Issue10782/ImmediatelyInvoked.hx
@@ -1,0 +1,5 @@
+class ImmediatelyInvoked {
+	static function main() {
+        var test:String = function(str) { return str; }("hello");
+    }
+}

--- a/tests/misc/projects/Issue10782/Main.hx
+++ b/tests/misc/projects/Issue10782/Main.hx
@@ -1,0 +1,22 @@
+@:callable
+abstract Function(Int->Int) to Int->Int from Int->Int {
+	@:op(a + b)
+	static function add(a:Function, b:Function):Function {
+		return function(i) {
+			return a(b(i));
+		};
+	}
+}
+
+class Main {
+	static function main() {
+		var f:Function = function(a) {
+			return a + 1;
+		}
+
+		var g = function(a) { return a * a; } + f;
+        if (g(10) != 121) {
+            throw "Incorrect function return value";
+        }
+	}
+}

--- a/tests/misc/projects/Issue10782/Main.hx
+++ b/tests/misc/projects/Issue10782/Main.hx
@@ -15,8 +15,8 @@ class Main {
 		}
 
 		var g = function(a) { return a * a; } + f;
-        if (g(10) != 121) {
-            throw "Incorrect function return value";
-        }
+		if (g(10) != 121) {
+			throw "Incorrect function return value";
+		}
 	}
 }

--- a/tests/misc/projects/Issue10782/compile.hxml
+++ b/tests/misc/projects/Issue10782/compile.hxml
@@ -1,0 +1,1 @@
+--run Main

--- a/tests/misc/projects/Issue10782/immediately-invoked.hxml
+++ b/tests/misc/projects/Issue10782/immediately-invoked.hxml
@@ -1,0 +1,1 @@
+--run ImmediatelyInvoked

--- a/tests/misc/projects/Issue5854/NamedLocal.hx
+++ b/tests/misc/projects/Issue5854/NamedLocal.hx
@@ -1,0 +1,11 @@
+class NamedLocal {
+	static function main() {
+        // shouldn't be parsed as a call
+        function test(str) {
+            trace(str);
+            throw "This function shouldn't have been called!!";
+        }
+		("hello");
+    }
+}
+

--- a/tests/misc/projects/Issue5854/NamedLocal.hx
+++ b/tests/misc/projects/Issue5854/NamedLocal.hx
@@ -1,11 +1,10 @@
 class NamedLocal {
 	static function main() {
-        // shouldn't be parsed as a call
-        function test(str) {
-            trace(str);
-            throw "This function shouldn't have been called!!";
-        }
+		// shouldn't be parsed as a call
+		function test(str) {
+			trace(str);
+			throw "This function shouldn't have been called!!";
+		}
 		("hello");
-    }
+	}
 }
-

--- a/tests/misc/projects/Issue5854/UnnamedLocal.hx
+++ b/tests/misc/projects/Issue5854/UnnamedLocal.hx
@@ -1,0 +1,8 @@
+class UnnamedLocal {
+	static function main() {
+        function(str) {
+            trace(str);
+        }
+        ("hello");
+    }
+}

--- a/tests/misc/projects/Issue5854/UnnamedLocal.hx
+++ b/tests/misc/projects/Issue5854/UnnamedLocal.hx
@@ -1,8 +1,8 @@
 class UnnamedLocal {
 	static function main() {
-        function(str) {
-            trace(str);
-        }
-        ("hello");
-    }
+		function(str) {
+			trace(str);
+		}
+		("hello");
+	}
 }

--- a/tests/misc/projects/Issue5854/compile-fail.hxml
+++ b/tests/misc/projects/Issue5854/compile-fail.hxml
@@ -1,0 +1,1 @@
+--main UnnamedLocal

--- a/tests/misc/projects/Issue5854/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue5854/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+UnnamedLocal.hx:3: lines 3-5 : Unnamed lvalue functions are not supported

--- a/tests/misc/projects/Issue5854/compile.hxml
+++ b/tests/misc/projects/Issue5854/compile.hxml
@@ -1,0 +1,1 @@
+--run NamedLocal


### PR DESCRIPTION
Fixes #10782, a regression caused by 2183ca5.

The commit was made to solve #5854, however, this PR fixes that issue in a more precise way that avoids collateral breakages, while being much more consistent with other languages like JavaScript or TypeScript.

E.g. this now parses again, where an anonymous function is embedded in an expression (as opposed to a "top-level" declaration in a block as was the case in #5854). This is consistent with Javascript:
```haxe
var test:String = function(str) { return str; }("hello");
```

I've also added tests for #5854 to confirm that the original issue remains solved.