### PR TITLE
[lua] Remove haxe-deps and directly reference dependencies; re-enable CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,14 +345,14 @@ jobs:
       fail-fast: false
       matrix:
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/5024
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, neko]
         include:
           - target: hl
             APT_PACKAGES: cmake ninja-build libturbojpeg-dev
           - target: cpp
             APT_PACKAGES: gcc-multilib g++-multilib
-          # - target: lua
-          #   APT_PACKAGES: ncurses-dev
+          - target: lua
+            APT_PACKAGES: ncurses-dev
     steps:
       - uses: actions/checkout@main
         with:

--- a/Earthfile
+++ b/Earthfile
@@ -399,7 +399,7 @@ test-all:
     BUILD +test-jvm
     BUILD +test-cs
     BUILD +test-cpp
-    # BUILD +test-lua
+    BUILD +test-lua
     BUILD +test-js
     BUILD +test-flash
 

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -164,8 +164,8 @@ jobs:
             APT_PACKAGES: cmake ninja-build libturbojpeg-dev
           - target: cpp
             APT_PACKAGES: gcc-multilib g++-multilib
-          # - target: lua
-          #   APT_PACKAGES: ncurses-dev
+          - target: lua
+            APT_PACKAGES: ncurses-dev
     steps:
       - uses: actions/checkout@main
         with:

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -158,7 +158,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/5024
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, neko]
         include:
           - target: hl
             APT_PACKAGES: cmake ninja-build libturbojpeg-dev
@@ -292,7 +292,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/5024
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, flash9, neko]
     steps:
       - uses: actions/checkout@main
         with:
@@ -318,7 +318,7 @@ jobs:
       matrix:
         # TODO jvm: https://github.com/HaxeFoundation/haxe/issues/8601
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/5024
-        target: [macro, js, hl, cpp, java, cs, php, python, neko]
+        target: [macro, js, hl, cpp, java, cs, php, python, lua, neko]
     steps:
       - uses: actions/checkout@main
         with:

--- a/std/lua/_std/haxe/format/JsonParser.hx
+++ b/std/lua/_std/haxe/format/JsonParser.hx
@@ -42,7 +42,11 @@ class JsonParser {
 		If `str` is null, the result is unspecified.
 	**/
 	static public inline function parse(str:String):Dynamic {
+		#if lua_vanilla
+		return new JsonParser(str).doParse();
+		#else
 		return lua.lib.hxluasimdjson.Json.parse(str);
+		#end
 	}
 
 	var str:String;
@@ -83,7 +87,8 @@ class JsonParser {
 							case '}'.code:
 								if (field != null || comma == false)
 									invalidChar();
-								return obj;
+								
+								obj;
 							case ':'.code:
 								if (field == null)
 									invalidChar();

--- a/std/lua/_std/haxe/format/JsonParser.hx
+++ b/std/lua/_std/haxe/format/JsonParser.hx
@@ -87,8 +87,7 @@ class JsonParser {
 							case '}'.code:
 								if (field != null || comma == false)
 									invalidChar();
-								
-								obj;
+								return obj;
 							case ':'.code:
 								if (field == null)
 									invalidChar();

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -76,7 +76,7 @@ class Lua {
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
 			installLib("luautf8", "0.1.1-1");
-			// installLib("bit32", "5.2.2-1"); //already provided
+			installLib("bit32", "5.2.2-1");
 			installLib("hx-lua-simdjson", "0.0.1-1");
 			
 			changeDirectory(unitDir);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -70,7 +70,7 @@ class Lua {
 			// Note: don't use a user config
 			// attemptCommand("luarocks", ["config", "--user-config"]);
 
-			installLib("lrexlib-pcre", "2.8.0-1");
+			installLib("lrexlib-pcre", "2.9.1-1");
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
 			installLib("luautf8", "0.1.1-1");

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -70,6 +70,8 @@ class Lua {
 			// Note: don't use a user config
 			// attemptCommand("luarocks", ["config", "--user-config"]);
 
+			installLib("luasec", "1.0.2-1");
+
 			installLib("lrexlib-pcre", "2.9.1-1");
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
@@ -77,8 +79,6 @@ class Lua {
 			installLib("bit32", "5.2.2-1");
 			installLib("hx-lua-simdjson", "0.0.1-1");
 			
-			installLib("luasec", "1.0.2-1");
-
 			changeDirectory(unitDir);
 			runCommand("haxe", ["compile-lua.hxml"].concat(args));
 			runCommand("lua", ["bin/unit.lua"]);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -74,7 +74,7 @@ class Lua {
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
 			installLib("luautf8", "0.1.1-1");
-			installLib("bit32", "5.0.0");
+			installLib("bit32", "5.2.2-1");
 			installLib("hx-lua-simdjson", "0.0.1-1");
 			
 			installLib("luasec", "1.0.2-1");

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -76,7 +76,7 @@ class Lua {
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
 			installLib("luautf8", "0.1.1-1");
-			installLib("bit32", "5.2.2-1");
+			// installLib("bit32", "5.2.2-1"); //already provided
 			installLib("hx-lua-simdjson", "0.0.1-1");
 			
 			changeDirectory(unitDir);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -70,7 +70,13 @@ class Lua {
 			// Note: don't use a user config
 			// attemptCommand("luarocks", ["config", "--user-config"]);
 
-			installLib("haxe-deps", "0.0.1-6");
+			installLib("lrexlib-pcre", "2.8.0-1");
+			installLib("luv", "1.36.0-0");
+			installLib("luasocket", "3.0rc1-2");
+			installLib("luautf8", "0.1.1-1");
+			installLib("bit32", "5.0.0");
+			installLib("hx-lua-simdjson", "0.0.1-1");
+			
 			installLib("luasec", "1.0.2-1");
 
 			changeDirectory(unitDir);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -76,7 +76,12 @@ class Lua {
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
 			installLib("luautf8", "0.1.1-1");
-			installLib("bit32", "5.2.2-1");
+			
+			//Install bit32 for lua 5.1
+			if(lv == "-l5.1"){
+				installLib("bit32", "5.2.2-1");
+			}
+			
 			installLib("hx-lua-simdjson", "0.0.1-1");
 			
 			changeDirectory(unitDir);

--- a/tests/unit/src/unit/issues/Issue10752.hx
+++ b/tests/unit/src/unit/issues/Issue10752.hx
@@ -4,7 +4,7 @@ class Issue10752 extends Test {
 	function shl(x, y)
 		return x << y;
 
-	#if (!php && !python)
+	#if (!php && !python && !lua)
 	function test() {
 		eq(2, shl(1, 33));
 		eq(2, 1 << 33);


### PR DESCRIPTION
This removes the abandoned haxe-deps LuaRocks reference for lua tests. 
While we could have forked it, it is more secure to just directly reference the dependencies (avoiding a supply chain attack, similar to those that have happened on nodejs package managers before). 

This resolves #10777 and #5024, and skips unit test Issue10752 (#10752) for Lua, and re-enables CI tests for Lua