### PR TITLE
Make `Context.definedValue` return `Null<String>` and document `Context.resolvePath` exception

### DIFF
--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -292,7 +292,7 @@ class Context {
 
 		@see https://haxe.org/manual/lf-condition-compilation.html
 	**/
-	public static function definedValue(key:String):String {
+	public static function definedValue(key:String):Null<String> {
 		return load("defined_value", 1)(key);
 	}
 

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -112,6 +112,8 @@ class Context {
 
 		If a class path was declared relative, this method returns the relative
 		file path. Otherwise it returns the absolute file path.
+
+		If no type can be found, an exception of type `String` is thrown.
 	**/
 	public static function resolvePath(file:String):String {
 		return load("resolve_path", 1)(file);


### PR DESCRIPTION
`Context.definedValue` always throws me off since it's the only Context function that can return `null` but isn't communicated with `Null<T>`.

While checking the other functions, I noticed that `resolvePath` has an undocumented exception, so I added that as well. 👍 