### PR TITLE
[cpp] Fix duplicate newlines in Options.txt on Windows

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -7028,6 +7028,7 @@ let write_build_options common_ctx filename defines =
       | "true" | "sys" | "dce" | "cpp" | "debug" -> ()
       | _ ->  writer#write (Printf.sprintf "%s=%s\n" name (escape_command value))) defines;
    let pin,pid = Process_helper.open_process_args_in_pid "haxelib" [|"haxelib"; "path"; "hxcpp"|] in
+   set_binary_mode_in pin false;
    writer#write (Printf.sprintf "hxcpp=%s\n" (Pervasives.input_line pin));
    Pervasives.ignore (Process_helper.close_process_in_pid (pin,pid));
    writer#close;;

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -7024,12 +7024,13 @@ let write_build_data common_ctx filename classes main_deps boot_deps build_extra
 
 let write_build_options common_ctx filename defines =
    let writer = cached_source_writer common_ctx filename in
+   let write_define name value = writer#write (Printf.sprintf "%s=%s\n" name value) in
    PMap.iter ( fun name value -> match name with
       | "true" | "sys" | "dce" | "cpp" | "debug" -> ()
-      | _ ->  writer#write (Printf.sprintf "%s=%s\n" name (escape_command value))) defines;
+      | _ ->  write_define name (escape_command value)) defines;
    let pin,pid = Process_helper.open_process_args_in_pid "haxelib" [|"haxelib"; "path"; "hxcpp"|] in
    set_binary_mode_in pin false;
-   writer#write (Printf.sprintf "hxcpp=%s\n" (Pervasives.input_line pin));
+   write_define "hxcpp" (Pervasives.input_line pin);
    Pervasives.ignore (Process_helper.close_process_in_pid (pin,pid));
    writer#close;;
 


### PR DESCRIPTION
On Windows, Options.txt files would have duplicate trailing newlines. This is because `Pervasives.input_line` has incorrect new line behaviour unless binary mode is set to false for the stream.

See:
https://github.com/ocaml/ocaml/issues/6088

> You can, however, use "set_binary_mode_in" or "set_binary_mode_out" on the returned channel to put it into text mode. These operations are no-ops under non-Windows systems, so your code remains fully portable.