### PR TITLE
macro '#if (a != b)' should be true for missing defines

### DIFF
--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -87,7 +87,7 @@ let rec eval ctx (e,p) =
 		in
 		(match op with
 		| OpEq -> compare (=)
-		| OpNotEq -> compare (<>)
+		| OpNotEq -> TBool (not (is_true (compare (=))))
 		| OpGt -> compare (>)
 		| OpGte -> compare (>=)
 		| OpLt -> compare (<)

--- a/tests/misc/projects/Issue10152/Main.hx
+++ b/tests/misc/projects/Issue10152/Main.hx
@@ -1,0 +1,9 @@
+class Main {
+	static function main () {
+	#if (foo != "bar")
+		trace("NOT EQUAL");
+	#else
+		trace("EQUAL");
+	#end
+	}
+}

--- a/tests/misc/projects/Issue10152/compile-defined.hxml
+++ b/tests/misc/projects/Issue10152/compile-defined.hxml
@@ -1,0 +1,3 @@
+--main Main
+-D foo=bar
+--interp

--- a/tests/misc/projects/Issue10152/compile-defined.hxml.stdout
+++ b/tests/misc/projects/Issue10152/compile-defined.hxml.stdout
@@ -1,0 +1,1 @@
+Main.hx:6: EQUAL

--- a/tests/misc/projects/Issue10152/compile-undefined.hxml
+++ b/tests/misc/projects/Issue10152/compile-undefined.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue10152/compile-undefined.hxml.stdout
+++ b/tests/misc/projects/Issue10152/compile-undefined.hxml.stdout
@@ -1,0 +1,1 @@
+Main.hx:4: NOT EQUAL


### PR DESCRIPTION
I think the least surprising implementation here is for `!=` to be the inverse of `==`.

(fixes #10152)