### PR TITLE
fix: prevent null errors StringMap.get

### DIFF
--- a/std/lua/_std/haxe/ds/StringMap.hx
+++ b/std/lua/_std/haxe/ds/StringMap.hx
@@ -46,7 +46,7 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 		untyped {
 			var ret = h[key];
 			if (ret == tnull) {
-				ret = null;
+				return null;
 			}
 			return ret;
 		}


### PR DESCRIPTION
Not sure why this was changed. The previous implementation was playing well with null safety on, the current one does not.