### PR TITLE
[lua] Add missing FileHandle.lines() function

### DIFF
--- a/std/lua/FileHandle.hx
+++ b/std/lua/FileHandle.hx
@@ -29,6 +29,7 @@ import sys.io.FileInput;
 extern class FileHandle extends UserData {
 	function flush():Void;
 	function read(arg:Rest<EitherType<String, Int>>):String;
+	function lines():NativeIterator<String>;
 	function close():Void;
 
 	function write(str:String):Void;


### PR DESCRIPTION
This allows to iterate over all available lines of a file handle, e.g.
```haxe
final fh = lua.Io.popen(cmd);
if (fh != null) {
  for (line in p.lines()) {
    trace(line);
  }
}
```