### PR TITLE
[display] Config to disable populating cache from display requests

### DIFF
--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -48,7 +48,7 @@ let handle_display_argument_old com file_pos actx =
 			| "diagnostics" ->
 				com.report_mode <- RMDiagnostics [file_unique];
 				let dm = create DMNone in
-				{dm with dms_display_file_policy = DFPAlso; dms_per_file = true}
+				{dm with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display}
 			| "statistics" ->
 				com.report_mode <- RMStatistics;
 				let dm = create DMNone in

--- a/src/compiler/serverCompilationContext.ml
+++ b/src/compiler/serverCompilationContext.ml
@@ -58,7 +58,7 @@ let reset sctx =
 	Helper.start_time := get_time()
 
 let maybe_cache_context sctx com =
-	if com.display.dms_full_typing then begin
+	if com.display.dms_full_typing && com.display.dms_populate_cache then begin
 		CommonCache.cache_context sctx.cs com;
 		ServerMessage.cached_modules com "" (List.length com.modules);
 	end

--- a/src/compiler/serverConfig.ml
+++ b/src/compiler/serverConfig.ml
@@ -1,2 +1,3 @@
 let do_not_check_modules = ref false
+let populate_cache_from_display = ref true
 let legacy_completion = ref false

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -296,6 +296,12 @@ let handler =
 				l := jstring ("Legacy completion " ^ (if b then "enabled" else "disabled")) :: !l;
 				()
 			) ();
+			hctx.jsonrpc#get_opt_param (fun () ->
+				let b = hctx.jsonrpc#get_bool_param "populateCacheFromDisplay" in
+				ServerConfig.populate_cache_from_display := b;
+				l := jstring ("Compilation cache refill from display " ^ (if b then "enabled" else "disabled")) :: !l;
+				()
+			) ();
 			hctx.send_result (jarray !l)
 		);
 		"server/memory",(fun hctx ->

--- a/src/core/displayTypes.ml
+++ b/src/core/displayTypes.ml
@@ -196,6 +196,7 @@ module DisplayMode = struct
 		dms_inline : bool;
 		dms_display_file_policy : display_file_policy;
 		dms_exit_during_typing : bool;
+		dms_populate_cache : bool;
 		dms_per_file : bool;
 	}
 
@@ -208,6 +209,7 @@ module DisplayMode = struct
 		dms_inline = false;
 		dms_display_file_policy = DFPOnly;
 		dms_exit_during_typing = true;
+		dms_populate_cache = false;
 		dms_per_file = false;
 	}
 
@@ -220,6 +222,7 @@ module DisplayMode = struct
 		dms_inline = true;
 		dms_display_file_policy = DFPNo;
 		dms_exit_during_typing = false;
+		dms_populate_cache = true;
 		dms_per_file = false;
 	}
 
