### PR TITLE
Restore -lib in help command

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -125,6 +125,7 @@ let parse_args com =
 			com.main_class <- Some cpath;
 			actx.classes <- cpath :: actx.classes
 		),"<class>","select startup class");
+		("Compilation",["-L";"--library"],["-lib"],Arg.String (fun _ -> ()),"<name[:ver]>","use a haxelib library");
 		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
 			let flag, value = try let split = ExtString.String.split var "=" in (fst split, Some (snd split)) with _ -> var, None in
 			match value with


### PR DESCRIPTION
Was removed by mistake during refactoring, see:

https://github.com/HaxeFoundation/haxe/commit/bbcf09c7681882a213fa9b24ccfc85b128c5fd9d#r105939733