### PR TITLE
[typer] Delay typer creation to after init macros

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -336,7 +336,6 @@ let filter ctx tctx =
 
 let compile ctx actx callbacks =
 	let com = ctx.com in
-	MacroContext.macro_interp_cache := None;
 	(* Set up display configuration *)
 	DisplayProcessing.process_display_configuration ctx;
 	let display_file_dot_path = DisplayProcessing.process_display_file com actx in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -363,7 +363,6 @@ let compile ctx actx callbacks =
 		if actx.cmds = [] && not actx.did_something then actx.raise_usage();
 	end else begin
 		(* Actual compilation starts here *)
-		com.stage <- CTyperCreated;
 		ServerMessage.compiler_stage com;
 		(* let display_file_dot_path = DisplayProcessing.maybe_load_display_file_before_typing tctx display_file_dot_path in *)
 		let tctx = try

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -286,11 +286,13 @@ let do_type ctx mctx actx display_file_dot_path =
 	com.stage <- CInitMacrosDone;
 	ServerMessage.compiler_stage com;
 	MacroContext.macro_enable_cache := macro_cache_enabled;
+
 	let macros = match mctx with None -> None | Some mctx -> mctx.g.macros in
 	let tctx = Setup.create_typer_context ctx macros actx.native_libs in
 	let display_file_dot_path = DisplayProcessing.maybe_load_display_file_before_typing tctx display_file_dot_path in
 	check_defines ctx.com;
 	CommonCache.lock_signature com "after_init_macros";
