### PR TITLE
[lua] Fix for https requests failing immediately and updating _hx_bit to work with lua 5.4

### DIFF
--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -1,17 +1,21 @@
-if pcall(require, 'bit32') then --if we are on Lua 5.1, bit32 will be the default. 
+local hasBit32, bit32 = pcall(require, 'bit32')
+if hasBit32 then --if we are on Lua 5.1, bit32 will be the default.
   _hx_bit_raw = bit32
-  _hx_bit = setmetatable({}, { __index = _hx_bit_raw });
+  _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
   -- lua 5.2 weirdness
-  _hx_bit.bnot = function(...) return _hx_bit_clamp(_hx_bit_raw.bnot(...)) end;
-  _hx_bit.bxor = function(...) return _hx_bit_clamp(_hx_bit_raw.bxor(...)) end;
+  _hx_bit.bnot = function(...) return _hx_bit_clamp(_hx_bit_raw.bnot(...)) end
+  _hx_bit.bxor = function(...) return _hx_bit_clamp(_hx_bit_raw.bxor(...)) end
 else
   --If we do not have bit32, fallback to 'bit'
-  pcall(require, 'bit')
+  local hasBit, bit = pcall(require, 'bit')
+  if not hasBit then
+    error("Failed to load bit or bit32")
+  end
   _hx_bit_raw = bit
-  _hx_bit = setmetatable({}, { __index = _hx_bit_raw });
+  _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
 end
 
 -- see https://github.com/HaxeFoundation/haxe/issues/8849
-_hx_bit.bor = function(...) return _hx_bit_clamp(_hx_bit_raw.bor(...)) end;
-_hx_bit.band = function(...) return _hx_bit_clamp(_hx_bit_raw.band(...)) end;
-_hx_bit.arshift = function(...) return _hx_bit_clamp(_hx_bit_raw.arshift(...)) end;
+_hx_bit.bor = function(...) return _hx_bit_clamp(_hx_bit_raw.bor(...)) end
+_hx_bit.band = function(...) return _hx_bit_clamp(_hx_bit_raw.band(...)) end
+_hx_bit.arshift = function(...) return _hx_bit_clamp(_hx_bit_raw.arshift(...)) end

--- a/std/lua/_std/sys/ssl/Socket.hx
+++ b/std/lua/_std/sys/ssl/Socket.hx
@@ -66,4 +66,4 @@ class Socket extends sys.net.Socket {
     public override function close():Void {
 		_sslSocket.close();
 	}
- }
+}

--- a/std/lua/_std/sys/ssl/Socket.hx
+++ b/std/lua/_std/sys/ssl/Socket.hx
@@ -62,5 +62,8 @@ class Socket extends sys.net.Socket {
 		_sslSocket.settimeout(timeout);
         this.handshake();
     }
+
+    public override function close():Void {
+		_sslSocket.close();
+	}
  }
- 

--- a/std/lua/_std/sys/ssl/Socket.hx
+++ b/std/lua/_std/sys/ssl/Socket.hx
@@ -65,5 +65,5 @@ class Socket extends sys.net.Socket {
 
     public override function close():Void {
 		_sslSocket.close();
-	}
+    }
 }


### PR DESCRIPTION
I've been trying to make some build scripts with the Lua target and I've ran into two issues.

The first is that https requests were failing on all Lua targets. This was due to sys.ssl.Socket.hx using the parent close method that called close on a different socket type.

The second issue is that on Lua 5.4 http requests fail when attempting to construct EReg, this was due to the _hx_bit_raw not being initialized properly. In Lua 5.4 `require` cannot load modules into the global namespace so I updated the pcalls to the more conventional format of assigning the result to the second assignment variable.

This works in Lua 5.1 through Lua 5.4:
https://www.lua.org/manual/5.1/manual.html#pdf-pcall
https://www.lua.org/manual/5.4/manual.html#pdf-pcall

I'll look into updating the unit tests later this week. 