### PR TITLE
Add `TypeTools.resolveTypeParameters`

### DIFF
--- a/std/haxe/macro/TypeTools.hx
+++ b/std/haxe/macro/TypeTools.hx
@@ -162,6 +162,59 @@ class TypeTools {
 			}
 		}
 
+	/**
+		Checks if Type `type` has the correct number of type parameters.
+
+		If incorrect, a modified version with `KTypeParameter` placeholders
+		is returned. Otherwise, the original `Type` is returned unchanged.
+
+		Malformed `Type` objects may cause internal compiler errors.
+		Therefore, this function should be called on user created `Type`
+		objects prior to passing as arguments to macro API functions
+		such as `Context.follow` or `Context.unify`.
+	**/
+	public static function validateTypeParams(type:Null<Type>):Null<Type> {
+		final result = switch (type) {
+			case null:
+				return null;
+			case TInst(t, params):
+				TInst(t, fillMissingTypeParams(params, t.get().params));
+			case TEnum(t, params):
+				TEnum(t, fillMissingTypeParams(params, t.get().params));
+			case TType(t, params):
+				TType(t, fillMissingTypeParams(params, t.get().params));
+			case TAbstract(t, params):
+				TAbstract(t, fillMissingTypeParams(params, t.get().params));
+			case _:
+				type;
+		}
+
+		return map(result, validateTypeParams);
+	}
+
+	static function fillMissingTypeParams(typeParams: Array<Type>, declParams: Array<TypeParameter>): Array<Type>
+		return {
+			if (typeParams.length > declParams.length) {
+				typeParams.slice(0, declParams.length);
+			} else {
+				var requiredParamCount = 0;
+				for (p in declParams)
+					if (p.defaultType == null) requiredParamCount++;
+					else break;
+				if (typeParams.length >= requiredParamCount) {
+					typeParams;
+				} else {
+					final result = [];
+					for (i in 0...requiredParamCount)
+						if (i < typeParams.length)
+							result.push(typeParams[i]);
+						else
+							result.push(declParams[i].t);
+					result;
+				}
+			}
+		}
+
 	#if macro
 	/**
 		Follows all typedefs of `t` to reach the actual type.

--- a/std/haxe/macro/TypeTools.hx
+++ b/std/haxe/macro/TypeTools.hx
@@ -162,59 +162,6 @@ class TypeTools {
 			}
 		}
 
-	/**
-		Checks if Type `type` has the correct number of type parameters.
-
-		If incorrect, a modified version with `KTypeParameter` placeholders
-		is returned. Otherwise, the original `Type` is returned unchanged.
-
-		Malformed `Type` objects may cause internal compiler errors.
-		Therefore, this function should be called on user created `Type`
-		objects prior to passing as arguments to macro API functions
-		such as `Context.follow` or `Context.unify`.
-	**/
-	public static function validateTypeParams(type:Null<Type>):Null<Type> {
-		final result = switch (type) {
-			case null:
-				return null;
-			case TInst(t, params):
-				TInst(t, fillMissingTypeParams(params, t.get().params));
-			case TEnum(t, params):
-				TEnum(t, fillMissingTypeParams(params, t.get().params));
-			case TType(t, params):
-				TType(t, fillMissingTypeParams(params, t.get().params));
-			case TAbstract(t, params):
-				TAbstract(t, fillMissingTypeParams(params, t.get().params));
-			case _:
-				type;
-		}
-
-		return map(result, validateTypeParams);
-	}
-
-	static function fillMissingTypeParams(typeParams: Array<Type>, declParams: Array<TypeParameter>): Array<Type>
-		return {
-			if (typeParams.length > declParams.length) {
-				typeParams.slice(0, declParams.length);
-			} else {
-				var requiredParamCount = 0;
-				for (p in declParams)
-					if (p.defaultType == null) requiredParamCount++;
-					else break;
-				if (typeParams.length >= requiredParamCount) {
-					typeParams;
-				} else {
-					final result = [];
-					for (i in 0...requiredParamCount)
-						if (i < typeParams.length)
-							result.push(typeParams[i]);
-						else
-							result.push(declParams[i].t);
-					result;
-				}
-			}
-		}
-
 	#if macro
 	/**
 		Follows all typedefs of `t` to reach the actual type.
@@ -450,6 +397,59 @@ class TypeTools {
 		return null;
 		#end
 	}
+
+	/**
+		Checks if Type `type` has the correct number of type parameters.
+
+		If incorrect, a modified version with `KTypeParameter` placeholders
+		is returned. Otherwise, the original `Type` is returned unchanged.
+
+		Malformed `Type` objects may cause internal compiler errors.
+		Therefore, this function should be called on user created `Type`
+		objects prior to passing as arguments to macro API functions
+		such as `Context.follow` or `Context.unify`.
+	**/
+	public static function validateTypeParams(type:Null<Type>):Null<Type> {
+		final result = switch (type) {
+			case null:
+				return null;
+			case TInst(t, params):
+				TInst(t, fillMissingTypeParams(params, t.get().params));
+			case TEnum(t, params):
+				TEnum(t, fillMissingTypeParams(params, t.get().params));
+			case TType(t, params):
+				TType(t, fillMissingTypeParams(params, t.get().params));
+			case TAbstract(t, params):
+				TAbstract(t, fillMissingTypeParams(params, t.get().params));
+			case _:
+				type;
+		}
+
+		return map(result, validateTypeParams);
+	}
+
+	static function fillMissingTypeParams(typeParams: Array<Type>, declParams: Array<TypeParameter>): Array<Type>
+		return {
+			if (typeParams.length > declParams.length) {
+				typeParams.slice(0, declParams.length);
+			} else {
+				var requiredParamCount = 0;
+				for (p in declParams)
+					if (p.defaultType == null) requiredParamCount++;
+					else break;
+				if (typeParams.length >= requiredParamCount) {
+					typeParams;
+				} else {
+					final result = [];
+					for (i in 0...requiredParamCount)
+						if (i < typeParams.length)
+							result.push(typeParams[i]);
+						else
+							result.push(declParams[i].t);
+					result;
+				}
+			}
+		}
 	#end
 
 	/**

--- a/tests/misc/projects/Issue10959/Macro.hx
+++ b/tests/misc/projects/Issue10959/Macro.hx
@@ -1,0 +1,87 @@
+package;
+
+#if macro
+
+import haxe.macro.Type;
+
+using haxe.macro.TypeTools;
+
+class Macro {
+	public static function start() {
+		haxe.macro.Context.onGenerate(function(types: Array<haxe.macro.Type>) {
+			// Make sure this actually runs.
+			Sys.println("On Generate");
+
+			for(t in types) {
+				switch (t) {
+					case TAbstract(a, _): {
+						makeMalformedType(a);
+					}
+					case TInst(c, _) if(c.get().name == "TestClass"): {
+						testWithClass(c);
+					}
+					case _: {}
+				}
+			}
+		});
+	}
+
+	// General test that ensures crash doesn't occur
+	static function makeMalformedType(a: Ref<AbstractType>) {
+		// If passed as it is, this will crash the Haxe compiler.
+		// https://github.com/HaxeFoundation/haxe/issues/10959
+		final type = TAbstract(a, []);
+
+		// Use TypeTools.validateTypeParams
+		final valid = type.validateTypeParams();
+
+		haxe.macro.Context.followWithAbstracts(valid);
+	}
+
+	// Test specific aspects of the validateTypeParams function
+	static function testWithClass(c: Ref<ClassType>) {
+		// Various types to use with tests
+		final voidType = haxe.macro.Context.getType("Void");
+		final intType = haxe.macro.Context.getType("Int");
+		final floatType = haxe.macro.Context.getType("Float");
+		final stringType = haxe.macro.Context.getType("String");
+		
+		// Print type before and after using "validateTypeParams"
+		function print(t:Type) {
+			Sys.println("Before: " + t.toString());
+			Sys.println("After:  " + t.validateTypeParams().toString());
+			Sys.println("");
+		}
+
+		Sys.println("-- Too Few Params --");
+
+		print(TInst(c, []));
+		print(TInst(c, [voidType]));
+
+		Sys.println("-- Too Many Params --");
+
+		print(TInst(c, [voidType, intType, floatType, stringType]));
+
+		Sys.println("-- Correct Number of Params (3rd is optional) --");
+
+		print(TInst(c, [voidType, intType, floatType]));
+		print(TInst(c, [voidType, intType]));
+
+		Sys.println("-- Shouldn't Have Params --");
+
+		switch(voidType) {
+			case TAbstract(absRef, _): {
+				print(TAbstract(absRef, [intType, floatType]));
+			}
+			case _:
+		}
+
+		Sys.println("-- Recursive Test --");
+
+		final inner1 = TInst(c, []);
+		final inner2 = TInst(c, [voidType, intType, floatType, stringType]);
+		print(TInst(c, [inner1, inner2]));
+	}
+}
+
+#end

--- a/tests/misc/projects/Issue10959/Main.hx
+++ b/tests/misc/projects/Issue10959/Main.hx
@@ -1,0 +1,6 @@
+package;
+
+// Some Haxe code must be present or Context.onGenerate will have no types.
+function main() {
+	trace("Hello world!");
+}

--- a/tests/misc/projects/Issue10959/TestClass.hx
+++ b/tests/misc/projects/Issue10959/TestClass.hx
@@ -1,0 +1,5 @@
+package;
+
+@:keep
+class TestClass<T, U, V = Void> {
+}

--- a/tests/misc/projects/Issue10959/build.hxml
+++ b/tests/misc/projects/Issue10959/build.hxml
@@ -1,0 +1,4 @@
+--macro Macro.start()
+Macro
+Main
+TestClass

--- a/tests/misc/projects/Issue10959/build.hxml.stdout
+++ b/tests/misc/projects/Issue10959/build.hxml.stdout
@@ -1,0 +1,26 @@
+On Generate
+-- Too Few Params --
+Before: TestClass
+After:  TestClass<TestClass.T, TestClass.U>
+
+Before: TestClass<Void>
+After:  TestClass<Void, TestClass.U>
+
+-- Too Many Params --
+Before: TestClass<Void, Int, Float, String>
+After:  TestClass<Void, Int, Float>
+
+-- Correct Number of Params (3rd is optional) --
+Before: TestClass<Void, Int, Float>
+After:  TestClass<Void, Int, Float>
+
+Before: TestClass<Void, Int>
+After:  TestClass<Void, Int>
+
+-- Shouldn't Have Params --
+Before: Void<Int, Float>
+After:  Void
+
+-- Recursive Test --
+Before: TestClass<TestClass, TestClass<Void, Int, Float, String>>
+After:  TestClass<TestClass<TestClass.T, TestClass.U>, TestClass<Void, Int, Float>>

--- a/tests/misc/projects/Issue10959/build.hxml.stdout
+++ b/tests/misc/projects/Issue10959/build.hxml.stdout
@@ -1,10 +1,10 @@
 On Generate
 -- Too Few Params --
 Before: TestClass
-After:  TestClass<TestClass.T, TestClass.U>
+After:  TestClass<TestClass.T, TestClass.U, Void>
 
 Before: TestClass<Void>
-After:  TestClass<Void, TestClass.U>
+After:  TestClass<Void, TestClass.U, Void>
 
 -- Too Many Params --
 Before: TestClass<Void, Int, Float, String>
@@ -15,7 +15,7 @@ Before: TestClass<Void, Int, Float>
 After:  TestClass<Void, Int, Float>
 
 Before: TestClass<Void, Int>
-After:  TestClass<Void, Int>
+After:  TestClass<Void, Int, Void>
 
 -- Shouldn't Have Params --
 Before: Void<Int, Float>
@@ -23,4 +23,24 @@ After:  Void
 
 -- Recursive Test --
 Before: TestClass<TestClass, TestClass<Void, Int, Float, String>>
-After:  TestClass<TestClass<TestClass.T, TestClass.U>, TestClass<Void, Int, Float>>
+After:  TestClass<TestClass<TestClass.T, TestClass.U, Void>, TestClass<Void, Int, Float>, Void>
+
+-- Fill With Specific Type --
+Before: TestClass
+After:  TestClass<Int, Int, Int>
+
+Before: TestClass
+After:  TestClass<String, String, String>
+
+Before: TestClass<Void, Int, Float, String>
+After:  TestClass<Void, Int, Float>
+
+-- Recursive Param OFF --
+Before: TestClass<TestClass, TestClass<Void, Int, Float, String>>
+After:  TestClass<TestClass, TestClass<Void, Int, Float, String>, String>
+
+-- Index Print --
+TestClass<TestClass, TestClass<Void, Int, Float, String>> - 2
+TestClass - 0
+TestClass - 1
+TestClass - 2


### PR DESCRIPTION
Function to help prevent user created `haxe.macro.Type`s from crashing the compiler as described in #10959 