### PR TITLE
Fix lua String with `no-inline`

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1210,7 +1210,13 @@ and gen_value ctx e =
         spr ctx (ctx.type_accessor t);
         spr ctx ")"
     | TCast (e1, _) ->
-        gen_value ctx e1
+        let rec unwrap_casts e = match e.eexpr with
+			| TCast(e1,None) -> skip e1
+			| _ -> e
+		in
+        spr ctx "(";
+        gen_value ctx (unwrap_casts e1);
+        spr ctx ")"
     | TVar _
     | TFor _
     | TWhile _

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -2091,6 +2091,12 @@ let generate com =
     println ctx "_hx_array_mt.__index = Array.prototype";
     newline ctx;
 
+    (* Patch string metatable *)
+    println ctx "local _hx_str_mt = getmetatable('')";
+    println ctx "String.__oldindex = _hx_str_mt.__index";
+    println ctx "_hx_str_mt.__index = String.__index";
+    newline ctx;
+
     (* Functions to support auto-run of libuv loop *)
     print_file (Common.find_file com "lua/_lua/_hx_luv.lua");
 

--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -62,19 +62,15 @@ class String {
 	public inline function toLowerCase():String
 		return BaseString.lower(this);
 
-	public inline function indexOf(str:String, ?startIndex:Int):Int {
-		return _indexOf(this, str, startIndex);
-	}
-
-	static function _indexOf(sthis:String, str:String, ?startIndex:Int):Int {
+	public function indexOf(str:String, ?startIndex:Int):Int {
 		if (startIndex == null)
 			startIndex = 1;
 		else
 			startIndex += 1;
 		if (str == "") {
-			return indexOfEmpty(sthis, startIndex - 1);
+			return indexOfEmpty(this, startIndex - 1);
 		}
-		var r = BaseString.find(sthis, str, startIndex, true).begin;
+		var r = BaseString.find(this, str, startIndex, true).begin;
 		if (r != null && r > 0)
 			return r - 1;
 		else
@@ -90,16 +86,12 @@ class String {
 		return startIndex > length ? length : startIndex;
 	}
 
-	public inline function lastIndexOf(str:String, ?startIndex:Int):Int {
-		return _lastIndexOf(this, str, startIndex);
-	}
-
-	static function _lastIndexOf(sthis:String, str:String, ?startIndex:Int):Int {
+	public function lastIndexOf(str:String, ?startIndex:Int):Int {
 		var ret = -1;
 		if (startIndex == null)
-			startIndex = sthis.length;
+			startIndex = length;
 		while (true) {
-			var p = _indexOf(sthis, str, ret + 1);
+			var p = indexOf(str, ret + 1);
 			if (p == -1 || p > startIndex || p == ret)
 				break;
 			ret = p;
@@ -107,29 +99,25 @@ class String {
 		return ret;
 	}
 
-	public inline function split(delimiter:String):Array<String> {
-		return _split(this, delimiter);
-	}
-
-	static function _split(sthis:String, delimiter:String):Array<String> {
+	public function split(delimiter:String):Array<String> {
 		var idx:Null<Int> = 1;
 		var ret = [];
 		while (idx != null) {
 			var newidx:Null<Int> = 0;
 			if (delimiter.length > 0) {
-				newidx = BaseString.find(sthis, delimiter, idx, true).begin;
-			} else if (idx >= sthis.length) {
+				newidx = BaseString.find(this, delimiter, idx, true).begin;
+			} else if (idx >= this.length) {
 				newidx = null;
 			} else {
 				newidx = idx + 1;
 			}
 
 			if (newidx != null) {
-				var match = BaseString.sub(sthis, idx, newidx - 1).match;
+				var match = BaseString.sub(this, idx, newidx - 1).match;
 				ret.push(match);
 				idx = newidx + delimiter.length;
 			} else {
-				ret.push(BaseString.sub(sthis, idx, sthis.length).match);
+				ret.push(BaseString.sub(this, idx, this.length).match);
 				idx = null;
 			}
 		}
@@ -140,22 +128,18 @@ class String {
 		return this;
 	}
 
-	public inline function substring(startIndex:Int, ?endIndex:Int):String {
-		return _substring(this, startIndex, endIndex);
-	}
-
-	static function _substring(sthis:String, startIndex:Int, ?endIndex:Int):String {
+	public function substring(startIndex:Int, ?endIndex:Int):String {
 		if (endIndex == null)
-			endIndex = sthis.length;
+			endIndex = this.length;
 		if (endIndex < 0)
 			endIndex = 0;
 		if (startIndex < 0)
 			startIndex = 0;
 		if (endIndex < startIndex) {
 			// swap the index positions
-			return BaseString.sub(sthis, endIndex + 1, startIndex).match;
+			return BaseString.sub(this, endIndex + 1, startIndex).match;
 		} else {
-			return BaseString.sub(sthis, startIndex + 1, endIndex).match;
+			return BaseString.sub(this, startIndex + 1, endIndex).match;
 		}
 	}
 
@@ -167,20 +151,16 @@ class String {
 		return BaseString.byte(this, index + 1);
 	}
 
-	public inline function substr(pos:Int, ?len:Int):String {
-		return _substr(this, pos, len);
-	}
-
-	static function _substr(sthis:String, pos:Int, ?len:Int):String {
-		if (len == null || len > pos + sthis.length)
-			len = sthis.length;
+	public function substr(pos:Int, ?len:Int):String {
+		if (len == null || len > pos + this.length)
+			len = this.length;
 		else if (len < 0)
-			len = sthis.length + len;
+			len = length + len;
 		if (pos < 0)
-			pos = sthis.length + pos;
+			pos = length + pos;
 		if (pos < 0)
 			pos = 0;
-		return BaseString.sub(sthis, pos + 1, pos + len).match;
+		return BaseString.sub(this, pos + 1, pos + len).match;
 	}
 
 	public inline static function fromCharCode(code:Int):String {

--- a/std/lua/_std/String.hx
+++ b/std/lua/_std/String.hx
@@ -63,14 +63,18 @@ class String {
 		return BaseString.lower(this);
 
 	public inline function indexOf(str:String, ?startIndex:Int):Int {
+		return _indexOf(this, str, startIndex);
+	}
+
+	static function _indexOf(sthis:String, str:String, ?startIndex:Int):Int {
 		if (startIndex == null)
 			startIndex = 1;
 		else
 			startIndex += 1;
 		if (str == "") {
-			return indexOfEmpty(this, startIndex - 1);
+			return indexOfEmpty(sthis, startIndex - 1);
 		}
-		var r = BaseString.find(this, str, startIndex, true).begin;
+		var r = BaseString.find(sthis, str, startIndex, true).begin;
 		if (r != null && r > 0)
 			return r - 1;
 		else
@@ -87,11 +91,15 @@ class String {
 	}
 
 	public inline function lastIndexOf(str:String, ?startIndex:Int):Int {
+		return _lastIndexOf(this, str, startIndex);
+	}
+
+	static function _lastIndexOf(sthis:String, str:String, ?startIndex:Int):Int {
 		var ret = -1;
 		if (startIndex == null)
-			startIndex = length;
+			startIndex = sthis.length;
 		while (true) {
-			var p = indexOf(str, ret + 1);
+			var p = _indexOf(sthis, str, ret + 1);
 			if (p == -1 || p > startIndex || p == ret)
 				break;
 			ret = p;
@@ -100,24 +108,28 @@ class String {
 	}
 
 	public inline function split(delimiter:String):Array<String> {
-		var idx = 1;
+		return _split(this, delimiter);
+	}
+
+	static function _split(sthis:String, delimiter:String):Array<String> {
+		var idx:Null<Int> = 1;
 		var ret = [];
 		while (idx != null) {
-			var newidx = 0;
+			var newidx:Null<Int> = 0;
 			if (delimiter.length > 0) {
-				newidx = BaseString.find(this, delimiter, idx, true).begin;
-			} else if (idx >= this.length) {
+				newidx = BaseString.find(sthis, delimiter, idx, true).begin;
+			} else if (idx >= sthis.length) {
 				newidx = null;
 			} else {
 				newidx = idx + 1;
 			}
 
 			if (newidx != null) {
-				var match = BaseString.sub(this, idx, newidx - 1).match;
+				var match = BaseString.sub(sthis, idx, newidx - 1).match;
 				ret.push(match);
 				idx = newidx + delimiter.length;
 			} else {
-				ret.push(BaseString.sub(this, idx, this.length).match);
+				ret.push(BaseString.sub(sthis, idx, sthis.length).match);
 				idx = null;
 			}
 		}
@@ -129,17 +141,21 @@ class String {
 	}
 
 	public inline function substring(startIndex:Int, ?endIndex:Int):String {
+		return _substring(this, startIndex, endIndex);
+	}
+
+	static function _substring(sthis:String, startIndex:Int, ?endIndex:Int):String {
 		if (endIndex == null)
-			endIndex = this.length;
+			endIndex = sthis.length;
 		if (endIndex < 0)
 			endIndex = 0;
 		if (startIndex < 0)
 			startIndex = 0;
 		if (endIndex < startIndex) {
 			// swap the index positions
-			return BaseString.sub(this, endIndex + 1, startIndex).match;
+			return BaseString.sub(sthis, endIndex + 1, startIndex).match;
 		} else {
-			return BaseString.sub(this, startIndex + 1, endIndex).match;
+			return BaseString.sub(sthis, startIndex + 1, endIndex).match;
 		}
 	}
 
@@ -152,15 +168,19 @@ class String {
 	}
 
 	public inline function substr(pos:Int, ?len:Int):String {
-		if (len == null || len > pos + this.length)
-			len = this.length;
+		return _substr(this, pos, len);
+	}
+
+	static function _substr(sthis:String, pos:Int, ?len:Int):String {
+		if (len == null || len > pos + sthis.length)
+			len = sthis.length;
 		else if (len < 0)
-			len = length + len;
+			len = sthis.length + len;
 		if (pos < 0)
-			pos = length + pos;
+			pos = sthis.length + pos;
 		if (pos < 0)
 			pos = 0;
-		return BaseString.sub(this, pos + 1, pos + len).match;
+		return BaseString.sub(sthis, pos + 1, pos + len).match;
 	}
 
 	public inline static function fromCharCode(code:Int):String {

--- a/tests/misc/lua/projects/Issue9530/Main.hx
+++ b/tests/misc/lua/projects/Issue9530/Main.hx
@@ -1,0 +1,21 @@
+using StringTools;
+
+@:nullSafety(Strict)
+class Main {
+	static var f = "field";
+	static function main() {
+		final sclass = new String("foo");
+		final scl = sclass.toUpperCase();
+		trace(scl);
+		final f2 = f.toUpperCase();
+		trace(f2);
+		final str = "str".toUpperCase();
+		trace(str);
+		final isS = "sss".startsWith("s");
+		trace(isS);
+		// test internal static call
+		final i = "foo".indexOf("");
+		trace(i);
+		trace(("dyn" : Dynamic).toUpperCase());
+	}
+}

--- a/tests/misc/lua/projects/Issue9530/compile.hxml
+++ b/tests/misc/lua/projects/Issue9530/compile.hxml
@@ -1,0 +1,4 @@
+-main Main
+-lua bin/test.lua
+--cmd lua bin/test.lua
+-D no-inline

--- a/tests/misc/lua/projects/Issue9530/compile.hxml.stdout
+++ b/tests/misc/lua/projects/Issue9530/compile.hxml.stdout
@@ -1,0 +1,6 @@
+Main.hx:9: FOO
+Main.hx:11: FIELD
+Main.hx:13: STR
+Main.hx:15: true
+Main.hx:18: 0
+Main.hx:19: DYN

--- a/tests/unit/.vscode/settings.json
+++ b/tests/unit/.vscode/settings.json
@@ -4,6 +4,7 @@
 		{"label": "JavaScript", "args": ["compile-js.hxml", "-cmd", "node -e \"require('./bin/unit.js').unit.TestMain.main()\""]},
 		{"label": "JVM", "args": ["compile-jvm-only.hxml", "-cmd", "java -jar bin/unit.jar"]},
 		{"label": "Interp", "args": ["compile-macro.hxml"]},
+		{"label": "Lua", "args": ["compile-lua.hxml", "-cmd", "lua bin/unit.lua"]},
 	],
 	"[haxe]": {
 		"editor.formatOnSave": true,


### PR DESCRIPTION
`no-inline` fix seems complicated, so this change just makes unit.lua loc output 5% smaller, performance looks same.
UPD: I think `no-inline` is fixed
Fixes https://github.com/HaxeFoundation/haxe/issues/9530
Also fixes https://github.com/HaxeFoundation/haxe/issues/10136

UPD2: I found better PR about it, made it to patch only instances and write test. (thanks to @piotrklibert)
Also also closes #10242