### PR TITLE
MacroApi.type_expr vs diagnostics

### DIFF
--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -84,6 +84,7 @@ let macro_timer ctx l =
 let typing_timer ctx need_type f =
 	let t = Timer.timer ["typing"] in
 	let old = ctx.com.error and oldp = ctx.pass and oldlocals = ctx.locals in
+	let restore_report_mode = disable_report_mode ctx.com in
 	(*
 		disable resumable errors... unless we are in display mode (we want to reach point of completion)
 	*)
@@ -98,6 +99,7 @@ let typing_timer ctx need_type f =
 		ctx.com.error <- old;
 		ctx.pass <- oldp;
 		ctx.locals <- oldlocals;
+		restore_report_mode ();
 	in
 	try
 		let r = f() in

--- a/tests/misc/projects/Issue6794/Main.hx
+++ b/tests/misc/projects/Issue6794/Main.hx
@@ -1,0 +1,17 @@
+#if macro
+import haxe.macro.Expr;
+import haxe.macro.Context;
+#end
+
+class Main {
+	#if !macro
+	static function main()
+		test();
+	#end
+
+	static macro function test() {
+		try Context.typeof(macro foo)
+		catch (e) Context.warning("foo", (macro 0).pos);
+		return macro {};
+	}
+}

--- a/tests/misc/projects/Issue6794/compile.hxml
+++ b/tests/misc/projects/Issue6794/compile.hxml
@@ -1,0 +1,2 @@
+--main Main
+--display "Main.hx@0@diagnostics"

--- a/tests/misc/projects/Issue6794/compile.hxml.stderr
+++ b/tests/misc/projects/Issue6794/compile.hxml.stderr
@@ -1,0 +1,1 @@
+[{"file":"$$normPath(::cwd::/,true)Main.hx","diagnostics":[{"kind":2,"severity":2,"range":{"start":{"line":13,"character":42},"end":{"line":13,"character":43}},"args":"foo"}]}]


### PR DESCRIPTION
Ignores diagnostics specific behavior while typing through `MacroApi.type_expr` (eg via `Context.typeof()`), falling back to normal errors in that case, which can be caught (like during compilation) or not, in which case they'll still end up in diagnostics (might need to add a test to demonstrate that part?).

Fixes #6794 
Should also handle #10028