### PR TITLE
Use ubuntu 20.04 for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -572,7 +572,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: ~/.opam/
-          key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}-1
+          key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}-2
 
       - name: Install Neko from S3
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,7 +243,7 @@ jobs:
 
 
   linux-build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       OPAMYES: 1
@@ -342,7 +342,7 @@ jobs:
 
   linux-test:
     needs: linux-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       TEST: ${{matrix.target}}
@@ -425,7 +425,7 @@ jobs:
 
   test-docgen:
     needs: linux-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       HXCPP_COMPILE_CACHE: ~/hxcache
@@ -501,7 +501,7 @@ jobs:
         working-directory: ${{github.workspace}}/tests/docgen
 
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
     env:
@@ -923,7 +923,7 @@ jobs:
   deploy:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
     needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
       # maybe https://github.community/t/expose-commit-timestamp-in-the-github-context-data/16460/3
@@ -999,7 +999,7 @@ jobs:
   deploy_apidoc:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
     needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
           - target: lua
             APT_PACKAGES: ncurses-dev
           - target: flash
-            APT_PACKAGES: libglib2.0-0 libfreetype6 xvfb
+            APT_PACKAGES: libglib2.0-0 libgtk2.0-0 libfreetype6 xvfb
     steps:
       - uses: actions/checkout@main
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,7 @@ jobs:
         uses: actions/cache@v3.0.11
         with:
           path: ~/.opam/
-          key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}-1
+          key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}-2
 
       - name: Install Neko from S3
         run: |

--- a/extra/github-actions/cache-opam.yml
+++ b/extra/github-actions/cache-opam.yml
@@ -3,4 +3,4 @@
   uses: actions/cache@v3.0.11
   with:
     path: ~/.opam/
-    key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}-1
+    key: ${{ runner.os }}-${{ hashFiles('./opam', './libs/') }}-2

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
       @import build-windows.yml
 
   linux-build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       OPAMYES: 1
@@ -152,7 +152,7 @@ jobs:
 
   linux-test:
     needs: linux-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       TEST: ${{matrix.target}}
@@ -170,7 +170,7 @@ jobs:
           - target: lua
             APT_PACKAGES: ncurses-dev
           - target: flash
-            APT_PACKAGES: libglib2.0-0 libfreetype6 xvfb
+            APT_PACKAGES: libglib2.0-0 libgtk2.0-0 libfreetype6 xvfb
     steps:
       - uses: actions/checkout@main
         with:
@@ -219,7 +219,7 @@ jobs:
 
   test-docgen:
     needs: linux-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       PLATFORM: linux64
       HXCPP_COMPILE_CACHE: ~/hxcache
@@ -279,7 +279,7 @@ jobs:
         working-directory: ${{github.workspace}}/tests/docgen
 
   linux-arm64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     permissions:
       packages: write
     env:
@@ -429,7 +429,7 @@ jobs:
   deploy:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
     needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       # this is only needed for to get `COMMIT_DATE`...
       # maybe https://github.community/t/expose-commit-timestamp-in-the-github-context-data/16460/3
@@ -505,7 +505,7 @@ jobs:
   deploy_apidoc:
     if: success() && github.repository_owner == 'HaxeFoundation' && github.event_name != 'pull_request'
     needs: [linux-test, linux-arm64, mac-test, windows-test, windows64-test]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Ubuntu 18 is having another brownout today and won't be available anymore in a couple days.