### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -617,7 +617,7 @@ jobs:
         env:
           # For compatibility with macOS 10.13
           ZLIB_VERSION: 1.3
-          MBEDTLS_VERSION: 2.25.0
+          MBEDTLS_VERSION: 2.28.5
           PCRE2_VERSION: 10.42
         run: |
           set -ex

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -2,7 +2,7 @@
   env:
     # For compatibility with macOS 10.13
     ZLIB_VERSION: 1.3
-    MBEDTLS_VERSION: 2.25.0
+    MBEDTLS_VERSION: 2.28.5
     PCRE2_VERSION: 10.42
   run: |
     set -ex


### PR DESCRIPTION
Update mbedtls to 2.28.5.

Fixes #11358.

There's still some other weirdness going on, but it doesn't break CI, so I'll leave that for a future PR.