### PR TITLE
Account for sub-types in `ComplexTypeTools.toComplex()`.

### DIFF
--- a/std/haxe/macro/MacroStringTools.hx
+++ b/std/haxe/macro/MacroStringTools.hx
@@ -94,6 +94,10 @@ class MacroStringTools {
 
 	static public function toComplex(path:String):ComplexType {
 		var pack = path.split(".");
-		return TPath({pack: pack, name: pack.pop(), params: []});
+		if(pack.length >= 2 && ~/^[A-Z]/.match(pack[pack.length - 2])) {
+			return TPath({pack: pack, sub: pack.pop(), name: pack.pop(), params: []});
+		} else {
+			return TPath({pack: pack, name: pack.pop(), params: []});
+		}
 	}
 }


### PR DESCRIPTION
Currently, if you pass `"package.Module.SubType"` you'll get `TPath({ pack: ["package", "Module"], name: "SubType" })`. After this change, you'll instead get `TPath({ pack: ["package"], name: "Module", sub: "SubType" })`.

Resolves #8342.

Apparently this was [first brought up in 2014](https://github.com/HaxeFoundation/haxe/pull/3623), but not resolved because the implementation was too complex (no pun intended). Hopefully this is better!