@@ -230,6 +233,7 @@ module DisplayMode = struct
 		| DMDefault | DMDefinition | DMTypeDefinition | DMPackage | DMHover | DMSignature -> settings
 		| DMUsage _ | DMImplementation -> { settings with
 				dms_full_typing = true;
+				dms_populate_cache = !ServerConfig.populate_cache_from_display;
 				dms_force_macro_typing = true;
 				dms_display_file_policy = DFPAlso;
 				dms_exit_during_typing = false

--- a/std/haxe/display/Server.hx
+++ b/std/haxe/display/Server.hx
@@ -73,6 +73,7 @@ typedef ConfigurePrintParams = {
 
 typedef ConfigureParams = {
 	final ?noModuleChecks:Bool;
+	final ?populateCacheFromDisplay:Bool;
 	final ?legacyCompletion:Bool;
 	final ?print:ConfigurePrintParams;
 }

--- a/tests/server/src/cases/issues/Issue11177.hx
+++ b/tests/server/src/cases/issues/Issue11177.hx
@@ -1,0 +1,31 @@
+package cases.issues;
+
+class Issue11177 extends TestCase {
+	// Disabled for now until #11177 is actually fixed, likely by #11220
+	// function test(_) {
+	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
+	// 	vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
+	// 	vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
+	// 	var args = ["-main", "Main", "--interp"];
+	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
+	// 	runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+	// 	runHaxe(args);
+	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+	// 	Assert.isTrue(lastResult.stderr.length == 2);
+	// }
+
+	function testWithoutCacheFromDisplay(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
+		vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
+		vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxeJson([], ServerMethods.Configure, {populateCacheFromDisplay: false});
+		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+		runHaxe(args);
+		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+		Assert.isTrue(lastResult.stderr.length == 2);
+	}
+}

--- a/tests/server/src/cases/issues/Issue11184.hx
+++ b/tests/server/src/cases/issues/Issue11184.hx
@@ -1,0 +1,25 @@
+package cases.issues;
+
+class Issue11184 extends TestCase {
+	// Disabled for now until #11184 is actually fixed, likely by #11220
+	// function test(_) {
+	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
+	// 	var args = ["-main", "Main", "-js", "bin/test.js"];
+	// 	runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+	// 	runHaxe(args);
+	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	// 	runHaxe(args);
+	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	// }
+
+	function testWithoutCacheFromDisplay(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
+		var args = ["-main", "Main", "-js", "bin/test.js"];
+		runHaxeJson([], ServerMethods.Configure, {populateCacheFromDisplay: false});
+		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+		runHaxe(args);
+		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+		runHaxe(args);
+		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	}
+}

--- a/tests/server/test/templates/issues/Issue11177/Buttons.hx
+++ b/tests/server/test/templates/issues/Issue11177/Buttons.hx
@@ -1,0 +1,6 @@
+class Buttons {
+	public static function init(main:Main):Void {
+		// Recursive inline is not supported
+		trace(KeyCode.Backspace);
+	}
+}

--- a/tests/server/test/templates/issues/Issue11177/KeyCode.hx
+++ b/tests/server/test/templates/issues/Issue11177/KeyCode.hx
@@ -1,0 +1,3 @@
+enum abstract KeyCode(Int) {
+	var Backspace = 8;
+}

--- a/tests/server/test/templates/issues/Issue11177/Main.hx
+++ b/tests/server/test/templates/issues/Issue11177/Main.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main():Void {
+		trace("change this line");
+	}
+}

--- a/tests/server/test/templates/issues/Issue11177/Main2.hx
+++ b/tests/server/test/templates/issues/Issue11177/Main2.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main():Void {
+		trace("change this trace");
+	}
+}

--- a/tests/server/test/templates/issues/Issue11184/Main.hx
+++ b/tests/server/test/templates/issues/Issue11184/Main.hx
@@ -1,0 +1,7 @@
+class Main {
+	static function main() {
+		function foo():Void {}
+		final arr = [foo()];
+	}
+}
+


### PR DESCRIPTION
Since https://github.com/HaxeFoundation/haxe/commit/7321f188b826e862d1eaff9cdb25e34abcd57279, successful "full typing" display requests (which includes diagnostics, find references/implementations) can populate compilation server cache.

This can lead to some issues while this feature is not 100% working yet, like #11177 or #11184 (which would have a proper fix with #11220). Some projects might come across different issues or even do things differently in `#if display` (that would not impact diagnostics but would impact find references/implementations I think?) that could result in types that would not be suited for final generation.

This PR adds a compilation server configuration to opt _out_ of this, so default behavior is supposed to be left unchanged. I also added tests for above issues, commented out for now with default config (failing until #11220 is merged) and only running with custom config.

This configuration option can be useful as a workaround for such issues, for personal preferences (I'd personally take slow cache over corrupted cache) or for troubleshooting the source of an issue.

I will open a couple PRs on vshaxe / Haxe LSP to allow the configuration to be edited, if this is accepted.