### PR TITLE
[typer] Add define to retain meta upon typing

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -574,6 +574,11 @@
 		"platforms": ["cs", "java"]
 	},
 	{
+		"name": "RetainUntypedMeta",
+		"define": "retain-untyped-meta",
+		"doc": "Prevents arbitrary expression metadata from being discarded upon typing."
+	},
+	{
 		"name": "Scriptable",
 		"define": "scriptable",
 		"doc": "GenCPP internal.",

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -71,6 +71,7 @@ type typer_globals = {
 	mutable delayed : (typer_pass * (unit -> unit) list) list;
 	mutable debug_delayed : (typer_pass * ((unit -> unit) * string * typer) list) list;
 	doinline : bool;
+	retain_meta : bool;
 	mutable core_api : typer option;
 	mutable macros : ((unit -> unit) * typer) option;
 	mutable std : module_def;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1685,7 +1685,12 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 		| (Meta.Dollar s,_,p) ->
 			display_error ctx.com (Printf.sprintf "Reification $%s is not allowed outside of `macro` expression" s) p;
 			e()
-		| _ -> e()
+		| _ ->
+			if ctx.g.retain_meta then
+				let e = e() in
+				{e with eexpr = TMeta(m,e)}
+			else
+				e()
 	in
 	ctx.meta <- old;
 	e
@@ -2056,6 +2061,7 @@ let rec create com =
 			delayed = [];
 			debug_delayed = [];
 			doinline = com.display.dms_inline && not (Common.defined com Define.NoInline);
+			retain_meta = Common.defined com Define.RetainUntypedMeta;
 			std = null_module;
 			global_using = [];
 			complete = false;


### PR DESCRIPTION
Might be a rare use case, but when generating custom output from the typed AST it would be really nice if all metadata, not just a select few, was retained during typing.

This pr adds an option to enable this using the define `-D retain-untyped-meta`.

This currently applies to all meta, but maybe it should only apply to `Meta.Custom` metadata? Open to feedback. Thanks!