### PR TITLE
Fix issues with haxelib ndll behaviour

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -461,6 +461,14 @@
 		"platforms": ["neko"]
 	},
 	{
+		"name": "NekoNoHaxelibPaths",
+		"define": "neko-no-haxelib-paths",
+		"doc": "Disable hard-coded Haxelib ndll paths.",
+		"platforms": [
+			"neko"
+		]
+	},
+	{
 		"name": "NekoV1",
 		"define": "neko-v1",
 		"doc": "Keep Neko 1.x compatibility.",

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -198,7 +198,7 @@ let parse_args com =
 		("Target-specific",["--swf-lib"],["-swf-lib"],Arg.String (fun file ->
 			add_native_lib file false;
 		),"<file>","add the SWF library to the compiled SWF");
-		("Target-specific",["--neko-lib-path"],[],Arg.String (fun dir ->
+		("Target-specific",[],["--neko-lib-path"],Arg.String (fun dir ->
 			com.neko_lib_paths <- dir :: com.neko_lib_paths
 		),"<directory>","add the neko library path");
 		("Target-specific",["--swf-lib-extern"],["-swf-lib-extern"],Arg.String (fun file ->

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -198,9 +198,9 @@ let parse_args com =
 		("Target-specific",["--swf-lib"],["-swf-lib"],Arg.String (fun file ->
 			add_native_lib file false;
 		),"<file>","add the SWF library to the compiled SWF");
-		("Target-specific",["--neko-lib"],[],Arg.String (fun file ->
-			com.neko_libs <- file :: com.neko_libs
-		),"<file>","add the neko library");
+		("Target-specific",["--neko-lib-path"],[],Arg.String (fun dir ->
+			com.neko_lib_paths <- dir :: com.neko_lib_paths
+		),"<directory>","add the neko library path");
 		("Target-specific",["--swf-lib-extern"],["-swf-lib-extern"],Arg.String (fun file ->
 			add_native_lib file true;
 		),"<file>","use the SWF library for type checking");

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -481,7 +481,7 @@ module HighLevel = struct
 					"-cp" :: l :: acc
 				else match (try ExtString.String.split l " " with _ -> l, "") with
 				| ("-L",dir) ->
-					"--neko-lib" :: (String.sub l 3 (String.length l - 3)) :: acc
+					"--neko-lib-path" :: (String.sub l 3 (String.length l - 3)) :: acc
 				| param, value ->
 					let acc = if value <> "" then value :: acc else acc in
 					let acc = param :: acc in

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -402,7 +402,7 @@ type context = {
 	mutable resources : (string,string) Hashtbl.t;
 	(* target-specific *)
 	mutable flash_version : float;
-	mutable neko_libs : string list;
+	mutable neko_lib_paths : string list;
 	mutable include_files : (string * string) list;
 	mutable native_libs : native_libraries;
 	mutable net_std : string list;
@@ -820,7 +820,7 @@ let create compilation_step cs version args =
 		native_libs = create_native_libs();
 		net_path_map = Hashtbl.create 0;
 		c_args = [];
-		neko_libs = [];
+		neko_lib_paths = [];
 		include_files = [];
 		js_gen = None;
 		load_extern_type = [];

--- a/src/generators/genneko.ml
+++ b/src/generators/genneko.ml
@@ -801,7 +801,7 @@ let build ctx types =
 let generate com =
 	Hashtbl.clear files;
 	let ctx = new_context com (if Common.defined com Define.NekoV1 then 1 else 2) false in
-	let libs = (EBlock (generate_libs_init com.neko_libs) , { psource = "<header>"; pline = 1; }) in
+	let libs = (EBlock (generate_libs_init com.neko_lib_paths) , { psource = "<header>"; pline = 1; }) in
 	let el = build ctx com.types in
 	let emain = (match com.main with None -> [] | Some e -> [gen_expr ctx e]) in
 	let e = (EBlock ((header()) @ libs :: el @ emain), null_pos) in

--- a/src/generators/genneko.ml
+++ b/src/generators/genneko.ml
@@ -773,7 +773,11 @@ let build ctx types =
 let generate com =
 	Hashtbl.clear files;
 	let ctx = new_context com (if Common.defined com Define.NekoV1 then 1 else 2) false in
-	let libs = (EBlock (generate_libs_init com.neko_lib_paths) , { psource = "<header>"; pline = 1; }) in
+	let libs = (EBlock
+		(if Common.defined com Define.NekoNoHaxelibPaths then []
+		else generate_libs_init com.neko_lib_paths),
+		{ psource = "<header>"; pline = 1; }
+	) in
 	let el = build ctx com.types in
 	let emain = (match com.main with None -> [] | Some e -> [gen_expr ctx e]) in
 	let e = (EBlock ((header()) @ libs :: el @ emain), null_pos) in

--- a/src/generators/genneko.ml
+++ b/src/generators/genneko.ml
@@ -662,19 +662,6 @@ let generate_libs_init = function
 	| libs ->
 		(*
 			var @s = $loader.loadprim("std@sys_string",0)();
-			var @env = $loader.loadprim("std@get_env",1);
-			var @b = if( @s == "Windows" )
-				@env("HAXEPATH") + "\\lib\\"
-				else try $loader.loadprim("std@file_contents",1)(@env("HOME")+"/.haxelib") + "/"
-				catch e
-					if( @s == "Linux" )
-						if( $loader(loadprim("std@sys_exists",1))("/usr/lib/haxe/lib") )
-							"/usr/lib/haxe/lib"
-						else
-							"/usr/share/haxe/lib/"
-					else
-						"/usr/local/lib/haxe/lib/";
-			if( try $loader.loadprim("std@sys_file_type",1)(".haxelib") == "dir" catch e false ) @b = $loader.loadprim("std@file_full_path",1)(".haxelib") + "/";
 			if( $version() >= 240 )
 				@s = @s + switch $loader.loadprim("std@sys_cpu_arch",0)() {
 					"arm64" => "Arm64"
@@ -682,8 +669,9 @@ let generate_libs_init = function
 					"x86_64" => "64"
 					default => ""
 				};
-			else if( $loader.loadprim("std@sys_is64",0)() ) @s = @s + 64;
-			@b = @b + "/"
+			else if( $loader.loadprim("std@sys_is64",0)() )
+				@s = @s + 64;
+			@s = @s + "/";
 		*)
 		let p = null_pos in
 		let es = ident p "@s" in
@@ -696,22 +684,7 @@ let generate_libs_init = function
 		let boot = [
 			(EVars [
 				"@s",Some (call p (loadp "sys_string" 0) []);
-				"@env",Some (loadp "get_env" 1);
-				"@b", Some (EIf (op "==" es (str p "Windows"),
-					op "+" (call p (ident p "@env") [str p "HAXEPATH"]) (str p "\\lib\\"),
-					Some (ETry (
-						op "+" (call p (loadp "file_contents" 1) [op "+" (call p (ident p "@env") [str p "HOME"]) (str p "/.haxelib")]) (str p "/"),
-						"e",
-						(EIf (op "==" es (str p "Linux"),
-							(EIf (call p (loadp "sys_exists" 1) [ str p "/usr/lib/haxe/lib" ],
-								str p "/usr/lib/haxe/lib/",
-								Some (str p "/usr/share/haxe/lib/")),p),
-							Some (str p "/usr/local/lib/haxe/lib/")
-						),p)
-					),p)
-				),p);
 			],p);
-			(EIf ((ETry (op "==" (call p (loadp "sys_file_type" 1) [str p ".haxelib"]) (str p "dir"),"e",(EConst False,p)),p),op "=" (ident p "@b") (op "+" (call p (loadp "file_full_path" 1) [str p ".haxelib"]) (str p "/")), None),p);
 			(EIf (op ">=" (builtin p "version") (int p 240),
 				(op "=" es (op "+" es (ESwitch (call p (loadp "sys_cpu_arch" 0) [],[
 					(str p "arm64", str p "Arm64");
@@ -724,13 +697,12 @@ let generate_libs_init = function
 		] in
 		let lpath = field p (builtin p "loader") "path" in
 		boot @ List.map (fun dir ->
-			let full_path = dir.[0] = '/' || dir.[1] = ':' in
 			let dstr = str p dir in
 			(*
 				// for each lib dir
-				$loader.path = $array($loader.path,@b+dir+@s);
+				$loader.path = $array(dir+@s,$loader.path);
 			*)
-			op "=" lpath (call p (builtin p "array") [op "+" (if full_path then dstr else op "+" (ident p "@b") dstr) (ident p "@s"); lpath])
+			op "=" lpath (call p (builtin p "array") [op "+" dstr (ident p "@s"); lpath])
 		) libs
 
 let new_context com ver macros =


### PR DESCRIPTION
Closes #10997.

- Renamed internal --neko-lib to --neko-lib-path and hid it from the help menu.
- Removed obsolete haxelib resolution code from genneko.
- Added `-D neko-no-haxelib-paths` to allow disabling system-specific hard-coded ndll paths.