### PR TITLE
Fix null arg check

### DIFF
--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1368,7 +1368,7 @@ class expr_checker mode immediate_execution report =
 				(* Local named functions like `function fn() {}`, which are generated as `var fn = null; fn = function(){}` *)
 				| Some { eexpr = TConst TNull } when v.v_kind = VUser TVOLocalFunction -> ()
 				(* `_this = null` is generated for local `inline function` *)
-				| Some { eexpr = TConst TNull } when v.v_kind = VGenerated -> ()
+				(* | Some { eexpr = TConst TNull } when v.v_kind = VGenerated -> () *)
 				| Some e ->
 					let local = { eexpr = TLocal v; epos = v.v_pos; etype = v.v_type } in
 					self#check_binop OpAssign local e p

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -289,6 +289,13 @@ class TestStrict {
 		shouldFail((true ? 'hello' : v).length);
 	}
 
+	static function inlineCallWithNullArg_shouldFail() {
+		inline function check(value: Int): Int {
+			return value;
+		}
+		shouldFail(check((null : Null<Int>)));
+	}
+
 	static function ternary_returnedFromInlinedFunction_shouldPass() {
 		var str:String = inlinedNullableSafeString([null]);
 	}
@@ -779,6 +786,12 @@ class TestStrict {
 				cb();
 			}
 		}
+		inline function cb2() {
+			if(foo != null) {
+				trace(foo);
+			}
+		}
+		cb2();
 	}
 
 	static public function closure_immediatelyExecuted_shouldInheritSafety(?s:String) {


### PR DESCRIPTION
I cannot reproduce `_this = null` generation from `inline function`, so this should only fix inline args.
Closes https://github.com/HaxeFoundation/haxe/issues/9614