### PR TITLE
Add decimal to binary conversion

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -458,6 +458,19 @@ class StringTools {
 		#end
 		return s;
 	}
+	
+	/**
+		Encodes `n` into a binary representation.
+	**/
+	public static function binary(n:Int) {
+		var s = "";
+		while (n != 0) {
+			var isOdd = (n & 1) == 1;
+			s = ((isOdd) ? "1" : "0") + s;
+			n >>>= 1;
+		}
+		return s;
+	}
 
 	/**
 		Returns the character code at position `index` of String `s`, or an


### PR DESCRIPTION
This pull will add Int to binary String conversion .
The following code give a better performance for Hashlink, Eval and other targets,I'm not sure why as StringBuf use String internally.
```haxe
    var s = "";
    var binaryString = new StringBuf();
    while (n != 0)
    { 
      var isOdd:Bool = (n & 1) == 1;
      if (isOdd) binaryString.add("1");
      else binaryString.add("0");
      n >>>= 1;
    }
    s = binaryString.toString();
```