### PR TITLE
[server] add support for ipv6 addresses for --wait/--connect

### DIFF
--- a/haxe.opam
+++ b/haxe.opam
@@ -31,4 +31,5 @@ depends: [
   "conf-zlib"
   "conf-neko"
   "luv" {>= "0.5.12"}
+  "ipaddr"
 ]

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -54,11 +54,11 @@ type server_api = {
 	cache : CompilationCache.t;
 	callbacks : compilation_callbacks;
 	on_context_create : unit -> int;
-	init_wait_socket : string -> int -> server_accept;
-	init_wait_connect : string -> int -> server_accept;
+	init_wait_socket : (Ipaddr.V4.t, Ipaddr.V6.t) Ipaddr.v4v6 -> int -> server_accept;
+	init_wait_connect : (Ipaddr.V4.t, Ipaddr.V6.t) Ipaddr.v4v6 -> int -> server_accept;
 	init_wait_stdio : unit -> server_accept;
 	wait_loop : bool -> server_accept -> int;
-	do_connect : string -> int -> string list -> unit;
+	do_connect : (Ipaddr.V4.t, Ipaddr.V6.t) Ipaddr.v4v6 -> int -> string list -> unit;
 }
 
 let message ctx msg =

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -572,8 +572,8 @@ module HighLevel = struct
 					(* If we are already connected, ignore (issue #10813) *)
 					loop acc l
 				else begin
-					let host, port = (try ExtString.String.split hp ":" with _ -> "127.0.0.1", hp) in
-					server_api.do_connect host (try int_of_string port with _ -> raise (Arg.Bad "Invalid port")) ((List.rev acc) @ l);
+					let host, port = Helper.parse_host_port hp in
+					server_api.do_connect host port ((List.rev acc) @ l);
 					[],None
 				end
 			| "--server-connect" :: hp :: l ->

--- a/src/dune
+++ b/src/dune
@@ -19,7 +19,7 @@
 	(libraries
 		extc extproc extlib_leftovers ilib javalib mbedtls neko objsize pcre2 swflib ttflib ziplib
 		json
-		unix str bigarray threads dynlink
+		unix ipaddr str bigarray threads dynlink
 		xml-light extlib sha
 		luv
 	)


### PR DESCRIPTION
(Note: `--connect` will behave the same as `--wait` and other related args)

* `haxe --connect 6000` will connect to `127.0.0.1`, port `6000`
* `haxe --connect 1.2.3.4:6000` will connect to `1.2.3.4`, port `6000`
* `haxe --connect 2001:0db8:0000:0000:0000:8a2e:0370:7334:6000` and `haxe --connect 2001:db8::8a2e:370:7334:6000` will connect to ipv6 `2001:db8::8a2e:370:7334`, port `6000`
* `haxe --connect ::1:6000` and `haxe --connect 0000:0000:0000:0000:0000:0000:0000:0001:6000` will connect to ipv6 `::1`, port `6000`