### PR TITLE
[ci] stay on node 18.17.1 for windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -719,6 +719,10 @@ jobs:
       - name: Print Neko version
         run: neko -version 2>&1
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.17.1
+
       # - name: Quick test
       #   shell: pwsh
       #   run: |
@@ -811,6 +815,10 @@ jobs:
 
       - name: Print Neko version
         run: neko -version 2>&1
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.17.1
 
       # - name: Quick test
       #   shell: pwsh

--- a/extra/github-actions/test-windows.yml
+++ b/extra/github-actions/test-windows.yml
@@ -1,3 +1,7 @@
+- uses: actions/setup-node@v3
+  with:
+    node-version: 18.17.1
+
 # - name: Quick test
 #   shell: pwsh
 #   run: |


### PR DESCRIPTION
Our windows runners started using node `18.18.0` instead of `18.17.1` last week, which led to TestUnicode failures:

<details>
<summary>Tests output</summary>

```
TestUnicode
  testFilesystem: ERROR .............................................................................................................................................................FFFFFF.........FFFFFF.........FFFFFF.........FFFFFF...........................E
    line: 190, setCwd + absolutePath + endsWith failed (Only([65536]) in test-res)
    line: 190, setCwd + absolutePath + endsWith failed (Only([131071]) in test-res)
    line: 190, setCwd + absolutePath + endsWith failed (Only([1048575]) in test-res)
    line: 190, setCwd + absolutePath + endsWith failed (Only([1048576]) in test-res)
    line: 190, setCwd + absolutePath + endsWith failed (Only([1114111]) in test-res)
    line: 190, setCwd + absolutePath + endsWith failed (Only([128514,128516,128537]) in test-res)
    line: 212, expected exists == true (Only([65536]) in test-res/a)
    line: 212, expected exists == true (Only([131071]) in test-res/a)
    line: 212, expected exists == true (Only([1048575]) in test-res/a)
    line: 212, expected exists == true (Only([1048576]) in test-res/a)
    line: 212, expected exists == true (Only([1114111]) in test-res/a)
    line: 212, expected exists == true (Only([128514,128516,128537]) in test-res/a)
    line: 213, expected exists == false (Only([65536]) in test-res/b)
    line: 213, expected exists == false (Only([131071]) in test-res/b)
    line: 213, expected exists == false (Only([1048575]) in test-res/b)
    line: 213, expected exists == false (Only([1048576]) in test-res/b)
    line: 213, expected exists == false (Only([1114111]) in test-res/b)
    line: 213, expected exists == false (Only([128514,128516,128537]) in test-res/b)
    line: 231, expected isDirectory == true (Only([65536]) in test-res/a)
    line: 231, expected isDirectory == true (Only([131071]) in test-res/a)
    line: 231, expected isDirectory == true (Only([1048575]) in test-res/a)
    line: 231, expected isDirectory == true (Only([1048576]) in test-res/a)
    line: 231, expected isDirectory == true (Only([1114111]) in test-res/a)
    line: 231, expected isDirectory == true (Only([128514,128516,128537]) in test-res/a)
    Error: ENOENT: no such file or directory, stat 'test-res/a/𐀀'
Called from Object.statSync (node:fs line 1690 column 3)
Called from assertNormalEither.fileName (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 1866 column 22)
Called from TestUnicode.assertNormalEither (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 1644 column 11)
Called from TestUnicode.testFilesystem (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 1865 column 8)
Called from Object.execute (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 2005 column 11)
Called from utest_ITestHandler.runTest (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5495 column 31)
Called from utest_ITestHandler.checkSetup (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5490 column 9)
Called from utest_Async.then (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5082 column 4)
Called from utest_ITestHandler.runSetup (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5483 column 19)
Called from utest_ITestHandler.execute (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5471 column 8)
  testIO: ERROR ........E
    Error: ENOENT: no such file or directory, open 'test-res/b/𐀀'
Called from Object.openSync (node:fs line 603 column 3)
Called from Object.readFileSync (node:fs line 471 column 35)
Called from module at D:\a\haxe\haxe\tests\sys\bin\js\sys.js:1936:84
Called from TestUnicode.pathBoth (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 1613 column 5)
Called from TestUnicode.testIO (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 1935 column 8)
Called from Object.execute (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 2001 column 11)
Called from utest_ITestHandler.runTest (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5495 column 31)
Called from utest_ITestHandler.checkSetup (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5490 column 9)
Called from utest_Async.then (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5082 column 4)
Called from utest_ITestHandler.runSetup (D:\a\haxe\haxe\tests\sys\bin\js\sys.js line 5483 column 19)
```
</details>

Node [18.18.0](https://nodejs.org/en/blog/release/v18.18.0) updates luv from 1.44.2 to 1.46.0 (https://github.com/nodejs/node/pull/48078), which includes https://github.com/libuv/libuv/pull/2970
that seems to be the reason of these failures:
> fs: use WTF-8 on Windows

Bad news is, since it's linked to a change in libuv, we'll continue having issues with these tests on windows in the future. We might have to change/disable the tests or try to make libuv maintainers avoid such errors (see the discussion in the PR comments).

For now we'll just dodge the issue to get our CI green again :copyright: 