### PR TITLE
[docs] Add TypeTools.follow() example for use with typedefs

### DIFF
--- a/std/haxe/macro/TypeTools.hx
+++ b/std/haxe/macro/TypeTools.hx
@@ -174,11 +174,16 @@ class TypeTools {
 
 		If `t` is null, an internal exception is thrown.
 
-		Usage example:
+		Usage example with monomorphs:
 			var t = Context.typeof(macro null); // TMono(<mono>)
 			var ts = Context.typeof(macro "foo"); //TInst(String,[])
 			Context.unify(t, ts);
 			trace(t); // TMono(<mono>)
+			trace(t.follow()); //TInst(String,[])
+
+		Usage example with typedefs:
+			var t = Context.typeof(macro ("foo" :MyString)); // typedef MyString = String
+			trace(t); // TType(MyString,[])
 			trace(t.follow()); //TInst(String,[])
 	**/
 	static public inline function follow(t:Type, ?once:Bool):Type


### PR DESCRIPTION
`TypeTools.follow()` documentation currently focuses on usage with monomorphs, while usage with typedefs is very common.