### PR TITLE
[js] Fix enums parameters generation to make it compatible with advanced JS minification tools

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1664,11 +1664,11 @@ let generate_enum ctx e =
 			let sargs = String.concat "," (List.map (fun (n,_,_) -> ident n) args) in begin
 			if as_objects then begin
 				let sfields = String.concat "," (List.map (fun (n,_,_) -> (ident n) ^ ":" ^ (ident n) ) args) in
-				let sparams = String.concat "," (List.map (fun (n,_,_) -> "\"" ^ (ident n) ^ "\"" ) args) in
+				let sparams = String.concat "," (List.map (fun (n,_,_) -> "this." ^ (ident n) ) args) in
 				print ctx "($_=function(%s) { return {_hx_index:%d,%s,__enum__:\"%s\"" sargs f.ef_index sfields dotp;
 				if has_enum_feature then
 					spr ctx ",toString:$estr";
-				print ctx "}; },$_._hx_name=\"%s\",$_.__params__ = [%s],$_)" f.ef_name sparams
+				print ctx ",__params__:function(){ return [%s];}}; },$_._hx_name=\"%s\",$_)" sparams f.ef_name
 			end else begin
 				print ctx "function(%s) { var $x = [\"%s\",%d,%s]; $x.__enum__ = %s;" sargs f.ef_name f.ef_index sargs p;
 				if has_enum_feature then

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -71,9 +71,12 @@ class Boot {
 						var e = $hxEnums[o.__enum__];
 						var con = e.__constructs__[o._hx_index];
 						var n = con._hx_name;
-						if (con.__params__) {
+						if (o.__params__) {
 							s += "\t";
-							return n + "(" + [for (p in (con.__params__ : Array<String>)) __string_rec(o[p], s)].join(",") + ")";
+							var params:Array<Any> = o.__params__();
+							for (i in 0...params.length)
+								params[i] = __string_rec(params[i], s);
+							return n + "(" + params.join(",") + ")";
 						} else {
 							return n;
 						}

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -290,9 +290,10 @@ enum ValueType {
 				if (a._hx_index != b._hx_index)
 					return false;
 				var enm = $hxEnums[e];
-				var params:Array<String> = enm.__constructs__[a._hx_index].__params__;
-				for (f in params) {
-					if (!enumEq(a[f], b[f])) {
+				var aparams:Array<Any> = a.__params__();
+				var bparams:Array<Any> = b.__params__();
+				for (i in 0...aparams.length) {
+					if (!enumEq(aparams[i], bparams[i])) {
 						return false;
 					}
 				}
@@ -318,9 +319,7 @@ enum ValueType {
 	#else
 	public static function enumParameters(e:EnumValue):Array<Dynamic>
 		untyped {
-			var enm:Enum<Dynamic> = $hxEnums[e.__enum__];
-			var params:Array<String> = enm.__constructs__[e._hx_index].__params__;
-			return params != null ? [for (p in params) e[p]] : [];
+			return e.__params__ != null ? e.__params__() : [];
 		}
 	#end
 

--- a/std/js/_std/Type.hx
+++ b/std/js/_std/Type.hx
@@ -289,7 +289,6 @@ enum ValueType {
 				#else
 				if (a._hx_index != b._hx_index)
 					return false;
-				var enm = $hxEnums[e];
 				var aparams:Array<Any> = a.__params__();
 				var bparams:Array<Any> = b.__params__();
 				for (i in 0...aparams.length) {


### PR DESCRIPTION
Fixes #11327
Sample enum:
```haxe
enum Sample {
  ConstructorName(paramName:String);
}
```
This PR changes enum constructor generation from 
```
ConstructorName: ($_=function(paramName) { return {_hx_index:0,paramName:paramName,__enum__:"Sample",toString:$estr}; },$_._hx_name="ConstructorName",$_.__params__ = ["paramName"],$_)
```
to
```
ConstructorName: ($_=function(paramName) { return {_hx_index:0,paramName:paramName,__enum__:"Sample",toString:$estr,__params__:function(){ return [this.paramName];}}; },$_._hx_name="ConstructorName",$_)
```
to avoid usage of stringified parameters names. 