### PR TITLE
Allow boolean operators in patterns

### DIFF
--- a/src/typing/matcher/exprToPattern.ml
+++ b/src/typing/matcher/exprToPattern.ml
@@ -412,6 +412,9 @@ let rec make pctx toplevel t e =
 			restore();
 			let pat = make pctx toplevel e1.etype e2 in
 			PatExtractor {ex_var = v; ex_expr = e1; ex_pattern = pat}
+		| EBinop((OpEq | OpNotEq | OpLt | OpLte | OpGt | OpGte | OpBoolAnd | OpBoolOr),_,_) ->
+			let e_rhs = (EConst (Ident "true"),null_pos) in
+			loop (EBinop(OpArrow,e,e_rhs),(pos e))
 		(* Special case for completion on a pattern local: We don't want to add the local to the context
 		   while displaying (#7319) *)
 		| EDisplay((EConst (Ident _),_ as e),dk) when pctx.ctx.com.display.dms_kind = DMDefault ->

--- a/tests/unit/src/unit/issues/Issue11157.hx
+++ b/tests/unit/src/unit/issues/Issue11157.hx
@@ -1,0 +1,25 @@
+package unit.issues;
+
+private enum E {
+	CInt(i:Int);
+	CString(s:String);
+}
+
+class Issue11157 extends Test {
+	function process(e:E) {
+		return switch e {
+			case CInt(_ > 0 && _ < 12):
+				"in range";
+			case CString(_.toLowerCase() == "foo"):
+				return "foo";
+			case _:
+				return "something else";
+		}
+	}
+
+	function test() {
+		eq("in range", (process(CInt(11))));
+		eq("something else", (process(CInt(12))));
+		eq("foo", (process(CString("FOO"))));
+	}
+}


### PR DESCRIPTION
It was suggested to support boolean operators when pattern matching. The pattern one would currently use is `case a == b => true:`, which is both more verbose and less readable than a simpler `case a == b:`. This PR supports the latter by transforming it into the former:

```haxe
enum E {
	CInt(i:Int);
	CString(s:String);
}

function process(e:E) {
	return switch e {
		case CInt(_ > 0 && _ < 12):
			"in range";
		case CString(_.toLowerCase() == "foo"):
			return "foo";
		case _:
			return "something else";
	}
}

function main() {
	trace(process(CInt(11))); // in range
	trace(process(CInt(12))); // something else
	trace(process(CString("FOO"))); // foo
}
```

Unless I'm missing something, this syntax is clearly superior and unambiguous.

Interested in opinions!