### PR TITLE
Use available terminal columns instead of hardcoded 80 columns

### DIFF
--- a/haxe.opam
+++ b/haxe.opam
@@ -33,4 +33,5 @@ depends: [
   "conf-neko"
   "luv" {>= "0.5.12"}
   "ipaddr"
+  "terminal_size"
 ]

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -2,8 +2,16 @@ open Globals
 open Common
 open CompilationContext
 
+let terminal_width = ref None
+let get_columns = match !terminal_width with
+	| Some w -> w
+	| None ->
+		let width = match Terminal_size.get_columns () with None -> 80 | Some c -> c in
+		terminal_width := Some width;
+		width
+
 let limit_string s offset =
-	let rest = 80 - offset in
+	let rest = get_columns - offset in
 	let words = ExtString.String.nsplit s " " in
 	let rec loop i words = match words with
 		| word :: words ->

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -3,7 +3,7 @@ open Common
 open CompilationContext
 
 let terminal_width = ref None
-let get_columns = match !terminal_width with
+let get_columns () = match !terminal_width with
 	| Some w -> w
 	| None ->
 		let width = match Terminal_size.get_columns () with None -> 80 | Some c -> c in
@@ -11,7 +11,7 @@ let get_columns = match !terminal_width with
 		width
 
 let limit_string s offset =
-	let rest = get_columns - offset in
+	let rest = (get_columns ())- offset in
 	let words = ExtString.String.nsplit s " " in
 	let rec loop i words = match words with
 		| word :: words ->

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -2,16 +2,10 @@ open Globals
 open Common
 open CompilationContext
 
-let terminal_width = ref None
-let get_columns () = match !terminal_width with
-	| Some w -> w
-	| None ->
-		let width = match Terminal_size.get_columns () with None -> 80 | Some c -> c in
-		terminal_width := Some width;
-		width
+let columns = lazy (match Terminal_size.get_columns () with None -> 80 | Some c -> c)
 
 let limit_string s offset =
-	let rest = (get_columns ())- offset in
+	let rest = (Lazy.force columns) - offset in
 	let words = ExtString.String.nsplit s " " in
 	let rec loop i words = match words with
 		| word :: words ->

--- a/src/dune
+++ b/src/dune
@@ -20,7 +20,7 @@
 		extc extproc extlib_leftovers ilib javalib mbedtls neko objsize pcre2 camlp-streams swflib ttflib ziplib
 		json
 		unix ipaddr str bigarray threads dynlink
-		xml-light extlib sha
+		xml-light extlib sha terminal_size
 		luv
 	)
 	(modules (:standard \ haxe))


### PR DESCRIPTION
Using https://github.com/cryptosense/terminal_size, detect available terminal columns instead of hardcoded 80 columns when possible. Helps with help messages, for example.

Haven't tested on windows myself