### PR TITLE
Syntax.code: remove double curly braces escaping

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -476,10 +476,6 @@ let interpolate_code com code tl f_string f_expr p =
 			i := !i + String.length txt;
 			f_string txt;
 			loop tl
-		| Str.Delim a :: Str.Delim b :: tl when a = b ->
-			i := !i + 2;
-			f_string a;
-			loop tl
 		| Str.Delim "{" :: Str.Text n :: Str.Delim "}" :: tl ->
 			begin try
 				let expr = Array.get exprs (int_of_string n) in


### PR DESCRIPTION
That escaping is a bit weird and doesn't even seem needed.
Now that we're heading for 5.0.0 I suppose it's fine to "break" it?

Closes #10580 