### PR TITLE
Catch errors during callbacks

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -167,7 +167,7 @@ module Setup = struct
 		) com.defines.values;
 		Buffer.truncate buffer (Buffer.length buffer - 1);
 		Common.log com (Buffer.contents buffer);
-		com.callbacks#run com.callbacks#get_before_typer_create;
+		com.callbacks#run com.error_ext com.callbacks#get_before_typer_create;
 		(* Native lib pass 1: Register *)
 		let fl = List.map (fun (file,extern) -> NativeLibraryHandler.add_native_lib com file extern) (List.rev native_libs) in
 		(* Native lib pass 2: Initialize *)
@@ -281,7 +281,7 @@ let do_type ctx tctx actx =
 	ServerMessage.compiler_stage com;
 	check_defines ctx.com;
 	CommonCache.lock_signature com "after_init_macros";
-	com.callbacks#run com.callbacks#get_after_init_macros;
+	com.callbacks#run com.error_ext com.callbacks#get_after_init_macros;
 	run_or_diagnose ctx (fun () ->
 		if com.display.dms_kind <> DMNone then DisplayTexpr.check_display_file tctx cs;
 		List.iter (fun cpath -> ignore(tctx.Typecore.g.Typecore.do_load_module tctx cpath null_pos)) (List.rev actx.classes);
@@ -374,7 +374,7 @@ let compile ctx actx callbacks =
 		ServerMessage.compiler_stage com;
 	end;
 	Sys.catch_break false;
-	com.callbacks#run com.callbacks#get_after_generation;
+	com.callbacks#run com.error_ext com.callbacks#get_after_generation;
 	if not actx.no_output then begin
 		List.iter (fun c ->
 			let r = run_command ctx c in

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -207,7 +207,7 @@ class compiler_callbacks = object(self)
 			()
 		| l ->
 			r := [];
-			(try List.iter (fun f -> f()) (List.rev l) with Error.Error err -> handle_error err);
+			List.iter (fun f -> try f() with Error.Error err -> handle_error err) (List.rev l);
 			self#run handle_error r
 
 	method get_before_typer_create = before_typer_create

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -201,14 +201,14 @@ class compiler_callbacks = object(self)
 	method add_null_safety_report (f : (string*pos) list -> unit) : unit =
 		null_safety_report <- f :: null_safety_report
 
-	method run r =
+	method run handle_error r =
 		match !r with
 		| [] ->
 			()
 		| l ->
 			r := [];
-			List.iter (fun f -> f()) (List.rev l);
-			self#run r
+			(try List.iter (fun f -> f()) (List.rev l) with Error.Error err -> handle_error err);
+			self#run handle_error r
 
 	method get_before_typer_create = before_typer_create
 	method get_after_init_macros = after_init_macros

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -771,7 +771,7 @@ let destruction tctx detail_times main locals =
 			List.iter (fun f -> f t) type_filters
 		) com.types;
 	);
-	com.callbacks#run com.callbacks#get_after_filters;
+	com.callbacks#run com.error_ext com.callbacks#get_after_filters;
 	com.stage <- CFilteringDone
 
 let update_cache_dependencies com t =
@@ -1009,7 +1009,7 @@ let run tctx main =
 	] in
 	List.iter (run_expression_filters tctx detail_times filters) new_types;
 	with_timer detail_times "callbacks" None (fun () ->
-		com.callbacks#run com.callbacks#get_before_save;
+		com.callbacks#run com.error_ext com.callbacks#get_before_save;
 	);
 	com.stage <- CSaveStart;
 	with_timer detail_times "save state" None (fun () ->
@@ -1020,6 +1020,6 @@ let run tctx main =
 	);
 	com.stage <- CSaveDone;
 	with_timer detail_times "callbacks" None (fun () ->
-		com.callbacks#run com.callbacks#get_after_save;
+		com.callbacks#run com.error_ext com.callbacks#get_after_save;
 	);
 	destruction tctx detail_times main locals


### PR DESCRIPTION
Allows continuing and calling later callbacks (with an error state).
Not 100% sure it is the behavior we want, but I did need that when working with save callbacks