### PR TITLE
[server] remove early macro context flush

### DIFF
--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -431,7 +431,7 @@ let rec init_macro_interp ctx mctx mint =
 	let p = null_pos in
 	ignore(TypeloadModule.load_module mctx (["haxe";"macro"],"Expr") p);
 	ignore(TypeloadModule.load_module mctx (["haxe";"macro"],"Type") p);
-	flush_macro_context mint ctx;
+	(* flush_macro_context mint ctx; *)
 	Interp.init mint;
 	if !macro_enable_cache && not (Common.defined mctx.com Define.NoMacroCache) then begin
 		macro_interp_cache := Some mint;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -431,7 +431,6 @@ let rec init_macro_interp ctx mctx mint =
 	let p = null_pos in
 	ignore(TypeloadModule.load_module mctx (["haxe";"macro"],"Expr") p);
 	ignore(TypeloadModule.load_module mctx (["haxe";"macro"],"Type") p);
-	(* flush_macro_context mint ctx; *)
 	Interp.init mint;
 	if !macro_enable_cache && not (Common.defined mctx.com Define.NoMacroCache) then begin
 		macro_interp_cache := Some mint;


### PR DESCRIPTION
This flush can lead to macro context being broken after a display request in some cases (for example https://github.com/kLabz/haxerepro-xredefined/)

Removing the flush does fix that, and did not break anything else so far for me after a week of using it in several projects, and trying a few things that could potentially be affected.

Still, if you have any idea of a precise workflow that could break with this change, please share so I can add tests and we can try to handle these cases nicely without this flush (or with this flush under some conditions only).