### PR TITLE
Fix SSLWantWriteError bug with python's SSL sockets

### DIFF
--- a/std/python/_std/sys/net/Socket.hx
+++ b/std/python/_std/sys/net/Socket.hx
@@ -55,7 +55,11 @@ private class SocketInput extends haxe.io.Input {
 		var r;
 		var data = buf.getData();
 		try {
-			r = __s.recv(len, 0);
+			try {
+				r = __s.recv(len, 0);
+			} catch(e:SSLWantReadError) {
+				return 0;
+			}
 			for (i in pos...(pos + r.length)) {
 				data.set(i, r[i - pos]);
 			}
@@ -93,7 +97,12 @@ private class SocketOutput extends haxe.io.Output {
 		try {
 			var data = buf.getData();
 			var payload = python.Syntax.code("{0}[{1}:{1}+{2}]", data, pos, len);
-			var r = __s.send(payload, 0);
+			var r = 0;
+			try {
+				r = __s.send(payload, 0);
+			} catch(e:SSLWantWriteError) {
+				return 0;
+			}
 			return r;
 		} catch (e:BlockingIOError) {
 			throw Blocked;

--- a/std/python/_std/sys/net/Socket.hx
+++ b/std/python/_std/sys/net/Socket.hx
@@ -31,6 +31,7 @@ import python.lib.socket.Socket in PSocket;
 import python.lib.Socket in PSocketModule;
 import python.lib.socket.Address in PAddress;
 import python.lib.Select;
+import python.lib.ssl.Errors;
 
 private class SocketInput extends haxe.io.Input {
 	var __s:PSocket;

--- a/std/python/lib/ssl/Errors.hx
+++ b/std/python/lib/ssl/Errors.hx
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package python.lib.ssl;
+
+@:pythonImport("ssl", "SSLWantReadError")
+extern class SSLWantReadError {}
+
+@:pythonImport("ssl", "SSLWantWriteError")
+extern class SSLWantWriteError {}


### PR DESCRIPTION
This fixes an ancient bug relating python's SSL sockets.
I'm not sure how to put it into words, but SSLWantReadError and SSLWantWriteFunction can happen at anytime, and can be safely ignored.