### PR TITLE
[lua] Modify default lua native bitops library from bit to bit32

### DIFF
--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -1,15 +1,16 @@
--- require this for lua 5.1
-pcall(require, 'bit')
-if bit then
-  _hx_bit_raw = bit
-  _hx_bit = setmetatable({}, { __index = _hx_bit_raw });
-else
+if pcall(require, 'bit32') then --if we are on Lua 5.1, bit32 will be the default. 
   _hx_bit_raw = _G.require('bit32')
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw });
   -- lua 5.2 weirdness
   _hx_bit.bnot = function(...) return _hx_bit_clamp(_hx_bit_raw.bnot(...)) end;
   _hx_bit.bxor = function(...) return _hx_bit_clamp(_hx_bit_raw.bxor(...)) end;
+else
+  --If we do not have bit32, fallback to 'bit'
+  pcall(require, 'bit')
+  _hx_bit_raw = bit
+  _hx_bit = setmetatable({}, { __index = _hx_bit_raw });
 end
+
 -- see https://github.com/HaxeFoundation/haxe/issues/8849
 _hx_bit.bor = function(...) return _hx_bit_clamp(_hx_bit_raw.bor(...)) end;
 _hx_bit.band = function(...) return _hx_bit_clamp(_hx_bit_raw.band(...)) end;

--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -1,5 +1,5 @@
 if pcall(require, 'bit32') then --if we are on Lua 5.1, bit32 will be the default. 
-  _hx_bit_raw = _G.require('bit32')
+  _hx_bit_raw = bit32
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw });
   -- lua 5.2 weirdness
   _hx_bit.bnot = function(...) return _hx_bit_clamp(_hx_bit_raw.bnot(...)) end;


### PR DESCRIPTION
This PR modifies the default lua native bitops library from bit to bit32.

This resolves a bug with some Lua 5.1 runtimes. In general, on Lua 5.1 the "official" bitops library is bit32 (installed from Luarocks). Some runtimes have backported versions of the 5.2 "bit" library, but these are generally not recommended to use. 
Accidentally using the backported version of bit can cause unexpected issues in some Lua runtimes such as [Cobalt ](https://github.com/SquidDev/Cobalt)