### PR TITLE
Fix Printer EField again

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -458,6 +458,7 @@ class Printer {
 					loopI(e1);
 					loopI(e2);
 				case EField(e, field, kind):
+					if (kind == null) kind = Normal;
 					add('EField $field (${kind.getName()})');
 					loopI(e);
 				case EParenthesis(e):


### PR DESCRIPTION
`If kind is null, it is equal to Normal.` doc on `EField` was little confusing when you're sleepy.
I can also change this to only add `(Safe)` part to string, idk how will be better. 