### PR TITLE
More strict macro API for init vs non init macros

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -264,7 +264,7 @@
 	{
 		"name": "HaxeNext",
 		"define": "haxe-next",
-		"doc": "Enable warnings/errors that would otherwise only trigger starting next Haxe version."
+		"doc": "Enable experimental features that are meant to be released on next Haxe version."
 	},
 	{
 		"name": "HlVer",

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -262,6 +262,11 @@
 		"reserved": true
 	},
 	{
+		"name": "HaxeNext",
+		"define": "haxe-next",
+		"doc": "Enable warnings/errors that would otherwise only trigger starting next Haxe version."
+	},
+	{
 		"name": "HlVer",
 		"define": "hl-ver",
 		"doc": "The HashLink version to target. (default: 1.10.0)",

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -70,7 +70,7 @@ class Compiler {
 	**/
 	public static function define(flag:String, ?value:String) {
 		#if (neko || eval)
-		Context.assertInitMacros();
+		Context.assertInitMacro();
 		load("define", 2)(flag, value);
 		#end
 	}
@@ -138,7 +138,7 @@ class Compiler {
 	**/
 	public static function addClassPath(path:String) {
 		#if (neko || eval)
-		Context.assertInitMacros();
+		Context.assertInitMacro();
 		load("add_class_path", 1)(path);
 		#end
 	}
@@ -185,7 +185,7 @@ class Compiler {
 	**/
 	public static function addNativeLib(name:String) {
 		#if (neko || eval)
-		Context.assertInitMacros();
+		Context.assertInitMacro();
 		load("add_native_lib", 1)(name);
 		#end
 	}
@@ -218,69 +218,77 @@ class Compiler {
 		@param strict If true and given package wasn't found in any of class paths, fail with an error.
 	**/
 	public static function include(pack:String, ?rec = true, ?ignore:Array<String>, ?classPaths:Array<String>, strict = false) {
-		var ignoreWildcard:Array<String> = [];
-		var ignoreString:Array<String> = [];
-		if (ignore != null) {
-			for (ignoreRule in ignore) {
-				if (StringTools.endsWith(ignoreRule, "*")) {
-					ignoreWildcard.push(ignoreRule.substr(0, ignoreRule.length - 1));
-				} else {
-					ignoreString.push(ignoreRule);
+		function include(pack:String, ?rec = true, ?ignore:Array<String>, ?classPaths:Array<String>, strict = false) {
+			var ignoreWildcard:Array<String> = [];
+			var ignoreString:Array<String> = [];
+			if (ignore != null) {
+				for (ignoreRule in ignore) {
+					if (StringTools.endsWith(ignoreRule, "*")) {
+						ignoreWildcard.push(ignoreRule.substr(0, ignoreRule.length - 1));
+					} else {
+						ignoreString.push(ignoreRule);
+					}
 				}
 			}
-		}
-		var skip = if (ignore == null) {
-			function(c) return false;
-		} else {
-			function(c:String) {
-				if (Lambda.has(ignoreString, c))
-					return true;
-				for (ignoreRule in ignoreWildcard)
-					if (StringTools.startsWith(c, ignoreRule))
+			var skip = if (ignore == null) {
+				function(c) return false;
+			} else {
+				function(c:String) {
+					if (Lambda.has(ignoreString, c))
 						return true;
-				return false;
+					for (ignoreRule in ignoreWildcard)
+						if (StringTools.startsWith(c, ignoreRule))
+							return true;
+					return false;
+				}
 			}
+			var displayValue = Context.definedValue("display");
+			if (classPaths == null) {
+				classPaths = Context.getClassPath();
+				// do not force inclusion when using completion
+				switch (displayValue) {
+					case null:
+					case "usage":
+					case _:
+						return;
+				}
+				// normalize class path
+				for (i in 0...classPaths.length) {
+					var cp = StringTools.replace(classPaths[i], "\\", "/");
+					if (StringTools.endsWith(cp, "/"))
+						cp = cp.substr(0, -1);
+					if (cp == "")
+						cp = ".";
+					classPaths[i] = cp;
+				}
+			}
+			var prefix = pack == '' ? '' : pack + '.';
+			var found = false;
+			for (cp in classPaths) {
+				var path = pack == '' ? cp : cp + "/" + pack.split(".").join("/");
+				if (!sys.FileSystem.exists(path) || !sys.FileSystem.isDirectory(path))
+					continue;
+				found = true;
+				for (file in sys.FileSystem.readDirectory(path)) {
+					if (StringTools.endsWith(file, ".hx") && file.substr(0, file.length - 3).indexOf(".") < 0) {
+						if( file == "import.hx" ) continue;
+						var cl = prefix + file.substr(0, file.length - 3);
+						if (skip(cl))
+							continue;
+						Context.getModule(cl);
+					} else if (rec && sys.FileSystem.isDirectory(path + "/" + file) && !skip(prefix + file))
+						include(prefix + file, true, ignore, classPaths);
+				}
+			}
+			if (strict && !found)
+				Context.error('Package "$pack" was not found in any of class paths', Context.currentPos());
 		}
-		var displayValue = Context.definedValue("display");
-		if (classPaths == null) {
-			classPaths = Context.getClassPath();
-			// do not force inclusion when using completion
-			switch (displayValue) {
-				case null:
-				case "usage":
-				case _:
-					return;
-			}
-			// normalize class path
-			for (i in 0...classPaths.length) {
-				var cp = StringTools.replace(classPaths[i], "\\", "/");
-				if (StringTools.endsWith(cp, "/"))
-					cp = cp.substr(0, -1);
-				if (cp == "")
-					cp = ".";
-				classPaths[i] = cp;
-			}
+
+		if (!Context.initMacrosDone()) {
+			Context.onAfterInitMacros(() -> include(pack, rec, ignore, classPaths, strict));
+		} else {
+			include(pack, rec, ignore, classPaths, strict);
 		}
-		var prefix = pack == '' ? '' : pack + '.';
-		var found = false;
-		for (cp in classPaths) {
-			var path = pack == '' ? cp : cp + "/" + pack.split(".").join("/");
-			if (!sys.FileSystem.exists(path) || !sys.FileSystem.isDirectory(path))
-				continue;
-			found = true;
-			for (file in sys.FileSystem.readDirectory(path)) {
-				if (StringTools.endsWith(file, ".hx") && file.substr(0, file.length - 3).indexOf(".") < 0) {
-					if( file == "import.hx" ) continue;
-					var cl = prefix + file.substr(0, file.length - 3);
-					if (skip(cl))
-						continue;
-					Context.getModule(cl);
-				} else if (rec && sys.FileSystem.isDirectory(path + "/" + file) && !skip(prefix + file))
-					include(prefix + file, true, ignore, classPaths);
-			}
-		}
-		if (strict && !found)
-			Context.error('Package "$pack" was not found in any of class paths', Context.currentPos());
 	}
 
 	/**

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -195,7 +195,6 @@ class Compiler {
 	**/
 	public static function addNativeArg(argument:String) {
 		#if (neko || eval)
-		Context.assertInitMacros();
 		load("add_native_arg", 1)(argument);
 		#end
 	}
@@ -443,7 +442,6 @@ class Compiler {
 		@param recursive If true, recurses into sub-packages for package paths.
 	**/
 	public static function nullSafety(path:String, mode:NullSafetyMode = Loose, recursive:Bool = true) {
-		Context.assertInitMacros();
 		addGlobalMetadata(path, '@:nullSafety($mode)', recursive);
 	}
 

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -70,6 +70,7 @@ class Compiler {
 	**/
 	public static function define(flag:String, ?value:String) {
 		#if (neko || eval)
+		Context.assertInitMacro();
 		load("define", 2)(flag, value);
 		#end
 	}
@@ -137,6 +138,7 @@ class Compiler {
 	**/
 	public static function addClassPath(path:String) {
 		#if (neko || eval)
+		Context.assertInitMacro();
 		load("add_class_path", 1)(path);
 		#end
 	}
@@ -183,6 +185,7 @@ class Compiler {
 	**/
 	public static function addNativeLib(name:String) {
 		#if (neko || eval)
+		Context.assertInitMacro();
 		load("add_native_lib", 1)(name);
 		#end
 	}
@@ -192,6 +195,7 @@ class Compiler {
 	**/
 	public static function addNativeArg(argument:String) {
 		#if (neko || eval)
+		Context.assertInitMacro();
 		load("add_native_arg", 1)(argument);
 		#end
 	}
@@ -439,6 +443,7 @@ class Compiler {
 		@param recursive If true, recurses into sub-packages for package paths.
 	**/
 	public static function nullSafety(path:String, mode:NullSafetyMode = Loose, recursive:Bool = true) {
+		Context.assertInitMacro();
 		addGlobalMetadata(path, '@:nullSafety($mode)', recursive);
 	}
 

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -712,7 +712,7 @@ typedef CompilerConfiguration = {
 	final platform:haxe.display.Display.Platform;
 
 	/**
-		The compilation configuration for the target platform. 
+		The compilation configuration for the target platform.
 	**/
 	final platformConfig:PlatformConfig;
 

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -70,7 +70,7 @@ class Compiler {
 	**/
 	public static function define(flag:String, ?value:String) {
 		#if (neko || eval)
-		Context.assertInitMacro();
+		Context.assertInitMacros();
 		load("define", 2)(flag, value);
 		#end
 	}
@@ -138,7 +138,7 @@ class Compiler {
 	**/
 	public static function addClassPath(path:String) {
 		#if (neko || eval)
-		Context.assertInitMacro();
+		Context.assertInitMacros();
 		load("add_class_path", 1)(path);
 		#end
 	}
@@ -185,7 +185,7 @@ class Compiler {
 	**/
 	public static function addNativeLib(name:String) {
 		#if (neko || eval)
-		Context.assertInitMacro();
+		Context.assertInitMacros();
 		load("add_native_lib", 1)(name);
 		#end
 	}
@@ -195,7 +195,7 @@ class Compiler {
 	**/
 	public static function addNativeArg(argument:String) {
 		#if (neko || eval)
-		Context.assertInitMacro();
+		Context.assertInitMacros();
 		load("add_native_arg", 1)(argument);
 		#end
 	}
@@ -443,7 +443,7 @@ class Compiler {
 		@param recursive If true, recurses into sub-packages for package paths.
 	**/
 	public static function nullSafety(path:String, mode:NullSafetyMode = Loose, recursive:Bool = true) {
-		Context.assertInitMacro();
+		Context.assertInitMacros();
 		addGlobalMetadata(path, '@:nullSafety($mode)', recursive);
 	}
 

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -162,7 +162,7 @@ class Context {
 		macro is not an expression-macro.
 	**/
 	public static function getExpectedType():Null<Type> {
-		assertInitMacroDone(false);
+		assertInitMacrosDone(false);
 		return load("get_expected_type", 0)();
 	}
 
@@ -308,7 +308,7 @@ class Context {
 		If no type can be found, an exception of type `String` is thrown.
 	**/
 	public static function getType(name:String):Type {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("get_type", 1)(name);
 	}
 
@@ -459,7 +459,7 @@ class Context {
 		caught using `try ... catch`.
 	**/
 	public static function typeof(e:Expr):Type {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("typeof", 1)(e);
 	}
 
@@ -473,7 +473,7 @@ class Context {
 		active.
 	**/
 	public static function typeExpr(e:Expr):TypedExpr {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("type_expr", 1)(e);
 	}
 
@@ -485,7 +485,7 @@ class Context {
 		Resolution is performed based on the current context in which the macro is called.
 	**/
 	public static function resolveType(t:ComplexType, p:Position):Type {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("resolve_type", 2)(t, p);
 	}
 
@@ -502,7 +502,7 @@ class Context {
 		Tries to unify `t1` and `t2` and returns `true` if successful.
 	**/
 	public static function unify(t1:Type, t2:Type):Bool {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("unify", 2)(t1, t2);
 	}
 
@@ -512,7 +512,7 @@ class Context {
 		See `haxe.macro.TypeTools.follow` for details.
 	**/
 	public static function follow(t:Type, ?once:Bool):Type {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("follow", 2)(t, once);
 	}
 
@@ -522,7 +522,7 @@ class Context {
 		See `haxe.macro.TypeTools.followWithAbstracts` for details.
 	**/
 	public static function followWithAbstracts(t:Type, once:Bool = false):Type {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("follow_with_abstracts", 2)(t, once);
 	}
 
@@ -583,7 +583,7 @@ class Context {
 		instead of the current module.
 	**/
 	public static function defineType(t:TypeDefinition, ?moduleDependency:String):Void {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		load("define_type", 2)(t, moduleDependency);
 	}
 
@@ -594,7 +594,7 @@ class Context {
 		bind the monomorph to an actual type and let macro further process the resulting type.
 	**/
 	public static function makeMonomorph():Type {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("make_monomorph", 0)();
 	}
 
@@ -611,7 +611,7 @@ class Context {
 			imports = [];
 		if (usings == null)
 			usings = [];
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		load("define_module", 4)(modulePath, types, imports, usings);
 	}
 
@@ -621,7 +621,7 @@ class Context {
 		This process may lose some information.
 	**/
 	public static function getTypedExpr(t:Type.TypedExpr):Expr {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("get_typed_expr", 1)(t);
 	}
 
@@ -638,7 +638,7 @@ class Context {
 		compilation server.
 	**/
 	public static function storeTypedExpr(t:Type.TypedExpr):Expr {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("store_typed_expr", 1)(t);
 	}
 
@@ -658,7 +658,7 @@ class Context {
 		compilation server.
 	**/
 	public static function storeExpr(e:Expr):Expr {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("store_expr", 1)(e);
 	}
 
@@ -667,7 +667,7 @@ class Context {
 		type through the `type` field of the return value.
 	**/
 	public static function typeAndStoreExpr(e:Expr):{final type:Type.Ref<Type>; final expr:Expr;} {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		return load("type_and_store_expr", 1)(e);
 	}
 
@@ -681,7 +681,7 @@ class Context {
 		Has no effect if the compilation cache is not used.
 	**/
 	public static function registerModuleDependency(modulePath:String, externFile:String) {
-		assertInitMacroDone();
+		assertInitMacrosDone();
 		load("register_module_dependency", 2)(modulePath, externFile);
 	}
 
@@ -763,7 +763,7 @@ class Context {
 	}
 
 	@:allow(haxe.macro.Compiler)
-	private static function assertInitMacro():Void {
+	private static function assertInitMacros():Void {
 		if (initMacrosDone()) {
 			var stack = getMacroStack();
 
@@ -775,7 +775,7 @@ class Context {
 	}
 
 	// @:allow(haxe.macro.Compiler)
-	private static function assertInitMacroDone(includeSuggestion = true):Void {
+	private static function assertInitMacrosDone(includeSuggestion = true):Void {
 		#if haxe_next
 		if (!initMacrosDone()) {
 			var stack = getMacroStack();

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -452,7 +452,7 @@ class Context {
 
 	/**
 		Adds a callback function `callback` which is invoked after the compiler
-		is done running initialization macros, before typing.
+		is done running initialization macros, when typing begins.
 
 		`onAfterInitMacros` should be used to delay typer-dependant code from
 		your initalization macros, to properly separate configuration phase and

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -308,6 +308,10 @@ class Context {
 		declared class path has priority.
 
 		If no type can be found, an exception of type `String` is thrown.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function getType(name:String):Type {
 		assertInitMacrosDone();
@@ -464,6 +468,10 @@ class Context {
 
 		Typing the expression may result in a compiler error which can be
 		caught using `try ... catch`.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function typeof(e:Expr):Type {
 		assertInitMacrosDone();
@@ -478,6 +486,10 @@ class Context {
 		be caught this way because the compiler might delay various checks
 		to a later stage, at which point the exception handler is no longer
 		active.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function typeExpr(e:Expr):TypedExpr {
 		assertInitMacrosDone();
@@ -490,6 +502,10 @@ class Context {
 		Resolving the type may result in a compiler error which can be
 		caught using `try ... catch`.
 		Resolution is performed based on the current context in which the macro is called.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function resolveType(t:ComplexType, p:Position):Type {
 		assertInitMacrosDone();
@@ -507,6 +523,10 @@ class Context {
 
 	/**
 		Tries to unify `t1` and `t2` and returns `true` if successful.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function unify(t1:Type, t2:Type):Bool {
 		assertInitMacrosDone();
@@ -517,6 +537,10 @@ class Context {
 		Follows a type.
 
 		See `haxe.macro.TypeTools.follow` for details.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function follow(t:Type, ?once:Bool):Type {
 		assertInitMacrosDone();
@@ -527,6 +551,10 @@ class Context {
 		Follows a type, including abstracts' underlying implementation
 
 		See `haxe.macro.TypeTools.followWithAbstracts` for details.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function followWithAbstracts(t:Type, once:Bool = false):Type {
 		assertInitMacrosDone();
@@ -588,6 +616,10 @@ class Context {
 		If `moduleDependency` is given and is not `null`, it should contain
 		a module path that will be used as a dependency for the newly defined module
 		instead of the current module.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function defineType(t:TypeDefinition, ?moduleDependency:String):Void {
 		assertInitMacrosDone();
@@ -599,6 +631,10 @@ class Context {
 
 		Returned monomorph can be used with e.g. `Context.unify` to make the compiler
 		bind the monomorph to an actual type and let macro further process the resulting type.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function makeMonomorph():Type {
 		assertInitMacrosDone();
@@ -612,6 +648,10 @@ class Context {
 		The individual `types` can reference each other and any identifier
 		respects the `imports` and `usings` as usual, expect that imports are
 		not allowed to have `.*` wildcards or `as s` shorthands.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function defineModule(modulePath:String, types:Array<TypeDefinition>, ?imports:Array<ImportExpr>, ?usings:Array<TypePath>):Void {
 		if (imports == null)
@@ -626,6 +666,10 @@ class Context {
 		Returns a syntax-level expression corresponding to typed expression `t`.
 
 		This process may lose some information.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function getTypedExpr(t:Type.TypedExpr):Expr {
 		assertInitMacrosDone();
@@ -643,6 +687,10 @@ class Context {
 		that is reset between compilations, so care should be taken when storing
 		the expression returned by this method in a static variable and using the
 		compilation server.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function storeTypedExpr(t:Type.TypedExpr):Expr {
 		assertInitMacrosDone();
@@ -663,6 +711,10 @@ class Context {
 		that is reset between compilations, so care should be taken when storing
 		the expression returned by this method in a static variable and using the
 		compilation server.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function storeExpr(e:Expr):Expr {
 		assertInitMacrosDone();
@@ -672,6 +724,10 @@ class Context {
 	/**
 		This function works like `storeExpr`, but also returns access to the expression's
 		type through the `type` field of the return value.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function typeAndStoreExpr(e:Expr):{final type:Type.Ref<Type>; final expr:Expr;} {
 		assertInitMacrosDone();
@@ -686,6 +742,10 @@ class Context {
 		`externFile` has changed.
 
 		Has no effect if the compilation cache is not used.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function registerModuleDependency(modulePath:String, externFile:String) {
 		assertInitMacrosDone();

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -784,7 +784,7 @@ class Context {
 				: "";
 
 			warning(
-				"Cannot use this macro API from initialization macros." + suggestion,
+				"Cannot use this API from initialization macros." + suggestion,
 				if (stack.length > 2) stack[2] else currentPos()
 			);
 		}

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -459,6 +459,7 @@ class Context {
 		actual typing.
 	**/
 	public static function onAfterInitMacros(callback:Void->Void):Void {
+		assertInitMacro();
 		load("on_after_init_macros", 1)(callback);
 	}
 

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -863,7 +863,6 @@ class Context {
 		}
 	}
 
-	// @:allow(haxe.macro.Compiler)
 	private static function assertInitMacrosDone(includeSuggestion = true):Void {
 		#if haxe_next
 		if (!initMacrosDone()) {

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -326,8 +326,13 @@ class Context {
 		declared class path has priority.
 
 		If no module can be found, an exception of type `String` is thrown.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function getModule(name:String):Array<Type> {
+		assertInitMacrosDone();
 		return load("get_module", 1)(name);
 	}
 
@@ -349,8 +354,13 @@ class Context {
 		should not be treated as conclusive until the generation phase.
 
 		Modifying the returned array has no effect on the compilation.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function getAllModuleTypes():Array<haxe.macro.Type.ModuleType> {
+		assertInitMacrosDone();
 		return load("get_module_types", 0)();
 	}
 
@@ -391,6 +401,7 @@ class Context {
 		Returns a hashed MD5 signature of value `v`.
 	**/
 	public static function signature(v:Dynamic):String {
+		assertInitMacrosDone(false);
 		return load("signature", 1)(v);
 	}
 
@@ -778,8 +789,13 @@ class Context {
 		is true even if `code` throws an exception.
 
 		If any argument is `null`, the result is unspecified.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function withImports<X>(imports:Array<String>, usings:Array<String>, code:() -> X):X {
+		assertInitMacrosDone();
 		return load("with_imports", 3)(imports, usings, code);
 	}
 
@@ -792,8 +808,13 @@ class Context {
 
 		`allowTransform`: when disabled, the code typed with `typeExpr` will be almost exactly the same
 		as the input code. This will disable some abstract types transformations.
+
+		Usage of this function from initialization macros is deprecated and may
+		cause compilation server issues. Use `Context.onAfterInitMacros` to
+		run your code once typer is ready to be used.
 	**/
 	public static function withOptions<X>(options:{?allowInlining:Bool,?allowTransform:Bool}, code : () -> X) : X {
+		assertInitMacrosDone();
 		return load("with_options", 2)(options, code);
 	}
 
@@ -830,7 +851,7 @@ class Context {
 	}
 
 	@:allow(haxe.macro.Compiler)
-	private static function assertInitMacros():Void {
+	private static function assertInitMacro():Void {
 		if (initMacrosDone()) {
 			var stack = getMacroStack();
 

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -97,7 +97,8 @@ class Context {
 	}
 
 	/**
-		TODO: documentation
+		Check if compiler is past initializations macros or not.
+		When it is, configuration phase is over and parsing/typing can start.
 	**/
 	public static function initMacrosDone():Bool {
 		return load("init_macros_done", 0)();
@@ -146,7 +147,8 @@ class Context {
 	}
 
 	/**
-		TODO: documentation
+		Get the call stack (excluding the call to `Context.getMacroStack()`
+		that led to current macro.
 	**/
 	public static function getMacroStack():Array<Position> {
 		return load("get_macro_stack", 0)();
@@ -434,7 +436,12 @@ class Context {
 	}
 
 	/**
-		TODO: documentation
+		Adds a callback function `callback` which is invoked after the compiler
+		is done running initialization macros, before typing.
+
+		`onAfterInitMacros` should be used to delay typer-dependant code from
+		your initalization macros, to properly separate configuration phase and
+		actual typing.
 	**/
 	public static function onAfterInitMacros(callback:Void->Void):Void {
 		load("on_after_init_macros", 1)(callback);

--- a/tests/misc/projects/Issue10844/user-defined-define-json-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-define-json-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file define.jsno
-$$normPath(::std::)/haxe/macro/Compiler.hx:485: characters 11-39 : Called from here
+$$normPath(::std::)/haxe/macro/Compiler.hx:493: characters 11-39 : Called from here
 (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-define-json-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-define-json-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file define.jsno
-$$normPath(::std::)/haxe/macro/Compiler.hx:487: characters 11-39 : Called from here
+$$normPath(::std::)/haxe/macro/Compiler.hx:485: characters 11-39 : Called from here
 (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-define-json-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-define-json-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file define.jsno
-$$normPath(::std::)/haxe/macro/Compiler.hx:482: characters 11-39 : Called from here
+$$normPath(::std::)/haxe/macro/Compiler.hx:487: characters 11-39 : Called from here
 (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file meta.jsno
-$$normPath(::std::)/haxe/macro/Compiler.hx:472: characters 11-39 : Called from here
+$$normPath(::std::)/haxe/macro/Compiler.hx:477: characters 11-39 : Called from here
 (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file meta.jsno
-$$normPath(::std::)/haxe/macro/Compiler.hx:477: characters 11-39 : Called from here
+$$normPath(::std::)/haxe/macro/Compiler.hx:475: characters 11-39 : Called from here
 (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file meta.jsno
-$$normPath(::std::)/haxe/macro/Compiler.hx:475: characters 11-39 : Called from here
+$$normPath(::std::)/haxe/macro/Compiler.hx:483: characters 11-39 : Called from here
 (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file meta.jsno
-  $$normPath(::std::)/haxe/macro/Compiler.hx:477: characters 11-39 : Called from here
+  $$normPath(::std::)/haxe/macro/Compiler.hx:475: characters 11-39 : Called from here
   (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file meta.jsno
-  $$normPath(::std::)/haxe/macro/Compiler.hx:472: characters 11-39 : Called from here
+  $$normPath(::std::)/haxe/macro/Compiler.hx:477: characters 11-39 : Called from here
   (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml.stderr
@@ -1,3 +1,3 @@
 (unknown) : Uncaught exception Could not read file meta.jsno
-  $$normPath(::std::)/haxe/macro/Compiler.hx:475: characters 11-39 : Called from here
+  $$normPath(::std::)/haxe/macro/Compiler.hx:483: characters 11-39 : Called from here
   (unknown) : Called from here

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml.stderr
@@ -2,9 +2,9 @@
 
    | Uncaught exception Could not read file meta.jsno
 
-    ->  $$normPath(::std::)/haxe/macro/Compiler.hx:477: characters 11-39
+    ->  $$normPath(::std::)/haxe/macro/Compiler.hx:475: characters 11-39
 
-    477 |   var f = sys.io.File.getContent(path);
+    475 |   var f = sys.io.File.getContent(path);
         |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         | Called from here
 

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml.stderr
@@ -2,9 +2,9 @@
 
    | Uncaught exception Could not read file meta.jsno
 
-    ->  $$normPath(::std::)/haxe/macro/Compiler.hx:475: characters 11-39
+    ->  $$normPath(::std::)/haxe/macro/Compiler.hx:483: characters 11-39
 
-    475 |   var f = sys.io.File.getContent(path);
+    483 |   var f = sys.io.File.getContent(path);
         |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         | Called from here
 

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml.stderr
@@ -2,9 +2,9 @@
 
    | Uncaught exception Could not read file meta.jsno
 
-    ->  $$normPath(::std::)/haxe/macro/Compiler.hx:472: characters 11-39
+    ->  $$normPath(::std::)/haxe/macro/Compiler.hx:477: characters 11-39
 
-    472 |   var f = sys.io.File.getContent(path);
+    477 |   var f = sys.io.File.getContent(path);
         |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         | Called from here
 

--- a/tests/misc/projects/Issue7871/Macro.hx
+++ b/tests/misc/projects/Issue7871/Macro.hx
@@ -1,0 +1,19 @@
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+
+function init() {
+	var e = macro 42;
+	Context.typeof(e);
+	if (Context.defined("haxe")) Context.warning("ok", (macro 0).pos);
+	Compiler.define("foo", "foo");
+
+	Context.onAfterInitMacros(() -> {
+		Context.warning("after init 1", (macro 0).pos);
+		Compiler.define("bar", "bar");
+		Context.typeof(e);
+	});
+	Compiler.include("hax.ds", true, true);
+	Context.onAfterInitMacros(() -> {
+		Context.warning("after init 2", (macro 0).pos);
+	});
+}

--- a/tests/misc/projects/Issue7871/compile-fail.hxml
+++ b/tests/misc/projects/Issue7871/compile-fail.hxml
@@ -1,0 +1,1 @@
+--macro Macro.init()

--- a/tests/misc/projects/Issue7871/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7871/compile-fail.hxml.stderr
@@ -1,0 +1,5 @@
+Macro.hx:7: characters 60-61 : Warning : ok
+Macro.hx:11: characters 42-43 : Warning : after init 1
+Macro.hx:12: characters 3-32 : Warning : This API should only be used from initialization macros.
+Package "hax.ds" was not found in any of class paths
+Macro.hx:17: characters 42-43 : Warning : after init 2

--- a/tests/misc/projects/Issue7871/compile-next-fail.hxml
+++ b/tests/misc/projects/Issue7871/compile-next-fail.hxml
@@ -1,0 +1,2 @@
+compile-fail.hxml
+-D haxe-next

--- a/tests/misc/projects/Issue7871/compile-next-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7871/compile-next-fail.hxml.stderr
@@ -1,0 +1,7 @@
+Macro.hx:6: characters 2-19 : Warning : Cannot use this API from initialization macros.
+Macro.hx:6: characters 2-19 : ... Use `Context.onAfterInitMacros` to register a callback to run when context is ready.
+Macro.hx:7: characters 60-61 : Warning : ok
+Macro.hx:11: characters 42-43 : Warning : after init 1
+Macro.hx:12: characters 3-32 : Warning : This API should only be used from initialization macros.
+Package "hax.ds" was not found in any of class paths
+Macro.hx:17: characters 42-43 : Warning : after init 2


### PR DESCRIPTION
As a first step towards #7871, adds:
 * `Context.onAfterInitMacros` to register typer-related code from init macros to be run once typer is ready
 * `Context.initMacrosDone` to check if configuration phase is over
 * Warnings, hidden behind `-D haxe-next` for now, about code currently run from init macros that should be delayed using `Context.onAfterInitMacros`
 * Warnings, that were (mostly?) already present with different message/position, about code meant for configuration phase that is currently run after init macros

Also adds `Context.getMacroStack()` to get a call stack of `haxe.macro.Position` for code running in macro context. Useful for custom message reporting.

Closes #11039