### PR TITLE
Jvm annotation rework

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -41,7 +41,8 @@
 	{
 		"name": "Annotation",
 		"metadata": ":annotation",
-		"doc": "Annotation (`@interface`) definitions on `--java-lib` imports will be annotated with this metadata. Has no effect on types compiled by Haxe.",
+		"doc": "Marks a class as a Java annotation",
+		"params": ["Retention policy"],
 		"platforms": ["java"],
 		"targets": ["TClass"]
 	},

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -931,10 +931,12 @@ module Converter = struct
 		let is_interface = AccessFlags.has_flag jc.jc_flags MInterface in
 		if is_interface then add_flag HInterface
 		else if AccessFlags.has_flag jc.jc_flags MAbstract then add_flag HAbstract;
+		let is_annotation = AccessFlags.has_flag jc.jc_flags MAnnotation in
 		begin match jc.jc_super with
 			| TObject(([],""),_)
 			| TObject((["java";"lang"],"Object"),_) ->
-				()
+				if is_annotation then
+					add_flag (HExtends ({tpackage = ["java";"lang";"annotation"]; tname = "Annotation"; tsub = None; tparams = []},null_pos));
 			| jsig ->
 				add_flag (HExtends (get_type_path (convert_signature ctx p jsig),p))
 		end;
@@ -980,7 +982,7 @@ module Converter = struct
 		end;
 		let _,class_name = jname_to_hx (snd jc.jc_path) in
 		add_meta (Meta.Native, [EConst (String (s_type_path jc.jc_path,SDoubleQuotes) ),p],p);
-		if AccessFlags.has_flag jc.jc_flags MAnnotation then begin
+		if is_annotation then begin
 			let args = match extract_retention_policy jc.jc_attributes with
 				| None ->
 					[]

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -272,6 +272,8 @@ module AnnotationHandler = struct
 				with Exit -> match path with
 					| ([],"Void") ->
 						None
+					| ([],name) ->
+						Some (TObject((["haxe";"root"],name),[]))
 					| _ ->
 						Some (TObject(path,[]))
 				in

--- a/src/generators/jvm/jvmAttribute.ml
+++ b/src/generators/jvm/jvmAttribute.ml
@@ -85,7 +85,9 @@ type j_attribute =
 	| AttributeInnerClasses of jvm_inner_class array
 	| AttributeEnclosingMethod of jvm_constant_pool_index * jvm_constant_pool_index
 	| AttributeRuntimeVisibleAnnotations of j_annotation array
+	| AttributeRuntimeInvisibleAnnotations of j_annotation array
 	| AttributeRuntimeVisibleParameterAnnotations of j_annotation array array
+	| AttributeRuntimeInvisibleParameterAnnotations of j_annotation array array
 	| AttributeBootstrapMethods of j_bootstrap_method array
 
 let write_verification_type ch = function
@@ -236,10 +238,17 @@ let write_attribute pool jvma =
 	| AttributeRuntimeVisibleAnnotations al ->
 		write_array16 ch write_annotation al;
 		"RuntimeVisibleAnnotations"
+	| AttributeRuntimeInvisibleAnnotations al ->
+		write_array16 ch write_annotation al;
+		"RuntimeInvisibleAnnotations"
 	| AttributeRuntimeVisibleParameterAnnotations al ->
 		write_byte ch (Array.length al);
 		Array.iter (write_array16 ch write_annotation) al;
 		"RuntimeVisibleParameterAnnotations"
