### PR TITLE
Dont infer string on concat

### DIFF
--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -239,14 +239,12 @@ let make_binop ctx op e1 e2 is_assign_op with_type p =
 			if unify_int ctx e1 KUnk then tint else tfloat
 		| KUnk , KFloat
 		| KUnk , KString  ->
-			unify ctx e1.etype e2.etype e1.epos;
-			e1.etype
+			e2.etype
 		| KInt , KUnk ->
 			if unify_int ctx e2 KUnk then tint else tfloat
 		| KFloat , KUnk
 		| KString , KUnk ->
-			unify ctx e2.etype e1.etype e2.epos;
-			e2.etype
+			e1.etype
 		| _ , KString
 		| KString , _ ->
 			tstring

--- a/std/neko/Boot.hx
+++ b/std/neko/Boot.hx
@@ -48,7 +48,7 @@ class Boot {
 			i += 1;
 		}
 		e.__string = old;
-		return s + untyped ")".__s;
+		return NativeString.ofString(s + untyped ")".__s);
 	}
 
 	private static function __interfLoop(cc:Dynamic, cl:Dynamic) {


### PR DESCRIPTION
Currently, monomorphs are bound to `String` when we `concat + them` to a string. This PR avoids this unification and instead inserts `Std.string(mono)`:

```haxe
function main() {
	var a = null;
	trace("Value: " + a);
	$type(a); // Null<Unknown<0>> (was Null<String>)
}
```

This seems much more natural, given that we allow concatenating any type to a string.

Closes #11284, but probably ruins somebody's day.