### PR TITLE
Detect transitive casts

### DIFF
--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -651,18 +651,18 @@ let generate_typedef ctx td =
 		"type",generate_type ctx td.t_type;
 	]
 
-let generate_abstract ctx a =
+let generate_casts ctx fields casts =
 	let generate_cast_relation t cfo =
 		jobject [
 			"t",generate_type ctx t;
 			"field",jopt (classfield_ref ctx) cfo
 		]
 	in
-	let generate_casts fields casts =
-		let l1 = List.map (fun (t,cf) -> generate_cast_relation t (Some cf)) fields in
-		let l2 = List.map (fun t -> generate_cast_relation t None) casts in
-		jarray (l1 @ l2)
-	in
+	let l1 = List.map (fun (t,cf) -> generate_cast_relation t (Some cf)) fields in
+	let l2 = List.map (fun t -> generate_cast_relation t None) casts in
+	jarray (l1 @ l2)
+
+let generate_abstract ctx a =
 	let generate_binop (op,cf) =
 		jobject [
 			"op",generate_binop ctx op;
@@ -687,8 +687,8 @@ let generate_abstract ctx a =
 		"impl",impl;
 		"binops",jlist generate_binop a.a_ops;
 		"unops",jlist generate_unop a.a_unops;
-		"from",generate_casts a.a_from_field a.a_from;
-		"to",generate_casts a.a_to_field a.a_to;
+		"from",generate_casts ctx a.a_from_field a.a_from;
+		"to",generate_casts ctx a.a_to_field a.a_to;
 		"array",jlist (classfield_ref ctx) a.a_array;
 		"read",jopt (classfield_ref ctx) a.a_read;
 		"write",jopt (classfield_ref ctx) a.a_write;


### PR DESCRIPTION
Sorry for spending your attention here for silly stuff, basically i wanted to solve this todo somehow:
https://github.com/vshaxe/haxe-language-server/blob/314183133ce3d593b11c702dcd3fada276a3c1d9/src/haxeLanguageServer/protocol/Extensions.hx#L65
So i tried to get `abstract` type param name (like `T1`) and check abstract `from/to` casts, and then build `bool list` if type parameter from `ct_params` list is in `from/to`, and can be resolved in completion.
So completion will work better with params in instances of
`abstract EitherType<T1, T2>(Dynamic) from T1 to T1 from T2 to T2 {}`
and in stuff like
`abstract EitherType3<T1, T2, T3>(Dynamic) from T1 to T1 from T2 to T2 from T3 to T3 {}`
Just interested if there can be less ugly solution and if i understand type casting correctly.