### PR TITLE
Add test for compilation server stack overflow issue

### DIFF
--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -179,32 +179,32 @@ class TestCase implements ITest {
 	}
 
 	function assertSuccess(?p:haxe.PosInfos) {
-		Assert.isTrue(0 == errorMessages.length, p);
+		return Assert.isTrue(0 == errorMessages.length, p);
 	}
 
 	function assertErrorMessage(message:String, ?p:haxe.PosInfos) {
-		Assert.isTrue(hasErrorMessage(message), p);
+		return Assert.isTrue(hasErrorMessage(message), p);
 	}
 
 	function assertHasPrint(line:String, ?p:haxe.PosInfos) {
-		Assert.isTrue(hasMessage("Haxe print: " + line), null, p);
+		return Assert.isTrue(hasMessage("Haxe print: " + line), null, p);
 	}
 
 	function assertReuse(module:String, ?p:haxe.PosInfos) {
-		Assert.isTrue(hasMessage('reusing $module'), null, p);
+		return Assert.isTrue(hasMessage('reusing $module'), null, p);
 	}
 
 	function assertSkipping(module:String, reason:SkipReason, ?p:haxe.PosInfos) {
 		var msg = 'skipping $module (${printSkipReason(reason))})';
-		Assert.isTrue(hasMessage(msg), null, p);
+		return Assert.isTrue(hasMessage(msg), null, p);
 	}
 
 	function assertNotCacheModified(module:String, ?p:haxe.PosInfos) {
-		Assert.isTrue(hasMessage('$module not cached (modified)'), null, p);
+		return Assert.isTrue(hasMessage('$module not cached (modified)'), null, p);
 	}
 
 	function assertHasType(typePackage:String, typeName:String, ?p:haxe.PosInfos) {
-		Assert.isTrue(getStoredType(typePackage, typeName) != null, null, p);
+		return Assert.isTrue(getStoredType(typePackage, typeName) != null, null, p);
 	}
 
 	function assertHasField(typePackage:String, typeName:String, fieldName:String, isStatic:Bool, ?p:haxe.PosInfos) {

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -275,6 +275,24 @@ class ServerTests extends TestCase {
 		assertSuccess();
 	}
 
+	@:async function testStackOverflow(async:utest.Async) {
+		vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
+		var args = ["-main", "Empty.hx", "--macro", "allowPackage('sys')", "--interp", "--no-output"];
+		var runs = 0;
+
+		function runLoop() {
+			runHaxe(args.concat(["--display", "Empty.hx@0@diagnostics"]), () -> {
+				runHaxe(args.concat(["-D", "compile-only-define"]), () -> {
+					if (assertSuccess() && ++runs < 20) runLoop();
+					else async.done();
+				});
+			});
+		}
+
+		async.setTimeout(20000);
+		runLoop();
+	}
+
 	function testMacroStaticsReset() {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue8631/Main.hx"));
 		vfs.putContent("Init.hx", getTemplate("issues/Issue8631/Init.hx"));

--- a/tests/server/src/utils/macro/TestBuilder.macro.hx
+++ b/tests/server/src/utils/macro/TestBuilder.macro.hx
@@ -12,6 +12,9 @@ class TestBuilder {
 				continue;
 			}
 			switch (field.kind) {
+				case FFun(f) if (field.meta.exists(m -> m.name == ":async")):
+					// Async is already manually handled, nothing to do
+
 				case FFun(f):
 					var asyncName = switch f.args {
 						case []:


### PR DESCRIPTION
Had to run in a loop because depending on the environment (depending on the stack size and/or paths stored in compiler memory) it takes something like 15-20 iterations to trigger the issue.

Tested locally with 100 iterations, didn't break either.