### PR TITLE
[lua] Respect lua-vanilla for Json.parse

### DIFF
--- a/std/lua/_std/haxe/format/JsonParser.hx
+++ b/std/lua/_std/haxe/format/JsonParser.hx
@@ -42,7 +42,11 @@ class JsonParser {
 		If `str` is null, the result is unspecified.
 	**/
 	static public inline function parse(str:String):Dynamic {
+		#if lua_vanilla
+		return new JsonParser(str).doParse();
+		#else
 		return lua.lib.hxluasimdjson.Json.parse(str);
+		#end
 	}
 
 	var str:String;
@@ -83,7 +87,8 @@ class JsonParser {
 							case '}'.code:
 								if (field != null || comma == false)
 									invalidChar();
-								return obj;
+								
+								obj;
 							case ':'.code:
 								if (field == null)
 									invalidChar();

--- a/std/lua/_std/haxe/format/JsonParser.hx
+++ b/std/lua/_std/haxe/format/JsonParser.hx
@@ -87,8 +87,7 @@ class JsonParser {
 							case '}'.code:
 								if (field != null || comma == false)
 									invalidChar();
-								
-								obj;
+								return obj;
 							case ':'.code:
 								if (field == null)
 									invalidChar();


### PR DESCRIPTION
This PR returns the original std json parse function when lua-vanilla flag is set, instead of requiring hxsimdjson.

This fixes #9900