+	| AttributeRuntimeInvisibleParameterAnnotations al ->
+		write_byte ch (Array.length al);
+		Array.iter (write_array16 ch write_annotation) al;
+		"RuntimeInvisibleParameterAnnotations"
 	| AttributeBootstrapMethods a ->
 		write_array16 ch (fun _ bm ->
 			write_ui16 ch bm.bm_method_ref;

--- a/src/generators/jvm/jvmBuilder.ml
+++ b/src/generators/jvm/jvmBuilder.ml
@@ -29,6 +29,7 @@ type annotation_kind =
 	| AEnum of jsignature * string
 	| AArray of annotation_kind list
 	| AAnnotation of jsignature * annotation
+	| AClass of jsignature option
 
 and annotation = (string * annotation_kind) list
 
@@ -58,7 +59,8 @@ let convert_annotations pool annotations =
 				| AAnnotation (jsig, a) ->
 					let ann = process_annotation (jsig, a) in
 					'@',ValAnnotation(ann)
-
+				| AClass jsig ->
+					'c',ValClass(pool#add_string (Option.map_default (generate_signature false) "V" jsig))
 			in
 			offset,loop ak
 		) l in

--- a/src/generators/jvm/jvmBuilder.ml
+++ b/src/generators/jvm/jvmBuilder.ml
@@ -67,13 +67,13 @@ let convert_annotations pool annotations =
 			ann_elements = Array.of_list l;
 		}
 	in
-	let a = Array.map process_annotation annotations in
-	a
+	Array.map process_annotation annotations
 
 class base_builder = object(self)
 	val mutable access_flags = 0
 	val attributes = DynArray.create ()
-	val annotations = DynArray.create ()
+	val runtime_visible_annotations = DynArray.create ()
+	val runtime_invisible_annotations = DynArray.create ()
 	val mutable was_exported = false
 
 	method add_access_flag i =
@@ -82,14 +82,19 @@ class base_builder = object(self)
 	method add_attribute (a : j_attribute) =
 		DynArray.add attributes a
 
-	method add_annotation (path : jpath) (a : annotation) =
-		DynArray.add annotations ((TObject(path,[])),a)
+	method add_annotation (path : jpath) (a : annotation) (is_runtime_visible : bool) =
+		DynArray.add (if is_runtime_visible then runtime_visible_annotations else runtime_invisible_annotations) ((TObject(path,[])),a)
 
 	method private commit_annotations pool =
-		if DynArray.length annotations > 0 then begin
+		if DynArray.length runtime_visible_annotations > 0 then begin
 			let open JvmAttribute in
-			let a = convert_annotations pool (DynArray.to_array annotations) in
+			let a = convert_annotations pool (DynArray.to_array runtime_visible_annotations) in
 			self#add_attribute (AttributeRuntimeVisibleAnnotations a)
+		end;
+		if DynArray.length runtime_invisible_annotations > 0 then begin
+			let open JvmAttribute in
+			let a = convert_annotations pool (DynArray.to_array runtime_invisible_annotations) in
+			self#add_attribute (AttributeRuntimeInvisibleAnnotations a)
 		end
 
 	method export_attributes (pool : JvmConstantPool.constant_pool) =

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -89,7 +89,8 @@ object(self)
 		| None ->
 			let make_local name kind t meta pn =
 				let v = alloc_var kind name t pn in
-				v.v_meta <- v.v_meta @ meta;
+				let meta = (StrictMeta.check_strict_meta ctx meta) @ meta in
+				v.v_meta <- meta;
 				v
 			in
 			let rec loop acc is_abstract_this syntax typed = match syntax,typed with

--- a/src/typing/strictMeta.ml
+++ b/src/typing/strictMeta.ml
@@ -131,12 +131,11 @@ let get_strict_meta ctx meta params pos =
 			display_error ctx.com "A @:strict metadata must contain exactly one parameter. Please check the documentation for more information" pos;
 			raise Exit
 	in
-	let t = Typeload.load_complex_type ctx false (ctype,pos) in
 	let texpr = type_expr ctx changed_expr NoValue in
 	let with_type_expr = (ECheckType( (EConst (Ident "null"), pos), (ctype,null_pos) ), pos) in
 	let extra = handle_fields ctx fields_to_check with_type_expr in
 	let args = [make_meta ctx texpr extra] in
-	let args = match t with
+	let args = if Common.defined ctx.com Define.Jvm then match Typeload.load_complex_type ctx false (ctype,pos) with
 		| TInst(c,_) ->
 			let v = get_meta_string c.cl_meta Meta.Annotation in
 			begin match v with
