### PR TITLE
[display] add server/typeContexts to show contexts in which a type is loaded

### DIFF
--- a/src/compiler/compilationCache.ml
+++ b/src/compiler/compilationCache.ml
@@ -54,6 +54,9 @@ class context_cache (index : int) = object(self)
 	method find_module path =
 		Hashtbl.find modules path
 
+	method find_module_opt path =
+		Hashtbl.find_opt modules path
+
 	method cache_module path value =
 		Hashtbl.replace modules path value
 


### PR DESCRIPTION
This is not mapped to editors (yet?) but can still be used with display API (manually, in tests, or in repro scripts) to check in which contexts a type has been loaded.

Example usage _(`haxe-display` here being a simple haxe wrapper to ease display API usage)_:

![image](https://user-images.githubusercontent.com/6101998/215218885-bff6a2c4-9147-40fb-a446-7de889456cf0.png)

I'm thinking of adding a Haxe LSP request to expose that to LSP clients, which I could easily map to a keybinding on types on neovim, but I'm not sure yet how I could integrate it in vscode :thinking: 