### PR TITLE
[hl/eval/cpp/neko] Fix exception stack when wrapping native exceptions

### DIFF
--- a/src/filters/exceptions.ml
+++ b/src/filters/exceptions.ml
@@ -480,9 +480,11 @@ let catch_native ctx catches t p =
 			)
 		(* Haxe-specific wildcard catches should go to if-fest because they need additional handling *)
 		| (v,_) :: _ when is_haxe_wildcard_catch ctx v.v_type ->
-			(match handle_as_value_exception with
-			| [] ->
+			(match handle_as_value_exception, value_exception_catch with
+			| [], None ->
 				catches_to_ifs ctx catches t p
+			| [], Some catch ->
+				catches_to_ifs ctx [catch] t p
 			| _ ->
 				catches_as_value_exception ctx handle_as_value_exception None t p
 				:: catches_to_ifs ctx catches t p

--- a/std/cpp/_std/haxe/Exception.hx
+++ b/std/cpp/_std/haxe/Exception.hx
@@ -19,7 +19,10 @@ class Exception {
 		if(Std.isOfType(value, Exception)) {
 			return value;
 		} else {
-			return new ValueException(value, null, value);
+			var e = new ValueException(value, null, value);
+			// Undo automatic __shiftStack()
+			e.__unshiftStack();
+			return e;
 		}
 	}
 
@@ -61,6 +64,12 @@ class Exception {
 	@:ifFeature("haxe.Exception.get_stack")
 	inline function __shiftStack():Void {
 		__skipStack++;
+	}
+
+	@:noCompletion
+	@:ifFeature("haxe.Exception.get_stack")
+	inline function __unshiftStack():Void {
+		__skipStack--;
 	}
 
 	function get_message():String {

--- a/std/eval/_std/haxe/Exception.hx
+++ b/std/eval/_std/haxe/Exception.hx
@@ -18,7 +18,10 @@ class Exception {
 		if(Std.isOfType(value, Exception)) {
 			return value;
 		} else {
-			return new ValueException(value, null, value);
+			var e = new ValueException(value, null, value);
+			// Undo automatic __shiftStack()
+			e.__unshiftStack();
+			return e;
 		}
 	}
 
@@ -61,6 +64,12 @@ class Exception {
 	@:ifFeature("haxe.Exception.get_stack")
 	inline function __shiftStack():Void {
 		__skipStack++;
+	}
+
+	@:noCompletion
+	@:ifFeature("haxe.Exception.get_stack")
+	inline function __unshiftStack():Void {
+		__skipStack--;
 	}
 
 	function get_message():String {

--- a/std/hl/_std/haxe/Exception.hx
+++ b/std/hl/_std/haxe/Exception.hx
@@ -18,7 +18,10 @@ class Exception {
 		if(Std.isOfType(value, Exception)) {
 			return value;
 		} else {
-			return new ValueException(value, null, value);
+			var e = new ValueException(value, null, value);
+			// Undo automatic __shiftStack()
+			e.__unshiftStack();
+			return e;
 		}
 	}
 
@@ -60,6 +63,12 @@ class Exception {
 	@:ifFeature("haxe.Exception.get_stack")
 	inline function __shiftStack():Void {
 		__skipStack++;
+	}
+
+	@:noCompletion
+	@:ifFeature("haxe.Exception.get_stack")
+	inline function __unshiftStack():Void {
+		__skipStack--;
 	}
 
 	function get_message():String {

--- a/std/hl/_std/haxe/NativeStackTrace.hx
+++ b/std/hl/_std/haxe/NativeStackTrace.hx
@@ -29,7 +29,7 @@ class NativeStackTrace {
 		var count = callStackRaw(null);
 		var arr = new NativeArray(count);
 		callStackRaw(arr);
-		return arr;
+		return arr.sub(1, arr.length - 1);
 	}
 
 	@:hlNative("std", "exception_stack_raw")

--- a/std/neko/_std/haxe/Exception.hx
+++ b/std/neko/_std/haxe/Exception.hx
@@ -18,7 +18,10 @@ class Exception {
 		if(Std.isOfType(value, Exception)) {
 			return value;
 		} else {
-			return new ValueException(value, null, value);
+			var e = new ValueException(value, null, value);
+			// Undo automatic __shiftStack()
+			e.__unshiftStack();
+			return e;
 		}
 	}
 
@@ -61,6 +64,12 @@ class Exception {
 	@:ifFeature("haxe.Exception.get_stack")
 	inline function __shiftStack():Void {
 		__skipStack++;
+	}
+
+	@:noCompletion
+	@:ifFeature("haxe.Exception.get_stack")
+	inline function __unshiftStack():Void {
+		__skipStack--;
 	}
 
 	function get_message():String {

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -336,6 +336,16 @@ class TestExceptions extends Test {
 		eq('haxe.Exception', HelperMacros.typeString(try throw new Exception('') catch(e) e));
 	}
 
+	function testCatchValueException() {
+		try {
+			throw "";
+		} catch(e:ValueException) {
+			Assert.pass();
+		} catch(e) {
+			Assert.fail();
+		}
+	}
+
 	function testNotImplemented() {
 		try {
 			futureFeature();

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -294,6 +294,7 @@ class TestExceptions extends Test {
 		return result;
 	}
 
+	#if (eval || hl || neko)
 	function stacksAutoWrappedLevel1() {
 		return stacksAutoWrappedLevel2();
 	}
@@ -309,6 +310,7 @@ class TestExceptions extends Test {
 		result.push(try wrapNativeError((null:String).length) catch(e:Exception) e.stack);
 		return result;
 	}
+	#end
 
 	function stackItemData(item:StackItem):ItemData {
 		var result:ItemData = {};

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -236,7 +236,9 @@ class TestExceptions extends Test {
 		var data = [
 			'_without_ throws' => stacksWithoutThrowLevel1(),
 			'_with_ throws' => stacksWithThrowLevel1(),
+			#if (eval || hl || neko)
 			'auto wrapped' => stacksAutoWrappedLevel1()
+			#end
 		];
 		for(label => stacks in data) {
 			Assert.isTrue(stacks.length > 1, '$label: wrong stacks.length');
@@ -304,7 +306,7 @@ class TestExceptions extends Test {
 		// order with no additional code in between.
 		result.push(try throw new Exception('') catch(e:Exception) e.stack);
 		result.push(try throw "" catch(e:Exception) e.stack);
-		#if (eval || hl || neko) result.push(try wrapNativeError((null:String).length) catch(e:Exception) e.stack); #end
+		result.push(try wrapNativeError((null:String).length) catch(e:Exception) e.stack);
 		return result;
 	}
 

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -304,7 +304,7 @@ class TestExceptions extends Test {
 		// order with no additional code in between.
 		result.push(try throw new Exception('') catch(e:Exception) e.stack);
 		result.push(try throw "" catch(e:Exception) e.stack);
-		#if (eval || hl || neko || cpp) result.push(try wrapNativeError((null:String).length) catch(e:Exception) e.stack); #end
+		#if (eval || hl || neko) result.push(try wrapNativeError((null:String).length) catch(e:Exception) e.stack); #end
 		return result;
 	}
 

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -243,10 +243,6 @@ class TestExceptions extends Test {
 			var expected = null;
 			var lineShift = 0;
 			for(s in stacks) {
-				// TODO: fix hl vs other targets difference with callstacks
-				// See https://github.com/HaxeFoundation/haxe/issues/10926
-				#if hl @:privateAccess s.asArray().shift(); #end
-
 				if(expected == null) {
 					expected = stackItemData(s[0]);
 				} else {

--- a/tests/unit/src/unit/TestExceptions.hx
+++ b/tests/unit/src/unit/TestExceptions.hx
@@ -1,4 +1,4 @@
-﻿package unit;
+package unit;
 
 import haxe.Exception;
 import haxe.exceptions.ArgumentException;
@@ -235,7 +235,8 @@ class TestExceptions extends Test {
 	public function testExceptionStack() {
 		var data = [
 			'_without_ throws' => stacksWithoutThrowLevel1(),
-			'_with_ throws' => stacksWithThrowLevel1()
+			'_with_ throws' => stacksWithThrowLevel1(),
+			'auto wrapped' => stacksAutoWrappedLevel1()
 		];
 		for(label => stacks in data) {
 			Assert.isTrue(stacks.length > 1, '$label: wrong stacks.length');
@@ -292,6 +293,22 @@ class TestExceptions extends Test {
 		result.push(try throw new WithConstructorValueException('') catch(e:Exception) e.stack);
 		result.push(try throw new NoConstructorValueException('') catch(e:Exception) e.stack);
 		result.push(try throw @:privateAccess (Exception.thrown(''):Exception) catch(e:Exception) e.stack);
+		return result;
+	}
+
+	function stacksAutoWrappedLevel1() {
+		return stacksAutoWrappedLevel2();
+	}
+
+	function stacksAutoWrappedLevel2():Array<CallStack> {
+		@:pure(false) function wrapNativeError(_) return [];
+
+		var result:Array<CallStack> = [];
+		// It's critical for `testExceptionStack` test to keep the following lines
+		// order with no additional code in between.
+		result.push(try throw new Exception('') catch(e:Exception) e.stack);
+		result.push(try throw "" catch(e:Exception) e.stack);
+		#if (eval || hl || neko || cpp) result.push(try wrapNativeError((null:String).length) catch(e:Exception) e.stack); #end
 		return result;
 	}
 


### PR DESCRIPTION
Fixes #11247 (caused by #10519), where auto wrapped exceptions on eval/hl/neko/cpp were missing their first entry, removed automatically by all `haxe.Exception` subclasses' constructor (`__shiftStack` call added by compiler itself) while we don't want it in this case.

Current implementation is hacky; an alternative could be to handle that directly in `filters/exceptions.ml` but I'm not sure how to proceed there.

This should also cover #10926, but since there was no issue/test for the commit that introduced the issue, it's hard to say if this covers everything from it.
Closes #10926

Added a related fix, closes #11265 