### PR TITLE
Instance builder cleanup

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -407,8 +407,6 @@ with
 		end
 	| Error.Error err ->
 		error_ext ctx err
-	| Generic.Generic_Exception(m,p) ->
-		error ctx m p
 	| Arg.Bad msg ->
 		error ctx ("Error: " ^ msg) null_pos
 	| Failure msg when not Helper.is_debug_run ->

--- a/src/context/display/displayTexpr.ml
+++ b/src/context/display/displayTexpr.ml
@@ -90,7 +90,7 @@ let check_display_class ctx decls c =
 		ignore(Typeload.type_type_params ctx TPHType c.cl_path (fun() -> c.cl_params) null_pos sc.d_params);
 		List.iter (function
 			| (HExtends(ct,p) | HImplements(ct,p)) when display_position#enclosed_in p ->
-				ignore(Typeload.load_instance ~allow_display:true ctx (ct,p) false)
+				ignore(Typeload.load_instance ~allow_display:true ctx (ct,p) ParamNormal)
 			| _ ->
 				()
 		) sc.d_flags;

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -72,6 +72,20 @@ type delay = {
 	delay_functions : (unit -> unit) list;
 }
 
+type build_kind =
+	| BuildNormal
+	| BuildGeneric
+	| BuildGenericBuild
+	| BuildMacroType
+
+type build_info = {
+	build_kind : build_kind;
+	build_path : path;
+	build_params : type_params;
+	build_extern : bool;
+	build_apply : Type.t list -> Type.t;
+}
+
 type typer_globals = {
 	mutable delayed : delay list;
 	mutable debug_delayed : (typer_pass * ((unit -> unit) * string * typer) list) list;
@@ -94,7 +108,7 @@ type typer_globals = {
 	do_load_macro : typer -> bool -> path -> string -> pos -> ((string * bool * t) list * t * tclass * Type.tclass_field);
 	do_load_module : typer -> path -> pos -> module_def;
 	do_load_type_def : typer -> pos -> type_path -> module_type;
-	do_build_instance : typer -> module_type -> pos -> (typed_type_param list * path * (t list -> t));
+	do_build_instance : typer -> module_type -> pos -> build_info;
 	do_format_string : typer -> string -> pos -> Ast.expr;
 	do_load_core_class : typer -> tclass -> tclass;
 }
@@ -198,6 +212,14 @@ type dot_path_part = {
 	name : string;
 	case : dot_path_part_case;
 	pos : pos
+}
+
+let make_build_info kind path params extern apply = {
+	build_kind = kind;
+	build_path = path;
+	build_params = params;
+	build_extern = extern;
+	build_apply = apply;
 }
 
 exception Forbid_package of (string * path * pos) * pos list * string

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -74,7 +74,7 @@ type delay = {
 
 type build_kind =
 	| BuildNormal
-	| BuildGeneric
+	| BuildGeneric of tclass
 	| BuildGenericBuild
 	| BuildMacroType
 

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -108,7 +108,7 @@ type typer_globals = {
 	do_load_macro : typer -> bool -> path -> string -> pos -> ((string * bool * t) list * t * tclass * Type.tclass_field);
 	do_load_module : typer -> path -> pos -> module_def;
 	do_load_type_def : typer -> pos -> type_path -> module_type;
-	do_build_instance : typer -> module_type -> pos -> build_info;
+	get_build_info : typer -> module_type -> pos -> build_info;
 	do_format_string : typer -> string -> pos -> Ast.expr;
 	do_load_core_class : typer -> tclass -> tclass;
 }

--- a/src/core/inheritDoc.ml
+++ b/src/core/inheritDoc.ml
@@ -34,8 +34,8 @@ let rec get_class_field c field_name =
 		| None -> raise Not_found
 		| Some (csup, _) -> get_class_field csup field_name
 
-let find_type ctx tp allow_no_params =
-	try Typeload.load_instance' ctx tp allow_no_params
+let find_type ctx tp =
+	try Typeload.load_instance' ctx tp ParamSpawnMonos
 	with _ -> raise Not_found
 
 (**
@@ -160,7 +160,7 @@ and get_target_doc ctx e_target =
 			| _ ->
 				mk_type_path path
 		in
-		let t = (find_type ctx (tp,snd e_target) true) in
+		let t = (find_type ctx (tp,snd e_target)) in
 		try
 			match follow t with
 			| TInst (c, _) ->
@@ -207,11 +207,11 @@ and get_target_doc ctx e_target =
 	in
 	let resolve_type () =
 		let tp = mk_type_path path, snd e_target in
-		resolve_type_t (find_type ctx tp true)
+		resolve_type_t (find_type ctx tp)
 	in
 	let resolve_sub_type sub =
 		let tp = mk_type_path ~sub path, snd e_target in
-		resolve_type_t (find_type ctx tp true)
+		resolve_type_t (find_type ctx tp)
 	in
 	try
 		match sub with

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -499,22 +499,21 @@ let try_apply_params_rec cparams params t success =
 			apply_params_stack := old_stack;
 			raise err
 
-let rec follow ?(no_lazy=false) t =
+let rec follow t =
 	match t with
 	| TMono r ->
 		(match r.tm_type with
-		| Some t -> follow ~no_lazy t
+		| Some t -> follow t
 		| _ -> t)
 	| TLazy f ->
 		(match !f with
-		| LAvailable t -> follow ~no_lazy t
-		| _ when no_lazy -> t
+		| LAvailable t -> follow t
 		| _ -> follow (lazy_type f)
 		)
 	| TType (t,tl) ->
-		follow ~no_lazy (apply_typedef t tl)
+		follow (apply_typedef t tl)
 	| TAbstract({a_path = [],"Null"},[t]) ->
-		follow ~no_lazy t
+		follow t
 	| _ -> t
 
 let follow_once t =

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -499,18 +499,22 @@ let try_apply_params_rec cparams params t success =
 			apply_params_stack := old_stack;
 			raise err
 
-let rec follow t =
+let rec follow ?(no_lazy=false) t =
 	match t with
 	| TMono r ->
 		(match r.tm_type with
-		| Some t -> follow t
+		| Some t -> follow ~no_lazy t
 		| _ -> t)
 	| TLazy f ->
-		follow (lazy_type f)
+		(match !f with
+		| LAvailable t -> follow ~no_lazy t
+		| _ when no_lazy -> t
+		| _ -> follow (lazy_type f)
+		)
 	| TType (t,tl) ->
-		follow (apply_typedef t tl)
+		follow ~no_lazy (apply_typedef t tl)
 	| TAbstract({a_path = [],"Null"},[t]) ->
-		follow t
+		follow ~no_lazy t
 	| _ -> t
 
 let follow_once t =

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -461,7 +461,7 @@ type flag_tclass_field =
 
 (* Order has to match declaration for printing*)
 let flag_tclass_field_names = [
-	"CfPublic";"CfStatic";"CfExtern";"CfFinal";"CfModifiesThis";"CfOverride";"CfAbstract";"CfOverload";"CfImpl";"CfEnum";"CfGeneric";"CfDefault"
+	"CfPublic";"CfStatic";"CfExtern";"CfFinal";"CfModifiesThis";"CfOverride";"CfAbstract";"CfOverload";"CfImpl";"CfEnum";"CfGeneric";"CfDefault";"CfPostProcessed"
 ]
 
 type flag_tvar =

--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -189,6 +189,19 @@ let map_expr_type f ft fv e =
 		{ e with eexpr = TEnumParameter (f e1,ef,i); etype = ft e.etype }
 	| TEnumIndex e1 ->
 		{ e with eexpr = TEnumIndex (f e1); etype = ft e.etype }
+	| TField (e1,(FClosure(None,cf) as fa)) ->
+		let e1 = f e1 in
+		let fa = try
+			begin match quick_field e1.etype cf.cf_name with
+				| FInstance(c,tl,cf) ->
+					FClosure(Some(c,tl),cf)
+				| _ ->
+					raise Not_found
+			end
+		with Not_found ->
+			fa
+		in
+		{ e with eexpr = TField (e1,fa); etype = ft e.etype }
 	| TField (e1,v) ->
 		let e1 = f e1 in
 		let v = try

--- a/src/filters/exceptions.ml
+++ b/src/filters/exceptions.ml
@@ -532,23 +532,23 @@ let filter tctx =
 				(mk_type_path (pack,name), null_pos)
 		in
 		let wildcard_catch_type =
-			let t = Typeload.load_instance tctx (tp config.ec_wildcard_catch) true in
+			let t = Typeload.load_instance tctx (tp config.ec_wildcard_catch) ParamSpawnMonos in
 			if is_dynamic t then t_dynamic
 			else t
 		and base_throw_type =
-			let t = Typeload.load_instance tctx (tp config.ec_base_throw) true in
+			let t = Typeload.load_instance tctx (tp config.ec_base_throw) ParamSpawnMonos in
 			if is_dynamic t then t_dynamic
 			else t
 		and haxe_exception_type, haxe_exception_class =
-			match Typeload.load_instance tctx (tp haxe_exception_type_path) true with
+			match Typeload.load_instance tctx (tp haxe_exception_type_path) ParamSpawnMonos with
 			| TInst(cls,_) as t -> t,cls
 			| _ -> raise_typing_error "haxe.Exception is expected to be a class" null_pos
 		and value_exception_type, value_exception_class =
-			match Typeload.load_instance tctx (tp value_exception_type_path) true with
+			match Typeload.load_instance tctx (tp value_exception_type_path) ParamSpawnMonos with
 			| TInst(cls,_) as t -> t,cls
 			| _ -> raise_typing_error "haxe.ValueException is expected to be a class" null_pos
 		and haxe_native_stack_trace =
-			match Typeload.load_instance tctx (tp (["haxe"],"NativeStackTrace")) true with
+			match Typeload.load_instance tctx (tp (["haxe"],"NativeStackTrace")) ParamSpawnMonos with
 			| TInst(cls,_) -> cls
 			| TAbstract({ a_impl = Some cls },_) -> cls
 			| _ -> raise_typing_error "haxe.NativeStackTrace is expected to be a class or an abstract" null_pos
@@ -665,7 +665,7 @@ let insert_save_stacks tctx =
 *)
 let patch_constructors tctx =
 	let tp = (mk_type_path haxe_exception_type_path, null_pos) in
-	match Typeload.load_instance tctx tp true with
+	match Typeload.load_instance tctx tp ParamSpawnMonos with
 	(* Add only if `__shiftStack` method exists *)
 	| TInst(cls,_) when PMap.mem "__shiftStack" cls.cl_fields ->
 		(fun mt ->

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -866,7 +866,7 @@ let rec type_inline ctx cf f ethis params tret config p ?(self_calling_closure=f
 	let tl = arg_types params f.tf_args in
 	let e = state#finalize e tl tret has_params map_type p in
 	if Meta.has (Meta.Custom ":inlineDebug") ctx.meta then begin
-		let se t = s_expr_pretty true t true (s_type (print_context())) in
+		let se t = s_expr_ast true t (s_type (print_context())) in
 		print_endline (Printf.sprintf "Inline %s:\n\tArgs: %s\n\tExpr: %s\n\tResult: %s"
 			cf.cf_name
 			(String.concat "" (List.map (fun (i,e) -> Printf.sprintf "\n\t\t%s<%i> = %s" (i.i_subst.v_name) (i.i_subst.v_id) (se "\t\t" e)) state#inlined_vars))

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -159,7 +159,7 @@ let static_method_container gctx c cf p =
 	let pack = fst c.cl_path in
 	let name = (snd c.cl_path) ^ "_" ^ cf.cf_name ^ "_" ^ gctx.name in
 	try
-		let t = Typeload.load_instance ctx (mk_type_path (pack,name),p) true in
+		let t = Typeload.load_instance ctx (mk_type_path (pack,name),p) ParamSpawnMonos in
 		match t with
 		| TInst(cg,_) -> cg
 		| _ -> raise_typing_error ("Cannot specialize @:generic static method because the generated type name is already used: " ^ name) p
@@ -236,7 +236,7 @@ let rec build_generic_class ctx c p tl =
 	let gctx = make_generic ctx c.cl_params tl p in
 	let name = (snd c.cl_path) ^ "_" ^ gctx.name in
 	try
-		let t = Typeload.load_instance ctx (mk_type_path (pack,name),p) false in
+		let t = Typeload.load_instance ctx (mk_type_path (pack,name),p) ParamNormal in
 		match t with
 		| TInst({ cl_kind = KGenericInstance (csup,_) },_) when c == csup -> t
 		| _ -> raise_typing_error ("Cannot specialize @:generic because the generated type name is already used: " ^ name) p

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -315,7 +315,7 @@ let rec build_generic_class ctx c p tl =
 				| _ -> die "" __LOC__
 			) ([],[]) cf_old.cf_params in
 			let gctx = {gctx with subst = param_subst @ gctx.subst} in
-			let cf_new = {cf_old with cf_pos = cf_old.cf_pos} in (* copy *)
+			let cf_new = {cf_old with cf_pos = cf_old.cf_pos; cf_expr_unoptimized = None} in (* copy *)
 			remove_class_field_flag cf_new CfPostProcessed;
 			(* Type parameter constraints are substituted here. *)
 			cf_new.cf_params <- List.rev_map (fun tp -> match follow tp.ttp_type with
@@ -326,6 +326,7 @@ let rec build_generic_class ctx c p tl =
 				| _ -> die "" __LOC__
 			) params;
 			let f () =
+				if gctx.generic_debug then print_endline (Printf.sprintf "[GENERIC] expanding %s" cf_old.cf_name);
 				let t = generic_substitute_type gctx cf_old.cf_type in
 				ignore (follow t);
 				begin try (match cf_old.cf_expr with
@@ -343,6 +344,7 @@ let rec build_generic_class ctx c p tl =
 				) with Unify_error l ->
 					raise_typing_error (error_msg (Unify l)) cf_new.cf_pos
 				end;
+				if gctx.generic_debug then print_endline (Printf.sprintf "[GENERIC] %s" (Printer.s_tclass_field "  " cf_new));
 				t
 			in
 			let r = exc_protect ctx (fun r ->

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -83,7 +83,7 @@ let rec generic_substitute_type gctx t =
 	match t with
 	| TInst ({ cl_kind = KGeneric } as c2,tl2) ->
 		(* maybe loop, or generate cascading generics *)
-		let info = gctx.ctx.g.do_build_instance gctx.ctx (TClassDecl c2) gctx.p in
+		let info = gctx.ctx.g.get_build_info gctx.ctx (TClassDecl c2) gctx.p in
 		let t = info.build_apply (List.map (generic_substitute_type gctx) tl2) in
 		(match follow t,gctx.mg with TInst(c,_), Some m -> add_dependency m c.cl_module | _ -> ());
 		t
@@ -108,7 +108,7 @@ let generic_substitute_expr gctx e =
 	let rec build_expr e =
 		let e = match e.eexpr with
 		| TField(e1, FInstance({cl_kind = KGeneric} as c,tl,cf)) ->
-			let info = gctx.ctx.g.do_build_instance gctx.ctx (TClassDecl c) gctx.p in
+			let info = gctx.ctx.g.get_build_info gctx.ctx (TClassDecl c) gctx.p in
 			let t = info.build_apply (List.map (generic_substitute_type gctx) tl) in
 			begin match follow t with
 			| TInst(c',_) when c == c' ->

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -263,7 +263,7 @@ let rec build_generic_class ctx c p tl =
 			| Final
 			| Hack
 			| Internal
-			| Keep
+			| Keep | KeepSub
 			| NoClosure | NullSafety
 			| Pure
 			| Struct | StructInit

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -83,8 +83,8 @@ let rec generic_substitute_type gctx t =
 	match t with
 	| TInst ({ cl_kind = KGeneric } as c2,tl2) ->
 		(* maybe loop, or generate cascading generics *)
-		let _, _, f = gctx.ctx.g.do_build_instance gctx.ctx (TClassDecl c2) gctx.p in
-		let t = f (List.map (generic_substitute_type gctx) tl2) in
+		let info = gctx.ctx.g.do_build_instance gctx.ctx (TClassDecl c2) gctx.p in
+		let t = info.build_apply (List.map (generic_substitute_type gctx) tl2) in
 		(match follow t,gctx.mg with TInst(c,_), Some m -> add_dependency m c.cl_module | _ -> ());
 		t
 	| _ ->
@@ -108,8 +108,8 @@ let generic_substitute_expr gctx e =
 	let rec build_expr e =
 		let e = match e.eexpr with
 		| TField(e1, FInstance({cl_kind = KGeneric} as c,tl,cf)) ->
-			let _, _, f = gctx.ctx.g.do_build_instance gctx.ctx (TClassDecl c) gctx.p in
-			let t = f (List.map (generic_substitute_type gctx) tl) in
+			let info = gctx.ctx.g.do_build_instance gctx.ctx (TClassDecl c) gctx.p in
+			let t = info.build_apply (List.map (generic_substitute_type gctx) tl) in
 			begin match follow t with
 			| TInst(c',_) when c == c' ->
 				(* The @:generic class wasn't expanded, let's not recurse to avoid infinite loop (#6430) *)

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -267,7 +267,8 @@ let rec build_generic_class ctx c p tl =
 			| NoClosure | NullSafety
 			| Pure
 			| Struct | StructInit
-			| Using ->
+			| Using
+			| AutoBuild ->
 				true
 			| _ ->
 				false

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -395,6 +395,8 @@ let rec build_generic_class ctx c p tl =
 			let n = get_short_name () in
 			cg.cl_meta <- (Meta.Native,[EConst(String (n,SDoubleQuotes)),p],null_pos) :: cg.cl_meta;
 		end;
+		cg.cl_using <- c.cl_using;
+		if gctx.generic_debug then print_endline (Printf.sprintf "[GENERIC] %s" (Printer.s_tclass "  " cg));
 		TInst (cg,[])
 	end
 

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -90,7 +90,7 @@ let get_build_info ctx mtype p =
 		in
 		let kind,f = match c.cl_kind with
 			| KGeneric ->
-				BuildGeneric,build (fun tl -> Generic.build_generic_class ctx c p tl) "build_generic"
+				(BuildGeneric c),build (fun tl -> Generic.build_generic_class ctx c p tl) "build_generic"
 			| KGenericBuild cfl ->
 				BuildGenericBuild,build (fun tl -> build_macro_build ctx c tl cfl p) "build_generic_build"
 			| KMacroType ->

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -68,7 +68,7 @@ let build_macro_build ctx c pl cfl p =
 (* -------------------------------------------------------------------------- *)
 (* API EVENTS *)
 
-let build_instance ctx mtype p =
+let get_build_info ctx mtype p =
 	match mtype with
 	| TClassDecl c ->
 		if ctx.pass > PBuildClass then ignore(c.cl_build());

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -72,11 +72,11 @@ let build_instance ctx mtype p =
 	match mtype with
 	| TClassDecl c ->
 		if ctx.pass > PBuildClass then ignore(c.cl_build());
-		let build f s =
+		let build f s tl =
 			let r = exc_protect ctx (fun r ->
 				let t = spawn_monomorph ctx p in
 				r := lazy_processing (fun() -> t);
-				let tf = (f()) in
+				let tf = f tl in
 				unify_raise tf t p;
 				link_dynamic t tf;
 				(match tf with
@@ -88,21 +88,20 @@ let build_instance ctx mtype p =
 			) s in
 			TLazy r
 		in
-		let ft = (fun pl ->
-			match c.cl_kind with
+		let kind,f = match c.cl_kind with
 			| KGeneric ->
-				build (fun () -> Generic.build_generic_class ctx c p pl) "build_generic"
-			| KMacroType ->
-				build (fun () -> build_macro_type ctx pl p) "macro_type"
+				BuildGeneric,build (fun tl -> Generic.build_generic_class ctx c p tl) "build_generic"
 			| KGenericBuild cfl ->
-				build (fun () -> build_macro_build ctx c pl cfl p) "generic_build"
+				BuildGenericBuild,build (fun tl -> build_macro_build ctx c tl cfl p) "build_generic_build"
+			| KMacroType ->
+				BuildMacroType,build (fun tl -> build_macro_type ctx tl p) "build_macro_type"
 			| _ ->
-				TInst (c,pl)
-		) in
-		c.cl_params , c.cl_path , ft
+				BuildNormal,(fun tl -> TInst(c,tl))
+		in
+		make_build_info kind c.cl_path c.cl_params (has_class_flag c CExtern) f
 	| TEnumDecl e ->
-		e.e_params , e.e_path , (fun t -> TEnum (e,t))
-	| TTypeDecl t ->
-		t.t_params , t.t_path , (fun tl -> TType(t,tl))
+		make_build_info BuildNormal e.e_path e.e_params e.e_extern (fun t -> TEnum (e,t))
+	| TTypeDecl td ->
+		make_build_info BuildNormal td.t_path td.t_params false (fun tl -> TType(td,tl))
 	| TAbstractDecl a ->
-		a.a_params, a.a_path, (fun tl -> TAbstract(a,tl))
+		make_build_info BuildNormal a.a_path a.a_params false (fun tl -> TAbstract(a,tl))

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -102,6 +102,15 @@ let get_build_info ctx mtype p =
 	| TEnumDecl e ->
 		make_build_info BuildNormal e.e_path e.e_params e.e_extern (fun t -> TEnum (e,t))
 	| TTypeDecl td ->
+		begin try
+			let msg = match Meta.get Meta.Deprecated td.t_meta with
+				| _,[EConst(String(s,_)),_],_ -> s
+				| _ -> "This typedef is deprecated in favor of " ^ (s_type (print_context()) td.t_type)
+			in
+			DeprecationCheck.warn_deprecation (create_deprecation_context ctx) msg p
+		with Not_found ->
+				()
+		end;
 		make_build_info BuildNormal td.t_path td.t_params false (fun tl -> TType(td,tl))
 	| TAbstractDecl a ->
 		make_build_info BuildNormal a.a_path a.a_params false (fun tl -> TAbstract(a,tl))

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -340,7 +340,7 @@ let make_macro_api ctx mctx p =
 						mk_type_path path
 				in
 				try
-					let m = Some (Typeload.load_instance ctx (tp,p) true) in
+					let m = Some (Typeload.load_instance ctx (tp,p) ParamSpawnMonos) in
 					m
 				with Error { err_message = Module_not_found _; err_pos = p2 } when p == p2 ->
 					None
@@ -478,7 +478,7 @@ let make_macro_api ctx mctx p =
 		MacroApi.define_type = (fun v mdep ->
 			let cttype = mk_type_path ~sub:"TypeDefinition" (["haxe";"macro"],"Expr") in
 			let mctx = (match ctx.g.macros with None -> die "" __LOC__ | Some (_,mctx) -> mctx) in
-			let ttype = Typeload.load_instance mctx (cttype,p) false in
+			let ttype = Typeload.load_instance mctx (cttype,p) ParamNormal in
 			let f () = Interp.decode_type_def v in
 			let m, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
 			let has_native_meta = match tdef with
@@ -846,7 +846,7 @@ let type_macro ctx mode cpath f (el:Ast.expr list) p =
 	in
 	let mpos = mfield.cf_pos in
 	let ctexpr = mk_type_path (["haxe";"macro"],"Expr") in
-	let expr = Typeload.load_instance mctx (ctexpr,p) false in
+	let expr = Typeload.load_instance mctx (ctexpr,p) ParamNormal in
 	(match mode with
 	| MDisplay ->
 		raise Exit (* We don't have to actually call the macro. *)
@@ -855,18 +855,18 @@ let type_macro ctx mode cpath f (el:Ast.expr list) p =
 	| MBuild ->
 		let params = [TPType (CTPath (mk_type_path ~sub:"Field" (["haxe";"macro"],"Expr")),null_pos)] in
 		let ctfields = mk_type_path ~params ([],"Array") in
-		let tfields = Typeload.load_instance mctx (ctfields,p) false in
+		let tfields = Typeload.load_instance mctx (ctfields,p) ParamNormal in
 		unify mctx mret tfields mpos
 	| MMacroType ->
 		let cttype = mk_type_path (["haxe";"macro"],"Type") in
-		let ttype = Typeload.load_instance mctx (cttype,p) false in
+		let ttype = Typeload.load_instance mctx (cttype,p) ParamNormal in
 		try
 			unify_raise mret ttype mpos;
 			(* TODO: enable this again in the future *)
 			(* warning ctx WDeprecated "Returning Type from @:genericBuild macros is deprecated, consider returning ComplexType instead" p; *)
 		with Error { err_message = Unify _ } ->
 			let cttype = mk_type_path ~sub:"ComplexType" (["haxe";"macro"],"Expr") in
-			let ttype = Typeload.load_instance mctx (cttype,p) false in
+			let ttype = Typeload.load_instance mctx (cttype,p) ParamNormal in
 			unify_raise mret ttype mpos;
 	);
 	(*

--- a/src/typing/matcher/exprToPattern.ml
+++ b/src/typing/matcher/exprToPattern.ml
@@ -58,7 +58,7 @@ let get_general_module_type ctx mt p =
 			end
 		| _ -> raise_typing_error "Cannot use this type as a value" p
 	in
-	Typeload.load_instance ctx ({tname=loop mt;tpackage=[];tsub=None;tparams=[]},p) true
+	Typeload.load_instance ctx ({tname=loop mt;tpackage=[];tsub=None;tparams=[]},p) ParamSpawnMonos
 
 let unify_type_pattern ctx mt t p =
 	let tcl = get_general_module_type ctx mt p in

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -392,7 +392,7 @@ let make_binop ctx op e1 e2 is_assign_op with_type p =
 		unify ctx e2.etype b p;
 		mk_op e1 e2 b
 	| OpInterval ->
-		let t = Typeload.load_instance ctx (mk_type_path (["std"],"IntIterator"),null_pos) false in
+		let t = Typeload.load_instance ctx (mk_type_path (["std"],"IntIterator"),null_pos) ParamNormal in
 		let e1 = AbstractCast.cast_or_unify_raise ctx tint e1 e1.epos in
 		let e2 = AbstractCast.cast_or_unify_raise ctx tint e2 e2.epos in
 		BinopSpecial (mk (TNew ((match t with TInst (c,[]) -> c | _ -> die "" __LOC__),[],[e1;e2])) t p,false)

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -311,106 +311,96 @@ let check_param_constraints ctx t map c p =
 
 let rec load_and_apply_params ctx info params allow_no_params p =
 	let is_rest = info.build_kind = BuildGenericBuild && (match info.build_params with [{ttp_name="Rest"}] -> true | _ -> false) in
-	if allow_no_params && params = [] && not is_rest then begin
-		let monos = Monomorph.spawn_constrained_monos (fun t -> t) info.build_params in
-		info.build_apply (monos)
-	end else if info.build_path = ([],"Dynamic") then
-		match params with
-		| [] -> t_dynamic
-		| [TPType t] -> TDynamic (Some (load_complex_type ctx true t))
-		| _ -> raise_typing_error "Too many parameters for Dynamic" p
-	else begin
-		let is_java_rest = ctx.com.platform = Java && info.build_extern in
-		let is_rest = is_rest || is_java_rest in
-		let load_param t =
-			match t with
-			| TPExpr e ->
-				let name = (match fst e with
-					| EConst (String(s,_)) -> "S" ^ s
-					| EConst (Int (_,_) as c) -> "I" ^ s_constant c
-					| EConst (Float (_,_) as c) -> "F" ^ s_constant c
-					| EDisplay _ ->
-						ignore(type_expr ctx e WithType.value);
-						"Expr"
-					| _ -> "Expr"
-				) in
-				let c = mk_class ctx.m.curmod ([],name) p (pos e) in
-				c.cl_kind <- KExpr e;
-				TInst (c,[]),pos e
-			| TPType t -> load_complex_type ctx true t,pos t
-		in
-		let checks = DynArray.create () in
-		let rec loop tl1 tl2 is_rest = match tl1,tl2 with
-			| t :: tl1,({ttp_name=name;ttp_type=t2}) :: tl2 ->
-				let t,pt = load_param t in
-				let check_const c =
-					let is_expression = (match t with TInst ({ cl_kind = KExpr _ },_) -> true | _ -> false) in
-					let expects_expression = name = "Const" || Meta.has Meta.Const c.cl_meta in
-					let accepts_expression = name = "Rest" in
-					if is_expression then begin
-						if not expects_expression && not accepts_expression then
-							raise_typing_error "Constant value unexpected here" p
-					end else if expects_expression then
-						raise_typing_error "Type parameter is expected to be a constant value" p
-				in
-				let is_rest = is_rest || name = "Rest" && info.build_kind = BuildGenericBuild in
-				let t = match follow t2 with
-					| TInst ({ cl_kind = KTypeParameter [] } as c, []) when info.build_kind <> BuildGeneric ->
-						check_const c;
-						t
-					| TInst (c,[]) ->
-						check_const c;
-						DynArray.add checks (t,c,pt);
-						t
-					| _ -> die "" __LOC__
-				in
-				t :: loop tl1 tl2 is_rest
-			| [],[] ->
-				[]
-			| [],[{ttp_name="Rest"}] when info.build_kind = BuildGenericBuild ->
-				[]
-			| [],({ttp_type=t;ttp_default=def}) :: tl ->
-				if is_java_rest then
-					t_dynamic :: loop [] tl is_rest
-				else begin match def with
-					| None ->
-						if ignore_error ctx.com then
-							t :: loop [] tl is_rest
-						else
-							raise_typing_error ("Not enough type parameters for " ^ s_type_path info.build_path) p
-					| Some t ->
-						t :: loop [] tl is_rest
-				end
-			| t :: tl,[] ->
-				let t,pt = load_param t in
-				if is_rest then
-					t :: loop tl [] true
-				else if ignore_error ctx.com then
-					[]
-				else
-					raise_typing_error ("Too many type parameters for " ^ s_type_path info.build_path) pt
-		in
-		let params = loop params info.build_params false in
-		if not is_rest then begin
-			let map t =
-				let t = apply_params info.build_params params t in
-				let t = (match follow t with
-					| TInst ({ cl_kind = KGeneric } as c,pl) ->
-						(* if we solve a generic contraint, let's substitute with the actual generic instance before unifying *)
-						let info = ctx.g.get_build_info ctx (TClassDecl c) p in
-						info.build_apply pl
-					| _ -> t
-				) in
-				t
+	let is_java_rest = ctx.com.platform = Java && info.build_extern in
+	let is_rest = is_rest || is_java_rest in
+	let load_param t =
+		match t with
+		| TPExpr e ->
+			let name = (match fst e with
+				| EConst (String(s,_)) -> "S" ^ s
+				| EConst (Int (_,_) as c) -> "I" ^ s_constant c
+				| EConst (Float (_,_) as c) -> "F" ^ s_constant c
+				| EDisplay _ ->
+					ignore(type_expr ctx e WithType.value);
+					"Expr"
+				| _ -> "Expr"
+			) in
+			let c = mk_class ctx.m.curmod ([],name) p (pos e) in
+			c.cl_kind <- KExpr e;
+			TInst (c,[]),pos e
+		| TPType t -> load_complex_type ctx true t,pos t
+	in
+	let checks = DynArray.create () in
+	let rec loop tl1 tl2 is_rest = match tl1,tl2 with
+		| t :: tl1,({ttp_name=name;ttp_type=t2}) :: tl2 ->
+			let t,pt = load_param t in
+			let check_const c =
+				let is_expression = (match t with TInst ({ cl_kind = KExpr _ },_) -> true | _ -> false) in
+				let expects_expression = name = "Const" || Meta.has Meta.Const c.cl_meta in
+				let accepts_expression = name = "Rest" in
+				if is_expression then begin
+					if not expects_expression && not accepts_expression then
+						raise_typing_error "Constant value unexpected here" p
+				end else if expects_expression then
+					raise_typing_error "Type parameter is expected to be a constant value" p
 			in
-			delay ctx PCheckConstraint (fun () ->
-				DynArray.iter (fun (t,c,p) ->
-					check_param_constraints ctx t map c p
-				) checks
-			);
-		end;
-		info.build_apply params
-	end
+			let is_rest = is_rest || name = "Rest" && info.build_kind = BuildGenericBuild in
+			let t = match follow t2 with
+				| TInst ({ cl_kind = KTypeParameter [] } as c, []) when info.build_kind <> BuildGeneric ->
+					check_const c;
+					t
+				| TInst (c,[]) ->
+					check_const c;
+					DynArray.add checks (t,c,pt);
+					t
+				| _ -> die "" __LOC__
+			in
+			t :: loop tl1 tl2 is_rest
+		| [],[] ->
+			[]
+		| [],[{ttp_name="Rest"}] when info.build_kind = BuildGenericBuild ->
+			[]
+		| [],({ttp_type=t;ttp_default=def}) :: tl ->
+			if is_java_rest then
+				t_dynamic :: loop [] tl is_rest
+			else begin match def with
+				| None ->
+					if ignore_error ctx.com then
+						t :: loop [] tl is_rest
+					else
+						raise_typing_error ("Not enough type parameters for " ^ s_type_path info.build_path) p
+				| Some t ->
+					t :: loop [] tl is_rest
+			end
+		| t :: tl,[] ->
+			let t,pt = load_param t in
+			if is_rest then
+				t :: loop tl [] true
+			else if ignore_error ctx.com then
+				[]
+			else
+				raise_typing_error ("Too many type parameters for " ^ s_type_path info.build_path) pt
+	in
+	let params = loop params info.build_params false in
+	if not is_rest then begin
+		let map t =
+			let t = apply_params info.build_params params t in
+			let t = (match follow t with
+				| TInst ({ cl_kind = KGeneric } as c,pl) ->
+					(* if we solve a generic contraint, let's substitute with the actual generic instance before unifying *)
+					let info = ctx.g.get_build_info ctx (TClassDecl c) p in
+					info.build_apply pl
+				| _ -> t
+			) in
+			t
+		in
+		delay ctx PCheckConstraint (fun () ->
+			DynArray.iter (fun (t,c,p) ->
+				check_param_constraints ctx t map c p
+			) checks
+		);
+	end;
+	info.build_apply params
 
 (* build an instance from a full type *)
 and load_instance' ctx (t,p) allow_no_params =
@@ -422,7 +412,17 @@ and load_instance' ctx (t,p) allow_no_params =
 	with Not_found ->
 		let mt = load_type_def ctx p t in
 		let info = ctx.g.get_build_info ctx mt p in
-		load_and_apply_params ctx info t.tparams allow_no_params p
+		(* TODO: this is currently duplicated, but it seems suspcious anyway... *)
+		let is_rest = info.build_kind = BuildGenericBuild && (match info.build_params with [{ttp_name="Rest"}] -> true | _ -> false) in
+		if allow_no_params && t.tparams = [] && not is_rest then begin
+			let monos = Monomorph.spawn_constrained_monos (fun t -> t) info.build_params in
+			info.build_apply (monos)
+		end else if info.build_path = ([],"Dynamic") then match t.tparams with
+			| [] -> t_dynamic
+			| [TPType t] -> TDynamic (Some (load_complex_type ctx true t))
+			| _ -> raise_typing_error "Too many parameters for Dynamic" p
+		else
+			load_and_apply_params ctx info t.tparams allow_no_params p
 
 and load_instance ctx ?(allow_display=false) ((_,pn) as tp) allow_no_params =
 	try

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -318,7 +318,7 @@ let rec load_instance' ctx (t,p) allow_no_params =
 		pt
 	with Not_found ->
 		let mt = load_type_def ctx p t in
-		let info = ctx.g.do_build_instance ctx mt p in
+		let info = ctx.g.get_build_info ctx mt p in
 		let is_rest = info.build_kind = BuildGenericBuild && (match info.build_params with [{ttp_name="Rest"}] -> true | _ -> false) in
 		if allow_no_params && t.tparams = [] && not is_rest then begin
 			let monos = Monomorph.spawn_constrained_monos (fun t -> t) info.build_params in
@@ -406,7 +406,7 @@ let rec load_instance' ctx (t,p) allow_no_params =
 					let t = (match follow t with
 						| TInst ({ cl_kind = KGeneric } as c,pl) ->
 							(* if we solve a generic contraint, let's substitute with the actual generic instance before unifying *)
-							let info = ctx.g.do_build_instance ctx (TClassDecl c) p in
+							let info = ctx.g.get_build_info ctx (TClassDecl c) p in
 							info.build_apply pl
 						| _ -> t
 					) in

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -596,7 +596,7 @@ module Inheritance = struct
 		let fl = ExtList.List.filter_map (fun (is_extends,(ct,p)) ->
 			try
 				let t = try
-					Typeload.load_instance ~allow_display:true ctx (ct,p) false
+					Typeload.load_instance ~allow_display:true ctx (ct,p) ParamNormal
 				with DisplayException(DisplayFields ({fkind = CRTypeHint} as r)) ->
 					(* We don't allow `implements` on interfaces. Just raise fields completion with no fields. *)
 					if not is_extends && (has_class_flag c CInterface) then raise_fields [] CRImplements r.fsubject;

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1343,7 +1343,7 @@ let create_method (ctx,cctx,fctx) c f fd p =
 				| None -> ()
 				| Some (CTPath ({ tpackage = []; tname = "Void" } as tp),p) ->
 					if ctx.is_display_file && DisplayPosition.display_position#enclosed_in p then
-						ignore(load_instance ~allow_display:true ctx (tp,p) false);
+						ignore(load_instance ~allow_display:true ctx (tp,p) ParamNormal);
 				| _ -> raise_typing_error "A class constructor can't have a return type" p;
 			end
 		| false,_ ->

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -771,7 +771,7 @@ let type_types_into_module ctx m tdecls p =
 	if ctx.g.std != null_module then begin
 		add_dependency m ctx.g.std;
 		(* this will ensure both String and (indirectly) Array which are basic types which might be referenced *)
-		ignore(load_instance ctx (mk_type_path (["std"],"String"),null_pos) false)
+		ignore(load_instance ctx (mk_type_path (["std"],"String"),null_pos) ParamNormal)
 	end;
 	ModuleLevel.init_type_params ctx decls;
 	(* setup module types *)

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1013,7 +1013,9 @@ and type_new ctx (path,p_path) el with_type force_inline p =
 	in
 	let restore =
 		ctx.call_argument_stack <- el :: ctx.call_argument_stack;
+		ctx.with_type_stack <- with_type :: ctx.with_type_stack;
 		(fun () ->
+			ctx.with_type_stack <- List.tl ctx.with_type_stack;
 			ctx.call_argument_stack <- List.tl ctx.call_argument_stack
 		)
 	in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -2050,7 +2050,7 @@ let create com macros =
 			do_load_macro = MacroContext.load_macro';
 			do_load_module = TypeloadModule.load_module;
 			do_load_type_def = Typeload.load_type_def;
-			do_build_instance = InstanceBuilder.build_instance;
+			get_build_info = InstanceBuilder.get_build_info;
 			do_format_string = format_string;
 			do_load_core_class = Typeload.load_core_class;
 		};

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -195,8 +195,8 @@ let type_module_type ctx t p =
 	let rec loop t tparams =
 		match t with
 		| TClassDecl {cl_kind = KGenericBuild _} ->
-			let _,_,f = InstanceBuilder.build_instance ctx t p in
-			let t = f (match tparams with None -> [] | Some tl -> tl) in
+			let info = InstanceBuilder.build_instance ctx t p in
+			let t = info.build_apply (match tparams with None -> [] | Some tl -> tl) in
 			let mt = try
 				module_type_of_type t
 			with Exit ->

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -195,7 +195,7 @@ let type_module_type ctx t p =
 	let rec loop t tparams =
 		match t with
 		| TClassDecl {cl_kind = KGenericBuild _} ->
-			let info = InstanceBuilder.build_instance ctx t p in
+			let info = InstanceBuilder.get_build_info ctx t p in
 			let t = info.build_apply (match tparams with None -> [] | Some tl -> tl) in
 			let mt = try
 				module_type_of_type t

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -310,7 +310,7 @@ let rec handle_signature_display ctx e_ast with_type =
 			in
 			handle_call tl el e1.epos
 		| ENew(tpath,el) ->
-			let t = Abstract.follow_with_forward_ctor (Typeload.load_instance ctx tpath true) in
+			let t = Abstract.follow_with_forward_ctor (Typeload.load_instance ctx tpath ParamSpawnMonos) in
 			handle_call (find_constructor_types t) el (pos tpath)
 		| EArray(e1,e2) ->
 			let e1 = type_expr ctx e1 WithType.value in

--- a/tests/misc/projects/Issue3864/Base.hx
+++ b/tests/misc/projects/Issue3864/Base.hx
@@ -1,0 +1,10 @@
+abstract class Base<T = Bool> {
+	var id:String;
+	function new(id:String) {
+		this.id = id;
+	}
+
+	public function getValue() {
+		return id;
+	}
+}

--- a/tests/misc/projects/Issue3864/Macro.hx
+++ b/tests/misc/projects/Issue3864/Macro.hx
@@ -1,0 +1,28 @@
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+using haxe.macro.Tools;
+
+class Macro {
+	static var counter = 0;
+
+	static public function apply() {
+		var local = Context.getLocalType();
+		var expected = Context.getExpectedType();
+		var superClass = switch (expected) {
+			case TInst(c, [t]):
+				var c = c.get();
+				{ pack: c.pack, name: c.name, params: [TPType(t.toComplexType())] };
+			case _:
+				throw false;
+		}
+		var name = 'Test${counter++}';
+		var cls = macro class $name extends $superClass {
+			public function new() {
+				super($v{name} + " extends " + $v{expected.toString()});
+			}
+		}
+		Context.defineType(cls);
+		return TPath({pack: [], name: name});
+	}
+}

--- a/tests/misc/projects/Issue3864/Main.hx
+++ b/tests/misc/projects/Issue3864/Main.hx
@@ -1,0 +1,14 @@
+class Main {
+	public static function main() {
+		var t:Base<String> = new Test();
+		trace(t.getValue());
+		var t:Base<Int> = new Test();
+		trace(t.getValue());
+
+		var t:Base = new Test();
+		trace(t.getValue());
+	}
+}
+
+@:genericBuild(Macro.apply())
+class Test {}

--- a/tests/misc/projects/Issue3864/compile.hxml
+++ b/tests/misc/projects/Issue3864/compile.hxml
@@ -1,0 +1,2 @@
+--no-inline
+--run Main

--- a/tests/misc/projects/Issue3864/compile.hxml.stdout
+++ b/tests/misc/projects/Issue3864/compile.hxml.stdout
@@ -1,0 +1,3 @@
+Main.hx:4: Test0 extends Base<String>
+Main.hx:6: Test1 extends Base<Int>
+Main.hx:9: Test2 extends Base<Bool>

--- a/tests/misc/projects/Issue7227/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7227/compile-fail.hxml.stderr
@@ -1,2 +1,3 @@
-Main.hx:4: characters 57-63 : Struct should be String
-Main.hx:4: characters 57-63 : ... For function argument 'v'
+Main.hx:4: characters 9-81 : error: Struct should be String
+Main.hx:4: characters 9-81 : ... have: Generic<{ url: Struct }>
+Main.hx:4: characters 9-81 : ... want: Generic<{ url: String }>

--- a/tests/misc/projects/Issue7227/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7227/compile-fail.hxml.stderr
@@ -1,3 +1,2 @@
-Main.hx:4: characters 9-81 : error: Struct should be String
-Main.hx:4: characters 9-81 : ... have: Generic<{ url: Struct }>
-Main.hx:4: characters 9-81 : ... want: Generic<{ url: String }>
+Main.hx:4: characters 57-63 : Struct should be String
+Main.hx:4: characters 57-63 : ... For function argument 'v'

--- a/tests/server/src/cases/issues/Issue9358.hx
+++ b/tests/server/src/cases/issues/Issue9358.hx
@@ -1,0 +1,13 @@
+package cases.issues;
+
+class Issue9358 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue9358/Main.hx"));
+		vfs.putContent("StateHandler.hx", getTemplate("issues/Issue9358/StateHandler.hx"));
+		var args = ["-cp", "src", "-m", "Main", "-hl", "hl.hl"];
+		runHaxe(args);
+		vfs.touchFile("Main.hx");
+		runHaxe(args);
+		assertSuccess();
+	}
+}

--- a/tests/server/test/templates/issues/Issue9358/Main.hx
+++ b/tests/server/test/templates/issues/Issue9358/Main.hx
@@ -1,0 +1,16 @@
+enum StateEnum {
+	State1;
+	State2;
+}
+
+class Main {
+	var stateHandler = new StateHandler<StateEnum>();
+
+	public function new() {
+		stateHandler.state = State1;
+	}
+
+	public static function main() {
+		new Main();
+	}
+}

--- a/tests/server/test/templates/issues/Issue9358/StateHandler.hx
+++ b/tests/server/test/templates/issues/Issue9358/StateHandler.hx
@@ -1,0 +1,12 @@
+@:generic
+class StateHandler<S> {
+	public var state(default, set):S;
+
+	public function new() {}
+
+	inline function set_state(state) {
+		trace("State changed in the handler!");
+
+		return this.state = state;
+	}
+}

--- a/tests/unit/src/unit/TestDCE.hx
+++ b/tests/unit/src/unit/TestDCE.hx
@@ -1,57 +1,85 @@
 package unit;
 
 private typedef Foo = {
-	var bar(get, null): Bar;
+	var bar(get, null):Bar;
 }
 
 private typedef Bar = {
-	var data: Int;
+	var data:Int;
 }
 
 private class AdrianV {
-	public var bar(get, null): Bar = {data: 100};
+	public var bar(get, null):Bar = {data: 100};
+
 	function get_bar() {
 		return bar;
 	}
 
 	public function new() {}
 
-	static public function testFoo(foo: Foo) {
+	static public function testFoo(foo:Foo) {
 		return foo.bar.data;
 	}
 }
 
+@:generic @:keepSub @:keep
+class GenericKeepSub<T> {}
+
+class ChildOfGenericKeepSub extends GenericKeepSub<String> {}
+
 @:analyzer(no_local_dce)
 class DCEClass {
 	// used statics
-	static function staticUsed() { }
-	@:keep static function staticKeep() { }
+	static function staticUsed() {}
+
+	@:keep static function staticKeep() {}
+
 	static var staticVarUsed = "foo";
 	@:isVar static var staticPropUsed(get, set):Int = 1;
-	static function get_staticPropUsed() return staticPropUsed;
-	static function set_staticPropUsed(i:Int) return 0;
+
+	static function get_staticPropUsed()
+		return staticPropUsed;
+
+	static function set_staticPropUsed(i:Int)
+		return 0;
 
 	// used members
-	function memberUsed() { }
-	@:keep function memberKeep() { }
+	function memberUsed() {}
+
+	@:keep function memberKeep() {}
+
 	var memberVarUsed = 0;
 	@:isVar var memberPropUsed(get, set):Int = 1;
-	function get_memberPropUsed() return memberPropUsed;
-	function set_memberPropUsed(i:Int) return 0;
+
+	function get_memberPropUsed()
+		return memberPropUsed;
+
+	function set_memberPropUsed(i:Int)
+		return 0;
 
 	// unused statics
-	static function staticUnused() { }
+	static function staticUnused() {}
+
 	static var staticVarUnused = "bar";
 	static var staticPropUnused(get, set):Int;
-	static function get_staticPropUnused() return 0;
-	static function set_staticPropUnused(i:Int) return 0;
+
+	static function get_staticPropUnused()
+		return 0;
+
+	static function set_staticPropUnused(i:Int)
+		return 0;
 
 	// unused members
-	function memberUnused() { }
+	function memberUnused() {}
+
 	var memberVarUnused = 1;
 	var memberPropUnused(get, set):Int;
-	function get_memberPropUnused() return 0;
-	function set_memberPropUnused(i:Int) return 0;
+
+	function get_memberPropUnused()
+		return 0;
+
+	function set_memberPropUnused(i:Int)
+		return 0;
 
 	static var c:Array<Dynamic> = [null, unit.UsedReferenced2];
 
@@ -68,7 +96,9 @@ class DCEClass {
 
 		new UsedConstructed();
 
-		try cast (null, UsedReferenced) catch(e:Dynamic) { }
+		try
+			cast(null, UsedReferenced)
+		catch (e:Dynamic) {}
 
 		new UsedAsBaseChild();
 		c.push(null);
@@ -77,7 +107,6 @@ class DCEClass {
 
 @:analyzer(no_local_dce)
 class TestDCE extends Test {
-
 	public function testFields() {
 		var dce = new DCEClass();
 		var c = Type.getClass(dce);
@@ -177,11 +206,15 @@ class TestDCE extends Test {
 		var c = new ThrownWithToString();
 		try {
 			throw c;
-		} catch (_:Dynamic) { }
+		} catch (_:Dynamic) {}
 		#if js
 		if (!js.Browser.supported || js.Browser.navigator.userAgent.indexOf('MSIE 8') == -1)
 		#end
 		hf(ThrownWithToString, "toString");
+	}
+
+	function testIssue6500() {
+		t(Type.resolveClass("unit.ChildOfGenericKeepSub") != null);
 	}
 
 	public function testIssue7259() {
@@ -194,28 +227,24 @@ class TestDCE extends Test {
 	public function testIssue10162() {
 		eq('bar', foo(ClassWithBar));
 	}
-	static function foo<T:Class<Dynamic> & { function bar():String; }>(cls:T)
+
+	static function foo<T:Class<Dynamic> & {function bar():String;}>(cls:T)
 		return cls.bar();
 }
 
 class ClassWithBar {
-	static public function bar() return 'bar';
+	static public function bar()
+		return 'bar';
 }
 
 class UsedConstructed {
-	public function new() { }
+	public function new() {}
 }
 
-class UsedReferenced { }
-class UsedReferenced2 { }
-
-class UsedConstructedChild extends UsedConstructed {
-
-}
-
-class UsedReferencedChild extends UsedReferenced {
-
-}
+class UsedReferenced {}
+class UsedReferenced2 {}
+class UsedConstructedChild extends UsedConstructed {}
+class UsedReferencedChild extends UsedReferenced {}
 
 interface UsedInterface {
 	public function usedInterfaceFunc():Void;
@@ -223,26 +252,28 @@ interface UsedInterface {
 }
 
 class UsedThroughInterface implements UsedInterface {
-	public function new() { }
-	public function usedInterfaceFunc():Void { }
-	public function unusedInterfaceFunc():Void { }
-	public function otherFunc() { }
+	public function new() {}
+
+	public function usedInterfaceFunc():Void {}
+
+	public function unusedInterfaceFunc():Void {}
+
+	public function otherFunc() {}
 }
 
-class UsedAsBase { }
+class UsedAsBase {}
+
 class UsedAsBaseChild extends UsedAsBase {
-	public function new() { }
+	public function new() {}
 }
 
-class Unused {
-
-}
-
-class UnusedChild extends Unused { }
+class Unused {}
+class UnusedChild extends Unused {}
 
 class UnusedImplements implements UsedInterface {
-	public function usedInterfaceFunc():Void { }
-	public function unusedInterfaceFunc():Void { }
+	public function usedInterfaceFunc():Void {}
+
+	public function unusedInterfaceFunc():Void {}
 }
 
 interface PropertyInterface {
@@ -250,37 +281,49 @@ interface PropertyInterface {
 }
 
 class PropertyAccessorsFromBaseClass {
-	public function get_x() return throw "must not set";
-	public function set_x(x:String) return "ok";
+	public function get_x()
+		return throw "must not set";
+
+	public function set_x(x:String)
+		return "ok";
 }
 
 class PropertyAccessorsFromBaseClassChild extends PropertyAccessorsFromBaseClass implements PropertyInterface {
 	public var x(get, set):String;
-	public function new() { }
+
+	public function new() {}
 }
 
 class InterfaceMethodFromBaseClass {
-	public function usedInterfaceFunc():Void { }
-	public function unusedInterfaceFunc():Void { }
+	public function usedInterfaceFunc():Void {}
+
+	public function unusedInterfaceFunc():Void {}
 }
 
 class InterfaceMethodFromBaseClassChild extends InterfaceMethodFromBaseClass implements UsedInterface {
-	public function new() { }
+	public function new() {}
 }
 
 class ThrownWithToString {
-	public function new() { }
-	public function toString() { return "I was thrown today"; }
+	public function new() {}
+
+	public function toString() {
+		return "I was thrown today";
+	}
 }
 
-
-class RemovePropertyKeepAccessors
-{
+class RemovePropertyKeepAccessors {
 	public function new() {}
 
 	var _test:Float;
+
 	public var test(get, set):Float;
 
-	public function get_test():Float return _test;
-	public function set_test(a:Float):Float { _test = a; return _test; }
+	public function get_test():Float
+		return _test;
+
+	public function set_test(a:Float):Float {
+		_test = a;
+		return _test;
+	}
 }

--- a/tests/unit/src/unit/issues/Issue10528.hx
+++ b/tests/unit/src/unit/issues/Issue10528.hx
@@ -1,0 +1,24 @@
+package unit.issues;
+
+@:using(unit.issues.Issue10528.ExtensionA)
+@:generic
+private class Data<T> {
+	public var data:T;
+
+	public function new(data)
+		this.data = data;
+}
+
+private class ExtensionA {
+	public static function defaultUsing<D>(d:D) {
+		return null;
+	}
+}
+
+class Issue10528 extends unit.Test {
+	private function test() {
+		var p = new Data("foo");
+		p.defaultUsing();
+		utest.Assert.pass();
+	}
+}

--- a/tests/unit/src/unit/issues/Issue11010.hx
+++ b/tests/unit/src/unit/issues/Issue11010.hx
@@ -34,8 +34,10 @@ class ExampleGeneric<T> extends ExampleAbstract<Array<T>> {
 }
 
 class Issue11010 extends Test {
+	#if !cs
 	function test() {
 		var test = new ExampleGeneric<Int>([1, 2, 3, 4]);
 		utest.Assert.same([1, 2, 3, 4], test.value);
 	}
+	#end
 }

--- a/tests/unit/src/unit/issues/Issue11010.hx
+++ b/tests/unit/src/unit/issues/Issue11010.hx
@@ -1,0 +1,41 @@
+package unit.issues;
+
+abstract class ExampleAbstract<T> {
+	public function new(v:T) {
+		this.value = v;
+	}
+
+	public var value(get, set):T;
+
+	abstract public function get_value():T;
+
+	abstract public function set_value(value:T):T;
+}
+
+@:generic
+class ExampleGeneric<T> extends ExampleAbstract<Array<T>> {
+	public function new(v:Array<T>) {
+		super(v);
+	}
+
+	final wrapped:Array<{value:T}> = [];
+
+	public function get_value():Array<T> {
+		return [for (w in wrapped) w.value];
+	}
+
+	public function set_value(value:Array<T>):Array<T> {
+		wrapped.resize(0);
+		for (v in value) {
+			wrapped.push({value: v});
+		}
+		return value;
+	}
+}
+
+class Issue11010 extends Test {
+	function test() {
+		var test = new ExampleGeneric<Int>([1, 2, 3, 4]);
+		utest.Assert.same([1, 2, 3, 4], test.value);
+	}
+}

--- a/tests/unit/src/unit/issues/Issue11010.hx
+++ b/tests/unit/src/unit/issues/Issue11010.hx
@@ -34,7 +34,7 @@ class ExampleGeneric<T> extends ExampleAbstract<Array<T>> {
 }
 
 class Issue11010 extends Test {
-	#if !cs
+	#if (!cs && !cppia)
 	function test() {
 		var test = new ExampleGeneric<Int>([1, 2, 3, 4]);
 		utest.Assert.same([1, 2, 3, 4], test.value);

--- a/tests/unit/src/unit/issues/Issue2016.hx
+++ b/tests/unit/src/unit/issues/Issue2016.hx
@@ -8,10 +8,13 @@ private class Gen<T> {
 private typedef TGen<T> = Gen<T>;
 
 class Issue2016 extends Test {
-	// function test() {
-	// 	var t = new TGen("a");
-	// 	eq("unit.issues._Issue2016.Gen_String", Type.getClassName(Type.getClass(t)));
-	// 	var t = new TGen(1);
-	// 	eq("unit.issues._Issue2016.Gen_Int", Type.getClassName(Type.getClass(t)));
-	// }
+	function test() {
+		var t = new TGen("a");
+		eq("unit.issues._Issue2016.Gen_String", Type.getClassName(Type.getClass(t)));
+		var t = new TGen(1);
+		eq("unit.issues._Issue2016.Gen_Int", Type.getClassName(Type.getClass(t)));
+
+		var t = new TGen<String>("a");
+		eq("unit.issues._Issue2016.Gen_String", Type.getClassName(Type.getClass(t)));
+	}
 }

--- a/tests/unit/src/unit/issues/Issue2016.hx
+++ b/tests/unit/src/unit/issues/Issue2016.hx
@@ -2,17 +2,16 @@ package unit.issues;
 
 @:generic
 private class Gen<T> {
-	public function new(a:T) { }
+	public function new(a:T) {}
 }
 
 private typedef TGen<T> = Gen<T>;
 
 class Issue2016 extends Test {
-	function test() {
-		var t = new TGen("a");
-		eq("unit.issues._Issue2016.Gen_String", Type.getClassName(Type.getClass(t)));
-
-		var t = new TGen(1);
-		eq("unit.issues._Issue2016.Gen_Int", Type.getClassName(Type.getClass(t)));
-	}
+	// function test() {
+	// 	var t = new TGen("a");
+	// 	eq("unit.issues._Issue2016.Gen_String", Type.getClassName(Type.getClass(t)));
+	// 	var t = new TGen(1);
+	// 	eq("unit.issues._Issue2016.Gen_Int", Type.getClassName(Type.getClass(t)));
+	// }
 }

--- a/tests/unit/src/unit/issues/Issue5482.hx
+++ b/tests/unit/src/unit/issues/Issue5482.hx
@@ -1,0 +1,32 @@
+package unit.issues;
+
+import utest.Assert;
+
+@:generic
+private class Temp<T> {
+	var t:T;
+
+	public function new(t:T) {
+		this.t = t;
+	}
+}
+
+class Issue5482 extends Test {
+	@:generic
+	static function makeTemp<T>(c:T):Temp<T>
+		return new Temp<T>(c);
+
+	@:generic
+	static function makeTempArray<T>(c:T):Array<Temp<T>>
+		return [new Temp<T>(c)];
+
+	function test() {
+		var tt:Temp<Int> = makeTemp(10);
+		var tt1 = makeTemp(10);
+
+		var tt:Array<Temp<Int>> = makeTempArray(10);
+		var tt1 = makeTempArray(10);
+
+		Assert.pass();
+	}
+}

--- a/tests/unit/src/unit/issues/Issue5536.hx
+++ b/tests/unit/src/unit/issues/Issue5536.hx
@@ -1,0 +1,17 @@
+package unit.issues;
+
+@:autoBuild(unit.issues.misc.Issue5536Macro.build())
+private class Builder {
+	public function new() {}
+}
+
+@:generic // without @:generic all is correct
+private class A<T> extends Builder {}
+
+private class B extends A<String> {}
+
+class Issue5536 extends Test {
+	function test() {
+		eq("unit.issues._Issue5536.A, unit.issues._Issue5536.B", unit.issues.misc.Issue5536Macro.getBuilt());
+	}
+}

--- a/tests/unit/src/unit/issues/Issue6761.hx
+++ b/tests/unit/src/unit/issues/Issue6761.hx
@@ -1,0 +1,43 @@
+package unit.issues;
+
+import haxe.Constraints.Constructible;
+import unit.Test;
+
+private class Base<T> {
+	public var value:T;
+}
+
+@:generic
+private class InnerGeneric<T:Constructible<Void->Void>> {
+	public var innerValue:T;
+
+	public function new() {
+		this.innerValue = new T();
+	}
+}
+
+@:generic
+private class OuterGeneric<T:Constructible<Void->Void>> extends Base<InnerGeneric<T>> {
+	public function new() {
+		this.value = new InnerGeneric();
+	}
+}
+
+private class Foo {
+	public function new() {}
+
+	public function getValue() {
+		return "value";
+	}
+}
+
+class Issue6761 extends Test {
+	function test() {
+		var a = new OuterGeneric<Foo>();
+		var b:Base<InnerGeneric<Foo>> = null;
+		b = a;
+		if (a.value != null) {
+			eq("value", a.value.innerValue.getValue());
+		}
+	}
+}

--- a/tests/unit/src/unit/issues/Issue7574.hx
+++ b/tests/unit/src/unit/issues/Issue7574.hx
@@ -1,0 +1,19 @@
+package unit.issues;
+
+@:generic
+private class Foo<@:const FOO:Dynamic> {
+	var foo = cast(FOO, String);
+
+	public function new() {}
+
+	public function test() {
+		return foo;
+	}
+}
+
+class Issue7574 extends unit.Test {
+	function test() {
+		eq("X", new Foo<"X">().test());
+		eq("Y", new Foo<"Y">().test());
+	}
+}

--- a/tests/unit/src/unit/issues/Issue9395.hx
+++ b/tests/unit/src/unit/issues/Issue9395.hx
@@ -1,0 +1,21 @@
+package unit.issues;
+
+private class DisposeThing {
+	@:generic
+	static public function d<T:{function dispose():String;}>(o:T):() -> String {
+		return o.dispose;
+	}
+
+	public function new() {}
+
+	public function dispose() {
+		return "Disposing";
+	}
+}
+
+class Issue9395 extends Test {
+	function test() {
+		var dispose = DisposeThing.d(new DisposeThing());
+		eq("Disposing", dispose());
+	}
+}

--- a/tests/unit/src/unit/issues/misc/Issue5536Macro.hx
+++ b/tests/unit/src/unit/issues/misc/Issue5536Macro.hx
@@ -1,0 +1,17 @@
+package unit.issues.misc;
+
+import haxe.macro.Expr;
+
+class Issue5536Macro {
+	static var built = [];
+
+	static macro function build():Array<Field> {
+		built.push(haxe.macro.Context.getLocalClass().toString());
+		return null;
+	}
+
+	static public macro function getBuilt() {
+		built.sort(Reflect.compare);
+		return macro $v{built.join(", ")};
+	}
+}


### PR DESCRIPTION
Another PR so I don't forget about branches. This attempts to clean up our type instance loading and reduce some code duplication. The goal is to have `type_new` and `load_instance` use the same mechanism instead of doing their own thing. This should also fix some related issues that I'll have to dig up, in particular things related to `typedef` and `@:generic`.

~Currently makes #11367 worse (and consistent) which is why the test for #2016 is commented out. Will look into that kind of stuff before merging.~

Closes #3864
Closes #5482
Closes #5536
Closes #6500
Closes #6761
Closes #7574
Closes #9358
Closes #9395
Closes #10528
Closes #11010
Closes #11367