### PR TITLE
4.3.1 changelog

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -1,3 +1,22 @@
+2023-XX-XX 4.3.1
+
+	Breaking changes:
+
+	all : namespace message reporting defines (#11142)
+
+	Bugfixes:
+
+	all : fix --times with compilation server (#11091)
+	all : fix default type parameters not respecting imports (#11161)
+	all : fix bytecode bindings issues (#11098)
+	all : support deprecation for defines
+	macro : allow local statics in macro functions (#11096)
+	cpp : fix AtomicInt warnings on cppia (#11105)
+	cpp : fix deprecated implicit casts of cpp.Int64 (#10998)
+	cpp : add white space around template type syntax (#11107)
+	java : don't check native signatures on extern functions (#11131)
+	lua : remove non existent luautf8 charCodeAt extern (#11097)
+
 2023-04-06 4.3.0
 
 	New features:


### PR DESCRIPTION
See https://github.com/HaxeFoundation/haxe/commits/4.3_bugfix

I put pretty much everything in there, maybe some are not worth mentioning?
Also not sure about the "breaking change"; it won't break code but will break pretty errors config and that's unexpected in a patch release so I thought it should be highlighted.

As for the date, I suppose it depends on what else we want to include + making sure packaging will be ok. Can be updated when actually preparing the release.

Would also be nice to have those around the same time or before:
* https://github.com/HaxeFoundation/api.haxe.org/pull/20
* https://github.com/HaxeFoundation/HaxeManual/pull/526