### PR TITLE
add support for `--undefine foo` to remove define

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -132,13 +132,13 @@ let parse_args com =
 		("Compilation",["-L";"--library"],["-lib"],Arg.String (fun _ -> ()),"<name[:ver]>","use a haxelib library");
 		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
 			let flag, value = try let split = ExtString.String.split var "=" in (fst split, Some (snd split)) with _ -> var, None in
-			match (value, ExtString.String.starts_with "!" flag) with
-				| (Some value, false) -> Common.external_define_value com flag value
-				| (None, false) -> Common.external_define com flag
-				| (None, true) -> Common.external_undefine com flag
-				| (Some _, true) -> raise (Arg.Bad "Cannot both unset define and specify its value");
-
+			match value with
+				| Some value -> Common.external_define_value com flag value
+				| None -> Common.external_define com flag;
 		),"<var[=value]>","define a conditional compilation flag");
+		("Compilation",["--undefine"],[],Arg.String (fun var ->
+			Common.external_undefine com var
+		),"","remove a conditional compilation flag");
 		("Debug",["-v";"--verbose"],[],Arg.Unit (fun () ->
 			com.verbose <- true
 		),"","turn on verbose mode");

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -132,9 +132,12 @@ let parse_args com =
 		("Compilation",["-L";"--library"],["-lib"],Arg.String (fun _ -> ()),"<name[:ver]>","use a haxelib library");
 		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
 			let flag, value = try let split = ExtString.String.split var "=" in (fst split, Some (snd split)) with _ -> var, None in
-			match value with
-				| Some value -> Common.external_define_value com flag value
-				| None -> Common.external_define com flag;
+			match (value, ExtString.String.starts_with "!" flag) with
+				| (Some value, false) -> Common.external_define_value com flag value
+				| (None, false) -> Common.external_define com flag
+				| (None, true) -> Common.external_undefine com flag
+				| (Some _, true) -> raise (Arg.Bad "Cannot both unset define and specify its value");
+
 		),"<var[=value]>","define a conditional compilation flag");
 		("Debug",["-v";"--verbose"],[],Arg.Unit (fun () ->
 			com.verbose <- true

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -505,6 +505,9 @@ let external_define_value ctx k v =
 let external_define ctx k =
 	Define.raw_define ctx.defines (convert_and_validate k)
 
+let external_undefine ctx k =
+	Define.raw_undefine ctx.defines (convert_and_validate k)
+
 let defines_for_external ctx =
 	PMap.foldi (fun k v acc ->
 		let added_underscore = PMap.add k v acc in

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -134,6 +134,10 @@ let define_value ctx k v =
 let raw_define ctx k =
 	raw_define_value ctx k "1"
 
+let raw_undefine ctx k =
+	ctx.values <- PMap.remove k ctx.values;
+	ctx.defines_signature <- None
+
 let define ctx k =
 	raw_define_value ctx (get_define_key k) "1"
 


### PR DESCRIPTION
~~Note that on unix, outside hxml files we need to escape with single quotes (so `-D '!foo'`)~~

Short syntax isn't worth it