### PR TITLE
Make break/continue exprs not-nullable

### DIFF
--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1041,6 +1041,8 @@ class expr_checker mode immediate_execution report =
 				| TMeta (_, e) -> self#is_nullable_expr e
 				| TThrow _ -> false
 				| TReturn _ -> false
+				| TContinue -> false
+				| TBreak -> false
 				| TBinop ((OpAssign | OpAssignOp _), _, right) -> self#is_nullable_expr right
 				| TBlock exprs ->
 					local_safety#block_declared;

--- a/tests/nullsafety/src/cases/TestLoose.hx
+++ b/tests/nullsafety/src/cases/TestLoose.hx
@@ -113,4 +113,11 @@ class TestLoose {
 		}
 		shouldFail(if (foo()) {});
 	}
+
+	static function nullCoal_continue_shouldPass():Void {
+		for (i in 0...1) {
+			var i:String = staticVar ?? continue;
+			var i2:String = staticVar ?? break;
+		}
+	}
 }


### PR DESCRIPTION
Required after https://github.com/HaxeFoundation/haxe/pull/11252 for null safety filter pass.
Both can be added to https://github.com/HaxeFoundation/haxe/issues/11201?