### PR TITLE
[4.3_bugfix] Namespace message reporting defines

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -760,24 +760,24 @@
 	},
 	{
 		"name": "MessageReporting",
-		"define": "message-reporting",
+		"define": "message.reporting",
 		"doc": "Select message reporting mode for compiler output. (default: classic)",
 		"params": ["mode: classic | pretty | indent"]
 	},
 	{
 		"name": "NoColor",
-		"define": "no-color",
+		"define": "message.no-color",
 		"doc": "Disable ANSI color codes when using rich output."
 	},
 	{
-		"name": "MessagesLogFile",
-		"define": "messages-log-file",
-		"doc": "Path to a text file to write messages log to, in addition to regular output."
+		"name": "MessageLogFile",
+		"define": "message.log-file",
+		"doc": "Path to a text file to write message reporting to, in addition to regular output."
 	},
 	{
-		"name": "MessagesLogFormat",
-		"define": "messages-log-format",
-		"doc": "Select message reporting mode for messages log output. (default: indent)",
+		"name": "MessageLogFormat",
+		"define": "message.log-format",
+		"doc": "Select message reporting mode for message log file. (default: indent)",
 		"params": ["format: classic | pretty | indent"]
 	}
 ]

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -765,9 +765,9 @@
 		"params": ["mode: classic | pretty | indent"]
 	},
 	{
-		"name": "NoColor",
+		"name": "MessageNoColor",
 		"define": "message.no-color",
-		"doc": "Disable ANSI color codes when using rich output."
+		"doc": "Disable ANSI color codes in message reporting."
 	},
 	{
 		"name": "MessageLogFile",

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -232,7 +232,7 @@ module Communication = struct
 
 			let gutter_len = (try String.length (Printf.sprintf "%d" (IntMap.find cm.cm_depth ectx.max_lines)) with Not_found -> 0) + 2 in
 
-			let no_color = Define.defined ctx.com.defines Define.NoColor in
+			let no_color = Define.defined ctx.com.defines Define.MessageNoColor in
 			let c_reset = if no_color then "" else "\x1b[0m" in
 			let c_bold = if no_color then "" else "\x1b[1m" in
 			let c_dim = if no_color then "" else "\x1b[2m" in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -401,9 +401,9 @@ module Communication = struct
 			in
 
 		let message_formatter = get_formatter Define.MessageReporting "classic" in
-		let log_formatter = get_formatter Define.MessagesLogFormat "indent" in
+		let log_formatter = get_formatter Define.MessageLogFormat "indent" in
 
-		let log_messages = ref (Define.defined ctx.com.defines Define.MessagesLogFile) in
+		let log_messages = ref (Define.defined ctx.com.defines Define.MessageLogFile) in
 		let log_message = ref None in
 		let close_logs = ref None in
 
@@ -411,7 +411,7 @@ module Communication = struct
 			try begin
 				let buf = Rbuffer.create 16000 in
 
-				let file = Define.defined_value ctx.com.defines Define.MessagesLogFile in
+				let file = Define.defined_value ctx.com.defines Define.MessageLogFile in
 				let chan =
 					Path.mkdir_from_path file;
 					open_out_bin file
@@ -429,7 +429,7 @@ module Communication = struct
 				));
 			end with
 				| Failure e | Sys_error e -> begin
-					let def = Define.get_define_key Define.MessagesLogFile in
+					let def = Define.get_define_key Define.MessageLogFile in
 					error ctx (Printf.sprintf "Error opening log file: %s. Logging to file disabled (-D %s)" e def) null_pos;
 					log_messages := false;
 				end

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -118,7 +118,7 @@ let get_signature def =
 			   Note that we should removed flags like use_rtti_doc here.
 			*)
 			| "display" | "use_rtti_doc" | "macro_times" | "display_details" | "no_copt" | "display_stdin"
-			| "message_reporting" | "messages_log_file" | "messages_log_format" | "no_color"
+			| "message.reporting" | "message.log_file" | "message.log_format" | "message.no_color"
 			| "dump" | "dump_dependencies" | "dump_ignore_var_ids" -> acc
 			| _ -> (k ^ "=" ^ v) :: acc
 		) def.values [] in

--- a/tests/misc/projects/Issue10623/indent-fail.hxml
+++ b/tests/misc/projects/Issue10623/indent-fail.hxml
@@ -1,2 +1,2 @@
 compile-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue10623/pretty-fail.hxml
+++ b/tests/misc/projects/Issue10623/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue10844/user-defined-meta-indent-fail.hxml
+++ b/tests/misc/projects/Issue10844/user-defined-meta-indent-fail.hxml
@@ -1,2 +1,2 @@
 user-defined-meta-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-indent-fail.hxml
@@ -1,2 +1,2 @@
 user-defined-meta-json-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml
+++ b/tests/misc/projects/Issue10844/user-defined-meta-json-pretty-fail.hxml
@@ -1,4 +1,4 @@
 user-defined-meta-json-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color
 

