### PR TITLE
[ci] unearthly CI build times

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -407,7 +407,7 @@ jobs:
         run: haxe RunCi.hxml
         working-directory: ${{github.workspace}}/tests
 
-  linux-arm64-build:
+  linux-arm64:
     runs-on: ubuntu-18.04
     permissions:
       packages: write
@@ -462,51 +462,6 @@ jobs:
         with:
           name: linuxArm64Binaries
           path: out/linux/arm64
-
-  linux-arm64-test:
-    needs: linux-arm64-build
-    runs-on: ubuntu-18.04
-    permissions:
-      packages: write
-    env:
-      FORCE_COLOR: 1
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Earthly
-        run: sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.13/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly && /usr/local/bin/earthly bootstrap --with-autocomplete'
-
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-            image: tonistiigi/binfmt:latest
-            platforms: all
-
-      - uses: actions/checkout@main
-        with:
-          submodules: recursive
-
-      - name: Set CONTAINER_ vars
-        run: |
-          echo "CONTAINER_REG=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV;
-          echo "CONTAINER_TAG=$(echo ${{ github.ref_name }} | sed -e 's/[^A-Za-z0-9\.]/-/g')" >> $GITHUB_ENV;
-
-      - name: Build devcontainer
-        run: earthly +devcontainer-multiarch --IMAGE_NAME="ghcr.io/${CONTAINER_REG}_devcontainer" --IMAGE_TAG="${CONTAINER_TAG}"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_USE_INLINE_CACHE: true
-          EARTHLY_SAVE_INLINE_CACHE: true
-
-      - name: Set ADD_REVISION=1 for non-release
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
 
   mac-build:
     runs-on: macos-latest
@@ -872,7 +827,7 @@ jobs:
 
   deploy:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
@@ -948,7 +903,7 @@ jobs:
 
   deploy_apidoc:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       - name: Download Haxe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: D:\.opam
-          key: ${{ runner.os }}64-${{ hashFiles('./opam') }}-1
+          key: ${{ runner.os }}64-${{ hashFiles('./opam', './libs/') }}
 
       - name: Install Neko from S3
         shell: pwsh
@@ -160,7 +160,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: D:\.opam
-          key: ${{ runner.os }}32-${{ hashFiles('./opam') }}-1
+          key: ${{ runner.os }}32-${{ hashFiles('./opam', './libs/') }}
 
       - name: Install Neko from S3
         shell: pwsh
@@ -265,7 +265,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: ~/.opam/
-          key: ${{ runner.os }}-${{ hashFiles('./opam') }}
+          key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}
 
       - name: Install Neko from S3
         run: |
@@ -479,7 +479,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: ~/.opam/
-          key: ${{ runner.os }}-${{ hashFiles('./opam') }}
+          key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}
 
       - name: Install Neko from S3
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -339,10 +339,7 @@ jobs:
 
       - name: Setup Haxe
         run: |