+	Option.may (fun mctx -> MacroContext.finalize_macro_api tctx mctx) mctx;
 
 	(try begin
 		com.callbacks#run com.callbacks#get_after_init_macros;

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -276,10 +276,12 @@ let do_type ctx mctx actx =
 	let cs = com.cs in
 	CommonCache.maybe_add_context_sign cs com "before_init_macros";
 	com.stage <- CInitMacrosStart;
+	ServerMessage.compiler_stage com;
 	let (mctx, api) = List.fold_left (fun (mctx,api) path ->
 		(MacroContext.call_init_macro ctx.com mctx api path)
 	) (Option.map (fun (_,mctx) -> mctx) mctx, None) (List.rev actx.config_macros) in
 	com.stage <- CInitMacrosDone;
+	ServerMessage.compiler_stage com;
 	let macros = match mctx with None -> None | Some mctx -> mctx.g.macros in
 	let tctx = Setup.create_typer_context ctx macros actx.native_libs in
 	check_defines ctx.com;
@@ -357,6 +359,7 @@ let compile ctx actx callbacks =
 	end else begin
 		(* Actual compilation starts here *)
 		com.stage <- CTyperCreated;
+		ServerMessage.compiler_stage com;
 		(* let display_file_dot_path = DisplayProcessing.maybe_load_display_file_before_typing tctx display_file_dot_path in *)
 		let tctx = try
 			do_type ctx mctx actx

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -270,13 +270,11 @@ let check_defines com =
 	end
 
 (** Creates the typer context and types [classes] into it. *)
-let do_type ctx mctx actx display_file_dot_path =
+let do_type ctx mctx actx display_file_dot_path macro_cache_enabled =
 	let com = ctx.com in
 	let t = Timer.timer ["typing"] in
 	let cs = com.cs in
 	CommonCache.maybe_add_context_sign cs com "before_init_macros";
-	let macro_cache_enabled = !MacroContext.macro_enable_cache in
-	MacroContext.macro_enable_cache := true;
 	com.stage <- CInitMacrosStart;
 	ServerMessage.compiler_stage com;
 
@@ -339,6 +337,8 @@ let compile ctx actx callbacks =
 	(* Set up display configuration *)
 	DisplayProcessing.process_display_configuration ctx;
 	let display_file_dot_path = DisplayProcessing.process_display_file com actx in
+	let macro_cache_enabled = !MacroContext.macro_enable_cache in
+	MacroContext.macro_enable_cache := true;
 	let mctx = match com.platform with
 		| CustomTarget name ->
 			begin try
@@ -363,7 +363,7 @@ let compile ctx actx callbacks =
 		if actx.cmds = [] && not actx.did_something then actx.raise_usage();
 	end else begin
 		(* Actual compilation starts here *)
-		let (tctx,display_file_dot_path) = do_type ctx mctx actx display_file_dot_path in
+		let (tctx,display_file_dot_path) = do_type ctx mctx actx display_file_dot_path macro_cache_enabled in
 		DisplayProcessing.handle_display_after_typing ctx tctx display_file_dot_path;
 		finalize_typing ctx tctx;
 		DisplayProcessing.handle_display_after_finalization ctx tctx display_file_dot_path;

--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -344,7 +344,7 @@ let handle_type_path_exception ctx p c is_import pos =
 			| None ->
 				DisplayPath.TypePathHandler.complete_type_path com p
 			| Some (c,cur_package) ->
-				let ctx = Typer.create com in
+				let ctx = Typer.create com None in
 				DisplayPath.TypePathHandler.complete_type_path_inner ctx p c cur_package is_import
 		end with Common.Abort msg ->
 			error_ext ctx msg;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -397,6 +397,7 @@ type context = {
 	mutable user_metas : (string, Meta.user_meta) Hashtbl.t;
 	mutable get_macros : unit -> context option;
 	(* typing state *)
+	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	shared : shared_context;
 	display_information : display_information;
 	file_lookup_cache : (string,string option) lookup;
@@ -829,6 +830,7 @@ let create compilation_step cs version args =
 		file = "";
 		types = [];
 		callbacks = new compiler_callbacks;
+		global_metadata = [];
 		modules = [];
 		module_lut = new hashtbl_lookup;
 		module_nonexistent_lut = new hashtbl_lookup;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -397,7 +397,6 @@ type context = {
 	mutable user_metas : (string, Meta.user_meta) Hashtbl.t;
 	mutable get_macros : unit -> context option;
 	(* typing state *)
-	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	shared : shared_context;
 	display_information : display_information;
 	file_lookup_cache : (string,string option) lookup;
@@ -830,7 +829,6 @@ let create compilation_step cs version args =
 		file = "";
 		types = [];
 		callbacks = new compiler_callbacks;
-		global_metadata = [];
 		modules = [];
 		module_lut = new hashtbl_lookup;
 		module_nonexistent_lut = new hashtbl_lookup;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -256,7 +256,6 @@ type json_api = {
 type compiler_stage =
 	| CCreated          (* Context was just created *)
 	| CInitialized      (* Context was initialized (from CLI args and such). *)
-	| CTyperCreated     (* The typer context was just created. *)
 	| CInitMacrosStart  (* Init macros are about to run. *)
 	| CInitMacrosDone   (* Init macros did run - at this point the signature is locked. *)
 	| CTypingDone       (* The typer is done - at this point com.types/modules/main is filled. *)
@@ -274,7 +273,6 @@ type compiler_stage =
 let s_compiler_stage = function
 	| CCreated          -> "CCreated"
 	| CInitialized      -> "CInitialized"
-	| CTyperCreated     -> "CTyperCreated"
 	| CInitMacrosStart  -> "CInitMacrosStart"
 	| CInitMacrosDone   -> "CInitMacrosDone"
 	| CTypingDone       -> "CTypingDone"

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -80,7 +80,6 @@ type typer_globals = {
 	mutable macros : ((unit -> unit) * typer) option;
 	mutable std : module_def;
 	type_patches : (path, (string * bool, type_patch) Hashtbl.t * type_patch) Hashtbl.t;
-	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	mutable module_check_policies : (string list * module_check_policy list * bool) list;
 	mutable global_using : (tclass * pos) list;
 	(* Indicates that Typer.create() finished building this instance *)
@@ -217,7 +216,7 @@ let analyzer_run_on_expr_ref : (Common.context -> string -> texpr -> texpr) ref 
 let cast_or_unify_raise_ref : (typer -> ?uctx:unification_context option -> Type.t -> texpr -> pos -> texpr) ref = ref (fun _ ?uctx _ _ _ -> assert false)
 let type_generic_function_ref : (typer -> field_access -> (unit -> texpr) field_call_candidate -> WithType.t -> pos -> texpr) ref = ref (fun _ _ _ _ _ -> assert false)
 
-let create_context_ref : (Common.context -> typer) ref = ref (fun _ -> assert false)
+let create_context_ref : (Common.context -> ((unit -> unit) * typer) option -> typer) ref = ref (fun _ -> assert false)
 
 let pass_name = function
 	| PBuildModule -> "build-module"

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -80,6 +80,7 @@ type typer_globals = {
 	mutable macros : ((unit -> unit) * typer) option;
 	mutable std : module_def;
 	type_patches : (path, (string * bool, type_patch) Hashtbl.t * type_patch) Hashtbl.t;
+	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	mutable module_check_policies : (string list * module_check_policy list * bool) list;
 	mutable global_using : (tclass * pos) list;
 	(* Indicates that Typer.create() finished building this instance *)

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -80,7 +80,6 @@ type typer_globals = {
 	mutable macros : ((unit -> unit) * typer) option;
 	mutable std : module_def;
 	type_patches : (path, (string * bool, type_patch) Hashtbl.t * type_patch) Hashtbl.t;
-	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
 	mutable module_check_policies : (string list * module_check_policy list * bool) list;
 	mutable global_using : (tclass * pos) list;
 	(* Indicates that Typer.create() finished building this instance *)

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1893,10 +1893,8 @@ let macro_api ccom get_api =
 			encode_array (List.map encode_type ((get_api()).get_module (decode_string s)))
 		);
 		"on_after_init_macros", vfun1 (fun f ->
-			(get_api()).after_init_macros (fun tctx ->
-				let f = prepare_callback f 1 in
-				ignore(f [])
-			);
+			let f = prepare_callback f 1 in
+			(get_api()).after_init_macros (fun tctx -> ignore(f []));
 			vnull
 		);
 		"on_after_typing", vfun1 (fun f ->

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -19,6 +19,7 @@ type compiler_options = {
 **)
 
 type 'value compiler_api = {
+	is_full : bool;
 	pos : Globals.pos;
 	get_com : unit -> Common.context;
 	get_macro_stack : unit -> pos list;
@@ -1893,8 +1894,10 @@ let macro_api ccom get_api =
 			encode_array (List.map encode_type ((get_api()).get_module (decode_string s)))
 		);
 		"on_after_init_macros", vfun1 (fun f ->
-			let f = prepare_callback f 1 in
-			(get_api()).after_init_macros (fun tl -> ignore(f []));
+			if (get_api()).is_full then begin
+				let f = prepare_callback f 1 in
+				(get_api()).after_init_macros (fun tctx -> ignore(f []));
+			end;
 			vnull
 		);
 		"on_after_typing", vfun1 (fun f ->

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -19,7 +19,6 @@ type compiler_options = {
 **)
 
 type 'value compiler_api = {
-	is_full : bool;
 	pos : Globals.pos;
 	get_com : unit -> Common.context;
 	get_macro_stack : unit -> pos list;
@@ -1894,10 +1893,10 @@ let macro_api ccom get_api =
 			encode_array (List.map encode_type ((get_api()).get_module (decode_string s)))
 		);
 		"on_after_init_macros", vfun1 (fun f ->
-			if (get_api()).is_full then begin
+			(get_api()).after_init_macros (fun tctx ->
 				let f = prepare_callback f 1 in
-				(get_api()).after_init_macros (fun tctx -> ignore(f []));
-			end;
+				ignore(f [])
+			);
 			vnull
 		);
 		"on_after_typing", vfun1 (fun f ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -738,6 +738,7 @@ let get_macro_context ctx =
 		let mctx = create_macro_context ctx.com in
 		let api = make_macro_api mctx null_pos in
 		let init = create_macro_interp api mctx in
+		ctx.g.macros <- Some (init,mctx);
 		mctx.g.macros <- Some (init,mctx);
 		mctx
 

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -1053,18 +1053,20 @@ let call_init_macro com mctx e =
 	let api = make_macro_com_api com p in
 	(match !macro_interp_cache with
 	| None ->
+		(* trace "create macro interp for init macro"; *)
 		let init,_ = create_macro_interp api mctx in
 		init();
 	| _ -> ());
 
 	let mctx, (margs,_,mclass,mfield), call = load_macro mctx com mctx api false path meth p in
 	ignore(call_macro mctx args margs call p);
+	(* (Some mctx, Some api) *)
 	mctx
 
 let finalize_macro_api tctx mctx =
 	let api = make_macro_api tctx null_pos in
 	let mint = (match !macro_interp_cache with None -> snd (create_macro_interp api mctx) | Some mint -> mint) in
-	Interp.do_reuse mint api;
+	mint.curapi <- api;
 
 module MacroLight = struct
 	let load_macro_light com mctx api display cpath f p =

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -117,14 +117,6 @@ let typing_timer ctx need_type f =
 		raise e
 
 let make_macro_com_api com p =
-	let parse_metadata s p =
-		try
-			match ParserEntry.parse_string Grammar.parse_meta com.defines s null_pos raise_typing_error false with
-			| ParseSuccess(meta,_,_) -> meta
-			| ParseError(_,_,_) -> raise_typing_error "Malformed metadata string" p
-		with _ ->
-			raise_typing_error "Malformed metadata string" p
-	in
 	{
 		MacroApi.pos = p;
 		get_com = (fun () -> com);
@@ -286,11 +278,7 @@ let make_macro_com_api com p =
 			Interp.exc_string "unsupported"
 		);
 		add_global_metadata = (fun s1 s2 config p ->
-			let meta = parse_metadata s2 p in
-			List.iter (fun (m,el,_) ->
-				let m = (m,el,p) in
-				com.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: com.global_metadata;
-			) meta;
+			Interp.exc_string "unsupported"
 		);
 		add_module_check_policy = (fun sl il b i ->
 			Interp.exc_string "unsupported"
@@ -549,7 +537,7 @@ let make_macro_api ctx p =
 			let meta = parse_metadata s2 p in
 			List.iter (fun (m,el,_) ->
 				let m = (m,el,p) in
-				ctx.com.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: ctx.com.global_metadata;
+				ctx.g.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: ctx.g.global_metadata;
 			) meta;
 		);
 		MacroApi.add_module_check_policy = (fun sl il b i ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -117,6 +117,14 @@ let typing_timer ctx need_type f =
 		raise e
 
 let make_macro_com_api com p =
+	let parse_metadata s p =
+		try
+			match ParserEntry.parse_string Grammar.parse_meta com.defines s null_pos raise_typing_error false with
+			| ParseSuccess(meta,_,_) -> meta
+			| ParseError(_,_,_) -> raise_typing_error "Malformed metadata string" p
+		with _ ->
+			raise_typing_error "Malformed metadata string" p
+	in
 	{
 		MacroApi.pos = p;
 		get_com = (fun () -> com);
@@ -278,7 +286,11 @@ let make_macro_com_api com p =
 			Interp.exc_string "unsupported"
 		);
 		add_global_metadata = (fun s1 s2 config p ->
-			Interp.exc_string "unsupported"
+			let meta = parse_metadata s2 p in
+			List.iter (fun (m,el,_) ->
+				let m = (m,el,p) in
+				com.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: com.global_metadata;
+			) meta;
 		);
 		add_module_check_policy = (fun sl il b i ->
 			Interp.exc_string "unsupported"
@@ -537,7 +549,7 @@ let make_macro_api ctx p =
 			let meta = parse_metadata s2 p in
 			List.iter (fun (m,el,_) ->
 				let m = (m,el,p) in
-				ctx.g.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: ctx.g.global_metadata;
+				ctx.com.global_metadata <- (ExtString.String.nsplit s1 ".",m,config) :: ctx.com.global_metadata;
 			) meta;
 		);
 		MacroApi.add_module_check_policy = (fun sl il b i ->
@@ -712,7 +724,7 @@ let create_macro_context com =
 	com2.defines.defines_signature <- None;
 	com2.platform <- !Globals.macro_platform;
 	Common.init_platform com2;
-	let mctx = !create_context_ref com2 in
+	let mctx = !create_context_ref com2 None in
 	mctx.is_display_file <- false;
 	CommonCache.lock_signature com2 "get_macro_context";
 	mctx
@@ -724,9 +736,8 @@ let get_macro_context ctx =
 		ctx
 	| None ->
 		let mctx = create_macro_context ctx.com in
-		let api = make_macro_api ctx null_pos in
+		let api = make_macro_api mctx null_pos in
 		let init = create_macro_interp api mctx in
-		ctx.g.macros <- Some (init,mctx);
 		mctx.g.macros <- Some (init,mctx);
 		mctx
 
@@ -803,10 +814,8 @@ let do_call_macro com api cpath f args p =
 	if com.verbose then Common.log com ("Exiting macro " ^ s_type_path cpath ^ "." ^ f);
 	r
 
-let load_macro ctx display cpath f p =
-	let api = make_macro_api ctx p in
-	let mctx = get_macro_context ctx in
-	let meth,mloaded = load_macro'' ctx.com mctx display cpath f p in
+let load_macro ctx com mctx api display cpath f p =
+	let meth,mloaded = load_macro'' com mctx display cpath f p in
 	let _,_,{cl_path = cpath},_ = meth in
 	let call args =
 		add_dependency ctx.m.curmod mloaded;
@@ -820,7 +829,9 @@ type macro_arg_type =
 	| MAOther
 
 let type_macro ctx mode cpath f (el:Ast.expr list) p =
-	let mctx, (margs,mret,mclass,mfield), call_macro = load_macro ctx (mode = MDisplay) cpath f p in
+	let api = make_macro_api ctx p in
+	let mctx = get_macro_context ctx in
+	let mctx, (margs,mret,mclass,mfield), call_macro = load_macro ctx ctx.com mctx api (mode = MDisplay) cpath f p in
 	let margs =
 		(*
 			Replace "rest:haxe.Rest<Expr>" in macro signatures with "rest:Array<Expr>".
@@ -1031,10 +1042,19 @@ let resolve_init_macro com e =
 	| _ ->
 		raise_typing_error "Invalid macro call" p
 
-let call_init_macro ctx e =
-	let (path,meth,args,p) = resolve_init_macro ctx.com e in
-	let mctx, (margs,_,mclass,mfield), call = load_macro ctx false path meth p in
+let call_init_macro com mctx api e =
+	let mctx = match mctx with Some mctx -> mctx | None -> create_macro_context com in
+	let api = match api with Some api -> api | None ->
+		let api = make_macro_com_api com null_pos in
+		let init = create_macro_interp api mctx in
+		init();
+		api
+	in
+
+	let (path,meth,args,p) = resolve_init_macro com e in
+	let mctx, (margs,_,mclass,mfield), call = load_macro mctx com mctx api false path meth p in
 	ignore(call_macro mctx args margs call p);
+	(Some mctx, Some api)
 
 module MacroLight = struct
 	let load_macro_light com mctx api display cpath f p =

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -1053,14 +1053,12 @@ let call_init_macro com mctx e =
 	let api = make_macro_com_api com p in
 	(match !macro_interp_cache with
 	| None ->
-		(* trace "create macro interp for init macro"; *)
 		let init,_ = create_macro_interp api mctx in
 		init();
 	| _ -> ());
 
 	let mctx, (margs,_,mclass,mfield), call = load_macro mctx com mctx api false path meth p in
 	ignore(call_macro mctx args margs call p);
-	(* (Some mctx, Some api) *)
 	mctx
 
 let finalize_macro_api tctx mctx =

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -1045,10 +1045,18 @@ let resolve_init_macro com e =
 
 let call_init_macro com mctx e =
 	let (path,meth,args,p) = resolve_init_macro com e in
+	let (mctx, api) = match mctx with
+	| Some mctx ->
+		let api = make_macro_com_api com p in
+		(mctx, api)
+	| None ->
+		let mctx = create_macro_context com in
+		let api = make_macro_com_api com p in
+		let init,_ = create_macro_interp api mctx in
+		mctx.g.macros <- Some (init,mctx);
+		(mctx, api)
+	in
 
-	let mctx = match mctx with Some mctx -> mctx | None -> create_macro_context com in
-	let api = make_macro_com_api com p in
-	if Option.is_none !macro_interp_cache then (fst (create_macro_interp api mctx)) ();
 	let mctx, (margs,_,mclass,mfield), call = load_macro mctx com mctx api false path meth p in
 	ignore(call_macro mctx args margs call p);
 	mctx

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -316,7 +316,7 @@ let make_macro_com_api com p =
 		);
 	}
 
-and promote_com_api com_api ctx p =
+let make_macro_api ctx p =
 	let parse_metadata s p =
 		try
 			match ParserEntry.parse_string Grammar.parse_meta ctx.com.defines s null_pos raise_typing_error false with
@@ -325,6 +325,7 @@ and promote_com_api com_api ctx p =
 		with _ ->
 			raise_typing_error "Malformed metadata string" p
 	in
+	let com_api = make_macro_com_api ctx.com p in
 	{
 		com_api with
 		MacroApi.get_type = (fun s ->
@@ -607,10 +608,6 @@ and promote_com_api com_api ctx p =
 			warning ~depth ctx w msg p
 		);
 	}
-
-let make_macro_api ctx p =
-	let com_api = make_macro_com_api ctx.com p in
-	promote_com_api com_api ctx p
 
 let init_macro_interp mctx mint =
 	let p = null_pos in
@@ -1058,8 +1055,9 @@ let call_init_macro com mctx e =
 
 let finalize_macro_api tctx mctx =
 	let api = make_macro_api tctx null_pos in
-	let mint = (match !macro_interp_cache with None -> snd (create_macro_interp api mctx) | Some mint -> mint) in
-	mint.curapi <- api
+	match !macro_interp_cache with
+		| None -> ignore(create_macro_interp api mctx)
+		| Some mint -> mint.curapi <- api
 
 let interpret ctx =
 	let mctx = Interp.create ctx.com (make_macro_api ctx null_pos) false in

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -739,7 +739,7 @@ let get_macro_context ctx =
 		ctx
 	| None ->
 		let mctx = create_macro_context ctx.com in
-		let api = make_macro_api mctx null_pos in
+		let api = make_macro_api ctx null_pos in
 		let init,_ = create_macro_interp api mctx in
 		ctx.g.macros <- Some (init,mctx);
 		mctx.g.macros <- Some (init,mctx);

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -823,7 +823,7 @@ let load_core_class ctx c =
 			com2.class_path <- ctx.com.std_path;
 			if com2.display.dms_check_core_api then com2.display <- {com2.display with dms_check_core_api = false};
 			CommonCache.lock_signature com2 "load_core_class";
-			let ctx2 = !create_context_ref com2 in
+			let ctx2 = !create_context_ref com2 ctx.g.macros in
 			ctx.g.core_api <- Some ctx2;
 			ctx2
 		| Some c ->

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -312,7 +312,7 @@ let check_global_metadata ctx meta f_add mpath tpath so =
 	List.iter (fun (sl2,m,(recursive,to_types,to_fields)) ->
 		let add = ((field_mode && to_fields) || (not field_mode && to_types)) && (match_path recursive sl1 sl2) in
 		if add then f_add m
-	) ctx.com.global_metadata;
+	) ctx.g.global_metadata;
 	if ctx.is_display_file then delay ctx PCheckConstraint (fun () -> DisplayEmitter.check_display_metadata ctx meta)
 
 let check_module_types ctx m p t =

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -312,7 +312,7 @@ let check_global_metadata ctx meta f_add mpath tpath so =
 	List.iter (fun (sl2,m,(recursive,to_types,to_fields)) ->
 		let add = ((field_mode && to_fields) || (not field_mode && to_types)) && (match_path recursive sl1 sl2) in
 		if add then f_add m
-	) ctx.g.global_metadata;
+	) ctx.com.global_metadata;
 	if ctx.is_display_file then delay ctx PCheckConstraint (fun () -> DisplayEmitter.check_display_metadata ctx meta)
 
 let check_module_types ctx m p t =

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1999,6 +1999,7 @@ let create com =
 			core_api = None;
 			macros = None;
 			type_patches = Hashtbl.create 0;
+			global_metadata = [];
 			module_check_policies = [];
 			delayed = [];
 			debug_delayed = [];

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1991,15 +1991,14 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 (* ---------------------------------------------------------------------- *)
 (* TYPER INITIALIZATION *)
 
-let create com =
+let create com macros =
 	let ctx = {
 		com = com;
 		t = com.basic;
 		g = {
 			core_api = None;
-			macros = None;
+			macros = macros;
 			type_patches = Hashtbl.create 0;
-			global_metadata = [];
 			module_check_policies = [];
 			delayed = [];
 			debug_delayed = [];

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1999,7 +1999,6 @@ let create com =
 			core_api = None;
 			macros = None;
 			type_patches = Hashtbl.create 0;
-			global_metadata = [];
 			module_check_policies = [];
 			delayed = [];
 			debug_delayed = [];

--- a/tests/misc/projects/Issue11128/InitMacro.hx
+++ b/tests/misc/projects/Issue11128/InitMacro.hx
@@ -1,0 +1,25 @@
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+import haxe.macro.Type;
+
+class InitMacro {
+	static function setup() {
+		switch (Compiler.getConfiguration().platform) {
+			case CustomTarget("mylang"): {}
+			case _: throw "this shouldnt happen.";
+		}
+
+		Context.onAfterTyping(check);
+	}
+
+	static function check(types:Array<ModuleType>) {
+		for (m in types) {
+			switch (m) {
+				case TClassDecl(_.get() => c):
+					for (f in c.fields.get()) f.expr();
+
+				case _:
+			}
+		}
+	}
+}

--- a/tests/misc/projects/Issue11128/Main2.hx
+++ b/tests/misc/projects/Issue11128/Main2.hx
@@ -1,0 +1,1 @@
+function main() {}

--- a/tests/misc/projects/Issue11128/compile5.hxml
+++ b/tests/misc/projects/Issue11128/compile5.hxml
@@ -1,0 +1,3 @@
+-main Main2
+--custom-target mylang=out
+--macro InitMacro.setup()

--- a/tests/misc/projects/Issue11128/mylang/Init.hx
+++ b/tests/misc/projects/Issue11128/mylang/Init.hx
@@ -1,0 +1,6 @@
+package mylang;
+
+class Init {
+	public static function init() {
+	}
+}


### PR DESCRIPTION
Following #11043, this PR turns the warnings (previously only enabled with `-D haxe-next`) into errors and actually delay the typer creation to after init macros.

This avoids ending up with more typing contexts than needed, which were leading to some nasty errors (including some infamous "type X is redefined from X" ones). This happened because init macros (or even other macros without the macro API separation) could change the context signature by altering defines.

A follow up will be needed, to ensure `4.3_bugfix` displays warnings for all macro API that this PR covers (a few more than in previous PR) when using `-D haxe-next`.

I think this closes #7871 ?