### PR TITLE
fixed wrong return type for DateTimeFormatter's getDateTimePattern fu…

### DIFF
--- a/std/flash/globalization/DateTimeFormatter.hx
+++ b/std/flash/globalization/DateTimeFormatter.hx
@@ -8,7 +8,7 @@ package flash.globalization;
 	function format(dateTime : Date) : String;
 	function formatUTC(dateTime : Date) : String;
 	function getDateStyle() : DateTimeStyle;
-	function getDateTimePattern() : DateTimeStyle;
+	function getDateTimePattern() : String;
 	function getFirstWeekday() : Int;
 	function getMonthNames(?nameStyle : DateTimeNameStyle, ?context : DateTimeNameContext) : flash.Vector<String>;
 	function getTimeStyle() : DateTimeStyle;


### PR DESCRIPTION
…nction
reference : https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/globalization/DateTimeFormatter.html#getDateTimePattern()