### PR TITLE
[macro] add flags to TDAbstract to be able to construct enum abstracts

### DIFF
--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1664,10 +1664,19 @@ let decode_type_def v =
 		EClass (mk flags fields)
 	| 3, [t] ->
 		ETypedef (mk (if isExtern then [EExtern] else []) (decode_ctype t))
-	| 4, [tthis;tfrom;tto] ->
-		let flags = match opt decode_array tfrom with None -> [] | Some ta -> List.map (fun t -> AbFrom (decode_ctype t)) ta in
+	| 4, [tthis;tflags;tfrom;tto] ->
+		let flags = match opt decode_array tflags with
+			| None -> []
+			| Some ta -> List.map (fun f -> match decode_enum f with
+				| 0, [] -> AbEnum
+				| 1, [ct] -> AbFrom (decode_ctype ct)
+				| 2, [ct] -> AbTo (decode_ctype ct)
+				| _ -> raise Invalid_expr
+		) ta in
+		let flags = match opt decode_array tfrom with None -> flags | Some ta -> List.map (fun t -> AbFrom (decode_ctype t)) ta @ flags in
 		let flags = match opt decode_array tto with None -> flags | Some ta -> (List.map (fun t -> AbTo (decode_ctype t)) ta) @ flags in
 		let flags = match opt decode_ctype tthis with None -> flags | Some t -> (AbOver t) :: flags in
+		let flags = if isExtern then AbExtern :: flags else flags in
 		EAbstract(mk flags fields)
 	| 5, [fk;al] ->
 		let fk = decode_class_field_kind fk in

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -1004,13 +1004,35 @@ enum TypeDefKind {
 	/**
 		Represents an abstract kind.
 	**/
-	TDAbstract(tthis:Null<ComplexType>, ?from:Array<ComplexType>, ?to:Array<ComplexType>);
+	TDAbstract(tthis:Null<ComplexType>, ?flags:Array<AbstractFlag>, ?from:Array<ComplexType>, ?to:Array<ComplexType>);
 
 	/**
 		Represents a module-level field.
 	**/
 	TDField(kind:FieldType, ?access:Array<Access>); // ignore TypeDefinition.fields
 
+}
+
+/**
+	Represents an abstract flag.
+**/
+enum AbstractFlag {
+	/**
+		Indicates that this abstract is an `enum abstract`
+	**/
+	AbEnum;
+
+	/**
+		Indicates that this abstract can be assigned from `ct`.
+		This flag can be added several times to add multiple "from" types.
+	**/
+	AbFrom(ct:ComplexType);
+
+	/**
+		Indicates that this abstract can be assigned to `ct`.
+		This flag can be added several times to add multiple "to" types.
+	**/
+	AbTo(ct:ComplexType);
 }
 
 /**

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -386,8 +386,8 @@ class Printer {
 					})
 					+ ";";
 				case TDAbstract(tthis, tflags, from, to):
-					var from = from.copy();
-					var to = to.copy();
+					var from = from == null ? [] : from.copy();
+					var to = to == null ? [] : to.copy();
 					var isEnum = false;
 
 					for (flag in tflags) {
@@ -403,8 +403,8 @@ class Printer {
 					+ t.name
 					+ ((t.params != null && t.params.length > 0) ? "<" + t.params.map(printTypeParamDecl).join(", ") + ">" : "")
 					+ (tthis == null ? "" : "(" + printComplexType(tthis) + ")")
-					+ (from == null ? "" : [for (f in from) " from " + printComplexType(f)].join(""))
-					+ (to == null ? "" : [for (t in to) " to " + printComplexType(t)].join(""))
+					+ [for (f in from) " from " + printComplexType(f)].join("")
+					+ [for (f in to) " to " + printComplexType(f)].join("")
 					+ " {\n"
 					+ [
 						for (f in t.fields) {

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -389,19 +389,16 @@ class Printer {
 					var from = from.copy();
 					var to = to.copy();
 					var isEnum = false;
-					var isExtern = false;
 
 					for (flag in tflags) {
 						switch (flag) {
 							case AbEnum: isEnum = true;
-							case AbExtern: isExtern = true;
 							case AbFrom(ct): from.push(ct);
 							case AbTo(ct): to.push(ct);
 						}
 					}
 
-					(!t.isExtern && isExtern ? "extern " : "")
-					+ (isEnum ? "enum " : "")
+					(isEnum ? "enum " : "")
 					+ "abstract "
 					+ t.name
 					+ ((t.params != null && t.params.length > 0) ? "<" + t.params.map(printTypeParamDecl).join(", ") + ">" : "")

--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -385,8 +385,24 @@ class Printer {
 						case _: printComplexType(ct);
 					})
 					+ ";";
-				case TDAbstract(tthis, from, to):
-					"abstract "
+				case TDAbstract(tthis, tflags, from, to):
+					var from = from.copy();
+					var to = to.copy();
+					var isEnum = false;
+					var isExtern = false;
+
+					for (flag in tflags) {
+						switch (flag) {
+							case AbEnum: isEnum = true;
+							case AbExtern: isExtern = true;
+							case AbFrom(ct): from.push(ct);
+							case AbTo(ct): to.push(ct);
+						}
+					}
+
+					(!t.isExtern && isExtern ? "extern " : "")
+					+ (isEnum ? "enum " : "")
+					+ "abstract "
 					+ t.name
 					+ ((t.params != null && t.params.length > 0) ? "<" + t.params.map(printTypeParamDecl).join(", ") + ">" : "")
 					+ (tthis == null ? "" : "(" + printComplexType(tthis) + ")")


### PR DESCRIPTION
Problem: we've deprecated `@:enum abstract` in favor of `enum abstract`, but macros can only build the former, not the later. This PR enables that.