### PR TITLE
[ci] Prevent random flash test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -765,7 +765,7 @@ jobs:
       matrix:
         # TODO jvm: https://github.com/HaxeFoundation/haxe/issues/8601
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/10919
-        target: [macro, js, hl, cpp, java, cs, php, python, neko]
+        target: [macro, js, hl, cpp, java, cs, php, python, flash9, neko]
     steps:
       - uses: actions/checkout@main
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -348,7 +348,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, flash, neko]
         include:
           - target: hl
             APT_PACKAGES: cmake ninja-build libturbojpeg-dev
@@ -356,7 +356,7 @@ jobs:
             APT_PACKAGES: gcc-multilib g++-multilib
           - target: lua
             APT_PACKAGES: ncurses-dev
-          - target: flash9
+          - target: flash
             APT_PACKAGES: libglib2.0-0 libfreetype6 xvfb
     steps:
       - uses: actions/checkout@main
@@ -413,7 +413,7 @@ jobs:
           sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Flash setup
-        if: matrix.target == 'flash9'
+        if: matrix.target == 'flash'
         run: export DISPLAY=:99.0
 
       - name: Test
@@ -673,7 +673,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/10919
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash, neko]
     steps:
       - uses: actions/checkout@main
         with:
@@ -733,7 +733,7 @@ jobs:
           call lua53/bin/activate
 
       - name: Install wget
-        if: matrix.target == 'flash9'
+        if: matrix.target == 'flash'
         shell: cmd
         run: |
           choco install wget
@@ -765,7 +765,7 @@ jobs:
       matrix:
         # TODO jvm: https://github.com/HaxeFoundation/haxe/issues/8601
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/10919
-        target: [macro, js, hl, cpp, java, cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, java, cs, php, python, flash, neko]
     steps:
       - uses: actions/checkout@main
         with:
@@ -825,7 +825,7 @@ jobs:
           call lua53/bin/activate
 
       - name: Install wget
-        if: matrix.target == 'flash9'
+        if: matrix.target == 'flash'
         shell: cmd
         run: |
           choco install wget
@@ -853,7 +853,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash, neko]
         include:
           - target: hl
             BREW_PACKAGES: ninja

--- a/Earthfile
+++ b/Earthfile
@@ -386,7 +386,7 @@ test-flash:
     FROM +test-environment-flash
     ARG GITHUB_ACTIONS
     ENV GITHUB_ACTIONS=$GITHUB_ACTIONS
-    DO +RUN_CI --TEST=flash9
+    DO +RUN_CI --TEST=flash
 
 test-all:
     ARG TARGETPLATFORM

--- a/extra/github-actions/test-windows.yml
+++ b/extra/github-actions/test-windows.yml
@@ -37,7 +37,7 @@
     call lua53/bin/activate
 
 - name: Install wget
-  if: matrix.target == 'flash9'
+  if: matrix.target == 'flash'
   shell: cmd
   run: |
     choco install wget

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, lua, flash, neko]
         include:
           - target: hl
             APT_PACKAGES: cmake ninja-build libturbojpeg-dev
@@ -169,7 +169,7 @@ jobs:
             APT_PACKAGES: gcc-multilib g++-multilib
           - target: lua
             APT_PACKAGES: ncurses-dev
-          - target: flash9
+          - target: flash
             APT_PACKAGES: libglib2.0-0 libfreetype6 xvfb
     steps:
       - uses: actions/checkout@main
@@ -210,7 +210,7 @@ jobs:
           sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Flash setup
-        if: matrix.target == 'flash9'
+        if: matrix.target == 'flash'
         run: export DISPLAY=:99.0
 
       - name: Test
@@ -362,7 +362,7 @@ jobs:
       fail-fast: false
       matrix:
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/10919
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash, neko]
     steps:
       - uses: actions/checkout@main
         with:
@@ -388,7 +388,7 @@ jobs:
       matrix:
         # TODO jvm: https://github.com/HaxeFoundation/haxe/issues/8601
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/10919
-        target: [macro, js, hl, cpp, java, cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, java, cs, php, python, flash, neko]
     steps:
       - uses: actions/checkout@main
         with:
@@ -410,7 +410,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash9, neko]
+        target: [macro, js, hl, cpp, 'java,jvm', cs, php, python, flash, neko]
         include:
           - target: hl
             BREW_PACKAGES: ninja

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -388,7 +388,7 @@ jobs:
       matrix:
         # TODO jvm: https://github.com/HaxeFoundation/haxe/issues/8601
         # TODO enable lua after https://github.com/HaxeFoundation/haxe/issues/10919
-        target: [macro, js, hl, cpp, java, cs, php, python, neko]
+        target: [macro, js, hl, cpp, java, cs, php, python, flash9, neko]
     steps:
       - uses: actions/checkout@main
         with:

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,7 @@ We have a number of test suites, which are placed in their own folders in this d
 It is possible to run it in local machines too:
 
  1. Change to this directory.