@@ -149,6 +148,8 @@ let get_strict_meta ctx meta params pos =
 			end;
 		| _ ->
 			args
+	else
+		args
 	in
 	meta, args, pos
 

--- a/src/typing/strictMeta.ml
+++ b/src/typing/strictMeta.ml
@@ -143,11 +143,13 @@ let get_strict_meta ctx meta params pos =
 			display_error ctx.com "A @:strict metadata must contain exactly one parameter. Please check the documentation for more information" pos;
 			raise Exit
 	in
+	let t = Typeload.load_complex_type ctx false (ctype,pos) in
+	flush_pass ctx PBuildClass "get_strict_meta";
 	let texpr = type_expr ctx changed_expr NoValue in
 	let with_type_expr = (ECheckType( (EConst (Ident "null"), pos), (ctype,null_pos) ), pos) in
 	let extra = handle_fields ctx fields_to_check with_type_expr in
 	let args = [make_meta ctx texpr extra] in
-	let args = if Common.defined ctx.com Define.Jvm then match Typeload.load_complex_type ctx false (ctype,pos) with
+	let args = if Common.defined ctx.com Define.Jvm then match t with
 		| TInst(c,_) ->
 			let v = get_meta_string c.cl_meta Meta.Annotation in
 			begin match v with

--- a/std/jvm/annotation/ClassReflectionInformation.hx
+++ b/std/jvm/annotation/ClassReflectionInformation.hx
@@ -22,7 +22,7 @@
 
 package jvm.annotation;
 
