### PR TITLE
Use Compiler.Platform enum for user defined meta/defines

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -979,7 +979,7 @@ let set_platform com pf file =
 	com.file <- file
 
 let set_custom_target com name path =
-	if List.find_opt (fun pf -> (platform_name pf) = name) platforms <> None then
+	if is_reserved_platform_name name then
 		raise (Arg.Bad (Printf.sprintf "--custom-target cannot use reserved name %s" name));
 	if String.length name > max_custom_target_len then
 		raise (Arg.Bad (Printf.sprintf "--custom-target name %s exceeds the maximum of %d characters" name max_custom_target_len));

--- a/src/core/globals.ml
+++ b/src/core/globals.ml
@@ -91,6 +91,8 @@ let platform_list_help = function
 	| [p] -> " (" ^ platform_name p ^ " only)"
 	| pl -> " (for " ^ String.concat "," (List.map platform_name pl) ^ ")"
 
+let is_reserved_platform_name name = (List.find_opt (fun pf -> (platform_name pf) = name) platforms) <> None
+
 let mk_zero_range_pos p = { p with pmax = p.pmin }
 
 let s_type_path (p,s) = match p with [] -> s | _ -> String.concat "." p ^ "." ^ s

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -22,7 +22,7 @@
 
 package haxe.macro;
 
-import haxe.display.Display;
+import haxe.display.Display.MetadataTarget;
 import haxe.macro.Expr;
 
 /**


### PR DESCRIPTION
Some leftover code from #11128. Figured might as well add here instead of getting rid of completely.