### PR TITLE
Add test for #8728

### DIFF
--- a/tests/sys/src/db/TestSqliteResultSet.hx
+++ b/tests/sys/src/db/TestSqliteResultSet.hx
@@ -26,6 +26,27 @@ class TestSqliteResultSet extends SqliteSetup {
 		equals(0, result.length);
 	}
 
+	function testIssue8728() {
+		final DB_FILE = 'temp/db.sqlite';
+		final DB_ROW_COUNT = 230;
+		final VALUE = "abxs";
+
+		if (sys.FileSystem.exists(DB_FILE))
+			sys.FileSystem.deleteFile(DB_FILE);
+		final cnx = sys.db.Sqlite.open(DB_FILE);
+		cnx.request('CREATE TABLE tbl (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT);');
+
+		final insert = "INSERT INTO tbl (value) VALUES " + [for (_ in 0...DB_ROW_COUNT) '(\'$VALUE\')'].join(",");
+		cnx.request(insert);
+		cnx.close();
+
+		// error was random, so repeat a few times for good measure
+		for (_ in 0...20) {
+			final rows = sys.db.Sqlite.open(DB_FILE).request("SELECT * FROM tbl");
+			equals(DB_ROW_COUNT, rows.length);
+		}
+	}
+
 	function testNfields() {
 		var result = cnx.request('SELECT * FROM test');
 		equals(3, result.nfields);


### PR DESCRIPTION
Closes #8728

Neko patch must be merged for the neko tests to pass: https://github.com/HaxeFoundation/neko/pull/200

The HashLink error is already covered by the `testResults()` case, HashLink 1.10.0 (on Windows) fails with:
```
testResults: FAILURE F
    line: 57, expected array element at [0] to have "one" but it is "뤘Ćn" for field array[0].value
```