### PR TITLE
[java,cs] fix stack overflow from closures constraints

### DIFF
--- a/src/codegen/gencommon/closuresToClass.ml
+++ b/src/codegen/gencommon/closuresToClass.ml
@@ -277,9 +277,8 @@ let traverse gen ?tparam_anon_decl ?tparam_anon_acc (handle_anon_func:texpr->tfu
 
 let rec get_type_params acc t =
 	match t with
-		| TInst(( { cl_kind = KTypeParameter constraints } as cl), []) ->
-			let params = List.fold_left get_type_params acc constraints in
-			List.filter (fun t -> not (List.memq t acc)) (cl :: params) @ acc;
+		| TInst(( { cl_kind = KTypeParameter _ } as cl), []) ->
+			if List.memq cl acc then acc else cl :: acc
 		| TFun (params,tret) ->
 			List.fold_left get_type_params acc ( tret :: List.map (fun (_,_,t) -> t) params )
 		| TDynamic None ->

--- a/tests/misc/cs/projects/Issue11350/Main.hx
+++ b/tests/misc/cs/projects/Issue11350/Main.hx
@@ -1,0 +1,10 @@
+class Main {
+	public static function main() {}
+
+	public static function forComparable<T : Comparable<T>>(): T->T->Void
+		return (a: T, b: T) -> {}
+}
+
+typedef Comparable<T> = {
+	public function compareTo(that : T) : Int;
+}

--- a/tests/misc/cs/projects/Issue11350/compile.hxml
+++ b/tests/misc/cs/projects/Issue11350/compile.hxml
@@ -1,0 +1,3 @@
+--main Main
+-cs bin
+-D net-ver=45


### PR DESCRIPTION
That change from #7863 doesn't seem needed (and seemed weird, even then) as tests added in the PR still pass, and was triggering a stack overflow (see [forums](https://community.haxe.org/t/wdeprecated-std-is-is-deprecated-use-std-isoftype-instead-stack-overflow/4066/1))

~~I don't have a minimal repro for the stack overflow yet, will try to craft one and add as a test~~

```haxe
class Main {
	public static function main() {}

	public static function forComparable<T : Comparable<T>>(): T->T->Void
		return (a: T, b: T) -> {}
}

typedef Comparable<T> = {
	public function compareTo(that : T) : Int;
}
```