### PR TITLE
[python] Fixed python.net.SslSocket when python-version >= 3.4 (#8401)

### DIFF
--- a/std/python/_std/sys/net/Socket.hx
+++ b/std/python/_std/sys/net/Socket.hx
@@ -126,6 +126,11 @@ private class SocketOutput extends haxe.io.Output {
 		__s = new PSocket();
 	}
 
+    function __rebuildIoStreams():Void {
+		input = new SocketInput(__s);
+		output = new SocketOutput(__s);
+    }
+
 	public function close():Void {
 		__s.close();
 	}

--- a/std/python/lib/socket/Socket.hx
+++ b/std/python/lib/socket/Socket.hx
@@ -81,6 +81,11 @@ extern class Socket {
 	function getsockname():python.lib.socket.Address;
 
 	/**
+		Return the timeout for the socket or null if no timeout has been set.
+	**/
+	function gettimeout():Null<Float>;
+
+	/**
 		Gives a timeout after which blocking socket operations (such as reading and writing) will abort and throw an exception.
 	**/
 	function settimeout(timeout:Float):Void;
@@ -91,13 +96,25 @@ extern class Socket {
 	function waitForRead():Void;
 
 	/**
+		Return the current blocking mode of the socket.
+	**/
+	@:require(python_version >= 3.7)
+	function getblocking():Bool;
+
+	/**
 		Change the blocking mode of the socket. A blocking socket is the default behavior. A non-blocking socket will abort blocking operations immediately by throwing a haxe.io.Error.Blocked value.
 	**/
 	function setblocking(b:Bool):Void;
 
 	/**
-
+		Return the current value of the sockopt as an Int or a Bytes buffer (if buflen is specified).
 	**/
+	function getsockopt(family:Int, option:Int):Int;
+
+	/**
+		Change the value of the given socket option.
+	**/
+	@:overload(function(family:Int, option:Int, value:Int):Void {})
 	function setsockopt(family:Int, option:Int, value:Bool):Void;
 
 	function fileno():Int;

--- a/std/python/net/SslSocket.hx
+++ b/std/python/net/SslSocket.hx
@@ -25,12 +25,15 @@ package python.net;
 import python.lib.Ssl;
 import python.lib.ssl.Purpose;
 import python.lib.socket.Socket as PSocket;
+import python.lib.Socket in PSocketModule;
 import sys.net.Host;
 
 class SslSocket extends sys.net.Socket {
-	var hostName:String;
+	var _timeout:Null<Float> = null;
+	var _blocking:Null<Bool> = null;
+	var _fastSend:Null<Bool> = null;
 
-	override function __initSocket():Void {
+	function wrapSocketWithSslContext(hostName:String):Void {
 		#if (python_version >= 3.4)
 		var context = Ssl.create_default_context(Purpose.SERVER_AUTH);
 		#else
@@ -43,16 +46,42 @@ class SslSocket extends sys.net.Socket {
 		context.options |= Ssl.OP_NO_COMPRESSION;
 		#end
 		context.options |= Ssl.OP_NO_TLSv1 #if (python_version >= 3.4) | Ssl.OP_NO_TLSv1_1 #end; // python 3.4 | Ssl.OP_NO_TLSv1_1;
-		__s = new PSocket();
-		__s = context.wrap_socket(__s, false, true, true, this.hostName);
+		__s = context.wrap_socket(__s, false, true, true, hostName);
+		if (_timeout != null) {
+			super.setTimeout(_timeout);
+		}
+
+		if (_blocking != null) {
+			super.setBlocking(_blocking);
+		}
+
+		if (_fastSend != null) {
+			super.setFastSend(_fastSend);
+		}
+		__rebuildIoStreams();
 	}
 
 	public override function connect(host:Host, port:Int):Void {
-		this.hostName = host.host;
+		wrapSocketWithSslContext(host.host);
 		super.connect(host, port);
 	}
 
 	public override function bind(host:Host, port:Int):Void {
 		throw new haxe.exceptions.NotImplementedException();
+	}
+
+	public override function setTimeout(timeout:Float):Void {
+		_timeout = timeout;
+		super.setTimeout(_timeout);
+	}
+
+	public override function setBlocking(b:Bool):Void {
+		_blocking = b;
+		super.setBlocking(_blocking);
+	}
+
+	public override function setFastSend(b:Bool):Void {
+		_fastSend = b;
+		super.setFastSend(_fastSend);
 	}
 }

--- a/tests/runci/targets/Python.hx
+++ b/tests/runci/targets/Python.hx
@@ -63,6 +63,8 @@ class Python {
 		runCommand("haxe", ["compile-python.hxml"].concat(args));
 		for (py in pys) {
 			runCommand(py, ["bin/unit.py"]);
+			// Additional test for python-version >= 3.4
+			runCommand(py, ["bin/unit34.py"]);
 		}
 
 		changeDirectory(sysDir);

--- a/tests/unit/compile-python.hxml
+++ b/tests/unit/compile-python.hxml
@@ -1,3 +1,12 @@
 compile-each.hxml
+
+--each
+
 --main unit.TestMain
 -python bin/unit.py
+
+--next
+
+-D python-version=3.4
+--main unit.TestMain
+-python bin/unit34.py

--- a/tests/unit/src/unit/issues/Issue8401.hx
+++ b/tests/unit/src/unit/issues/Issue8401.hx
@@ -14,10 +14,10 @@ class Issue8401 extends unit.Test {
 		var sock = new python.net.SslSocket();
 		eq(null, sock.__s.gettimeout());
 		sock.setTimeout(500);
-		eq(500, sock.__s.gettimeout());
+		feq(500, sock.__s.gettimeout());
 		// This will change __s.  Make sure we set the timeout properly.
 		sock.wrapSocketWithSslContext("127.0.0.1");
-		eq(500, sock.__s.gettimeout());
+		feq(500, sock.__s.gettimeout());
 	}
 
 	#if (python_verion >= 3.7)

--- a/tests/unit/src/unit/issues/Issue8401.hx
+++ b/tests/unit/src/unit/issues/Issue8401.hx
@@ -1,0 +1,55 @@
+package unit.issues;
+
+import sys.net.Host;
+
+class Issue8401 extends unit.Test {
+	function testNew() {
+		var sock = new python.net.SslSocket();
+		// With Issue8401, construction fails immediately; if we get this far, it's a pass
+		utest.Assert.pass();
+	}
+
+	@:access(python.net.SslSocket.__s)
+	@:access(python.net.SslSocket.wrapSocketWithSslContext)
+	function testTimeout() {
+		var sock = new python.net.SslSocket();
+		// gettimeout is not currently defined in the python socket extern, but it's
+		// present in the python socket type.
+		eq(null, (cast sock.__s).gettimeout());
+		sock.setTimeout(500);
+		eq(500, (cast sock.__s).gettimeout());
+		// This will change __s.  Make sure we set the timeout properly.
+		sock.wrapSocketWithSslContext("127.0.0.1");
+		eq(500, (cast sock.__s).gettimeout());
+	}
+
+	#if (python_verion >= 3.7)
+	@:access(python.net.SslSocket.__s)
+	@:access(python.net.SslSocket.wrapSocketWithSslContext)
+	function testBlocking() {
+		var sock = new python.net.SslSocket();
+		// getblocking is not currently defined in the python socket extern, but it's
+		// present in the python socket type.
+		t((cast sock.__s).getblocking());
+		sock.setBlocking(false);
+		f((cast sock.__s).getblocking());
+		// This will change __s.  Make sure we set the timeout properly.
+		sock.wrapSocketWithSslContext("127.0.0.1");
+		f((cast sock.__s).getblocking());
+	}
+	#end
+
+	@:access(python.net.SslSocket.__s)
+	@:access(python.net.SslSocket.wrapSocketWithSslContext)
+	function testFastSend() {
+		var sock = new python.net.SslSocket();
+		// getsockopt is not currently defined in the python socket extern, but it's
+		// present in the python socket type.
+		eq(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		sock.setFastSend(true);
+		eq(1, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		// This will change __s.  Make sure we set the timeout properly.
+		sock.wrapSocketWithSslContext("127.0.0.1");
+		eq(1, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+	}
+}

--- a/tests/unit/src/unit/issues/Issue8401.hx
+++ b/tests/unit/src/unit/issues/Issue8401.hx
@@ -12,14 +12,12 @@ class Issue8401 extends unit.Test {
 	@:access(python.net.SslSocket.wrapSocketWithSslContext)
 	function testTimeout() {
 		var sock = new python.net.SslSocket();
-		// gettimeout is not currently defined in the python socket extern, but it's
-		// present in the python socket type.
-		eq(null, (cast sock.__s).gettimeout());
+		eq(null, sock.__s.gettimeout());
 		sock.setTimeout(500);
-		eq(500, (cast sock.__s).gettimeout());
+		eq(500, sock.__s.gettimeout());
 		// This will change __s.  Make sure we set the timeout properly.
 		sock.wrapSocketWithSslContext("127.0.0.1");
-		eq(500, (cast sock.__s).gettimeout());
+		eq(500, sock.__s.gettimeout());
 	}
 
 	#if (python_verion >= 3.7)
@@ -27,14 +25,12 @@ class Issue8401 extends unit.Test {
 	@:access(python.net.SslSocket.wrapSocketWithSslContext)
 	function testBlocking() {
 		var sock = new python.net.SslSocket();
-		// getblocking is not currently defined in the python socket extern, but it's
-		// present in the python socket type.
-		t((cast sock.__s).getblocking());
+		t(sock.__s.getblocking());
 		sock.setBlocking(false);
-		f((cast sock.__s).getblocking());
+		f(sock.__s.getblocking());
 		// This will change __s.  Make sure we set the blocking flag properly.
 		sock.wrapSocketWithSslContext("127.0.0.1");
-		f((cast sock.__s).getblocking());
+		f(sock.__s.getblocking());
 	}
 	#end
 
@@ -42,15 +38,13 @@ class Issue8401 extends unit.Test {
 	@:access(python.net.SslSocket.wrapSocketWithSslContext)
 	function testFastSend() {
 		var sock = new python.net.SslSocket();
-		// getsockopt is not currently defined in the python socket extern, but it's
-		// present in the python socket type.
-		eq(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		eq(0, sock.__s.getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
 		sock.setFastSend(true);
         // NOTE: this number can vary per platform; non-zero means true/enabled
-		utest.Assert.notEquals(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		utest.Assert.notEquals(0, sock.__s.getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
 		// This will change __s.  Make sure we set the sock opt properly.
 		sock.wrapSocketWithSslContext("127.0.0.1");
-		utest.Assert.notEquals(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		utest.Assert.notEquals(0, sock.__s.getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
 	}
 #end
 }

--- a/tests/unit/src/unit/issues/Issue8401.hx
+++ b/tests/unit/src/unit/issues/Issue8401.hx
@@ -32,7 +32,7 @@ class Issue8401 extends unit.Test {
 		t((cast sock.__s).getblocking());
 		sock.setBlocking(false);
 		f((cast sock.__s).getblocking());
-		// This will change __s.  Make sure we set the timeout properly.
+		// This will change __s.  Make sure we set the blocking flag properly.
 		sock.wrapSocketWithSslContext("127.0.0.1");
 		f((cast sock.__s).getblocking());
 	}
@@ -46,10 +46,11 @@ class Issue8401 extends unit.Test {
 		// present in the python socket type.
 		eq(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
 		sock.setFastSend(true);
-		eq(1, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
-		// This will change __s.  Make sure we set the timeout properly.
+        // NOTE: this number can vary per platform; non-zero means true/enabled
+		utest.Assert.notEquals(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		// This will change __s.  Make sure we set the sock opt properly.
 		sock.wrapSocketWithSslContext("127.0.0.1");
-		eq(1, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
+		utest.Assert.notEquals(0, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
 	}
 #end
 }

--- a/tests/unit/src/unit/issues/Issue8401.hx
+++ b/tests/unit/src/unit/issues/Issue8401.hx
@@ -3,6 +3,7 @@ package unit.issues;
 import sys.net.Host;
 
 class Issue8401 extends unit.Test {
+#if python
 	function testNew() {
 		var sock = new python.net.SslSocket();
 		// With Issue8401, construction fails immediately; if we get this far, it's a pass
@@ -52,4 +53,5 @@ class Issue8401 extends unit.Test {
 		sock.wrapSocketWithSslContext("127.0.0.1");
 		eq(1, (cast sock.__s).getsockopt(python.lib.Socket.SOL_TCP, python.lib.Socket.TCP_NODELAY));
 	}
+#end
 }

--- a/tests/unit/src/unit/issues/Issue8401.hx
+++ b/tests/unit/src/unit/issues/Issue8401.hx
@@ -1,7 +1,5 @@
 package unit.issues;
 
-import sys.net.Host;
-
 class Issue8401 extends unit.Test {
 #if python
 	function testNew() {


### PR DESCRIPTION
The issue where SslSocket throws an exception is due to hostName being null in wrap_socket.  This fix delays wrap_socket until after connect is called, so we can pass a host in.

Primary and supporting tests in tests/unit/issues/Issue8401.hx.

This also adds a test compilation in tests/unit/compile-python.hxml for testing when python-version >= 3.4, and adds the output of that to the runci/targets/Python.hx file.