### PR TITLE
[cpp] Don't allow static casting of extern classes or enums

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -2314,6 +2314,8 @@ let cpp_can_static_cast funcType inferredType =
    | TCppReference(_) | TCppStar(_) | TCppStruct(_) -> false
    | _ ->
       (match inferredType with
+      | TCppInst (cls, _) when is_extern_class cls -> false
+      | TCppEnum e when is_extern_enum e -> false
       | TCppInst _
       | TCppClass
       | TCppEnum _

--- a/tests/unit/src/unit/issues/Issue10876.hx
+++ b/tests/unit/src/unit/issues/Issue10876.hx
@@ -1,0 +1,41 @@
+package unit.issues;
+
+import utest.Assert;
+
+#if (cpp && !cppia)
+@:native('MY_DEFINE')
+extern class MyDefine {}
+
+@:unreflective
+@:structAccess
+@:native('my_extern')
+extern class MyExtern<T> {
+	function new();
+
+	function create() : T;
+}
+
+@:headerCode('
+
+typedef int MY_DEFINE;
+
+template<class T>
+class my_extern {
+public:
+	T create() {
+		return T();
+	}
+};
+
+')
+#end
+class Issue10876 extends Test {
+    #if (cpp && !cppia)
+    function test() {
+        final vec = cpp.Pointer.fromStar(new MyExtern<MyDefine>());
+		final num = vec.ptr.create();
+
+        Assert.equals(0, num);
+    }
+    #end
+}


### PR DESCRIPTION
Ran into an issue where if you had a `cpp.Pointer` or similar (standard stack allocs work fine) holding a generic extern class it would try and use hxcpp generic semantics, meaning you would get calls to `.StaticCast<>` as it assumes all generic types are `::Dynamic`.

Not sure if the ideal solution would be for such function calls to be transformed to use a different `CppFunction` type, but I found that modifying `cpp_can_static_cast` to return false for extern types fixes the issue as well.