### PR TITLE
[ci] Enable missing hashlink tests

### DIFF
--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -52,7 +52,7 @@ class Hl {
 			"-DWITH_OPENAL=OFF",
 			"-DWITH_SDL=OFF",
 			"-DWITH_SQLITE=ON",
-			"-DWITH_SSL=OFF",
+			"-DWITH_SSL=ON",
 			"-DWITH_UI=OFF",
 			"-DWITH_UV=OFF",
 			"-DWITH_VIDEO=OFF",
@@ -72,15 +72,7 @@ class Hl {
 	static public function run(args:Array<String>) {
 		getHlDependencies();
 
-		switch (systemName) {
-			case "Windows":
-				runCommand("haxe", ["compile-hl.hxml"].concat(args));
-			case _:
-				runCommand("haxe", [
-					"compile-hl.hxml",
-					"-D", "no_http", // hl's ssl.hdll is only built on Windows
-				].concat(args));
-		}
+		runCommand("haxe", ["compile-hl.hxml"].concat(args));
 		runCommand(hlBinary, ["bin/unit.hl"]);
 
 		changeDirectory(threadsDir);

--- a/tests/unit/src/unit/TestHttp.hx
+++ b/tests/unit/src/unit/TestHttp.hx
@@ -27,7 +27,7 @@ class TestHttp extends Test {
 			return;
 		}
 		test();
-		#elseif (github && (hl || java || (flash && (Linux || Mac || Windows)) || (cs && Windows)))
+		#elseif (github && (java || (flash && (Linux || Mac || Windows)) || (cs && Windows)))
 		noAssert();
 		async.done();
 		return;
@@ -35,7 +35,7 @@ class TestHttp extends Test {
 		test();
 		#end
 	}
-#if !(github && hl)
+
 	@:timeout(1000)
 	public function testPostData(async:Async) run(async, () -> {
 		var srcStr = 'hello, world';
@@ -84,5 +84,4 @@ class TestHttp extends Test {
 		d.setPostBytes(srcData);
 		d.request();
 	});
-#end
 }

--- a/tests/unit/src/unit/TestHttp.hx
+++ b/tests/unit/src/unit/TestHttp.hx
@@ -3,37 +3,31 @@ package unit;
 import utest.Async;
 
 class TestHttp extends Test {
+	#if flash
 	public function setupClass() {
-		#if flash
 		flash.system.Security.allowDomain("*");
 		flash.system.Security.allowInsecureDomain("*");
 		flash.system.Security.loadPolicyFile("http://localhost:20200/crossdomain.xml");
-		#end
 	}
+	#end
+
+	static final RUN_HTTP_TESTS =
+		#if !github false && #end // comment out line to run http tests locally
+		#if (github && (java || flash || (cs && Windows)))
+			false
+		#elseif (js && !nodejs)
+			js.Browser.supported
+		#else
+			true
+		#end;
 
 	function run(async:Async, test:()->Void) {
-		// { comment this out to run http tests locally
-		#if (!github || (github && js && !nodejs)) //also don't run on sauce labs
-		noAssert();
-		async.done();
-		return;
-		#end
-		// }
-
-		#if (js && !nodejs)
-		if(!js.Browser.supported) {
-			noAssert();
-			async.done();
+		if (RUN_HTTP_TESTS) {
+			test();
 			return;
 		}
-		test();
-		#elseif (github && (java || (flash && (Linux || Mac || Windows)) || (cs && Windows)))
 		noAssert();
 		async.done();
-		return;
-		#else
-		test();
-		#end
 	}
 
 	@:timeout(1000)

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -78,8 +78,7 @@ function main() {
 		new TestNumericCasts(),
 		new TestHashMap(),
 		new TestRest(),
-		#if !no_http new TestHttp(),
-		#end
+		new TestHttp(),
 		#if !no_pattern_matching
 		new TestMatch(),
 		#end

--- a/tests/unit/src/unitstd/EReg.unit.hx
+++ b/tests/unit/src/unitstd/EReg.unit.hx
@@ -87,7 +87,7 @@ pos.len == 2;
 ~/a/g.replace("bab", "z") == "bzb";
 ~/a/g.replace("baba", "z") == "bzbz";
 
-#if !(interp) // not allowed in local interpreter, still allowed in hl runtime
+#if !(hl && interp) // not allowed in local hl interpreter, still allowed in hl runtime
 // replace + $
 ~/href="(.*?)"/.replace('lead href="foo" trail',"$1") == "lead foo trail";
 //~/href="(.*?)"/.replace('lead href="foo" trail',"$2") == "lead $2 trail";


### PR DESCRIPTION
Some hashlink tests were still disabled as the build was missing ssl.hdll on Linux and Mac.

These tests can be enabled once https://github.com/HaxeFoundation/hashlink/pull/596 is merged (done).