### PR TITLE
Detect non-empty block as struct too

### DIFF
--- a/src/context/display/display.ml
+++ b/src/context/display/display.ml
@@ -121,7 +121,7 @@ module ExprPreprocessing = struct
 				mk_null (pos e)
 			| EBlock [] when is_annotated (pos e) ->
 				annotate e DKStructure
-			| EBlock [EDisplay((EConst(Ident s),pn),DKMarked),_] when is_completion ->
+			| EBlock ((EDisplay((EConst(Ident s),pn),DKMarked),_) :: tail) when is_completion ->
 				let e = EObjectDecl [(s,pn,NoQuotes),(EConst (Ident "null"),null_pos)],(pos e) in
 				annotate e DKStructure
 			| EBlock el when is_annotated (pos e) && is_completion ->


### PR DESCRIPTION
Improves https://github.com/HaxeFoundation/haxe/issues/11018, now all structure fields are suggested for that case. They probably should be filtered in `handle_structure_display` next?

Related to https://github.com/HaxeFoundation/haxe/commit/a5a4552c443aff97cb0e4edfbf971195f5cb8d75