### PR TITLE
[neko] Add support for loading arm ndlls

### DIFF
--- a/tests/misc/neko/projects/Issue10937/Main.hx
+++ b/tests/misc/neko/projects/Issue10937/Main.hx
@@ -1,0 +1,70 @@
+import sys.io.Process;
+
+using StringTools;
+
+enum abstract Arch(String) {
+	final Arm64;
+	final Arm;
+	final X86;
+	final X86_64;
+
+	public function getNdllSuffix():String {
+		return switch abstract {
+			case Arm64: "Arm64";
+			case Arm: "Arm";
+			case X86_64: "64";
+			case X86: "";
+		};
+	}
+}
+
+function getArchWindows() {
+	return switch Sys.getEnv("PROCESSOR_ARCHITECTURE") {
+		case "x86": X86;
+		case "AMD64": X86_64;
+		case "ARM64": Arm64;
+		case other: throw 'Unknown CPU architecture: $other';
+	};
+}
+
+function getArchUnix() {
+	final uname = new Process("uname", ["-m"]);
+
+	final arch = try {
+		uname.stdout.readLine();
+	} catch (e:haxe.io.Eof) {
+		"";
+	};
+
+	uname.kill();
+	uname.close();
+
+	return switch arch {
+		case "x86_64" | "amd64": X86_64;
+		case "i386" | "x86": X86;
+		case "arm64" | "aarch64": Arm64;
+		case "arm": Arm;
+		case other: throw 'Unknown CPU architecture: "$other"';
+	};
+}
+
+function getArch() {
+	return switch Sys.systemName() {
+		case "Windows":	getArchWindows();
+		default: getArchUnix();
+	};
+}
+
+function main() {
+	final arch = getArch();
+
+	final expectedNdllSubDir = Sys.systemName() + arch.getNdllSuffix() + "/";
+
+	final ndllPath = neko.vm.Loader.local().getPath()[0];
+
+	if (ndllPath.endsWith(expectedNdllSubDir)) {
+		Sys.println("Success");
+	} else {
+		Sys.println('Failure: Expected $ndllPath to end with $expectedNdllSubDir');
+	}
+}

--- a/tests/misc/neko/projects/Issue10937/aaa-setup.hxml
+++ b/tests/misc/neko/projects/Issue10937/aaa-setup.hxml
@@ -1,0 +1,1 @@
+--cmd haxelib dev dummy_ndll dummy_ndll

--- a/tests/misc/neko/projects/Issue10937/compile.hxml
+++ b/tests/misc/neko/projects/Issue10937/compile.hxml
@@ -1,0 +1,4 @@
+--main Main
+--neko bin/main.n
+-lib dummy_ndll
+--cmd neko bin/main.n

--- a/tests/misc/neko/projects/Issue10937/compile.hxml.stdout
+++ b/tests/misc/neko/projects/Issue10937/compile.hxml.stdout
@@ -1,0 +1,1 @@
+Success

--- a/tests/misc/neko/run.hxml
+++ b/tests/misc/neko/run.hxml
@@ -1,0 +1,2 @@
+-cp ../src
+--run Main

--- a/tests/runci/targets/Neko.hx
+++ b/tests/runci/targets/Neko.hx
@@ -8,6 +8,9 @@ class Neko {
 		runCommand("haxe", ["compile-neko.hxml", "-D", "dump", "-D", "dump_ignore_var_ids"].concat(args));
 		runCommand("neko", ["bin/unit.n"]);
 
+		changeDirectory(getMiscSubDir('neko'));
+		runCommand("haxe", ["run.hxml"].concat(args));
+
 		changeDirectory(sysDir);
 		runCommand("haxe", ["compile-neko.hxml"].concat(args));
 		runSysTest("neko", ["bin/neko/sys.n"]);


### PR DESCRIPTION
Depends on https://github.com/HaxeFoundation/neko/pull/275 and https://github.com/HaxeFoundation/neko/pull/276.

Should add some tests to ensure the correct path is added to `$loader.path`.

Closes #10937.