### PR TITLE
DOMElement insertAdjacentElement should not be pure.

### DIFF
--- a/std/js/html/DOMElement.hx
+++ b/std/js/html/DOMElement.hx
@@ -391,7 +391,6 @@ extern class DOMElement extends Node {
 		Inserts a given element node at a given position relative to the element it is invoked upon.
 		@throws DOMError
 	**/
-	@:pure
 	function insertAdjacentElement( where : String, element : Element ) : Element;
 	
 	/**


### PR DESCRIPTION
This function modifies the DOM so should not be marked with @:pure. This is causing the call to be removed form the compiled code unless something is done with the return value.