### PR TITLE
Always flush PConnectField when entering PTypeField

### DIFF
--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -459,6 +459,10 @@ let rec flush_pass ctx p where =
 let make_pass ctx f = f
 
 let init_class_done ctx =
+	ctx.pass <- PConnectField
+
+let enter_field_typing_pass ctx info =
+	flush_pass ctx PConnectField info;
 	ctx.pass <- PTypeField
 
 let make_lazy ?(force=true) ctx t_proc f where =

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -93,8 +93,7 @@ let typing_timer ctx need_type f =
 	ctx.com.error_ext <- (fun err -> raise_error { err with err_from_macro = true });
 
 	if need_type && ctx.pass < PTypeField then begin
-		ctx.pass <- PTypeField;
-		flush_pass ctx PBuildClass ("typing_timer",[] (* TODO: ? *));
+		enter_field_typing_pass ctx ("typing_timer",[] (* TODO: ? *));
 	end;
 	let exit() =
 		t();

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -860,6 +860,7 @@ module TypeBinding = struct
 		let r = make_lazy ~force:false ctx t (fun r ->
 			(* type constant init fields (issue #1956) *)
 			if not !return_partial_type || (match fst e with EConst _ -> true | _ -> false) then begin
+				enter_field_typing_pass ctx ("bind_var_expression",fst ctx.curclass.cl_path @ [snd ctx.curclass.cl_path;ctx.curfield.cf_name]);
 				if (Meta.has (Meta.Custom ":debug.typing") (c.cl_meta @ cf.cf_meta)) then ctx.com.print (Printf.sprintf "Typing field %s.%s\n" (s_type_path c.cl_path) cf.cf_name);
 				let e = type_var_field ctx t e fctx.is_static fctx.is_display_field p in
 				let maybe_run_analyzer e = match e.eexpr with

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -54,6 +54,7 @@ let type_function ctx (args : function_arguments) ret fmode e do_display p =
 	ctx.ret <- ret;
 	ctx.opened <- [];
 	ctx.monomorphs.perfunction <- [];
+	enter_field_typing_pass ctx ("type_function",fst ctx.curclass.cl_path @ [snd ctx.curclass.cl_path;ctx.curfield.cf_name]);
 	args#bring_into_context;
 	let e = match e with
 		| None ->
@@ -191,7 +192,7 @@ let add_constructor ctx c force_constructor p =
 		let r = make_lazy ctx t (fun r ->
 			let ctx = { ctx with
 				curfield = cf;
-				pass = PTypeField;
+				pass = PConnectField;
 			} in
 			ignore (follow cfsup.cf_type); (* make sure it's typed *)
 			List.iter (fun cf -> ignore (follow cf.cf_type)) cf.cf_overloads;

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -446,10 +446,8 @@ module TypeLevel = struct
 			in
 			build()
 		in
-		ctx.pass <- PBuildClass;
 		ctx.curclass <- c;
 		c.cl_build <- make_pass ctx build;
-		ctx.pass <- PBuildModule;
 		ctx.curclass <- null_class;
 		delay ctx PBuildClass (fun() -> ignore(c.cl_build()));
 		if Meta.has Meta.InheritDoc c.cl_meta then


### PR DESCRIPTION
In #11353 I identified a case where we're in `PTypeField` mode without having flushed `PConnectField` first. This lead to a problem with static extensions because a delayed initialization to `ctx.m.module_using` wasn't done yet. With this PR we're changing it so that whenever we enter `PTypeField`, we make sure to flush `PConnectField` first. This could also fix some other problems related to typing order.

@kLabz Would be good to quickly check Shiro codebases because this has the potential to break something.