- 2. Define the test target by `export TEST=$TARGET` (or `set "TEST=$TARGET"` on Windows), where `$TARGET` should be a comma-seperated list of targets, e.g. `neko,macro`. Possible targets are `macro`, `neko`, `js`, `lua`, `php`, `cpp`, `cppia`, `flash9`, `java`, `jvm`, `cs`, `python`, and `hl`.
+ 2. Define the test target by `export TEST=$TARGET` (or `set "TEST=$TARGET"` on Windows), where `$TARGET` should be a comma-seperated list of targets, e.g. `neko,macro`. Possible targets are `macro`, `neko`, `js`, `lua`, `php`, `cpp`, `cppia`, `flash`, `java`, `jvm`, `cs`, `python`, and `hl`.
  3. Run the script: `haxe RunCi.hxml`.
 
 Note that the script will try to look for test dependencies and install them if they are not found. Look at the `getXXXDependencies` functions for the details.

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -78,7 +78,7 @@ class RunCi {
 						runci.targets.Jvm.run(args);
 					case Cs:
 						runci.targets.Cs.run(args);
-					case Flash9:
+					case Flash:
 						runci.targets.Flash.run(args);
 					case Hl:
 						runci.targets.Hl.run(args);

--- a/tests/runci/TestTarget.hx
+++ b/tests/runci/TestTarget.hx
@@ -8,7 +8,7 @@ enum abstract TestTarget(String) from String {
 	var Php = "php";
 	var Cpp = "cpp";
 	var Cppia = "cppia";
-	var Flash9 = "flash9";
+	var Flash = "flash";
 	var Java = "java";
 	var Jvm = "jvm";
 	var Cs = "cs";

--- a/tests/runci/targets/Flash.hx
+++ b/tests/runci/targets/Flash.hx
@@ -237,8 +237,8 @@ class Flash {
 		setupFlashPlayer();
 		setupFlexSdk();
 		for (flashVersion in ["11", "32"]) {
-			runCommand("haxe", ["compile-flash9.hxml", "-D", "fdb", "-D", "dump", "-D", "dump_ignore_var_ids", "--swf-version", flashVersion].concat(args));
-			runFlash("bin/unit9.swf");
+			runCommand("haxe", ["compile-flash.hxml", "-D", "fdb", "-D", "dump", "-D", "dump_ignore_var_ids", "--swf-version", flashVersion].concat(args));
+			runFlash("bin/unit.swf");
 		}
 
 		changeDirectory(miscFlashDir);

--- a/tests/unit/compile-flash.hxml
+++ b/tests/unit/compile-flash.hxml
@@ -4,6 +4,6 @@
 
 compile-each.hxml
 --main unit.TestMain
--swf bin/unit9.swf
+-swf bin/unit.swf
 -swf-lib native_swf/lib.swc
 -D network-sandbox

--- a/tests/unit/compile.hxml
+++ b/tests/unit/compile.hxml
@@ -11,7 +11,7 @@ compile-java-runner.hxml
 
 # targets
 
---next compile-flash9.hxml
+--next compile-flash.hxml
 --next compile-js.hxml
 --next compile-hl.hxml
 --next compile-lua.hxml

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -155,4 +155,8 @@ function main() {
 		});
 	#end
 	runner.run();
+
+	#if (flash && fdb)
+	flash.Lib.fscommand("quit");
+	#end
 }

--- a/tests/unit/unit.html
+++ b/tests/unit/unit.html
@@ -56,23 +56,23 @@ iframe {
   <div id="php_container" class="cont"><iframe src="bin/php/index.php"></iframe></div>
 </div>
 <div class="window">
-  <div class="label">Flash 9</div>
+  <div class="label">Flash</div>
   <object	classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"
 	width="400"
 	height="300"
-	id="haxeFlash9"
+	id="haxeFlash"
 	align="middle">
-    <param name="movie" value="bin/unit9.swf"/>
+    <param name="movie" value="bin/unit.swf"/>
     <param name="allowScriptAccess" value="always" />
     <param name="quality" value="high" />
     <param name="scale" value="noscale" />
     <param name="salign" value="lt" />
     <param name="bgcolor" value="#ffffff"/>
-    <embed src="bin/unit9.swf"
+    <embed src="bin/unit.swf"
       bgcolor="#ffffff"
       width="400"
       height="300"
-      name="haxeFlash9"
+      name="haxeFlash"
       quality="high"
       align="middle"
       allowScriptAccess="always"


### PR DESCRIPTION
Currently, we read the test output from a log file which for some reason doesn't always exist and is sometimes written to at the wrong time. This means that for some reason the tests don't work on 32-bit windows, and also seems to have caused flakey ci runs for 64-bit as well, especially recently. E.g.: 
https://github.com/HaxeFoundation/haxe/actions/runs/4324422064/jobs/7549781858#step:12:73

```
Running .swf file: D:\a\haxe\haxe\tests\unit\bin\unit9.swf
Waiting 2 seconds for flash log file...
Waiting 2 seconds for flash log file...
Waiting 2 seconds for flash log file...
Waiting 2 seconds for flash log file...
Waiting 2 seconds for flash log file...
C:\Users\runneradmin\AppData\Roaming\Macromedia\Flash Player\Logs\flashlog.txt not found.
```

Now it runs the swf through fdb which means the trace output is properly printed to a process, so there is less risk of something going wrong.