### PR TITLE
[cpp] Fix hxcpp_api_level check

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -7018,7 +7018,7 @@ let write_build_data common_ctx filename classes main_deps boot_deps build_extra
    output_string buildfile "<include name=\"${HXCPP}/build-tool/BuildCommon.xml\"/>\n";
    output_string buildfile build_extra;
    if (Common.defined common_ctx Define.HxcppSmartStings) then
-      output_string buildfile ("<error value=\"Hxcpp is out of date - please update\" unlessApi=\"400\" />\n");
+      output_string buildfile ("<error value=\"Hxcpp is out of date - please update\" unlessApi=\"" ^ api_string ^ "\" />\n");
    output_string buildfile "</xml>\n";
    close_out buildfile;;
 


### PR DESCRIPTION
Depends on https://github.com/HaxeFoundation/hxcpp/pull/1039

Currently, when compiling with hxcpp 4.2.1, which causes errors like this since some parts of the api have changed:
```
Error: ./src/sys/io/Process.cpp: In member function ‘Dynamic sys::io::Process_obj::exitCode(hx::Null<bool>)’:
./src/sys/io/Process.cpp:71:52: error: too many arguments to function ‘int _hx_std_process_exit(Dynamic)’
   71 | HXDLIN( 108)            return _hx_std_process_exit(this->p,block);
      |                                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
In file included from .../.haxelib/hxcpp/4,2,1/include/hxcpp.h:367:
.../.haxelib/hxcpp/4,2,1/include/hx/StdLibs.h:608:35: note: declared here
  608 | HXCPP_EXTERN_CLASS_ATTRIBUTES int _hx_std_process_exit( Dynamic handle );
      |
```
Now it correctly shows `Error: Hxcpp is out of date - please update`
