### PR TITLE
Revive test for #8616

### DIFF
--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -260,16 +260,17 @@ class ServerTests extends TestCase {
 		utest.Assert.equals('2', counter);
 	}
 
-	// function testIssue8616() {
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue8616/Main.hx"));
-	// 	vfs.putContent("A.hx", getTemplate("issues/Issue8616/A.hx"));
-	// 	var args = ["-main", "Main", "-js", "out.js"];
-	// 	runHaxe(args);
-	// 	runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-	// 	runHaxe(args);
-	// 	var content = sys.io.File.getContent(haxe.io.Path.join([testDir, "out.js"]));
-	// 	Assert.isTrue(content.indexOf("this1.use(v1)") != -1);
-	// }
+	function testIssue8616() {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue8616/Main.hx"));
+		vfs.putContent("A.hx", getTemplate("issues/Issue8616/A.hx"));
+		var args = ["-main", "Main", "-js", "out.js"];
+		runHaxe(args);
+		var originalContent = sys.io.File.getContent(haxe.io.Path.join([testDir, "out.js"]));
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+		runHaxe(args);
+		var content = sys.io.File.getContent(haxe.io.Path.join([testDir, "out.js"]));
+		Assert.isTrue(content == originalContent);
+	}
 
 	function test9918() {
 		vfs.putContent("Issue9918.hx", getTemplate("Issue9918.hx"));


### PR DESCRIPTION
`this1.use(v1)` was not found because `v` was being reused too:
```js
Main.main = function() {
	var this1 = Main.a;
	var v = Main.v;
	this1.use(v);
	this1.use(v);
	var this1 = Main.a;
	var v = Main.v;
	this1.use(v);
	this1.use(v);
};
```
(tbh I'm not sure why `this1.use(v1)` was expected, seemed to me either `this1.use(v)` or `this2.use(v1)` were to be expected?)

This version of the test compares output for the two compilations, which are expected to be the same.
Maybe this is overkill?

Closes #8616

