### PR TITLE
[lua] Use lrexlib-pcre2 for regular expressions

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -281,7 +281,7 @@ test-environment-hl:
 test-environment-lua:
     # hererocks uses pip
     FROM +test-environment-python
-    DO +INSTALL_PACKAGES --PACKAGES="libssl-dev libreadline-dev python3-pip unzip libpcre3-dev cmake"
+    DO +INSTALL_PACKAGES --PACKAGES="libssl-dev libreadline-dev python3-pip unzip libpcre2-dev cmake"
     RUN ln -s /root/.local/bin/hererocks /bin/
     SAVE IMAGE --cache-hint
 

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -52,7 +52,7 @@ class EReg {
 			}
 		}
 
-		ropt |= FLAGS.UTF8; // always check validity of utf8 string
+		ropt |= FLAGS.UTF; // always check validity of utf8 string
 		ropt |= FLAGS.UCP; // always enable utf8 character properties
 
 		if (global == null)
@@ -208,7 +208,7 @@ class EReg {
 
 	static function __init__():Void {
 		if (Rex == null) {
-			throw "Rex is missing.  Please install lrexlib-pcre.";
+			throw "Rex is missing.  Please install lrexlib-pcre2.";
 		}
 	}
 }

--- a/std/lua/lib/lrexlib/Rex.hx
+++ b/std/lua/lib/lrexlib/Rex.hx
@@ -24,7 +24,7 @@ package lua.lib.lrexlib;
 
 import haxe.extern.EitherType;
 
-@:luaRequire("rex_pcre")
+@:luaRequire("rex_pcre2")
 extern class Rex {
 	inline static function create(expr:String, flag:EitherType<Int, String>):Rex {
 		return untyped Rex['new'](expr, flag);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -11,7 +11,7 @@ class Lua {
 	static public function getLuaDependencies(){
 		switch (systemName){
 			case "Linux":
-				Linux.requireAptPackages(["libpcre3-dev", "libssl-dev", "libreadline-dev"]);
+				Linux.requireAptPackages(["libpcre2-dev", "libssl-dev", "libreadline-dev"]);
 				runCommand("pip", ["install", "--user", "hererocks"]);
 				final pyUserBase = commandResult("python", ["-m", "site", "--user-base"]).stdout.trim();
 				addToPATH(Path.join([pyUserBase, "bin"]));
@@ -21,7 +21,7 @@ class Lua {
 				else
 					runNetworkCommand("brew", ["install", "python3"]);
 
-				attemptCommand("brew", ["install", "pcre"]);
+				attemptCommand("brew", ["install", "pcre2"]);
 				runCommand("pip3", ["install", "hererocks"]);
 				runCommand("brew", ["install", "openssl"]);
 			}
@@ -72,18 +72,18 @@ class Lua {
 
 			installLib("luasec", "1.0.2-1");
 
-			installLib("lrexlib-pcre", "2.9.1-1");
+			installLib("lrexlib-pcre2", "2.9.1-1");
 			installLib("luv", "1.36.0-0");
 			installLib("luasocket", "3.0rc1-2");
 			installLib("luautf8", "0.1.1-1");
-			
+
 			//Install bit32 for lua 5.1
 			if(lv == "-l5.1"){
 				installLib("bit32", "5.2.2-1");
 			}
-			
+
 			installLib("hx-lua-simdjson", "0.0.1-1");
-			
+
 			changeDirectory(unitDir);
 			runCommand("haxe", ["compile-lua.hxml"].concat(args));
 			runCommand("lua", ["bin/unit.lua"]);


### PR DESCRIPTION
See #10491.

The manual will have to be updated as `lrexlib-pcre2` now replaces the `lrexlib-pcre` dependency.

This also solves the null byte bug for lua:  #10592