-          # mkdir ./linuxBinaries
-          # curl -sSL https://build.haxe.org/builds/haxe/linux64/haxe_latest.tar.gz -o ./linuxBinaries/haxe_bin.tar.gz
-
-          sudo apt install -qqy libmbedtls-dev libgtk2.0-0
+          sudo apt install -qqy libmbedtls-dev
 
           set -ex
           tar -xf linuxBinaries/*_bin.tar.gz -C linuxBinaries --strip-components=1
@@ -369,7 +366,6 @@ jobs:
           sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Test
-        # if: success()
         run: haxe RunCi.hxml
         working-directory: ${{github.workspace}}/tests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,51 +212,79 @@ jobs:
           path: out
 
 
-  linux-amd64:
-    runs-on: ubuntu-18.04
-    permissions:
-      packages: write
+  linux-build:
+    runs-on: ubuntu-20.04
     env:
-      FORCE_COLOR: 1
+      PLATFORM: linux64
+      OPAMYES: 1
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Earthly
-        run: sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.13/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly && /usr/local/bin/earthly bootstrap --with-autocomplete'
-
       - uses: actions/checkout@main
         with:
           submodules: recursive
 
-      - name: Set CONTAINER_ vars
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v3.0.11
+        with:
+          path: ~/.opam/
+          key: ${{ runner.os }}-${{ hashFiles('./opam') }}
+
+      - name: Install Neko from S3
         run: |
-          echo "CONTAINER_REG=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV;
-          echo "CONTAINER_TAG=$(echo ${{ github.ref_name }} | sed -e 's/[^A-Za-z0-9\.]/-/g')" >> $GITHUB_ENV;
+          set -ex
 
-      - name: Build devcontainer
-        run: earthly +devcontainer --IMAGE_NAME="ghcr.io/${CONTAINER_REG}_devcontainer" --IMAGE_TAG="${CONTAINER_TAG}-amd64" --IMAGE_CACHE="ghcr.io/haxefoundation/haxe_devcontainer:development-amd64"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_USE_INLINE_CACHE: true
-          EARTHLY_SAVE_INLINE_CACHE: true
+          curl -sSL https://build.haxe.org/builds/neko/$PLATFORM/neko_latest.tar.gz -o $RUNNER_TEMP/neko_latest.tar.gz
+          tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
+          NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
+          sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/lib/neko
+          sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
+          sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
+          echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 
-      - name: Set ADD_REVISION=1 for non-release
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
+      - name: Print Neko version
+        run: neko -version 2>&1
 
-      - name: Build
-        run: earthly +build --ADD_REVISION="$ADD_REVISION" --SET_SAFE_DIRECTORY="true"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_REMOTE_CACHE: "ghcr.io/${{env.CONTAINER_REG}}_cache:build-${{env.CONTAINER_TAG}}-amd64"
+
+      - name: Install dependencies
+        run: |
+          set -ex
+          sudo add-apt-repository ppa:avsm/ppa -y # provides OPAM 2
+          sudo add-apt-repository ppa:haxe/ocaml -y # provides newer version of mbedtls
+          sudo apt-get update -qqy
+          sudo apt-get install -qqy ocaml-nox camlp5 opam libpcre3-dev zlib1g-dev libgtk2.0-dev libmbedtls-dev ninja-build libstring-shellquote-perl libipc-system-simple-perl
+
+      - name: Install OCaml libraries
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        run: |
+          set -ex
+          opam init # --disable-sandboxing
+          opam update
+          opam pin add haxe . --no-action
+          opam install haxe --deps-only --assume-depexts
+          opam list
+          ocamlopt -v
+
+      - name: Build Haxe
+        run: |
+          set -ex
+          eval $(opam env)
+          opam config exec -- make -s -j`nproc` STATICLINK=1 haxe
+          opam config exec -- make -s haxelib
+          make -s package_unix
+          ls -l out
+          ldd -v ./haxe
+          ldd -v ./haxelib
 
       - name: Build xmldoc
-        run: earthly +xmldoc --COMMIT="${{ github.sha }}" --BRANCH="${{ github.ref_name }}"
+        run: make xmldoc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: linuxBinaries
+          path: out
 
       - name: Upload xmldoc artifact
         uses: actions/upload-artifact@v1.0.0
@@ -264,19 +292,88 @@ jobs:
           name: xmldoc
           path: extra/doc
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1.0.0
+  linux-test:
+    needs: linux-build
+    runs-on: ubuntu-20.04
+    env:
+      PLATFORM: linux64
+      TEST: ${{matrix.target}}
+      HXCPP_COMPILE_CACHE: ~/hxcache
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/5024
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, neko]
+        include:
+          - target: hl
+            APT_PACKAGES: cmake ninja-build libturbojpeg-dev
+          - target: cpp
+            APT_PACKAGES: gcc-multilib g++-multilib
+          # - target: lua
+          #   APT_PACKAGES: ncurses-dev
+    steps:
+      - uses: actions/checkout@main
+        with:
+          submodules: recursive
+      - uses: actions/download-artifact@v1
         with:
           name: linuxBinaries
-          path: out/linux/amd64
+
+      - name: Install Neko from S3
+        run: |
+          set -ex
+
+          curl -sSL https://build.haxe.org/builds/neko/$PLATFORM/neko_latest.tar.gz -o $RUNNER_TEMP/neko_latest.tar.gz
+          tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
+          NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
+          sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/lib/neko
+          sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
+          sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
+          echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
+
+      - name: Print Neko version
+        run: neko -version 2>&1
+
+
+      - name: Setup Haxe
+        run: |
+          # mkdir ./linuxBinaries
+          # curl -sSL https://build.haxe.org/builds/haxe/linux64/haxe_latest.tar.gz -o ./linuxBinaries/haxe_bin.tar.gz
+
+          sudo apt install -qqy libmbedtls-dev libgtk2.0-0
+
+          set -ex
+          tar -xf linuxBinaries/*_bin.tar.gz -C linuxBinaries --strip-components=1
+          sudo mkdir -p /usr/local/bin/
+          sudo mkdir -p /usr/local/share/haxe/
+          sudo ln -s `pwd`/linuxBinaries/haxe /usr/local/bin/haxe
+          sudo ln -s `pwd`/linuxBinaries/haxelib /usr/local/bin/haxelib
+          sudo ln -s `pwd`/linuxBinaries/std /usr/local/share/haxe/std
+
+      - name: Print Haxe version
+        run: haxe -version
+
+      - name: Setup haxelib
+        run: |
+          set -ex
+          mkdir ~/haxelib
+          haxelib setup ~/haxelib
+
+      - name: Install apt packages
+        if: matrix.APT_PACKAGES
+        run: |
+          set -ex
+          sudo apt update -qqy
+          sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Test
-        run: earthly +test-all --GITHUB_ACTIONS="$GITHUB_ACTIONS"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_REMOTE_CACHE: "ghcr.io/${{env.CONTAINER_REG}}_cache:test-${{env.CONTAINER_TAG}}-amd64"
+        # if: success()
+        run: haxe RunCi.hxml
+        working-directory: ${{github.workspace}}/tests
 
-  linux-arm64:
+  linux-arm64-build:
     runs-on: ubuntu-18.04
     permissions:
       packages: write
@@ -332,10 +429,8 @@ jobs:
           name: linuxArm64Binaries
           path: out/linux/arm64
 
-      # Do not run test for arm64 for now
-
-  linux-multiarch:
-    needs: [linux-amd64, linux-arm64]
+  linux-arm64-test:
+    needs: linux-arm64-build
     runs-on: ubuntu-18.04
     permissions:
       packages: write
@@ -390,6 +485,13 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v3.0.11
+        with:
+          path: ~/.opam/
+          key: ${{ runner.os }}-${{ hashFiles('./opam') }}
+
       - name: Install Neko from S3
         run: |
           set -ex
@@ -442,6 +544,7 @@ jobs:
 
 
       - name: Install OCaml libraries
+        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           set -ex
           opam init # --disable-sandboxing
@@ -735,7 +838,7 @@ jobs:
 
   deploy:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-amd64, linux-arm64, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
@@ -811,7 +914,7 @@ jobs:
 
   deploy_apidoc:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-amd64, linux-arm64, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       - name: Download Haxe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows64
       OPAMYES: 1
+      OPAMROOT: D:\.opam
       CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
       ARCH: 64
       MINGW_ARCH: x86_64
@@ -30,6 +31,18 @@ jobs:
       - uses: actions/checkout@main
         with:
           submodules: recursive
+
+      - name: Use GNU Tar from msys
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm C:\msys64\usr\bin\bash.exe
+
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v3.0.11
+        with:
+          path: D:\.opam
+          key: ${{ runner.os }}64-${{ hashFiles('./opam') }}-1
 
       - name: Install Neko from S3
         shell: pwsh
@@ -56,7 +69,7 @@ jobs:
         shell: pwsh
         run: Write-Host "::add-path::C:\ProgramData\chocolatey\bin"
 
-      - name: Install OCaml and OCaml libraries
+      - name: Install OCaml
         shell: pwsh
         run: |
           Set-PSDebug -Trace 1
@@ -71,6 +84,12 @@ jobs:
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -C / -xvf libmbedtls.tar.xz')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -xf opam.tar.xz')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && bash opam${ARCH}/install.sh')
+
+      - name: Install OCaml libraries
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          Set-PSDebug -Trace 1
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam init mingw "https://github.com/fdopen/opam-repository-mingw.git#opam2" --comp 4.07.0+mingw${ARCH}c --switch 4.07.0+mingw${ARCH}c --auto-setup --yes 2>&1')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam update --yes 2>&1')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam pin add haxe . --kind=path --no-action --yes 2>&1')
@@ -119,6 +138,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows
       OPAMYES: 1
+      OPAMROOT: D:\.opam
       CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
       ARCH: 32
       MINGW_ARCH: i686
@@ -129,6 +149,18 @@ jobs:
       - uses: actions/checkout@main
         with:
           submodules: recursive
+
+      - name: Use GNU Tar from msys
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm C:\msys64\usr\bin\bash.exe
+
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v3.0.11
+        with:
+          path: D:\.opam
+          key: ${{ runner.os }}32-${{ hashFiles('./opam') }}-1
 
       - name: Install Neko from S3
         shell: pwsh
@@ -155,7 +187,7 @@ jobs:
         shell: pwsh
         run: Write-Host "::add-path::C:\ProgramData\chocolatey\bin"
 
-      - name: Install OCaml and OCaml libraries
+      - name: Install OCaml
         shell: pwsh
         run: |
           Set-PSDebug -Trace 1
@@ -170,6 +202,12 @@ jobs:
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -C / -xvf libmbedtls.tar.xz')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -xf opam.tar.xz')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && bash opam${ARCH}/install.sh')
+
+      - name: Install OCaml libraries
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          Set-PSDebug -Trace 1
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam init mingw "https://github.com/fdopen/opam-repository-mingw.git#opam2" --comp 4.07.0+mingw${ARCH}c --switch 4.07.0+mingw${ARCH}c --auto-setup --yes 2>&1')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam update --yes 2>&1')
           & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam pin add haxe . --kind=path --no-action --yes 2>&1')

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -33,6 +33,7 @@
 
 
 - name: Install OCaml libraries
+  if: steps.cache-opam.outputs.cache-hit != 'true'
   run: |
     set -ex
     opam init # --disable-sandboxing

--- a/extra/github-actions/cache-opam.yml
+++ b/extra/github-actions/cache-opam.yml
@@ -3,4 +3,4 @@
   uses: actions/cache@v3.0.11
   with:
     path: ~/.opam/
-    key: ${{ runner.os }}-${{ hashFiles('./opam') }}
+    key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}

--- a/extra/github-actions/cache-opam.yml
+++ b/extra/github-actions/cache-opam.yml
@@ -1,0 +1,6 @@
+- name: Cache opam
+  id: cache-opam
+  uses: actions/cache@v3.0.11
+  with:
+    path: ~/.opam/
+    key: ${{ runner.os }}-${{ hashFiles('./opam') }}

--- a/extra/github-actions/install-ocaml-libs-windows.yml
+++ b/extra/github-actions/install-ocaml-libs-windows.yml
@@ -1,0 +1,11 @@
+- name: Install OCaml libraries
+  if: steps.cache-opam.outputs.cache-hit != 'true'
+  shell: pwsh
+  run: |
+    Set-PSDebug -Trace 1
+    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam init mingw "https://github.com/fdopen/opam-repository-mingw.git#opam2" --comp 4.07.0+mingw${ARCH}c --switch 4.07.0+mingw${ARCH}c --auto-setup --yes 2>&1')
+    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam update --yes 2>&1')
+    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam pin add haxe . --kind=path --no-action --yes 2>&1')
+    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam install haxe --deps-only --yes 2>&1')
+    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam list')
+    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'ocamlopt -v')

--- a/extra/github-actions/install-ocaml-windows.yml
+++ b/extra/github-actions/install-ocaml-windows.yml
@@ -1,4 +1,4 @@
-- name: Install OCaml and OCaml libraries
+- name: Install OCaml
   shell: pwsh
   run: |
     Set-PSDebug -Trace 1
@@ -13,9 +13,3 @@
     & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -C / -xvf libmbedtls.tar.xz')
     & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -xf opam.tar.xz')
     & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && bash opam${ARCH}/install.sh')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam init mingw "https://github.com/fdopen/opam-repository-mingw.git#opam2" --comp 4.07.0+mingw${ARCH}c --switch 4.07.0+mingw${ARCH}c --auto-setup --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam update --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam pin add haxe . --kind=path --no-action --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam install haxe --deps-only --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam list')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'ocamlopt -v')

--- a/extra/github-actions/install-ocaml-windows64.yml
+++ b/extra/github-actions/install-ocaml-windows64.yml
@@ -1,4 +1,4 @@
-- name: Install OCaml and OCaml libraries
+- name: Install OCaml
   shell: pwsh
   run: |
     Set-PSDebug -Trace 1
@@ -13,9 +13,3 @@
     & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -C / -xvf libmbedtls.tar.xz')
     & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && tar -xf opam.tar.xz')
     & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && bash opam${ARCH}/install.sh')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam init mingw "https://github.com/fdopen/opam-repository-mingw.git#opam2" --comp 4.07.0+mingw${ARCH}c --switch 4.07.0+mingw${ARCH}c --auto-setup --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam update --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'cd "$OLDPWD" && opam pin add haxe . --kind=path --no-action --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam install haxe --deps-only --yes 2>&1')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'opam list')
-    & "$($env:CYG_ROOT)/bin/bash.exe" @('-lc', 'ocamlopt -v')

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows64
       OPAMYES: 1
+      OPAMROOT: D:\.opam
       CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
       ARCH: 64
       MINGW_ARCH: x86_64
@@ -30,9 +31,22 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use GNU Tar from msys
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm C:\msys64\usr\bin\bash.exe
+
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v3.0.11
+        with:
+          path: D:\.opam
+          key: ${{ runner.os }}64-${{ hashFiles('./opam') }}-1
+
       @import install-neko-windows.yml
       @import install-nsis.yml
       @import install-ocaml-windows64.yml
+      @import install-ocaml-libs-windows.yml
       @import build-windows.yml
 
   windows-build:
@@ -41,6 +55,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows
       OPAMYES: 1
+      OPAMROOT: D:\.opam
       CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
       ARCH: 32
       MINGW_ARCH: i686
@@ -52,9 +67,22 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Use GNU Tar from msys
+        run: |
+          echo "C:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          rm C:\msys64\usr\bin\bash.exe
+
+      - name: Cache opam
+        id: cache-opam
+        uses: actions/cache@v3.0.11
+        with:
+          path: D:\.opam
+          key: ${{ runner.os }}32-${{ hashFiles('./opam') }}-1
+
       @import install-neko-windows.yml
       @import install-nsis.yml
       @import install-ocaml-windows.yml
+      @import install-ocaml-libs-windows.yml
       @import build-windows.yml
 
   linux-build:

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -204,7 +204,7 @@ jobs:
         run: haxe RunCi.hxml
         working-directory: ${{github.workspace}}/tests
 
-  linux-arm64-build:
+  linux-arm64:
     runs-on: ubuntu-18.04
     permissions:
       packages: write
@@ -259,51 +259,6 @@ jobs:
         with:
           name: linuxArm64Binaries
           path: out/linux/arm64
-
-  linux-arm64-test:
-    needs: linux-arm64-build
-    runs-on: ubuntu-18.04
-    permissions:
-      packages: write
-    env:
-      FORCE_COLOR: 1
-    steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Earthly
-        run: sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.13/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly && /usr/local/bin/earthly bootstrap --with-autocomplete'
-
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@v1
-        with:
-            image: tonistiigi/binfmt:latest
-            platforms: all
-
-      - uses: actions/checkout@main
-        with:
-          submodules: recursive
-
-      - name: Set CONTAINER_ vars
-        run: |
-          echo "CONTAINER_REG=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV;
-          echo "CONTAINER_TAG=$(echo ${{ github.ref_name }} | sed -e 's/[^A-Za-z0-9\.]/-/g')" >> $GITHUB_ENV;
-
-      - name: Build devcontainer
-        run: earthly +devcontainer-multiarch --IMAGE_NAME="ghcr.io/${CONTAINER_REG}_devcontainer" --IMAGE_TAG="${CONTAINER_TAG}"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_USE_INLINE_CACHE: true
-          EARTHLY_SAVE_INLINE_CACHE: true
-
-      - name: Set ADD_REVISION=1 for non-release
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
 
   mac-build:
     runs-on: macos-latest
@@ -398,7 +353,7 @@ jobs:
 
   deploy:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
@@ -474,7 +429,7 @@ jobs:
 
   deploy_apidoc:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       - name: Download Haxe

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -57,51 +57,57 @@ jobs:
       @import install-ocaml-windows.yml
       @import build-windows.yml
 
-  linux-amd64:
-    runs-on: ubuntu-18.04
-    permissions:
-      packages: write
+  linux-build:
+    runs-on: ubuntu-20.04
     env:
-      FORCE_COLOR: 1
+      PLATFORM: linux64
+      OPAMYES: 1
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Earthly
-        run: sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.6.13/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly && /usr/local/bin/earthly bootstrap --with-autocomplete'
-
       - uses: actions/checkout@main
         with:
           submodules: recursive
 
-      - name: Set CONTAINER_ vars
+      @import cache-opam.yml
+      @import install-neko-unix.yml
+
+      - name: Install dependencies
         run: |
-          echo "CONTAINER_REG=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV;
-          echo "CONTAINER_TAG=$(echo ${{ github.ref_name }} | sed -e 's/[^A-Za-z0-9\.]/-/g')" >> $GITHUB_ENV;
+          set -ex
+          sudo add-apt-repository ppa:avsm/ppa -y # provides OPAM 2
+          sudo add-apt-repository ppa:haxe/ocaml -y # provides newer version of mbedtls
+          sudo apt-get update -qqy
+          sudo apt-get install -qqy ocaml-nox camlp5 opam libpcre3-dev zlib1g-dev libgtk2.0-dev libmbedtls-dev ninja-build libstring-shellquote-perl libipc-system-simple-perl
 
-      - name: Build devcontainer
-        run: earthly +devcontainer --IMAGE_NAME="ghcr.io/${CONTAINER_REG}_devcontainer" --IMAGE_TAG="${CONTAINER_TAG}-amd64" --IMAGE_CACHE="ghcr.io/haxefoundation/haxe_devcontainer:development-amd64"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_USE_INLINE_CACHE: true
-          EARTHLY_SAVE_INLINE_CACHE: true
+      - name: Install OCaml libraries
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        run: |
+          set -ex
+          opam init # --disable-sandboxing
+          opam update
+          opam pin add haxe . --no-action
+          opam install haxe --deps-only --assume-depexts
+          opam list
+          ocamlopt -v
 
-      - name: Set ADD_REVISION=1 for non-release
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
-
-      - name: Build
-        run: earthly +build --ADD_REVISION="$ADD_REVISION" --SET_SAFE_DIRECTORY="true"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_REMOTE_CACHE: "ghcr.io/${{env.CONTAINER_REG}}_cache:build-${{env.CONTAINER_TAG}}-amd64"
+      - name: Build Haxe
+        run: |
+          set -ex
+          eval $(opam env)
+          opam config exec -- make -s -j`nproc` STATICLINK=1 haxe
+          opam config exec -- make -s haxelib
+          make -s package_unix
+          ls -l out
+          ldd -v ./haxe
+          ldd -v ./haxelib
 
       - name: Build xmldoc
-        run: earthly +xmldoc --COMMIT="${{ github.sha }}" --BRANCH="${{ github.ref_name }}"
+        run: make xmldoc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: linuxBinaries
+          path: out
 
       - name: Upload xmldoc artifact
         uses: actions/upload-artifact@v1.0.0
@@ -109,19 +115,72 @@ jobs:
           name: xmldoc
           path: extra/doc
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1.0.0
+  linux-test:
+    needs: linux-build
+    runs-on: ubuntu-20.04
+    env:
+      PLATFORM: linux64
+      TEST: ${{matrix.target}}
+      HXCPP_COMPILE_CACHE: ~/hxcache
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/5024
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, neko]
+        include:
+          - target: hl
+            APT_PACKAGES: cmake ninja-build libturbojpeg-dev
+          - target: cpp
+            APT_PACKAGES: gcc-multilib g++-multilib
+          # - target: lua
+          #   APT_PACKAGES: ncurses-dev
+    steps:
+      - uses: actions/checkout@main
+        with:
+          submodules: recursive
+      - uses: actions/download-artifact@v1
         with:
           name: linuxBinaries
-          path: out/linux/amd64
+
+      @import install-neko-unix.yml
+
+      - name: Setup Haxe
+        run: |
+          # mkdir ./linuxBinaries
+          # curl -sSL https://build.haxe.org/builds/haxe/linux64/haxe_latest.tar.gz -o ./linuxBinaries/haxe_bin.tar.gz
+
+          sudo apt install -qqy libmbedtls-dev libgtk2.0-0
+
+          set -ex
+          tar -xf linuxBinaries/*_bin.tar.gz -C linuxBinaries --strip-components=1
+          sudo mkdir -p /usr/local/bin/
+          sudo mkdir -p /usr/local/share/haxe/
+          sudo ln -s `pwd`/linuxBinaries/haxe /usr/local/bin/haxe
+          sudo ln -s `pwd`/linuxBinaries/haxelib /usr/local/bin/haxelib
+          sudo ln -s `pwd`/linuxBinaries/std /usr/local/share/haxe/std
+
+      - name: Print Haxe version
+        run: haxe -version
+
+      - name: Setup haxelib
+        run: |
+          set -ex
+          mkdir ~/haxelib
+          haxelib setup ~/haxelib
+
+      - name: Install apt packages
+        if: matrix.APT_PACKAGES
+        run: |
+          set -ex
+          sudo apt update -qqy
+          sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Test
-        run: earthly +test-all --GITHUB_ACTIONS="$GITHUB_ACTIONS"
-        env:
-          EARTHLY_PUSH: "${{ github.event_name == 'push' }}"
-          EARTHLY_REMOTE_CACHE: "ghcr.io/${{env.CONTAINER_REG}}_cache:test-${{env.CONTAINER_TAG}}-amd64"
+        # if: success()
+        run: haxe RunCi.hxml
+        working-directory: ${{github.workspace}}/tests
 
-  linux-arm64:
+  linux-arm64-build:
     runs-on: ubuntu-18.04
     permissions:
       packages: write
@@ -177,10 +236,8 @@ jobs:
           name: linuxArm64Binaries
           path: out/linux/arm64
 
-      # Do not run test for arm64 for now
-
-  linux-multiarch:
-    needs: [linux-amd64, linux-arm64]
+  linux-arm64-test:
+    needs: linux-arm64-build
     runs-on: ubuntu-18.04
     permissions:
       packages: write
@@ -235,6 +292,7 @@ jobs:
         with:
           submodules: recursive
 
+      @import cache-opam.yml
       @import install-neko-unix.yml
       @import build-mac.yml
 
@@ -316,7 +374,7 @@ jobs:
 
   deploy:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-amd64, linux-arm64, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
@@ -392,7 +450,7 @@ jobs:
 
   deploy_apidoc:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
-    needs: [linux-amd64, linux-arm64, mac-test, windows-test, windows64-test]
+    needs: [linux-test, linux-arm64-test, mac-test, windows-test, windows64-test]
     runs-on: ubuntu-18.04
     steps:
       - name: Download Haxe

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -146,10 +146,7 @@ jobs:
 
       - name: Setup Haxe
         run: |
-          # mkdir ./linuxBinaries
-          # curl -sSL https://build.haxe.org/builds/haxe/linux64/haxe_latest.tar.gz -o ./linuxBinaries/haxe_bin.tar.gz
-
-          sudo apt install -qqy libmbedtls-dev libgtk2.0-0
+          sudo apt install -qqy libmbedtls-dev
 
           set -ex
           tar -xf linuxBinaries/*_bin.tar.gz -C linuxBinaries --strip-components=1
@@ -176,7 +173,6 @@ jobs:
           sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Test
-        # if: success()
         run: haxe RunCi.hxml
         working-directory: ${{github.workspace}}/tests
 

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: D:\.opam
-          key: ${{ runner.os }}64-${{ hashFiles('./opam') }}-1
+          key: ${{ runner.os }}64-${{ hashFiles('./opam', './libs/') }}
 
       @import install-neko-windows.yml
       @import install-nsis.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: D:\.opam
-          key: ${{ runner.os }}32-${{ hashFiles('./opam') }}-1
+          key: ${{ runner.os }}32-${{ hashFiles('./opam', './libs/') }}
 
       @import install-neko-windows.yml
       @import install-nsis.yml


### PR DESCRIPTION
* [x] Reverting to previous CI implementation for linux64, because earthly times are too often very bad for it lately (when it even finishes)
* [x] Adding opam cache to further reduce >99% of CI build times by 10~20min; this implementation is naive but working well enough afaik
* [x] Flush the cache when libs folder changes too

## Random measurements

Showcase CI run: https://github.com/HaxeFoundation/haxe/actions/runs/3726658201 (41m total)

| platform | previous build | previous build+test | new build⁽¹⁾ | new build+test⁽¹⁾ | delta |
| --- | --: | --: | --: | --: | --: |
| linux-arm64 | 7m30s | 33m⁽²⁾ ~ 2h | 7m30s | 7m30s | :arrow_down:  -25m |
| linux-amd64 | 30m | 33m ~ 2h | 2m30s | 13~15m | :arrow_down:  -18~20m |
| mac | 30~40m | 60~80m⁽³⁾ | 10~15m | 40~55m⁽³⁾ | :arrow_down: -15~30m |
| windows32 | 30~40m | 40~55m | 15m | 25m | :arrow_down: -15~20m |
| windows64 | 30~40m | 40~55m | 15m | 25m | :arrow_down: -15~20m |
| total CI time | - | 75m ~ 2h | - | 40~55m | :arrow_down: -20~30m |

_⁽¹⁾: runs with opam cache hits; which represent near 100% of our runs since we don't change opam dependencies often_ 
_⁽²⁾: linux-arm64 needed to wait for linux-amd64 to complete before running the (removed) multiarch task_ 
_⁽³⁾: including 30~40min for cpp test, mac runners are generally bad and sometimes **really** bad_