### PR TITLE
[eval] add -D eval-print-depth

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -160,6 +160,13 @@
 		"platforms": ["eval"]
 	},
 	{
+		"name": "EvalPrintDepth",
+		"define": "eval-print-depth",
+		"doc": "Set maximum print depth (before replacing with '<...>') for eval. (default: 5)",
+		"platforms": ["eval"],
+		"params": ["depth"]
+	},
+	{
 		"name": "EvalStack",
 		"define": "eval-stack",
 		"doc": "Record stack information in macro/interp mode.",

--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -287,6 +287,7 @@ and context = {
 	mutable evals : eval IntMap.t;
 	mutable exception_stack : (pos * env_kind) list;
 	max_stack_depth : int;
+	max_print_depth : int;
 }
 
 module GlobalState = struct

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -129,6 +129,7 @@ let create com api is_macro =
 		evals = evals;
 		exception_stack = [];
 		max_stack_depth = int_of_string (Common.defined_value_safe ~default:"1000" com Define.EvalCallStackDepth);
+		max_print_depth = int_of_string (Common.defined_value_safe ~default:"5" com Define.EvalPrintDepth);
 	} in
 	if debug.support_debugger && not !GlobalState.debugger_initialized then begin
 		(* Let's wait till the debugger says we're good to continue. This allows it to finish configuration.

--- a/src/macro/eval/evalPrinting.ml
+++ b/src/macro/eval/evalPrinting.ml
@@ -107,7 +107,7 @@ and s_value depth v =
 		let vf = field_raise v EvalHash.key_toString in
 		s_value (depth + 1) (call_value_on v vf [])
 	in
-	if depth > 5 then rstop
+	if depth > (get_ctx()).max_print_depth then rstop
 	else match v with
 	| VNull -> rnull
 	| VInt32 i32 -> create_ascii(Int32.to_string i32)


### PR DESCRIPTION
Example use case:

```sh
$ haxe build.hxml
src/Macro.macro.hx:6: {pos: #pos(src/Macro.macro.hx:6: characters 15-46), expr: ECall({pos: #pos(src/Macro.macro.hx:6: characters 15-44), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-40), expr: EField(<...>,<...>,<...>)},nop,Normal)},[])}
```

vs

```sh
$ haxe build.hxml -D eval-print-depth=100
src/Macro.macro.hx:6: {pos: #pos(src/Macro.macro.hx:6: characters 15-46), expr: ECall({pos: #pos(src/Macro.macro.hx:6: characters 15-44), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-40), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-38), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-36), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-34), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-32), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-30), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-28), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-26), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-24), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-22), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-20), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-18), expr: EField({pos: #pos(src/Macro.macro.hx:6: characters 15-16), expr: EConst(CIdent(a))},b,Normal)},c,Normal)},d,Normal)},e,Normal)},f,Normal)},g,Normal)},h,Normal)},i,Normal)},j,Normal)},k,Normal)},l,Normal)},m,Normal)},nop,Normal)},[])}
```