--- a/tests/misc/projects/Issue10844/user-defined-meta-pretty-fail.hxml
+++ b/tests/misc/projects/Issue10844/user-defined-meta-pretty-fail.hxml
@@ -1,4 +1,4 @@
 user-defined-meta-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color
 

--- a/tests/misc/projects/Issue10863/compile.hxml
+++ b/tests/misc/projects/Issue10863/compile.hxml
@@ -1,5 +1,5 @@
 -main Main
 -js js.js
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color
 --no-output

--- a/tests/misc/projects/Issue10863/logmode-fail.hxml
+++ b/tests/misc/projects/Issue10863/logmode-fail.hxml
@@ -1,3 +1,3 @@
 Any
--D messages-log-file=error.log
--D messages-log-format=awesome
+-D message.log-file=error.log
+-D message.log-format=awesome

--- a/tests/misc/projects/Issue10863/logmode-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10863/logmode-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Invalid message reporting mode: "awesome", expected classic | pretty | indent (for -D messages_log_format).
+Invalid message reporting mode: "awesome", expected classic | pretty | indent (for -D message.log_format).

--- a/tests/misc/projects/Issue10863/reporting-fail.hxml
+++ b/tests/misc/projects/Issue10863/reporting-fail.hxml
@@ -1,2 +1,2 @@
 Any
--D message-reporting=awesome
+-D message.reporting=awesome

--- a/tests/misc/projects/Issue10863/reporting-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10863/reporting-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Invalid message reporting mode: "awesome", expected classic | pretty | indent (for -D message_reporting).
+Invalid message reporting mode: "awesome", expected classic | pretty | indent (for -D message.reporting).

--- a/tests/misc/projects/Issue11055/compile-pretty-fail.hxml
+++ b/tests/misc/projects/Issue11055/compile-pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue5644/pretty-fail.hxml
+++ b/tests/misc/projects/Issue5644/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue5949/indent-fail.hxml
+++ b/tests/misc/projects/Issue5949/indent-fail.hxml
@@ -1,2 +1,2 @@
 compile-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue5949/pretty-fail.hxml
+++ b/tests/misc/projects/Issue5949/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue6065/indent-fail.hxml
+++ b/tests/misc/projects/Issue6065/indent-fail.hxml
@@ -1,2 +1,2 @@
 compile-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue6065/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6065/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue6584/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6584/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile5-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue6790/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6790/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue6796/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6796/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue6810/indent-fail.hxml
+++ b/tests/misc/projects/Issue6810/indent-fail.hxml
@@ -1,2 +1,2 @@
 compile-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue6810/logfile-01-fail.hxml
+++ b/tests/misc/projects/Issue6810/logfile-01-fail.hxml
@@ -1,2 +1,2 @@
--D messages-log-file=logfile-02-fail.hxml.stderr
+-D message.log-file=logfile-02-fail.hxml.stderr
 compile-fail.hxml

--- a/tests/misc/projects/Issue6810/logfile-02-fail.hxml
+++ b/tests/misc/projects/Issue6810/logfile-02-fail.hxml
@@ -1,4 +1,4 @@
--D messages-log-file=logfile-03-fail.hxml.stderr
--D messages-log-format=pretty
--D message-reporting=indent
+-D message.log-file=logfile-03-fail.hxml.stderr
+-D message.log-format=pretty
+-D message.reporting=indent
 compile-fail.hxml

--- a/tests/misc/projects/Issue6810/logfile-03-fail.hxml
+++ b/tests/misc/projects/Issue6810/logfile-03-fail.hxml
@@ -1,4 +1,4 @@
--D messages-log-file=logfile-04-fail.hxml.stderr
--D messages-log-format=classic
--D message-reporting=pretty
+-D message.log-file=logfile-04-fail.hxml.stderr
+-D message.log-format=classic
+-D message.reporting=pretty
 compile-fail.hxml

--- a/tests/misc/projects/Issue6810/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6810/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue7968/pretty-fail.hxml
+++ b/tests/misc/projects/Issue7968/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue8303/indent-fail.hxml
+++ b/tests/misc/projects/Issue8303/indent-fail.hxml
@@ -1,2 +1,2 @@
 compile-fail.hxml
--D message-reporting=indent
+-D message.reporting=indent

--- a/tests/misc/projects/Issue8303/pretty-fail.hxml
+++ b/tests/misc/projects/Issue8303/pretty-fail.hxml
@@ -1,3 +1,3 @@
 compile-fail.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue8471/compile2-pretty.hxml
+++ b/tests/misc/projects/Issue8471/compile2-pretty.hxml
@@ -1,3 +1,3 @@
 compile2.hxml
--D message-reporting=pretty
--D no-color
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/unit/compile-each.hxml
+++ b/tests/unit/compile-each.hxml
@@ -10,4 +10,4 @@
 -lib utest
 -D analyzer-optimize
 -D analyzer-user-var-fusion
--D message-reporting=pretty
+-D message.reporting=pretty


### PR DESCRIPTION
# Warning: this is targeting `4.3_bugfix`

Kind of a breaking change for a patch version.. but if we want to namespace things we probably want to do it asap before it's too widely used.

Will update development too after that PR.