### PR TITLE
[ci] Restore revision hash for non-release Linux builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,6 +294,10 @@ jobs:
           opam list
           ocamlopt -v
 
+      - name: Set ADD_REVISION=1 for non-release
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
+
       - name: Build Haxe
         run: |
           set -ex

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -107,6 +107,10 @@ jobs:
           opam list
           ocamlopt -v
 
+      - name: Set ADD_REVISION=1 for non-release
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: echo "ADD_REVISION=1" >> $GITHUB_ENV
+
       - name: Build Haxe
         run: |
           set -ex


### PR DESCRIPTION
This should fix the failing hxcpp CI for Linux builds:

https://dev.azure.com/HaxeFoundation/GitHubPublic/_build/results?buildId=10533&view=logs&j=f68f8415-9497-565a-c30f-6cc647c5c3f5&t=c31d1e51-9339-5bc6-104a-a4f71b90d06b