### PR TITLE
[lua] Remove non-existent luautf8 charCodeAt extern

### DIFF
--- a/std/lua/lib/luautf8/Utf8.hx
+++ b/std/lua/lib/luautf8/Utf8.hx
@@ -33,11 +33,6 @@ extern class Utf8 {
 	static function sub(str:String, start:Int, ?end:Int):StringSub;
 
 	/**
-		Returns the character code at position `index` of `str`.
-	**/
-	static function charCodeAt(str:String, index:Int):Int;
-
-	/**
 		Looks for the first match of pattern in the string `str`.
 		If it finds a match, then `find` returns the indices of `str` where this
 		occurrence starts and ends.


### PR DESCRIPTION
This function doesn't exist in the lua-utf8 library, and has never existed. Attempting to use this function results in the runtime error: `attempt to call a nil value`.

Looks like this function was erroneously introduced in #7009.