-@:annotation
+@:annotation("RUNTIME")
 @:native("haxe.jvm.annotation.ClassReflectionInformation")
 @:keep
 interface ClassReflectionInformation extends java.lang.annotation.Annotation {

--- a/std/jvm/annotation/EnumReflectionInformation.hx
+++ b/std/jvm/annotation/EnumReflectionInformation.hx
@@ -22,7 +22,7 @@
 
 package jvm.annotation;
 
-@:annotation
+@:annotation("RUNTIME")
 @:native("haxe.jvm.annotation.EnumReflectionInformation")
 @:keep
 interface EnumReflectionInformation extends java.lang.annotation.Annotation {

--- a/std/jvm/annotation/EnumValueReflectionInformation.hx
+++ b/std/jvm/annotation/EnumValueReflectionInformation.hx
@@ -22,7 +22,7 @@
 
 package jvm.annotation;
 
-@:annotation
+@:annotation("RUNTIME")
 @:native("haxe.jvm.annotation.EnumValueReflectionInformation")
 @:keep
 interface EnumValueReflectionInformation extends java.lang.annotation.Annotation {

--- a/tests/misc/java/projects/Annotations/AnnotationLib.hx
+++ b/tests/misc/java/projects/Annotations/AnnotationLib.hx
@@ -9,9 +9,15 @@ interface MyVisibleArrayAnnotation {
 	function value():java.NativeArray<String>;
 }
 
+@:annotation("RUNTIME")
+interface MyVisibleArrayArrayAnnotation {
+	function value():java.NativeArray<java.NativeArray<String>>;
+}
+
 @:strict(MyVisibleAnnotation())
 @:strict(MyInvisibleAnnotation())
 @:strict(MyVisibleArrayAnnotation({value: ["foo", "bar"]}))
+@:strict(MyVisibleArrayArrayAnnotation({value: [["foo1", "bar1"], ["foo2", "bar2"]]}))
 class AnnotationLib {
 	@:strict(MyVisibleAnnotation())
 	@:strict(MyInvisibleAnnotation())

--- a/tests/misc/java/projects/Annotations/AnnotationLib.hx
+++ b/tests/misc/java/projects/Annotations/AnnotationLib.hx
@@ -1,11 +1,17 @@
 @:annotation("RUNTIME")
-class MyVisibleAnnotation {}
+interface MyVisibleAnnotation {}
 
 @:annotation("CLASS")
-class MyInvisibleAnnotation {}
+interface MyInvisibleAnnotation {}
+
+@:annotation("RUNTIME")
+interface MyVisibleArrayAnnotation {
+	function value():java.NativeArray<String>;
+}
 
 @:strict(MyVisibleAnnotation())
 @:strict(MyInvisibleAnnotation())
+@:strict(MyVisibleArrayAnnotation({value: ["foo", "bar"]}))
 class AnnotationLib {
 	@:strict(MyVisibleAnnotation())
 	@:strict(MyInvisibleAnnotation())

--- a/tests/misc/java/projects/Annotations/AnnotationLib.hx
+++ b/tests/misc/java/projects/Annotations/AnnotationLib.hx
@@ -1,0 +1,13 @@
+@:annotation("RUNTIME")
+class MyVisibleAnnotation {}
+
+@:annotation("CLASS")
+class MyInvisibleAnnotation {}
+
+@:strict(MyVisibleAnnotation())
+@:strict(MyInvisibleAnnotation())
+class AnnotationLib {
+	@:strict(MyVisibleAnnotation())
+	@:strict(MyInvisibleAnnotation())
+	static function test(@:strict(MyVisibleAnnotation()) arg1:String, @:strict(MyInvisibleAnnotation()) arg2:String) {}
+}

--- a/tests/misc/java/projects/Annotations/Main.hx
+++ b/tests/misc/java/projects/Annotations/Main.hx
@@ -72,5 +72,8 @@ function main() {
 				reportPresence(name, [annotations.runtimeVisibleParameter[i], annotations.runtimeInvisibleParameter[i]], "Lhaxe/root/MyInvisibleAnnotation;");
 			}
 		}
+
+		var ann = annotations.runtimeVisible.find(ann -> ann.type == "Lhaxe/root/MyVisibleArrayAnnotation;");
+		Sys.println(ann.elementValuePairs[0].elementValue.value);
 	}
 }

--- a/tests/misc/java/projects/Annotations/Main.hx
+++ b/tests/misc/java/projects/Annotations/Main.hx
@@ -1,0 +1,76 @@
+import haxe.io.BytesInput;
+import sys.io.File;
+import sys.io.FileInput;
+import format.jvm.Data;
+
+using StringTools;
+using Lambda;
+
+typedef Annotations = {
+	var ?runtimeVisible:Array<Annotation>;
+	var ?runtimeInvisible:Array<Annotation>;
+	var ?runtimeVisibleParameter:Array<Array<Annotation>>;
+	var ?runtimeInvisibleParameter:Array<Array<Annotation>>;
+}
+
+function getAnnotations(attributes:Array<Attribute>) {
+	var annotations:Annotations = {};
+
+	for (attribute in attributes) {
+		switch (attribute) {
+			case RuntimeVisibleAnnotations(a):
+				annotations.runtimeVisible = a;
+			case RuntimeInvisibleAnnotations(a):
+				annotations.runtimeInvisible = a;
+			case RuntimeVisibleParameterAnnotations(a):
+				annotations.runtimeVisibleParameter = a;
+			case RuntimeInvisibleParameterAnnotations(a):
+				annotations.runtimeInvisibleParameter = a;
+			case _:
+		}
+	}
+	return annotations;
+}
+
+function hasAnnotation(annotations:Array<Annotation>, name:String) {
+	return annotations.exists(ann -> ann.type == name);
+}
+
+function reportPresence(source:String, annotations:Array<Array<Annotation>>, name:String) {
+	Sys.println('Presence of $name on $source');
+	for (key => annotations in annotations) {
+		Sys.println('  $key: ${hasAnnotation(annotations, name)}');
+	}
+}
+
+function main() {
+	var input = File.read("annotationLib.jar");
+	var zip = new format.zip.Reader(input);
+	var data = zip.read();
+	for (entry in data) {
+		if (!entry.fileName.endsWith("AnnotationLib.class")) {
+			continue;
+		}
+		var input = new BytesInput(entry.data);
+		var reader = new format.jvm.Reader(input);
+		var jc = reader.read();
+		var annotations = getAnnotations(jc.attributes);
+		reportPresence(jc.thisClass, [annotations.runtimeVisible, annotations.runtimeInvisible], "Lhaxe/root/MyVisibleAnnotation;");
+		reportPresence(jc.thisClass, [annotations.runtimeVisible, annotations.runtimeInvisible], "Lhaxe/root/MyInvisibleAnnotation;");
+
+		for (method in jc.methods) {
+			if (method.name != "test") {
+				continue;
+			}
+			var annotations = getAnnotations(method.attributes);
+			reportPresence(method.name, [annotations.runtimeVisible, annotations.runtimeInvisible], "Lhaxe/root/MyVisibleAnnotation;");
+			reportPresence(method.name, [annotations.runtimeVisible, annotations.runtimeInvisible], "Lhaxe/root/MyInvisibleAnnotation;");
+
+			for (i in 0...2) {
+				var name = '${method.name} (arg $i)';
+				reportPresence(name, [annotations.runtimeVisibleParameter[i], annotations.runtimeInvisibleParameter[i]], "Lhaxe/root/MyVisibleAnnotation;");
+				reportPresence(name, [annotations.runtimeVisibleParameter[i], annotations.runtimeInvisibleParameter[i]], "Lhaxe/root/MyInvisibleAnnotation;");
+			}
+		}
+	}
+}

--- a/tests/misc/java/projects/Annotations/Main.hx
+++ b/tests/misc/java/projects/Annotations/Main.hx
@@ -75,5 +75,8 @@ function main() {
 
 		var ann = annotations.runtimeVisible.find(ann -> ann.type == "Lhaxe/root/MyVisibleArrayAnnotation;");
 		Sys.println(ann.elementValuePairs[0].elementValue.value);
+
+		var ann = annotations.runtimeVisible.find(ann -> ann.type == "Lhaxe/root/MyVisibleArrayArrayAnnotation;");
+		Sys.println(ann.elementValuePairs[0].elementValue.value);
 	}
 }

--- a/tests/misc/java/projects/Annotations/MainMixin.hx
+++ b/tests/misc/java/projects/Annotations/MainMixin.hx
@@ -1,0 +1,33 @@
+using jvm.NativeTools.NativeClassTools;
+
+@:annotation("RUNTIME")
+interface Mixin extends java.lang.annotation.Annotation {
+	function value():java.NativeArray<Class<Dynamic>>;
+	function targets():java.NativeArray<String>;
+	function priority():Int;
+	function remap():Bool;
+}
+
+class B {}
+
+@:strict(Mixin({
+	value: [String, B],
+	targets: ["here"],
+	priority: 9001,
+	remap: true
+}))
+class C {}
+
+class MainMixin {
+	static function main() {
+		var annot = C.native().getAnnotation(Mixin.native());
+		for (v in annot.value()) {
+			trace(v);
+		}
+		for (v in annot.targets()) {
+			trace(v);
+		}
+		trace(annot.priority());
+		trace(annot.remap());
+	}
+}

--- a/tests/misc/java/projects/Annotations/compile-mixin.hxml
+++ b/tests/misc/java/projects/Annotations/compile-mixin.hxml
@@ -1,0 +1,3 @@
+--main MainMixin
+--jvm mixin.jar
+--cmd java -jar mixin.jar

--- a/tests/misc/java/projects/Annotations/compile-mixin.hxml.stdout
+++ b/tests/misc/java/projects/Annotations/compile-mixin.hxml.stdout
@@ -1,0 +1,5 @@
+MainMixin.hx:25: class java.lang.String
+MainMixin.hx:25: class haxe.root.B
+MainMixin.hx:28: here
+MainMixin.hx:30: 9001
+MainMixin.hx:31: true

--- a/tests/misc/java/projects/Annotations/compile.hxml
+++ b/tests/misc/java/projects/Annotations/compile.hxml
@@ -1,0 +1,12 @@
+AnnotationLib
+--jvm annotationLib.jar
+
+--next
+
+--main Main
+-lib format
+--jvm jvm.jar
+
+--next
+
+--cmd java -jar jvm.jar

--- a/tests/misc/java/projects/Annotations/compile.hxml.stdout
+++ b/tests/misc/java/projects/Annotations/compile.hxml.stdout
@@ -1,0 +1,24 @@
+Presence of Lhaxe/root/MyVisibleAnnotation; on haxe/root/AnnotationLib
+  0: true
+  1: false
+Presence of Lhaxe/root/MyInvisibleAnnotation; on haxe/root/AnnotationLib
+  0: false
+  1: true
+Presence of Lhaxe/root/MyVisibleAnnotation; on test
+  0: true
+  1: false
+Presence of Lhaxe/root/MyInvisibleAnnotation; on test
+  0: false
+  1: true
+Presence of Lhaxe/root/MyVisibleAnnotation; on test (arg 0)
+  0: true
+  1: false
+Presence of Lhaxe/root/MyInvisibleAnnotation; on test (arg 0)
+  0: false
+  1: false
+Presence of Lhaxe/root/MyVisibleAnnotation; on test (arg 1)
+  0: false
+  1: false
+Presence of Lhaxe/root/MyInvisibleAnnotation; on test (arg 1)
+  0: false
+  1: true

--- a/tests/misc/java/projects/Annotations/compile.hxml.stdout
+++ b/tests/misc/java/projects/Annotations/compile.hxml.stdout
@@ -23,3 +23,4 @@ Presence of Lhaxe/root/MyInvisibleAnnotation; on test (arg 1)
   0: false
   1: true
 ArrayValue([{tag: 115, value: ConstValue(CONSTANT_Utf8(foo))},{tag: 115, value: ConstValue(CONSTANT_Utf8(bar))}])
+ArrayValue([{tag: 91, value: ArrayValue([{tag: 115, value: ConstValue(CONSTANT_Utf8(foo1))},{tag: 115, value: ConstValue(CONSTANT_Utf8(bar1))}])},{tag: 91, value: ArrayValue([{tag: 115, value: ConstValue(CONSTANT_Utf8(foo2))},{tag: 115, value: ConstValue(CONSTANT_Utf8(bar2))}])}])

--- a/tests/misc/java/projects/Annotations/compile.hxml.stdout
+++ b/tests/misc/java/projects/Annotations/compile.hxml.stdout
@@ -22,3 +22,4 @@ Presence of Lhaxe/root/MyVisibleAnnotation; on test (arg 1)
 Presence of Lhaxe/root/MyInvisibleAnnotation; on test (arg 1)
   0: false
   1: true
+ArrayValue([{tag: 115, value: ConstValue(CONSTANT_Utf8(foo))},{tag: 115, value: ConstValue(CONSTANT_Utf8(bar))}])

--- a/tests/runci/targets/Java.hx
+++ b/tests/runci/targets/Java.hx
@@ -7,8 +7,6 @@ import runci.Config.*;
 using StringTools;
 
 class Java {
-	static final miscJavaDir = getMiscSubDir('java');
-
 	static public function getJavaDependencies() {
 		haxelibInstallGit("HaxeFoundation", "hxjava", true);
 		haxelibInstallGit("HaxeFoundation", "format", "jvm", "--always");
@@ -24,9 +22,6 @@ class Java {
 
 		runCommand("haxe", ["compile-java.hxml","-dce","no"].concat(args));
 		runCommand("java", ["-jar", "bin/java/TestMain-Debug.jar"]);
-
-		changeDirectory(miscJavaDir);
-		runCommand("haxe", ["run.hxml"]);
 
 		changeDirectory(sysDir);
 		runCommand("haxe", ["compile-java.hxml"].concat(args));

--- a/tests/runci/targets/Java.hx
+++ b/tests/runci/targets/Java.hx
@@ -11,7 +11,6 @@ class Java {
 
 	static public function getJavaDependencies() {
 		haxelibInstallGit("HaxeFoundation", "hxjava", true);
-		haxelibInstallGit("HaxeFoundation", "format", "jvm");
 		runCommand("javac", ["-version"]);
 	}
 

--- a/tests/runci/targets/Java.hx
+++ b/tests/runci/targets/Java.hx
@@ -11,6 +11,7 @@ class Java {
 
 	static public function getJavaDependencies() {
 		haxelibInstallGit("HaxeFoundation", "hxjava", true);
+		haxelibInstallGit("HaxeFoundation", "format", "jvm");
 		runCommand("javac", ["-version"]);
 	}
 

--- a/tests/runci/targets/Java.hx
+++ b/tests/runci/targets/Java.hx
@@ -11,6 +11,7 @@ class Java {
 
 	static public function getJavaDependencies() {
 		haxelibInstallGit("HaxeFoundation", "hxjava", true);
+		haxelibInstallGit("HaxeFoundation", "format", "jvm", "--always");
 		runCommand("javac", ["-version"]);
 	}
 

--- a/tests/runci/targets/Jvm.hx
+++ b/tests/runci/targets/Jvm.hx
@@ -4,6 +4,8 @@ import runci.System.*;
 import runci.Config.*;
 
 class Jvm {
+	static final miscJavaDir = getMiscSubDir('java');
+
 	static public function run(args:Array<String>) {
 		deleteDirectoryRecursively("bin/jvm");
 		Java.getJavaDependencies();
@@ -16,6 +18,9 @@ class Jvm {
 			runCommand("haxe", ["compile-jvm.hxml","-dce","no"].concat(args));
 			runCommand("java", ["-jar", "bin/unit.jar"]);
 		}
+
+		changeDirectory(miscJavaDir);
+		runCommand("haxe", ["run.hxml"]);
 
 		changeDirectory(sysDir);
 		runCommand("haxe", ["compile-jvm.hxml"].concat(args));

--- a/tests/runci/targets/Jvm.hx
+++ b/tests/runci/targets/Jvm.hx
@@ -7,7 +7,6 @@ class Jvm {
 	static public function run(args:Array<String>) {
 		deleteDirectoryRecursively("bin/jvm");
 		Java.getJavaDependencies();
-		haxelibInstallGit("HaxeFoundation", "format", "jvm");
 
 		for (level in 0...3) {
 			final args = args.concat(["-D", "jvm.dynamic-level=" + level]);

--- a/tests/runci/targets/Jvm.hx
+++ b/tests/runci/targets/Jvm.hx
@@ -7,6 +7,7 @@ class Jvm {
 	static public function run(args:Array<String>) {
 		deleteDirectoryRecursively("bin/jvm");
 		Java.getJavaDependencies();
+		haxelibInstallGit("HaxeFoundation", "format", "jvm");
 
 		for (level in 0...3) {
 			final args = args.concat(["-D", "jvm.dynamic-level=" + level]);


### PR DESCRIPTION
This PR improves handling of Java annotations on the JVM target. We now respect Java's retention policy in order to determine which attribute to write annotations to:

* For `@:meta`, we default to `"RUNTIME"`. This seems necessary because there's no way to communicate the retention policy with untyped meta.
* For `@:strict`, we default to `"CLASS"` which is the Java default.
* `@:annotation` now accepts an argument which can either be `"RUNTIME"` or `"CLASS"`, the latter being the default if no argument is provided. If you use a different value you probably get a Java run-time error, so don't do that.

And then, we generate `RuntimeInvisibleAnnotation` if the retention policy is `"CLASS"`, and `RuntimeVisibleAnnotation` otherwise. Same thing for `RuntimeInvisibleParameterAnnotation` and `RuntimeVisibleParameterAnnotation`. 

Closes #11370