### PR TITLE
fix(lua): _hx_field_arr result and idx variables should be local

### DIFF
--- a/std/lua/_lua/_hx_anon.lua
+++ b/std/lua/_lua/_hx_anon.lua
@@ -33,8 +33,8 @@ local function _hx_new(prototype)
 end
 
 function _hx_field_arr(obj)
-    res = {}
-    idx = 0
+    local res = {}
+    local idx = 0
     if obj.__fields__ ~= nil then
         obj = obj.__fields__
     end


### PR DESCRIPTION
_hx_field_arr has to variables that are becoming global because the lac of local prefix when they are defined. Not sure if this is intentional, but I don't see a reason for it.