### PR TITLE
Fix API doc generation

### DIFF
--- a/src/codegen/genxml.ml
+++ b/src/codegen/genxml.ml
@@ -226,10 +226,7 @@ let rec gen_type_decl com pos t =
 			| None -> List.map (fun f -> f,[]) fields
 			| Some (csup,_) -> List.map (fun f -> if exists f csup then (f,["override","1"]) else (f,[])) fields
 		) in
-		let fields = ExtList.List.filter_map (fun (f,att) ->
-			if Meta.has Meta.NoDoc f.cf_meta then None
-			else Some (gen_field att f)
-		) fields in
+		let fields = List.map (fun (f,att) -> gen_field att f) fields in
 		let constr = (match c.cl_constructor with None -> [] | Some f -> [gen_field [] f]) in
 		let impl = List.map (gen_class_path (if (has_class_flag c CInterface) then "extends" else "implements")) c.cl_implements in
 		let tree = (match c.cl_super with

--- a/src/codegen/genxml.ml
+++ b/src/codegen/genxml.ml
@@ -226,7 +226,7 @@ let rec gen_type_decl com pos t =
 			| None -> List.map (fun f -> f,[]) fields
 			| Some (csup,_) -> List.map (fun f -> if exists f csup then (f,["override","1"]) else (f,[])) fields
 		) in
-		let fields = List.filter_map (fun (f,att) ->
+		let fields = ExtList.List.filter_map (fun (f,att) ->
 			if Meta.has Meta.NoDoc f.cf_meta then None
 			else Some (gen_field att f)
 		) fields in
@@ -259,8 +259,8 @@ let rec gen_type_decl com pos t =
 		let mk_field_cast (t,cf) =
 			if Meta.has Meta.NoDoc cf.cf_meta then None
 			else Some (node "icast" ["field",cf.cf_name] [gen_type t]) in
-		let sub = (match a.a_from,a.a_from_field with [],[] -> [] | l1,l2 -> [node "from" [] ((List.map mk_cast l1) @ (List.filter_map mk_field_cast l2))]) in
-		let super = (match a.a_to,a.a_to_field with [],[] -> [] | l1,l2 -> [node "to" [] ((List.map mk_cast l1) @ (List.filter_map mk_field_cast l2))]) in
+		let sub = (match a.a_from,a.a_from_field with [],[] -> [] | l1,l2 -> [node "from" [] ((List.map mk_cast l1) @ (ExtList.List.filter_map mk_field_cast l2))]) in
+		let super = (match a.a_to,a.a_to_field with [],[] -> [] | l1,l2 -> [node "to" [] ((List.map mk_cast l1) @ (ExtList.List.filter_map mk_field_cast l2))]) in
 		let impl = (match a.a_impl with None -> [] | Some c -> [node "impl" [] [gen_type_decl com pos (TClassDecl c)]]) in
 		let this = [node "this" [] [gen_type a.a_this]] in
 		node "abstract" (gen_type_params pos a.a_private (tpath t) a.a_params a.a_pos m) (sub @ this @ super @ doc @ meta @ impl)

--- a/src/codegen/genxml.ml
+++ b/src/codegen/genxml.ml
@@ -253,9 +253,7 @@ let rec gen_type_decl com pos t =
 		let doc = gen_doc_opt a.a_doc in
 		let meta = gen_meta a.a_meta in
 		let mk_cast t = node "icast" [] [gen_type t] in
-		let mk_field_cast (t,cf) =
-			if Meta.has Meta.NoDoc cf.cf_meta then None
-			else Some (node "icast" ["field",cf.cf_name] [gen_type t]) in
+		let mk_field_cast (t,cf) = if Meta.has Meta.NoDoc cf.cf_meta then None else Some (node "icast" ["field",cf.cf_name] [gen_type t]) in
 		let sub = (match a.a_from,a.a_from_field with [],[] -> [] | l1,l2 -> [node "from" [] ((List.map mk_cast l1) @ (ExtList.List.filter_map mk_field_cast l2))]) in
 		let super = (match a.a_to,a.a_to_field with [],[] -> [] | l1,l2 -> [node "to" [] ((List.map mk_cast l1) @ (ExtList.List.filter_map mk_field_cast l2))]) in
 		let impl = (match a.a_impl with None -> [] | Some c -> [node "impl" [] [gen_type_decl com pos (TClassDecl c)]]) in

--- a/std/java/_std/haxe/Rest.hx
+++ b/std/java/_std/haxe/Rest.hx
@@ -37,11 +37,11 @@ abstract Rest<T>(NativeRest<T>) {
 		return new Rest(cast result);
 	}
 
-	@:dox(hide)
+	@:noDoc
 	@:from static function ofNativeInt(collection:NativeArray<Int>):Rest<Int>
 		return ofNativePrimitive(new NativeRest<java.lang.Integer>(collection.length), collection);
 
-	@:dox(hide)
+	@:noDoc
 	@:from static function ofNativeFloat(collection:NativeArray<Float>):Rest<Float>
 		return ofNativePrimitive(new NativeRest<java.lang.Double>(collection.length), collection);
 


### PR DESCRIPTION
* `xml`: don't add fields that have `@:noDoc` (previously only applied on instance fields and types, now added statics and abstract @:from/@:to)
* Java: `haxe.Rest`: don't expose some native fields in xml doc

Closes https://github.com/HaxeFoundation/haxe/issues/10351
api.haxe.org CI run with this branch: https://github.com/HaxeFoundation/api.haxe.org/pull/17