### PR TITLE
Track actual path position for `path.Path<Params>`

### DIFF
--- a/src/codegen/dotnet.ml
+++ b/src/codegen/dotnet.ml
@@ -145,7 +145,7 @@ let mk_type_path ctx path params =
 			let nested = List.map (netcl_to_hx) nested in
 			ns, Some (String.concat "_" nested ^ "_" ^ netcl_to_hx cl), nhd
 	in
-	CTPath {
+	make_ptp_ct_null {
 		tpackage = fst (netpath_to_hx ctx.nstd (pack,[],""));
 		Ast.tname = name;
 		tparams = params;
@@ -153,12 +153,13 @@ let mk_type_path ctx path params =
 	}
 
 let raw_type_path ctx path params =
-	{
+	let tp = {
 		tpackage = fst path;
 		Ast.tname = snd path;
 		tparams = params;
 		tsub = None;
-	}
+	} in
+	make_ptp tp null_pos
 
 let rec convert_signature ctx p = function
 	| LVoid ->
@@ -577,7 +578,7 @@ let convert_ilprop ctx p prop is_explicit_impl =
 		cff_kind = kind;
 	}
 
-let get_type_path ctx ct = match ct with | CTPath p -> p | _ -> die "" __LOC__
+let get_type_path ctx ct = match ct with | CTPath ptp -> ptp | _ -> die "" __LOC__
 
 let is_explicit ctx ilcls i =
 	let s = match i with
@@ -754,12 +755,12 @@ let convert_ilclass ctx p ?(delegate=false) ilcls = match ilcls.csuper with
 		(match ilcls.csuper with
 			| Some { snorm = LClass ( (["System"],[],"Object"), [] ) } -> ()
 			| Some ({ snorm = LClass ( (["System"],[],"ValueType"), [] ) } as s) ->
-				flags := HExtends (get_type_path ctx (convert_signature ctx p s.snorm),null_pos) :: !flags;
+				flags := HExtends (get_type_path ctx (convert_signature ctx p s.snorm)) :: !flags;
 				meta := (Meta.Struct,[],p) :: !meta
 			| Some { snorm = LClass ( (["haxe";"lang"],[],"HxObject"), [] ) } ->
 				meta := (Meta.HxGen,[],p) :: !meta
 			| Some s ->
-				flags := HExtends (get_type_path ctx (convert_signature ctx p s.snorm),null_pos) :: !flags
+				flags := HExtends (get_type_path ctx (convert_signature ctx p s.snorm)) :: !flags
 			| _ -> ());
 
 			let has_explicit_ifaces = ref false in
@@ -771,9 +772,9 @@ let convert_ilclass ctx p ?(delegate=false) ilcls = match ilcls.csuper with
 				| i ->
 					if is_explicit ctx ilcls i then has_explicit_ifaces := true;
 					flags := if !is_interface then
-						HExtends (get_type_path ctx (convert_signature ctx p i),null_pos) :: !flags
+						HExtends (get_type_path ctx (convert_signature ctx p i)) :: !flags
 					else
-						HImplements (get_type_path ctx (convert_signature ctx p i),null_pos) :: !flags
+						HImplements (get_type_path ctx (convert_signature ctx p i)) :: !flags
 			) ilcls.cimplements;
 			(* this is needed because of explicit interfaces. see http://msdn.microsoft.com/en-us/library/aa288461(v=vs.71).aspx *)
 			(* explicit interfaces can't be mapped into Haxe in any way - since their fields can't be accessed directly, but they still implement that interface *)
@@ -784,9 +785,9 @@ let convert_ilclass ctx p ?(delegate=false) ilcls = match ilcls.csuper with
 			ignore (List.exists (function
 			| { psig = { snorm = LMethod(_,ret,[v]) } } ->
 				flags := if !is_interface then
-					(HExtends( raw_type_path ctx ([],"ArrayAccess") [ TPType (convert_signature ctx p ret,null_pos) ],null_pos) :: !flags)
+					(HExtends( raw_type_path ctx ([],"ArrayAccess") [ TPType (convert_signature ctx p ret,null_pos) ]) :: !flags)
 				else
-					(HImplements( raw_type_path ctx ([],"ArrayAccess") [ TPType (convert_signature ctx p ret,null_pos) ],null_pos) :: !flags);
+					(HImplements( raw_type_path ctx ([],"ArrayAccess") [ TPType (convert_signature ctx p ret,null_pos) ]) :: !flags);
 				true
 			| _ -> false) ilcls.cprops);
 

--- a/src/codegen/java.ml
+++ b/src/codegen/java.ml
@@ -81,7 +81,7 @@ let lookup_jclass com path =
 		| Some p -> Some p
 	) com.native_libs.java_libs None
 
-let mk_type_path ctx path params =
+let mk_type_path ctx path params p =
 	let name, sub = try
 		let p, _ = String.split (snd path) "$" in
 		jname_to_hx p, Some (jname_to_hx (snd path))
@@ -104,31 +104,31 @@ let mk_type_path ctx path params =
 		| _ ->
 			pack, sub, name
 	in
-	make_ptp_ct_null {
+	make_ptp_ct {
 		tpackage = pack;
 		tname = name;
 		tparams = params;
 		tsub = sub;
-	}
+	} p
 
 let has_tparam name params = List.exists(fun (n,_,_) -> n = name) params
 
 let rec convert_arg ctx p arg =
 	match arg with
-	| TAny | TType (WSuper, _) -> TPType (mk_type_path ctx ([], "Dynamic") [],null_pos)
+	| TAny | TType (WSuper, _) -> TPType (mk_type_path ctx ([], "Dynamic") [] p,null_pos)
 	| TType (_, jsig) -> TPType (convert_signature ctx p jsig,null_pos)
 
 and convert_signature ctx p jsig =
 	match jsig with
-	| TByte -> mk_type_path ctx (["java"; "types"], "Int8") []
-	| TChar -> mk_type_path ctx (["java"; "types"], "Char16") []
-	| TDouble -> mk_type_path ctx ([], "Float") []
-	| TFloat -> mk_type_path ctx ([], "Single") []
-	| TInt -> mk_type_path ctx ([], "Int") []
-	| TLong -> mk_type_path ctx (["haxe"], "Int64") []
-	| TShort -> mk_type_path ctx (["java"; "types"], "Int16") []
-	| TBool -> mk_type_path ctx ([], "Bool") []
-	| TObject ( (["haxe";"root"], name), args ) -> mk_type_path ctx ([], name) (List.map (convert_arg ctx p) args)
+	| TByte -> mk_type_path ctx (["java"; "types"], "Int8") [] p
+	| TChar -> mk_type_path ctx (["java"; "types"], "Char16") [] p
+	| TDouble -> mk_type_path ctx ([], "Float") [] p
+	| TFloat -> mk_type_path ctx ([], "Single") [] p
+	| TInt -> mk_type_path ctx ([], "Int") [] p
+	| TLong -> mk_type_path ctx (["haxe"], "Int64") [] p
+	| TShort -> mk_type_path ctx (["java"; "types"], "Int16") [] p
+	| TBool -> mk_type_path ctx ([], "Bool") [] p
+	| TObject ( (["haxe";"root"], name), args ) -> mk_type_path ctx ([], name) (List.map (convert_arg ctx p) args) p
 	(** nullable types *)
 	(* replaced from Null<Type> to the actual abstract type to fix #2738 *)
 	(* | TObject ( (["java";"lang"], "Integer"), [] ) -> mk_type_path ctx ([], "Null") [ TPType (mk_type_path ctx ([], "Int") []) ] *)
@@ -140,34 +140,34 @@ and convert_signature ctx p jsig =
 	(* | TObject ( (["java";"lang"], "Short"), [] ) -> mk_type_path ctx ([], "Null") [ TPType (mk_type_path ctx (["java";"types"], "Int16") []) ] *)
 	(* | TObject ( (["java";"lang"], "Long"), [] ) -> mk_type_path ctx ([], "Null") [ TPType (mk_type_path ctx (["haxe"], "Int64") []) ] *)
 	(** other std types *)
-	| TObject ( (["java";"lang"], "Object"), [] ) -> mk_type_path ctx ([], "Dynamic") []
-	| TObject ( (["java";"lang"], "String"), [] ) -> mk_type_path ctx ([], "String") []
-	| TObject ( (["java";"lang"], "Enum"), [_] ) -> mk_type_path ctx ([], "EnumValue") []
+	| TObject ( (["java";"lang"], "Object"), [] ) -> mk_type_path ctx ([], "Dynamic") [] p
+	| TObject ( (["java";"lang"], "String"), [] ) -> mk_type_path ctx ([], "String") [] p
+	| TObject ( (["java";"lang"], "Enum"), [_] ) -> mk_type_path ctx ([], "EnumValue") [] p
 	(** other types *)
 	| TObject ( path, [] ) ->
 		(match lookup_jclass ctx.jcom path with
-		| Some (jcl, _, _) -> mk_type_path ctx path (List.map (fun _ -> convert_arg ctx p TAny) jcl.ctypes)
-		| None -> mk_type_path ctx path [])
-	| TObject ( path, args ) -> mk_type_path ctx path (List.map (convert_arg ctx p) args)
+		| Some (jcl, _, _) -> mk_type_path ctx path (List.map (fun _ -> convert_arg ctx p TAny) jcl.ctypes) p
+		| None -> mk_type_path ctx path [] p)
+	| TObject ( path, args ) -> mk_type_path ctx path (List.map (convert_arg ctx p) args) p
 	| TObjectInner (pack, (name, params) :: inners) ->
 			let actual_param = match List.rev inners with
 			| (_, p) :: _ -> p
 			| _ -> die "" __LOC__ in
-			mk_type_path ctx (pack, name ^ "$" ^ String.concat "$" (List.map fst inners)) (List.map (fun param -> convert_arg ctx p param) actual_param)
+			mk_type_path ctx (pack, name ^ "$" ^ String.concat "$" (List.map fst inners)) (List.map (fun param -> convert_arg ctx p param) actual_param) p
 	| TObjectInner (pack, inners) -> die "" __LOC__
-	| TArray (jsig, _) -> mk_type_path ctx (["java"], "NativeArray") [ TPType (convert_signature ctx p jsig,null_pos) ]
+	| TArray (jsig, _) -> mk_type_path ctx (["java"], "NativeArray") [ TPType (convert_signature ctx p jsig,null_pos) ] p
 	| TMethod _ -> JReader.error "TMethod cannot be converted directly into Complex Type"
 	| TTypeParameter s -> (match ctx.jtparams with
 		| cur :: others ->
 			if has_tparam s cur then
-				mk_type_path ctx ([], s) []
+				mk_type_path ctx ([], s) [] p
 			else begin
 				if ctx.jcom.verbose && not(List.exists (has_tparam s) others) then print_endline ("Type parameter " ^ s ^ " was not found while building type!");
-				mk_type_path ctx ([], "Dynamic") []
+				mk_type_path ctx ([], "Dynamic") [] p
 			end
 		| _ ->
 			if ctx.jcom.verbose then print_endline ("Empty type parameter stack!");
-			mk_type_path ctx ([], "Dynamic") [])
+			mk_type_path ctx ([], "Dynamic") [] p)
 
 let convert_constant ctx p const =
 	Option.map_default (function
@@ -361,13 +361,13 @@ let convert_java_enum ctx p pe =
 						let hx_sig =
 							match s with
 							| TArray (s1,_) when !is_varargs && !i = args_count && is_eligible_for_haxe_rest_args s1 ->
-								mk_type_path ctx (["haxe"], "Rest") [TPType (convert_signature ctx p s1,null_pos)]
+								mk_type_path ctx (["haxe"], "Rest") [TPType (convert_signature ctx p s1,null_pos)] p
 							| _ ->
 								convert_signature ctx null_pos s
 						in
 						(local_names !i,null_pos), false, [], Some(hx_sig,null_pos), None
 					) args in
-					let t = Option.map_default (convert_signature ctx p) (mk_type_path ctx ([], "Void") []) ret in
+					let t = Option.map_default (convert_signature ctx p) (mk_type_path ctx ([], "Void") [] p) ret in
 					cff_access := (AOverload,p) :: !cff_access;
 					let types = List.map (function
 						| (name, Some ext, impl) ->

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -619,44 +619,46 @@ module SignatureConverter = struct
 
 	let mk_type_path path params =
 		let pack,(mname,name) = jpath_to_hx path in
-		match mname with
+		let path = match mname with
 		| None ->
-			CTPath {
+			{
 				tpackage = pack;
 				tname = name;
 				tparams = params;
 				tsub = None;
 			}
 		| Some mname ->
-			CTPath {
+			{
 				tpackage = pack;
 				tname = mname;
 				tparams = params;
 				tsub = Some name;
 			}
+		in
+		make_ptp_ct_null path
 
-	let ct_type_param name = CTPath {
+	let ct_type_param name = make_ptp_ct_null {
 		tpackage = [];
 		tname = name;
 		tparams = [];
 		tsub = None
 	}
 
-	let ct_void = CTPath {
+	let ct_void = make_ptp_ct_null {
 		tpackage = [];
 		tname = "Void";
 		tparams = [];
 		tsub = None;
 	}
 
-	let ct_dynamic = CTPath {
+	let ct_dynamic = make_ptp_ct_null {
 		tpackage = [];
 		tname = "Dynamic";
 		tparams = [];
 		tsub = None;
 	}
 
-	let ct_string = CTPath {
+	let ct_string = make_ptp_ct_null {
 		tpackage = [];
 		tname = "String";
 		tparams = [];
@@ -936,12 +938,12 @@ module Converter = struct
 			| TObject(([],""),_)
 			| TObject((["java";"lang"],"Object"),_) ->
 				if is_annotation then
-					add_flag (HExtends ({tpackage = ["java";"lang";"annotation"]; tname = "Annotation"; tsub = None; tparams = []},null_pos));
+					add_flag (HExtends (make_ptp {tpackage = ["java";"lang";"annotation"]; tname = "Annotation"; tsub = None; tparams = []} null_pos))
 			| jsig ->
-				add_flag (HExtends (get_type_path (convert_signature ctx p jsig),p))
+				add_flag (HExtends (get_type_path (convert_signature ctx p jsig)))
 		end;
 		List.iter (fun jsig ->
-			let path = (get_type_path (convert_signature ctx p jsig),p) in
+			let path = get_type_path (convert_signature ctx p jsig) in
 			if is_interface then
 				add_flag (HExtends path)
 			else

--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -617,7 +617,7 @@ type java_lib_ctx = {
 module SignatureConverter = struct
 	open PathConverter
 
-	let mk_type_path path params =
+	let mk_type_path path params p =
 		let pack,(mname,name) = jpath_to_hx path in
 		let path = match mname with
 		| None ->
@@ -635,7 +635,7 @@ module SignatureConverter = struct
 				tsub = Some name;
 			}
 		in
-		make_ptp_ct_null path
+		make_ptp_ct path p
 
 	let ct_type_param name = make_ptp_ct_null {
 		tpackage = [];
@@ -667,33 +667,33 @@ module SignatureConverter = struct
 
 	let rec convert_arg ctx p arg =
 		match arg with
-		| TAny | TType (WSuper, _) -> TPType (mk_type_path ([], "Dynamic") [],p)
+		| TAny | TType (WSuper, _) -> TPType (mk_type_path ([], "Dynamic") [] p,p)
 		| TType (_, jsig) -> TPType (convert_signature ctx p jsig,p)
 
 	and convert_signature ctx p jsig =
 		match jsig with
-		| TByte -> mk_type_path (["java"; "types"], "Int8") []
-		| TChar -> mk_type_path (["java"; "types"], "Char16") []
-		| TDouble -> mk_type_path ([], "Float") []
-		| TFloat -> mk_type_path ([], "Single") []
-		| TInt -> mk_type_path ([], "Int") []
-		| TLong -> mk_type_path (["haxe"], "Int64") []
-		| TShort -> mk_type_path (["java"; "types"], "Int16") []
-		| TBool -> mk_type_path ([], "Bool") []
-		| TObject ( (["haxe";"root"], name), args ) -> mk_type_path ([], name) (List.map (convert_arg ctx p) args)
-		| TObject ( (["java";"lang"], "Object"), [] ) -> mk_type_path ([], "Dynamic") []
-		| TObject ( (["java";"lang"], "String"), [] ) -> mk_type_path ([], "String") []
-		| TObject ( (["java";"lang"], "Enum"), [_] ) -> mk_type_path ([], "EnumValue") []
+		| TByte -> mk_type_path (["java"; "types"], "Int8") [] p
+		| TChar -> mk_type_path (["java"; "types"], "Char16") [] p
+		| TDouble -> mk_type_path ([], "Float") [] p
+		| TFloat -> mk_type_path ([], "Single") [] p
+		| TInt -> mk_type_path ([], "Int") [] p
+		| TLong -> mk_type_path (["haxe"], "Int64") [] p
+		| TShort -> mk_type_path (["java"; "types"], "Int16") [] p
+		| TBool -> mk_type_path ([], "Bool") [] p
+		| TObject ( (["haxe";"root"], name), args ) -> mk_type_path ([], name) (List.map (convert_arg ctx p) args) p
+		| TObject ( (["java";"lang"], "Object"), [] ) -> mk_type_path ([], "Dynamic") [] p
+		| TObject ( (["java";"lang"], "String"), [] ) -> mk_type_path ([], "String") [] p
+		| TObject ( (["java";"lang"], "Enum"), [_] ) -> mk_type_path ([], "EnumValue") [] p
 		| TObject ( path, [] ) ->
-			mk_type_path path []
-		| TObject ( path, args ) -> mk_type_path path (List.map (convert_arg ctx p) args)
+			mk_type_path path [] p
+		| TObject ( path, args ) -> mk_type_path path (List.map (convert_arg ctx p) args) p
 		| TObjectInner (pack, (name, params) :: inners) ->
 			let actual_param = match List.rev inners with
 			| (_, p) :: _ -> p
 			| _ -> die "" __LOC__ in
-			mk_type_path (pack, name ^ "$" ^ String.concat "$" (List.map fst inners)) (List.map (fun param -> convert_arg ctx p param) actual_param)
+			mk_type_path (pack, name ^ "$" ^ String.concat "$" (List.map fst inners)) (List.map (fun param -> convert_arg ctx p param) actual_param) p
 		| TObjectInner (pack, inners) -> die "" __LOC__
-		| TArray (jsig, _) -> mk_type_path (["java"], "NativeArray") [ TPType (convert_signature ctx p jsig,p) ]
+		| TArray (jsig, _) -> mk_type_path (["java"], "NativeArray") [ TPType (convert_signature ctx p jsig,p) ] p
 		| TMethod _ -> failwith "TMethod cannot be converted directly into Complex Type"
 		| TTypeParameter s ->
 			try
@@ -702,7 +702,7 @@ module SignatureConverter = struct
 				ct_dynamic
 end
 
-let get_type_path ct = match ct with | CTPath p -> p | _ -> die "" __LOC__
+let get_type_path ct = match ct with | CTPath ptp -> ptp | _ -> die "" __LOC__
 
 module Converter = struct
 
@@ -892,7 +892,7 @@ module Converter = struct
 						let hx_sig =
 							match jsig with
 							| TArray (jsig1,_) when is_varargs && i + 1 = args_count && is_eligible_for_haxe_rest_args jsig1 ->
-								mk_type_path (["haxe"], "Rest") [TPType (convert_signature ctx p jsig1,p)]
+								mk_type_path (["haxe"], "Rest") [TPType (convert_signature ctx p jsig1,p)] p
 							| _ ->
 								convert_signature ctx p jsig
 						in
@@ -938,7 +938,7 @@ module Converter = struct
 			| TObject(([],""),_)
 			| TObject((["java";"lang"],"Object"),_) ->
 				if is_annotation then
-					add_flag (HExtends (make_ptp {tpackage = ["java";"lang";"annotation"]; tname = "Annotation"; tsub = None; tparams = []} null_pos))
+					add_flag (HExtends (make_ptp {tpackage = ["java";"lang";"annotation"]; tname = "Annotation"; tsub = None; tparams = []} p))
 			| jsig ->
 				add_flag (HExtends (get_type_path (convert_signature ctx p jsig)))
 		end;

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -42,18 +42,19 @@ let lowercase_pack pack =
 	loop [] pack
 
 
-let tp_dyn = { tpackage = []; tname = "Dynamic"; tparams = []; tsub = None; }
+let tp_dyn = make_ptp { tpackage = []; tname = "Dynamic"; tparams = []; tsub = None; } null_pos
 
 let ct_dyn = CTPath tp_dyn
 
-let ct_rest = CTPath {
+let ct_rest = make_ptp_ct_null {
 	tpackage = ["haxe"];
 	tname = "Rest";
 	tparams = [TPType (ct_dyn,null_pos)];
 	tsub = None;
 }
 
-let rec make_tpath = function
+let rec make_tpath x =
+	let path = match x with
 	| HMPath (pack,name) ->
 		let pdyn = ref false in
 		let pack, name = match pack, name with
@@ -116,7 +117,10 @@ let rec make_tpath = function
 		die "" __LOC__
 	| HMParams (t,params) ->
 		let params = List.map (fun t -> TPType (CTPath (make_tpath t),null_pos)) params in
-		{ (make_tpath t) with tparams = params }
+		let ptp = make_tpath t in
+		{ptp.path with tparams = params}
+	in
+	make_ptp path null_pos
 
 let make_topt = function
 	| None -> tp_dyn
@@ -126,7 +130,7 @@ let make_type t = CTPath (make_topt t)
 
 let make_dyn_type t =
 	match make_topt t with
-	| { tpackage = ["flash";"utils"]; tname = ("Object"|"Function") } -> make_type None
+	| {path = { tpackage = ["flash";"utils"]; tname = ("Object"|"Function") }} -> make_type None
 	| o -> CTPath o
 
 let is_valid_path com pack name =
@@ -142,7 +146,7 @@ let is_valid_path com pack name =
 	loop com.load_extern_type || (try ignore(Common.find_file com file); true with Not_found -> false)
 
 let build_class com c file =
-	let path = make_tpath c.hlc_name in
+	let path = (make_tpath c.hlc_name).path in
 	let pos = { pfile = file ^ "@" ^ s_type_path (path.tpackage,path.tname); pmin = 0; pmax = 0 } in
 	match path with
 	| { tpackage = ["flash";"utils"]; tname = ("Object"|"Function") } ->
@@ -162,7 +166,7 @@ let build_class com c file =
 	let flags = (match c.hlc_super with
 		| None | Some (HMPath ([],"Object")) -> flags
 		| Some (HMPath ([],"Function")) -> flags (* found in AIR SDK *)
-		| Some s -> HExtends (make_tpath s,null_pos) :: flags
+		| Some s -> HExtends (make_tpath s) :: flags
 	) in
 	let flags = List.map (fun i ->
 		let i = (match i with
@@ -176,9 +180,9 @@ let build_class com c file =
 			| HMPath _ -> i
 			| _ -> die "" __LOC__
 		) in
-		if c.hlc_interface then HExtends (make_tpath i,null_pos) else HImplements (make_tpath i,null_pos)
+		if c.hlc_interface then HExtends (make_tpath i) else HImplements (make_tpath i)
 	) (Array.to_list c.hlc_implements) @ flags in
-	let flags = if c.hlc_sealed || Common.defined com Define.FlashStrict then flags else HImplements (tp_dyn,null_pos) :: flags in
+	let flags = if c.hlc_sealed || Common.defined com Define.FlashStrict then flags else HImplements tp_dyn :: flags in
 	(* make fields *)
 	let getters = Hashtbl.create 0 in
 	let setters = Hashtbl.create 0 in
@@ -209,7 +213,7 @@ let build_class com c file =
 		) in
 		if flags = [] then acc else
 		let flags = if stat then (AStatic,null_pos) :: flags else flags in
-		let name = (make_tpath f.hlf_name).tname in
+		let name = (make_tpath f.hlf_name).path.tname in
 		let mk_meta() =
 			List.map (fun (s,cl) -> s, List.map (fun c -> EConst c,pos) cl, pos) (!meta)
 		in
@@ -395,8 +399,8 @@ let build_class com c file =
 			| [] -> []
 			| f :: l ->
 				match f.cff_kind with
-				| FVar (Some ((CTPath { tpackage = []; tname = ("String" | "Int" | "UInt")} as real_t),_),None)
-				| FProp (("default",_),("never",_),Some ((CTPath { tpackage = []; tname = ("String" | "Int" | "UInt")}) as real_t,_),None) when List.mem_assoc AStatic f.cff_access ->
+				| FVar (Some ((CTPath {path = { tpackage = []; tname = ("String" | "Int" | "UInt")}} as real_t),_),None)
+				| FProp (("default",_),("never",_),Some ((CTPath { path = { tpackage = []; tname = ("String" | "Int" | "UInt")}}) as real_t,_),None) when List.mem_assoc AStatic f.cff_access ->
 					(match !real_type with
 					| None ->
 						real_type := Some real_t
@@ -457,7 +461,7 @@ let extract_data (_,tags) =
 	let loop_field f =
 		match f.hlf_kind with
 		| HFClass c ->
-			let path = make_tpath f.hlf_name in
+			let path = (make_tpath f.hlf_name).path in
 			(match path with
 			| { tpackage = []; tname = "Float" | "Bool" | "Int" | "UInt" | "Dynamic" } -> ()
 			| { tpackage = _; tname = "MethodClosure" } -> ()
@@ -650,7 +654,7 @@ let remove_classes toremove lib l =
 						let loop f =
 							match f.hlf_kind with
 							| HFClass _ ->
-								let path = make_tpath f.hlf_name in
+								let path = (make_tpath f.hlf_name).path in
 								not (List.mem (path.tpackage,path.tname) classes)
 							| _ -> true
 						in

--- a/src/compiler/retyper.ml
+++ b/src/compiler/retyper.ml
@@ -89,16 +89,16 @@ let pair_classes rctx c d p =
 		let has_extends = ref false in
 		let implements = ref c.cl_implements in
 		List.iter (function
-			| HExtends(path,p) ->
+			| HExtends ptp ->
 				has_extends := true;
 				begin match c.cl_super with
 				| None ->
-					fail rctx (Printf.sprintf "parent %s appeared" (Ast.Printer.s_complex_type_path "" (path,p)))
+					fail rctx (Printf.sprintf "parent %s appeared" (Ast.Printer.s_complex_type_path "" ptp))
 				| Some(c,tl) ->
-					let th = pair_type (Some(CTPath path,p)) (TInst(c,tl)) in
+					let th = pair_type (Some(CTPath ptp,ptp.pos_full)) (TInst(c,tl)) in
 					ignore (disable_typeloading rctx ctx (fun () -> Typeload.load_complex_type ctx false th))
 				end
-			| HImplements(path,p) ->
+			| HImplements ptp ->
 				begin match !implements with
 					| (c,tl) :: rest ->
 						(* TODO: I think this should somehow check if it's actually the same interface. There could be cases
@@ -106,10 +106,10 @@ let pair_classes rctx c d p =
 						   However, this doesn't matter until we start retyping invalidated modules.
 						*)
 						implements := rest;
-						let th = pair_type (Some(CTPath path,p)) (TInst(c,tl)) in
+						let th = pair_type (Some(CTPath ptp,ptp.pos_full)) (TInst(c,tl)) in
 						ignore (disable_typeloading rctx ctx (fun () -> Typeload.load_complex_type ctx false th));
 					| [] ->
-						fail rctx (Printf.sprintf "interface %s appeared" (Ast.Printer.s_complex_type_path "" (path,p)))
+						fail rctx (Printf.sprintf "interface %s appeared" (Ast.Printer.s_complex_type_path "" ptp))
 				end
 			| _ ->
 				()

--- a/src/context/display/display.ml
+++ b/src/context/display/display.ml
@@ -127,12 +127,12 @@ module ExprPreprocessing = struct
 			| ECall(e1,el) when is_annotated (pos e) && is_completion ->
 				let el = loop_el el in
 				ECall(e1,el),(pos e)
-			| ENew((tp,pp),el) when is_annotated (pos e) && is_completion ->
-				if is_annotated pp || pp.pmax >= (DisplayPosition.display_position#get).pmax then
+			| ENew(ptp,el) when is_annotated (pos e) && is_completion ->
+				if is_annotated ptp.pos_full || ptp.pos_full.pmax >= (DisplayPosition.display_position#get).pmax then
 					annotate_marked e
 				else begin
 					let el = loop_el el in
-					ENew((tp,pp),el),(pos e)
+					ENew(ptp,el),(pos e)
 				end
 			| EArrayDecl el when is_annotated (pos e) && is_completion ->
 				let el = loop_el el in

--- a/src/context/display/displayEmitter.ml
+++ b/src/context/display/displayEmitter.ml
@@ -66,20 +66,13 @@ let rec display_type ctx t p =
 			| _ ->
 				()
 
-let check_display_type ctx t path =
+let check_display_type ctx t ptp =
 	let add_type_hint () =
-		ctx.g.type_hints <- (ctx.m.curmod.m_extra.m_display,pos path,t) :: ctx.g.type_hints;
+		ctx.g.type_hints <- (ctx.m.curmod.m_extra.m_display,ptp.pos_full,t) :: ctx.g.type_hints;
 	in
 	let maybe_display_type () =
-		if ctx.is_display_file && display_position#enclosed_in (pos path) then
-			let p =
-				match path with
-				| ({ tpackage = pack; tname = name; tsub = sub },p) ->
-					let strings = match sub with None -> name :: pack | Some s -> s :: name :: pack in
-					let length = String.length (String.concat "." strings) in
-					{ p with pmax = p.pmin + length }
-			in
-			display_type ctx t p
+		if ctx.is_display_file && display_position#enclosed_in ptp.pos_full then
+			display_type ctx t ptp.pos_path
 	in
 	add_type_hint();
 	maybe_display_type()

--- a/src/context/display/displayTexpr.ml
+++ b/src/context/display/displayTexpr.ml
@@ -89,8 +89,8 @@ let check_display_class ctx decls c =
 		let sc = find_class_by_position decls c.cl_name_pos in
 		ignore(Typeload.type_type_params ctx TPHType c.cl_path (fun() -> c.cl_params) null_pos sc.d_params);
 		List.iter (function
-			| (HExtends(ct,p) | HImplements(ct,p)) when display_position#enclosed_in p ->
-				ignore(Typeload.load_instance ~allow_display:true ctx (ct,p) ParamNormal)
+			| (HExtends ptp | HImplements ptp) when display_position#enclosed_in ptp.pos_full ->
+				ignore(Typeload.load_instance ~allow_display:true ctx ptp ParamNormal)
 			| _ ->
 				()
 		) sc.d_flags;

--- a/src/context/display/syntaxExplorer.ml
+++ b/src/context/display/syntaxExplorer.ml
@@ -29,7 +29,7 @@ let find_in_syntax symbols (pack,decls) =
 					()
 		) symbols
 	in
-	let rec type_path kind path =
+	let rec type_path kind { path } =
 		check KModuleType path.tname;
 		Option.may (check KModuleType) path.tsub;
 		List.iter (function
@@ -45,7 +45,7 @@ let find_in_syntax symbols (pack,decls) =
 		| CTAnonymous cffl ->
 			List.iter field cffl
 		| CTExtend(tl,cffl) ->
-			List.iter (fun (path,_) -> type_path KModuleType path) tl;
+			List.iter (fun ptp -> type_path KModuleType ptp) tl;
 			List.iter field cffl;
 		| CTIntersection tl ->
 			List.iter type_hint tl
@@ -67,8 +67,8 @@ let find_in_syntax symbols (pack,decls) =
 		| ECast(e1,tho) ->
 			expr e1;
 			Option.may type_hint tho;
-		| ENew((path,_),el) ->
-			type_path KConstructor path;
+		| ENew(ptp,el) ->
+			type_path KConstructor ptp;
 			List.iter expr el;
 		| EFunction(_,f) ->
 			func f
@@ -129,7 +129,7 @@ let find_in_syntax symbols (pack,decls) =
 		| EClass d ->
 			check KModuleType (fst d.d_name);
 			List.iter (function
-				| HExtends(path,_) | HImplements(path,_) -> type_path KModuleType path
+				| HExtends ptp | HImplements ptp -> type_path KModuleType ptp
 				| _ -> ()
 			) d.d_flags;
 			List.iter type_param d.d_params;

--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -159,14 +159,18 @@ type type_path = {
 	tsub : string option;
 }
 
-and placed_type_path = type_path * pos
+and placed_type_path = {
+	path : type_path;
+	pos_full : pos;
+	pos_path : pos;
+}
 
 and type_param_or_const =
 	| TPType of type_hint
 	| TPExpr of expr
 
 and complex_type =
-	| CTPath of type_path
+	| CTPath of placed_type_path
 	| CTFunction of type_hint list * type_hint
 	| CTAnonymous of class_field list
 	| CTParent of type_hint
@@ -327,9 +331,6 @@ and evar = {
 	ev_meta : metadata;
 }
 
-(* TODO: should we introduce CTMono instead? *)
-let ct_mono = CTPath { tpackage = ["$"]; tname = "_hx_mono"; tparams = []; tsub = None }
-
 type enum_flag =
 	| EPrivate
 	| EExtern
@@ -404,6 +405,26 @@ let mk_evar ?(final=false) ?(static=false) ?(t:type_hint option) ?eo ?(meta=[]) 
 		ev_expr = eo;
 		ev_meta = meta;
 	}
+
+let make_ptp path ?p_path p_full = {
+	path = path;
+	pos_full = p_full;
+	pos_path = Option.default p_full p_path;
+}
+
+let make_ptp_ct path ?p_path p_full =
+	CTPath (make_ptp path ?p_path p_full)
+
+let make_ptp_ct_null path =
+	CTPath (make_ptp path null_pos)
+
+let make_ptp_th path ?p_path p_full =
+	(make_ptp_ct path ?p_path p_full,p_full)
+
+let make_ptp_th_null path =
+	make_ptp_th path null_pos
+
+let ct_mono = make_ptp_ct_null { tpackage = ["$"]; tname = "_hx_mono"; tparams = []; tsub = None }
 
 let is_lower_ident i =
 	if String.length i = 0 then
@@ -692,7 +713,7 @@ let map_expr loop (e,p) =
 				FProp (get,set,t,e))
 		}
 	and type_hint (t,p) = (match t with
-		| CTPath t -> CTPath { t with tparams = List.map tparam t.tparams }
+		| CTPath ptp -> CTPath { ptp with path = { ptp.path with tparams = List.map tparam ptp.path.tparams }}
 		| CTFunction (cl,c) ->
 			let cl = List.map type_hint cl in
 			let c = type_hint c in
@@ -727,7 +748,7 @@ let map_expr loop (e,p) =
 			f_type = t;
 			f_expr = e;
 		}
-	and tpath (t,p) = { t with tparams = List.map tparam t.tparams },p
+	and tpath ptp = { ptp with path = { ptp.path with tparams = List.map tparam ptp.path.tparams }}
 	in
 	let e = (match e with
 	| EConst _ -> e
@@ -896,7 +917,7 @@ module Printer = struct
 		| EDisplay (e1,dk) -> Printf.sprintf "#DISPLAY(%s, %s)" (s_expr_inner tabs e1) (s_display_kind dk)
 	and s_expr_list tabs el sep =
 		(String.concat sep (List.map (s_expr_inner tabs) el))
-	and s_complex_type_path tabs (t,_) =
+	and s_complex_type_path tabs {path = t} =
 		Printf.sprintf "%s%s%s"
 			(s_type_path (t.tpackage,t.tname))
 			(Option.map_default (fun s -> "." ^ s) "" t.tsub)
@@ -911,7 +932,7 @@ module Printer = struct
 		| TPExpr e -> s_expr_inner tabs e
 	and s_complex_type tabs ct =
 		match ct with
-		| CTPath t -> s_complex_type_path tabs (t,null_pos)
+		| CTPath ptp -> s_complex_type_path tabs ptp
 		| CTFunction (cl,(c,_)) -> if List.length cl > 0 then String.concat " -> " (List.map (fun (t,_) -> s_complex_type tabs t) cl) else "Void" ^ " -> " ^ s_complex_type tabs c
 		| CTAnonymous fl -> "{ " ^ String.concat "; " (List.map (s_class_field tabs) fl) ^ "}";
 		| CTParent(t,_) -> "(" ^ s_complex_type tabs t ^ ")"
@@ -1116,7 +1137,7 @@ module Expr = struct
 				add "ECall";
 				loop e1;
 				List.iter loop el
-			| ENew((tp,_),el) ->
+			| ENew({path = tp},el) ->
 				add ("ENew " ^ s_type_path(tp.tpackage,tp.tname));
 				List.iter loop el
 			| EUnop(op,_,e1) ->

--- a/src/core/inheritDoc.ml
+++ b/src/core/inheritDoc.ml
@@ -34,8 +34,8 @@ let rec get_class_field c field_name =
 		| None -> raise Not_found
 		| Some (csup, _) -> get_class_field csup field_name
 
-let find_type ctx tp =
-	try Typeload.load_instance' ctx tp ParamSpawnMonos
+let find_type ctx (tp,p) =
+	try Typeload.load_instance' ctx (make_ptp tp p) ParamSpawnMonos
 	with _ -> raise Not_found
 
 (**

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -645,8 +645,8 @@ module Printer = struct
 		| HInterface -> "HInterface"
 		| HExtern -> "HExtern"
 		| HPrivate -> "HPrivate"
-		| HExtends tp -> "HExtends " ^ (s_type_path (fst tp))
-		| HImplements tp -> "HImplements " ^ (s_type_path (fst tp))
+		| HExtends ptp -> "HExtends " ^ (s_type_path ptp.path)
+		| HImplements ptp -> "HImplements " ^ (s_type_path ptp.path)
 		| HFinal -> "HFinal"
 		| HAbstract -> "HAbstract"
 

--- a/src/filters/exceptions.ml
+++ b/src/filters/exceptions.ml
@@ -525,11 +525,13 @@ let filter tctx =
 	| Php | Js | Java | Cs | Python | Lua | Eval | Neko | Flash | Hl | Cpp ->
 		let config = tctx.com.config.pf_exceptions in
 		let tp (pack,name) =
-			match List.rev pack with
+			let tp = match List.rev pack with
 			| module_name :: pack_rev when not (Ast.is_lower_ident module_name) ->
-				(mk_type_path ~sub:name (List.rev pack_rev,module_name), null_pos)
+				mk_type_path ~sub:name (List.rev pack_rev,module_name)
 			| _ ->
-				(mk_type_path (pack,name), null_pos)
+				mk_type_path (pack,name)
+			in
+			make_ptp tp null_pos
 		in
 		let wildcard_catch_type =
 			let t = Typeload.load_instance tctx (tp config.ec_wildcard_catch) ParamSpawnMonos in
@@ -664,7 +666,7 @@ let insert_save_stacks tctx =
 	Adds `this.__shiftStack()` calls to constructors of classes which extend `haxe.Exception`
 *)
 let patch_constructors tctx =
-	let tp = (mk_type_path haxe_exception_type_path, null_pos) in
+	let tp = make_ptp (mk_type_path haxe_exception_type_path) null_pos in
 	match Typeload.load_instance tctx tp ParamSpawnMonos with
 	(* Add only if `__shiftStack` method exists *)
 	| TInst(cls,_) when PMap.mem "__shiftStack" cls.cl_fields ->

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -351,12 +351,13 @@ let rec expr_to_value ctx env e =
 			if flag = DoWhile then ignore(loop e2);
 			loop2();
 			vnull
-		| ENew((tp,_),el) ->
+		| ENew(ptp,el) ->
 			let rec loop2 v sl = match sl with
 				| [] -> v
 				| s :: sl ->
 					loop2 (EvalField.field v (hash s)) sl
 			in
+			let tp = ptp.path in
 			let v1 = loop2 ctx.toplevel tp.tpackage in
 			let v1 = loop2 v1 [match tp.tsub with None -> tp.tname | Some s -> s] in
 			let vl = List.map loop el in

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -290,13 +290,19 @@ let encode_path (p,n) =
 	]
 
 (* Ast.placed_type_path *)
-let rec encode_ast_path (t,p) =
+let rec encode_ast_path ptp =
+	let t = ptp.path in
 	let fields = [
 		"pack", encode_array (List.map encode_string t.tpackage);
 		"name", encode_string t.tname;
 		"params", encode_array (List.map encode_tparam t.tparams);
-		"pos", encode_pos p;
+		"pos", encode_pos ptp.pos_full;
 	] in
+	let fields = if ptp.pos_full <> ptp.pos_path then
+		("posPath", encode_pos ptp.pos_path) :: fields
+	else
+		fields
+	in
 	encode_obj (match t.tsub with
 		| None -> fields
 		| Some s -> ("sub", encode_string s) :: fields)
@@ -351,8 +357,8 @@ and encode_field (f:class_field) =
 
 and encode_ctype t =
 	let tag, pl = match fst t with
-	| CTPath p ->
-		0, [encode_ast_path (p,Globals.null_pos)]
+	| CTPath ptp ->
+		0, [encode_ast_path ptp]
 	| CTFunction (pl,r) ->
 		1, [encode_array (List.map encode_ctype pl);encode_ctype r]
 	| CTAnonymous fl ->
@@ -744,12 +750,15 @@ let decode_opt_array f v =
 
 (* Ast.placed_type_path *)
 let rec decode_ast_path t =
-	let p = field t "pos" in
 	let pack = List.map decode_string (decode_array (field t "pack"))
 	and name = decode_string (field t "name")
 	and params = decode_opt_array decode_tparam (field t "params")
 	and sub = opt decode_string (field t "sub") in
-	mk_type_path ~params ?sub (pack,name), if p = vnull then Globals.null_pos else decode_pos p
+	let p_full = field t "pos" in
+	let p_full = if p_full = vnull then Globals.null_pos else decode_pos p_full in
+	let p_path = field t "posPath" in
+	let p_path = if p_path = vnull then Globals.null_pos else decode_pos p_path in
+	make_ptp (mk_type_path ~params ?sub (pack,name)) ~p_path p_full
 
 and decode_tparam v =
 	match decode_enum v with
@@ -842,7 +851,7 @@ and decode_ctype t =
 	let (i,args),p = decode_enum_with_pos t in
 	(match i,args with
 	| 0, [p] ->
-		CTPath (fst (decode_ast_path p))
+		CTPath (decode_ast_path p)
 	| 1, [a;r] ->
 		CTFunction (List.map decode_ctype (decode_array a), decode_ctype r)
 	| 2, [fl] ->
@@ -2174,7 +2183,7 @@ let macro_api ccom get_api =
 			encode_type t
 		);
 		"define_module", vfun4 (fun path vl ui ul ->
-			(get_api()).define_module (decode_string path) (decode_array vl) (List.map decode_import (decode_array ui)) (List.map fst (List.map decode_ast_path (decode_array ul)));
+			(get_api()).define_module (decode_string path) (decode_array vl) (List.map decode_import (decode_array ui)) (List.map (fun ptp -> ptp.path) (List.map decode_ast_path (decode_array ul)));
 			vnull
 		);
 		"add_class_path", vfun1 (fun cp ->

--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -193,18 +193,18 @@ and parse_class_content doc meta flags n p1 s =
 				syntax_completion (if List.mem HInterface n then SCInterfaceRelation else SCClassRelation) None (display_position#with_pos p1)
 		in
 		match s with parser
-		| [< '(Kwd Extends,p1); t,b = parse_type_path_or_resume p1 >] ->
+		| [< '(Kwd Extends,p1); ptp,b = parse_type_path_or_resume p1 >] ->
 			check_display {p1 with pmin = p0.pmax; pmax = p1.pmin};
-			let p0 = pos t in
+			let p0 = ptp.pos_full in
 			(* If we don't have type parameters, we have to offset by one so to not complete `extends`
 				and `implements` after the identifier. *)
-			let p0 = {p0 with pmax = p0.pmax + (if (fst t).tparams = [] then 1 else 0)} in
-			loop (had_display || b) p0 ((HExtends t) :: acc)
-		| [< '(Kwd Implements,p1); t,b = parse_type_path_or_resume p1 >] ->
+			let p0 = {p0 with pmax = p0.pmax + (if ptp.path.tparams = [] then 1 else 0)} in
+			loop (had_display || b) p0 ((HExtends ptp) :: acc)
+		| [< '(Kwd Implements,p1); ptp,b = parse_type_path_or_resume p1 >] ->
 			check_display {p1 with pmin = p0.pmax; pmax = p1.pmin};
-			let p0 = pos t in
-			let p0 = {p0 with pmax = p0.pmax + (if (fst t).tparams = [] then 1 else 0)} in
-			loop (had_display || b) p0 ((HImplements t) :: acc)
+			let p0 = ptp.pos_full in
+			let p0 = {p0 with pmax = p0.pmax + (if ptp.path.tparams = [] then 1 else 0)} in
+			loop (had_display || b) p0 ((HImplements ptp) :: acc)
 		| [< '(BrOpen,p1) >] ->
 			check_display {p1 with pmin = p0.pmax; pmax = p1.pmin};
 			List.rev acc
@@ -446,7 +446,7 @@ and parse_abstract_relations s =
 		if !in_display_file && p1.pmax < (display_position#get).pmin && p2.pmin >= (display_position#get).pmax then
 			(* This means we skipped the display position between the to/from and the type-hint we parsed.
 			   Very weird case, it was probably a {} like in #7137. Let's discard it and use magic. *)
-			((CTPath magic_type_path,display_position#with_pos p2))
+			(magic_type_th (display_position#with_pos p2))
 		else
 			(ct,p2)
 	in
@@ -629,7 +629,7 @@ and parse_complex_type_at p = parser
 	| [< t = parse_complex_type >] -> t
 	| [< s >] ->
 		if would_skip_display_position p false s then
-			CTPath magic_type_path,display_position#with_pos p
+			(magic_type_th (display_position#with_pos p))
 		else
 			serror()
 
@@ -638,9 +638,8 @@ and parse_type_hint = parser
 		let f () = parse_complex_type_at p1 s in
 		check_resume_range p1 s
 			(fun p2 ->
-				let ct = CTPath magic_type_path in
 				pignore(f);
-				ct,display_position#with_pos p1
+				magic_type_th (display_position#with_pos p1)
 			)
 			f
 
@@ -682,8 +681,10 @@ and parse_structural_extension = parser
 					| [< '(Comma,_) >] -> ()
 					| [< >] -> ()
 				end;
-				magic_type_path,display_position#with_pos p1
-			end else raise Stream.Failure
+				let p = display_position#with_pos p1 in
+				make_ptp magic_type_path p
+			end else
+				raise Stream.Failure
 
 and parse_complex_type_inner allow_named = parser
 	| [< '(POpen,p1); t = parse_complex_type; '(PClose,p2) >] -> CTParent t,punion p1 p2
@@ -705,7 +706,8 @@ and parse_complex_type_inner allow_named = parser
 			| CTNamed (_,hint) -> hint
 			| _ -> (t,p2)
 		in
-		CTPath (mk_type_path ~params:[TPType hint] (["haxe"],"Rest")),punion p1 p2
+		let p = punion p1 p2 in
+		CTPath (make_ptp (mk_type_path ~params:[TPType hint] (["haxe"],"Rest")) p),p
 	| [< n = dollar_ident; s >] ->
 		(match s with parser
 		| [< '(DblDot,_) when allow_named; t = parse_complex_type >] ->
@@ -714,10 +716,10 @@ and parse_complex_type_inner allow_named = parser
 			CTNamed (n,t),punion p1 p2
 		| [< s >] ->
 			let n,p = n in
-			let t,p = parse_type_path2 None [] n p s in
-			CTPath t,p)
-	| [< t,p = parse_type_path >] ->
-		CTPath t,p
+			let ptp = parse_type_path2 None [] n p s in
+			CTPath ptp,ptp.pos_full)
+	| [< ptp = parse_type_path >] ->
+		CTPath ptp,ptp.pos_full
 
 and parse_type_path s = parse_type_path1 None [] s
 
@@ -725,14 +727,14 @@ and parse_type_path1 p0 pack = parser
 	| [< name, p1 = dollar_ident_macro pack; s >] ->
 		parse_type_path2 p0 pack name p1 s
 
-and parse_type_path2 p0 pack name p1 s =
+and parse_type_path2 p0 pack name p1 s : placed_type_path =
 	let check_display f =
 		let p = match p0 with
 			| None -> p1
 			| Some p -> punion p p1
 		in
 		if !in_display_file && display_position#enclosed_in p then begin
-			mk_type_path (List.rev pack,name), p
+			make_ptp (mk_type_path (List.rev pack,name)) p
 		end else
 			f()
 	in
@@ -756,6 +758,8 @@ and parse_type_path2 p0 pack name p1 s =
 					| [< >] -> serror()))
 			| [< >] -> None,p1
 		) in
+		let p1 = match p0 with None -> p1 | Some p -> p in
+		let p_path = punion p1 p2 in
 		let params,p2 = (match s with parser
 			| [< '(Binop OpLt,plt); l = psep Comma (parse_type_path_or_const plt) >] ->
 				begin match s with parser
@@ -766,8 +770,8 @@ and parse_type_path2 p0 pack name p1 s =
 			| [< >] -> [],p2
 		) in
 		let tp = mk_type_path ~params ?sub (List.rev pack,name)
-		and pos = punion (match p0 with None -> p1 | Some p -> p) p2 in
-		tp,pos
+		and p_full = punion p1 p2 in
+		make_ptp tp ~p_path p_full
 
 and type_name = parser
 	| [< '(Const (Ident name),p); s >] ->
@@ -790,8 +794,7 @@ and parse_type_path_or_const plt = parser
 	| [< s >] ->
 		if !in_display_file then begin
 			if would_skip_display_position plt false s then begin
-				let ct = CTPath magic_type_path in
-				TPType (ct,display_position#with_pos plt)
+				TPType (magic_type_th (display_position#with_pos plt))
 			end else
 				raise Stream.Failure
 		end else
@@ -816,8 +819,8 @@ and parse_complex_type_next (t : type_hint) s =
 		| [< t2,p2 = parse_complex_type >] -> make_fun t2 p2
 		| [< >] ->
 			if would_skip_display_position pa false s then begin
-				let ct = CTPath magic_type_path in
-				make_fun ct (display_position#with_pos pa)
+				let p = display_position#with_pos pa in
+				make_fun (magic_type_ct p) p
 			end else serror()
 		end
 	| [< '(Binop OpAnd,pa); s >] ->
@@ -825,8 +828,8 @@ and parse_complex_type_next (t : type_hint) s =
 		| [< t2,p2 = parse_complex_type >] -> make_intersection t2 p2
 		| [< >] ->
 			if would_skip_display_position pa false s then begin
-				let ct = CTPath magic_type_path in
-				make_intersection ct (display_position#with_pos pa)
+				let p = display_position#with_pos pa in
+				make_intersection (magic_type_ct p) p
 			end else serror()
 		end
 	| [< >] -> t
@@ -836,7 +839,7 @@ and parse_function_type_next tl p1 = parser
 		begin match s with parser
 		| [< tret = parse_complex_type_inner false >] -> CTFunction (tl,tret), punion p1 (snd tret)
 		| [< >] -> if would_skip_display_position pa false s then begin
-				let ct = (CTPath magic_type_path),(display_position#with_pos pa) in
+				let ct = magic_type_th (display_position#with_pos pa) in
 				CTFunction (tl,ct), punion p1 pa
 			end else serror()
 		end
@@ -1035,7 +1038,7 @@ and parse_fun_param s =
 	| [< name, pn = dollar_ident; t = popt parse_type_hint; c = parse_fun_param_value >] -> ((name,pn),false,meta,t,c)
 	| [< '(Spread,_); name, pn = dollar_ident; t = popt parse_type_hint; c = parse_fun_param_value >] ->
 		let t = match t with Some t -> t | None -> (ct_mono,null_pos) in
-		let t = CTPath (mk_type_path ~params:[TPType t] (["haxe"],"Rest")), snd t in
+		let t = CTPath (make_ptp (mk_type_path ~params:[TPType t] (["haxe"],"Rest")) (snd t)),(snd t) in
 		((name,pn),false,meta,Some t,c)
 
 and parse_fun_param_value = parser
@@ -1091,9 +1094,10 @@ and parse_constraint_param s =
 
 and parse_type_path_or_resume p1 s =
 	let check_resume exc =
-		if would_skip_display_position p1 true s then
-			(magic_type_path,display_position#with_pos p1),true
-		else
+		if would_skip_display_position p1 true s then begin
+			let p = display_position#with_pos p1 in
+			make_ptp magic_type_path p,true
+		end else
 			raise exc
 	in
 	try
@@ -1281,7 +1285,8 @@ and parse_macro_expr p = parser
 	| [< '(DblDot,_); t = parse_complex_type >] ->
 		let _, to_type, _  = reify !in_macro in
 		let t = to_type t p in
-		(ECheckType (t,(CTPath (mk_type_path ~sub:"ComplexType" (["haxe";"macro"],"Expr")),null_pos)),p)
+		let ct = make_ptp_ct_null (mk_type_path ~sub:"ComplexType" (["haxe";"macro"],"Expr")) in
+		(ECheckType (t,(ct,p)),p)
 	| [< '(Kwd Var,p1); vl = psep Comma (parse_var_decl false) >] ->
 		reify_expr (EVars vl,p1) !in_macro
 	| [< '(Kwd Final,p1); s >] ->
@@ -1294,7 +1299,8 @@ and parse_macro_expr p = parser
 		end
 	| [< d = parse_class None [] [] false >] ->
 		let _,_,to_type = reify !in_macro in
-		(ECheckType (to_type d,(CTPath (mk_type_path ~sub:"TypeDefinition" (["haxe";"macro"],"Expr")),null_pos)),p)
+		let ct = make_ptp_ct_null (mk_type_path ~sub:"TypeDefinition" (["haxe";"macro"],"Expr")) in
+		(ECheckType (to_type d,(ct,null_pos)),p)
 	| [< e = secure_expr >] ->
 		reify_expr e !in_macro
 
@@ -1438,7 +1444,7 @@ and expr = parser
 		begin match s with parser
 		| [< '(POpen,po); e = parse_call_params (fun el p2 -> (ENew(t,el)),punion p1 p2) po >] -> expr_next e s
 		| [< >] ->
-			syntax_error (Expected ["("]) s (ENew(t,[]),punion p1 (pos t))
+			syntax_error (Expected ["("]) s (ENew(t,[]),punion p1 t.pos_full)
 		end
 	| [< '(POpen,p1); s >] -> (match s with parser
 		| [< '(PClose,p2); er = arrow_expr; >] ->

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -244,6 +244,10 @@ let serror() = raise (Stream.Error "")
 let magic_display_field_name = " - display - "
 let magic_type_path = { tpackage = []; tname = ""; tparams = []; tsub = None }
 
+let magic_type_ct p = make_ptp_ct magic_type_path p
+
+let magic_type_th p = magic_type_ct p,p
+
 let delay_syntax_completion kind so p =
 	delayed_syntax_completion := Some(kind,DisplayTypes.make_subject so p)
 

--- a/src/syntax/reification.ml
+++ b/src/syntax/reification.ml
@@ -105,7 +105,9 @@ let reify in_macro =
 			| TPExpr e -> "TPExpr", to_expr e p
 		) in
 		mk_enum "TypeParam" n [v] p
-	and to_tpath (t,_) p =
+	and to_tpath ptp =
+		let t = ptp.path in
+		let p = ptp.pos_full in
 		let len = String.length t.tname in
 		if t.tpackage = [] && len > 1 && t.tname.[0] = '$' then begin
 			let name = String.sub t.tname 1 (len - 1) in
@@ -134,13 +136,13 @@ let reify in_macro =
 	and to_ctype t p =
 		let ct n vl = mk_enum "ComplexType" n vl p in
 		match fst t with
-		| CTPath ({ tpackage = []; tparams = []; tsub = None; tname = n }) when n.[0] = '$' ->
+		| CTPath ({ path = {tpackage = []; tparams = []; tsub = None; tname = n }}) when n.[0] = '$' ->
 			to_string n p
-		| CTPath t -> ct "TPath" [to_tpath (t,p) p]
+		| CTPath t -> ct "TPath" [to_tpath t]
 		| CTFunction (args,ret) -> ct "TFunction" [to_array to_type_hint args p; to_type_hint ret p]
 		| CTAnonymous fields -> ct "TAnonymous" [to_array to_cfield fields p]
 		| CTParent t -> ct "TParent" [to_type_hint t p]
-		| CTExtend (tl,fields) -> ct "TExtend" [to_array to_tpath tl p; to_array to_cfield fields p]
+		| CTExtend (tl,fields) -> ct "TExtend" [to_array (fun ptp _ -> to_tpath ptp) tl p; to_array to_cfield fields p]
 		| CTOptional t -> ct "TOptional" [to_type_hint t p]
 		| CTNamed (n,t) -> ct "TNamed" [to_placed_name n; to_type_hint t p]
 		| CTIntersection tl -> ct "TIntersection" [to_array to_ctype tl p]
@@ -277,8 +279,8 @@ let reify in_macro =
 			expr "EArrayDecl" [to_expr_array el p]
 		| ECall (e,el) ->
 			expr "ECall" [loop e;to_expr_array el p]
-		| ENew (t,el) ->
-			expr "ENew" [to_tpath t p;to_expr_array el p]
+		| ENew (ptp,el) ->
+			expr "ENew" [to_tpath ptp;to_expr_array el p]
 		| EUnop (op,flag,e) ->
 			let op = mk_enum "Unop" (match op with
 				| Increment -> "OpIncrement"
@@ -359,9 +361,9 @@ let reify in_macro =
 			(* TODO: can $v and $i be implemented better? *)
 			| Meta.Dollar "v", _ ->
 				begin match fst e1 with
-				| EParenthesis (ECheckType (e2, (CTPath{tname="String";tpackage=[]},_)),_) -> expr "EConst" [mk_enum "Constant" "CString" [e2] (pos e2)]
-				| EParenthesis (ECheckType (e2, (CTPath{tname="Int";tpackage=[]},_)),_) -> expr "EConst" [mk_enum "Constant" "CInt" [e2] (pos e2)]
-				| EParenthesis (ECheckType (e2, (CTPath{tname="Float";tpackage=[]},_)),_) -> expr "EConst" [mk_enum "Constant" "CFloat" [e2] (pos e2)]
+				| EParenthesis (ECheckType (e2, (CTPath({path = {tname="String";tpackage=[]}}),_)),_) -> expr "EConst" [mk_enum "Constant" "CString" [e2] (pos e2)]
+				| EParenthesis (ECheckType (e2, (CTPath({path = {tname="Int";tpackage=[]}}),_)),_) -> expr "EConst" [mk_enum "Constant" "CInt" [e2] (pos e2)]
+				| EParenthesis (ECheckType (e2, (CTPath({path = {tname="Float";tpackage=[]}}),_)),_) -> expr "EConst" [mk_enum "Constant" "CFloat" [e2] (pos e2)]
 				| EConst (Int (s, Some "i64")) ->
 					expr "EConst" [mk_enum "Constant" "CInt" [ (EConst(String (s, SDoubleQuotes)),(pos e1)); (EConst(String ("i64", SDoubleQuotes)),(pos e1)) ] (pos e1)]
 				| _ ->
@@ -394,13 +396,14 @@ let reify in_macro =
 			List.iter (function
 				| HExtern | HPrivate -> ()
 				| HInterface -> interf := true;
-				| HExtends t -> ext := (match !ext with
-					| None -> Some (to_tpath t p)
+				| HExtends ptp -> ext := (match !ext with
+					| None ->
+						Some (to_tpath ptp)
 					| Some _ -> begin
-						impl := (to_tpath t p) :: !impl;
+						impl := (to_tpath ptp) :: !impl;
 						!ext
 						end)
-				| HImplements i-> impl := (to_tpath i p) :: !impl
+				| HImplements ptp -> impl := (to_tpath ptp) :: !impl
 				| HFinal -> final := true
 				| HAbstract -> abstract := true
 			) d.d_flags;
@@ -421,4 +424,4 @@ let reify in_macro =
 let reify_expr e in_macro =
 	let to_expr,_,_ = reify in_macro in
 	let e = to_expr e in
-	(ECheckType (e,(CTPath (mk_type_path (["haxe";"macro"],"Expr")),null_pos)),pos e)
+	(ECheckType (e,(make_ptp_ct_null (mk_type_path (["haxe";"macro"],"Expr")),null_pos)),pos e)

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -113,10 +113,10 @@ let unify_call_args ctx el args r callp inline force_inline in_overload =
 								let e = EArrayDecl el,p in
 								(* typer requires dynamic arrays to be explicitly declared as Array<Dynamic> *)
 								if follow arg_t == t_dynamic then begin
-									let dynamic = CTPath(mk_type_path ([],"Dynamic")),p in
+									let dynamic = make_ptp_th (mk_type_path ([],"Dynamic")) p in
 									let params = [TPType dynamic] in
-									let tp = mk_type_path ~params ([],"Array") in
-									do_type (ECheckType(e,(CTPath tp, p)),p) (* ([arg1, arg2...]:Array<Dynamic>) *)
+									let ct = make_ptp_ct (mk_type_path ~params ([],"Array")) p in
+									do_type (ECheckType(e,(ct, p)),p) (* ([arg1, arg2...]:Array<Dynamic>) *)
 								end else
 									do_type e
 							with WithTypeError e ->

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -169,7 +169,7 @@ let static_method_container gctx c cf p =
 	let pack = fst c.cl_path in
 	let name = (snd c.cl_path) ^ "_" ^ cf.cf_name ^ "_" ^ gctx.name in
 	try
-		let t = Typeload.load_instance ctx (mk_type_path (pack,name),p) ParamSpawnMonos in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (pack,name)) p) ParamSpawnMonos in
 		match t with
 		| TInst(cg,_) -> cg
 		| _ -> raise_typing_error ("Cannot specialize @:generic static method because the generated type name is already used: " ^ name) p
@@ -254,7 +254,7 @@ let build_generic_class ctx c p tl =
 	let gctx = make_generic ctx c.cl_params tl (Meta.has (Meta.Custom ":debug.generic") c.cl_meta) p in
 	let name = (snd c.cl_path) ^ "_" ^ gctx.name in
 	try
-		let t = Typeload.load_instance ctx (mk_type_path (pack,name),p) ParamNormal in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (pack,name)) p) ParamNormal in
 		match t with
 		| TInst({ cl_kind = KGenericInstance (csup,_) },_) when c == csup -> t
 		| _ -> raise_typing_error ("Cannot specialize @:generic because the generated type name is already used: " ^ name) p

--- a/src/typing/matcher/exprToPattern.ml
+++ b/src/typing/matcher/exprToPattern.ml
@@ -58,7 +58,7 @@ let get_general_module_type ctx mt p =
 			end
 		| _ -> raise_typing_error "Cannot use this type as a value" p
 	in
-	Typeload.load_instance ctx ({tname=loop mt;tpackage=[];tsub=None;tparams=[]},p) ParamSpawnMonos
+	Typeload.load_instance ctx (make_ptp {tname=loop mt;tpackage=[];tsub=None;tparams=[]} p) ParamSpawnMonos
 
 let unify_type_pattern ctx mt t p =
 	let tcl = get_general_module_type ctx mt p in
@@ -216,7 +216,7 @@ let rec make pctx toplevel t e =
 	let rec loop e = match fst e with
 		| EParenthesis e1 | ECast(e1,None) ->
 			loop e1
-		| ECheckType(e, (CTPath({tpackage=["haxe";"macro"]; tname="Expr"}),_)) ->
+		| ECheckType(e, (CTPath({path = {tpackage=["haxe";"macro"]; tname="Expr"}}),_)) ->
 			let old = pctx.in_reification in
 			pctx.in_reification <- true;
 			let e = loop e in

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -390,7 +390,7 @@ let make_binop ctx op e1 e2 is_assign_op p =
 		unify ctx e2.etype b p;
 		mk_op e1 e2 b
 	| OpInterval ->
-		let t = Typeload.load_instance ctx (mk_type_path (["std"],"IntIterator"),null_pos) ParamNormal in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (["std"],"IntIterator")) null_pos) ParamNormal in
 		let e1 = AbstractCast.cast_or_unify_raise ctx tint e1 e1.epos in
 		let e2 = AbstractCast.cast_or_unify_raise ctx tint e2 e2.epos in
 		BinopSpecial (mk (TNew ((match t with TInst (c,[]) -> c | _ -> die "" __LOC__),[],[e1;e2])) t p,false)

--- a/src/typing/strictMeta.ml
+++ b/src/typing/strictMeta.ml
@@ -137,7 +137,8 @@ let get_strict_meta ctx meta params pos =
 					| _ ->
 						el, []
 				in
-				(ENew((tpath,snd ef), el), p), fields, CTPath tpath
+				let ptp = make_ptp tpath (snd ef) in
+				(ENew(ptp, el), p), fields, CTPath ptp
 			| Java ->
 				let fields = match el with
 				| [EObjectDecl(fields),_] ->
@@ -148,22 +149,24 @@ let get_strict_meta ctx meta params pos =
 					display_error ctx.com "Object declaration expected" p;
 					[]
 				in
-				ef, fields, CTPath tpath
+				ef, fields, CTPath (make_ptp tpath (snd ef))
 			| _ ->
 				Error.raise_typing_error "@:strict is not supported on this target" p
 			end
 		| [EConst(Ident i),p as expr] ->
 			let tpath = { tpackage=[]; tname=i; tparams=[]; tsub=None } in
+			let ptp = make_ptp tpath p in
 			if pf = Cs then
-				(ENew((tpath,p), []), p), [], CTPath tpath
+				(ENew(ptp, []), p), [], CTPath ptp
 			else
-				expr, [], CTPath tpath
+				expr, [], CTPath ptp
 		| [ (EField(_),p as field) ] ->
 			let tpath = field_to_type_path ctx.com field in
+			let ptp = make_ptp tpath p in
 			if pf = Cs then
-				(ENew((tpath,p), []), p), [], CTPath tpath
+				(ENew(ptp, []), p), [], CTPath ptp
 			else
-				field, [], CTPath tpath
+				field, [], CTPath ptp
 		| _ ->
 			display_error ctx.com "A @:strict metadata must contain exactly one parameter. Please check the documentation for more information" pos;
 			raise Exit

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -421,19 +421,20 @@ let rec load_params ctx info params p =
 	params
 
 (* build an instance from a full type *)
-and load_instance' ctx (t,p) get_params =
+and load_instance' ctx ptp get_params =
+	let t = ptp.path in
 	try
 		if t.tpackage <> [] || t.tsub <> None then raise Not_found;
 		let pt = lookup_param t.tname ctx.type_params in
-		if t.tparams <> [] then raise_typing_error ("Class type parameter " ^ t.tname ^ " can't have parameters") p;
+		if t.tparams <> [] then raise_typing_error ("Class type parameter " ^ t.tname ^ " can't have parameters") ptp.pos_full;
 		pt
 	with Not_found ->
-		let mt = load_type_def ctx p t in
-		let info = ctx.g.get_build_info ctx mt p in
+		let mt = load_type_def ctx ptp.pos_path t in
+		let info = ctx.g.get_build_info ctx mt ptp.pos_full in
 		if info.build_path = ([],"Dynamic") then match t.tparams with
 			| [] -> t_dynamic
 			| [TPType t] -> TDynamic (Some (load_complex_type ctx true t))
-			| _ -> raise_typing_error "Too many parameters for Dynamic" p
+			| _ -> raise_typing_error "Too many parameters for Dynamic" ptp.pos_full
 		else if info.build_params = [] then begin match t.tparams with
 			| [] ->
 				info.build_apply []
@@ -448,26 +449,26 @@ and load_instance' ctx (t,p) get_params =
 			let is_rest = info.build_kind = BuildGenericBuild && (match info.build_params with [{ttp_name="Rest"}] -> true | _ -> false) in
 			let tl = if t.tparams = [] && not is_rest then begin match get_params with
 				| ParamNormal ->
-					load_params ctx info t.tparams p
+					load_params ctx info t.tparams ptp.pos_full
 				| ParamSpawnMonos ->
 					Monomorph.spawn_constrained_monos (fun t -> t) info.build_params
 				| ParamCustom f ->
 					f info None
 			end else
-				load_params ctx info t.tparams p
+				load_params ctx info t.tparams ptp.pos_full
 			in
 			let t = info.build_apply tl in
-			maybe_build_instance ctx t get_params p
+			maybe_build_instance ctx t get_params ptp.pos_full
 		end
 
-and load_instance ctx ?(allow_display=false) ((_,pn) as tp) get_params =
+and load_instance ctx ?(allow_display=false) ptp get_params =
 	try
-		let t = load_instance' ctx tp get_params in
-		if allow_display then DisplayEmitter.check_display_type ctx t tp;
+		let t = load_instance' ctx ptp get_params in
+		if allow_display then DisplayEmitter.check_display_type ctx t ptp;
 		t
-	with Error { err_message = Module_not_found path } when ctx.macro_depth <= 0 && (ctx.com.display.dms_kind = DMDefault) && DisplayPosition.display_position#enclosed_in pn ->
+	with Error { err_message = Module_not_found path } when ctx.macro_depth <= 0 && (ctx.com.display.dms_kind = DMDefault) && DisplayPosition.display_position#enclosed_in ptp.pos_path ->
 		let s = s_type_path path in
-		DisplayToplevel.collect_and_raise ctx TKType NoValue CRTypeHint (s,pn) (patch_string_pos pn s)
+		DisplayToplevel.collect_and_raise ctx TKType NoValue CRTypeHint (s,ptp.pos_full) ptp.pos_path
 
 (*
 	build an instance from a complex type
@@ -475,8 +476,8 @@ and load_instance ctx ?(allow_display=false) ((_,pn) as tp) get_params =
 and load_complex_type' ctx allow_display (t,p) =
 	match t with
 	| CTParent t -> load_complex_type ctx allow_display t
-	| CTPath { tpackage = ["$"]; tname = "_hx_mono" } -> spawn_monomorph ctx p
-	| CTPath t -> load_instance ~allow_display ctx (t,p) ParamNormal
+	| CTPath { path = {tpackage = ["$"]; tname = "_hx_mono" }} -> spawn_monomorph ctx p
+	| CTPath ptp -> load_instance ~allow_display ctx ptp ParamNormal
 	| CTOptional _ -> raise_typing_error "Optional type not allowed here" p
 	| CTNamed _ -> raise_typing_error "Named type not allowed here" p
 	| CTIntersection tl ->
@@ -521,9 +522,9 @@ and load_complex_type' ctx allow_display (t,p) =
 				| _ ->
 					raise_typing_error "Can only extend structures" p
 			in
-			let il = List.map (fun (t,pn) ->
+			let il = List.map (fun ptp ->
 				try
-					(load_instance ctx ~allow_display (t,pn) ParamNormal,pn)
+					(load_instance ctx ~allow_display ptp ParamNormal,ptp.pos_full)
 				with DisplayException(DisplayFields ({fkind = CRTypeHint} as r)) ->
 					let l = List.filter (fun item -> match item.ci_kind with
 						| ITType({kind = Struct},_) -> true
@@ -584,7 +585,7 @@ and load_complex_type' ctx allow_display (t,p) =
 					no_expr e;
 					let t = (match t with None -> raise_typing_error "Type required for structure property" p | Some t -> t) in
 					load_complex_type ctx allow_display t, Var { v_read = AccNormal; v_write = AccNever }
-				| FVar (Some (CTPath({tpackage=[];tname="Void"}),_), _)  | FProp (_,_,Some (CTPath({tpackage=[];tname="Void"}),_),_) ->
+				| FVar (Some (CTPath({path = {tpackage=[];tname="Void"}}),_), _)  | FProp (_,_,Some (CTPath({path = {tpackage=[];tname="Void"}}),_),_) ->
 					raise_typing_error "Fields of type Void are not allowed in structures" p
 				| FVar (t, e) ->
 					no_expr e;
@@ -642,7 +643,7 @@ and load_complex_type' ctx allow_display (t,p) =
 		TAnon a
 	| CTFunction (args,r) ->
 		match args with
-		| [CTPath { tpackage = []; tparams = []; tname = "Void" },_] ->
+		| [CTPath { path = {tpackage = []; tparams = []; tname = "Void" }},_] ->
 			TFun ([],load_complex_type ctx allow_display r)
 		| _ ->
 			TFun (List.map (fun t ->

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -591,10 +591,10 @@ module Inheritance = struct
 					raise_typing_error "Should implement by using an interface" p
 			end
 		in
-		let fl = ExtList.List.filter_map (fun (is_extends,(ct,p)) ->
+		let fl = ExtList.List.filter_map (fun (is_extends,ptp) ->
 			try
 				let t = try
-					Typeload.load_instance ~allow_display:true ctx (ct,p) ParamNormal
+					Typeload.load_instance ~allow_display:true ctx ptp ParamNormal
 				with DisplayException(DisplayFields ({fkind = CRTypeHint} as r)) ->
 					(* We don't allow `implements` on interfaces. Just raise fields completion with no fields. *)
 					if not is_extends && (has_class_flag c CInterface) then raise_fields [] CRImplements r.fsubject;
@@ -608,7 +608,7 @@ module Inheritance = struct
 					) r.fitems in
 					raise_fields l (if is_extends then CRExtends else CRImplements) r.fsubject
 				in
-				Some (check_herit t is_extends p)
+				Some (check_herit t is_extends ptp.pos_full)
 			with Error { err_message = Module_not_found(([],name)); err_pos = p } when ctx.com.display.dms_kind <> DMNone ->
 				if Diagnostics.error_in_diagnostics_run ctx.com p then DisplayToplevel.handle_unresolved_identifier ctx name p true;
 				None

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1299,11 +1299,11 @@ let create_method (ctx,cctx,fctx) c f fd p =
 		if ctx.com.is_macro_context then begin
 			(* a class with a macro cannot be extern in macro context (issue #2015) *)
 			remove_class_flag c CExtern;
-			let texpr = CTPath (mk_type_path (["haxe";"macro"],"Expr")) in
+			let texpr = make_ptp_ct (mk_type_path (["haxe";"macro"],"Expr")) null_pos in
 			(* ExprOf type parameter might contain platform-specific type, let's replace it by Expr *)
 			let no_expr_of (t,p) = match t with
-				| CTPath { tpackage = ["haxe";"macro"]; tname = "Expr"; tsub = Some ("ExprOf"); tparams = [TPType _] }
-				| CTPath { tpackage = []; tname = ("ExprOf"); tsub = None; tparams = [TPType _] } -> Some (texpr,p)
+				| CTPath { path = {tpackage = ["haxe";"macro"]; tname = "Expr"; tsub = Some ("ExprOf"); tparams = [TPType _] }}
+				| CTPath { path = {tpackage = []; tname = ("ExprOf"); tsub = None; tparams = [TPType _] }} -> Some (texpr,p)
 				| t -> Some (t,p)
 			in
 			{
@@ -1313,8 +1313,8 @@ let create_method (ctx,cctx,fctx) c f fd p =
 				f_expr = fd.f_expr;
 			}
 		end else
-			let tdyn = Some (CTPath (mk_type_path ([],"Dynamic")),null_pos) in
-			let to_dyn p t = match t with
+			let tdyn = Some (make_ptp_th (mk_type_path ([],"Dynamic")) null_pos) in
+			let to_dyn p ptp = match ptp.path with
 				| { tpackage = ["haxe";"macro"]; tname = "Expr"; tsub = Some ("ExprOf"); tparams = [TPType t] } -> Some t
 				| { tpackage = []; tname = ("ExprOf"); tsub = None; tparams = [TPType t] } -> Some t
 				| { tpackage = ["haxe"]; tname = ("PosInfos"); tsub = None; tparams = [] } -> raise_typing_error "haxe.PosInfos is not allowed on macro functions, use Context.currentPos() instead" p
@@ -1337,9 +1337,9 @@ let create_method (ctx,cctx,fctx) c f fd p =
 			if fctx.is_static then invalid_modifier ctx.com fctx "static" "constructor" p;
 			begin match fd.f_type with
 				| None -> ()
-				| Some (CTPath ({ tpackage = []; tname = "Void" } as tp),p) ->
+				| Some (CTPath ({ path = {tpackage = []; tname = "Void" } as tp}),p) ->
 					if ctx.is_display_file && DisplayPosition.display_position#enclosed_in p then
-						ignore(load_instance ~allow_display:true ctx (tp,p) ParamNormal);
+						ignore(load_instance ~allow_display:true ctx (make_ptp tp p) ParamNormal);
 				| _ -> raise_typing_error "A class constructor can't have a return type" p;
 			end
 		| false,_ ->

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -214,8 +214,8 @@ module ModuleLevel = struct
 					acc
 				| fields ->
 					let a_t =
-						let params = List.map (fun t -> TPType (CTPath (mk_type_path ([],fst t.tp_name)),null_pos)) d.d_params in
-						CTPath (mk_type_path ~params ([],fst d.d_name)),null_pos
+						let params = List.map (fun t -> TPType (make_ptp_th (mk_type_path ([],fst t.tp_name)) null_pos)) d.d_params in
+						make_ptp_ct_null (mk_type_path ~params ([],fst d.d_name)),null_pos
 					in
 					let rec loop = function
 						| [] -> a_t
@@ -372,7 +372,7 @@ module TypeLevel = struct
 				is_flat := false;
 				let pnames = ref PMap.empty in
 				TFun (List.map (fun (s,opt,(t,tp)) ->
-					(match t with CTPath({tpackage=[];tname="Void"}) -> raise_typing_error "Arguments of type Void are not allowed in enum constructors" tp | _ -> ());
+					(match t with CTPath({path = {tpackage=[];tname="Void"}}) -> raise_typing_error "Arguments of type Void are not allowed in enum constructors" tp | _ -> ());
 					if PMap.mem s (!pnames) then raise_typing_error ("Duplicate argument `" ^ s ^ "` in enum constructor " ^ fst c.ec_name) p;
 					pnames := PMap.add s () (!pnames);
 					s, opt, load_type_hint ~opt ctx p (Some (t,tp))
@@ -558,7 +558,7 @@ module TypeLevel = struct
 		let tt = load_complex_type ctx true d.d_data in
 		let tt = (match fst d.d_data with
 		| CTExtend _ -> tt
-		| CTPath { tpackage = ["haxe";"macro"]; tname = "MacroType" } ->
+		| CTPath { path = {tpackage = ["haxe";"macro"]; tname = "MacroType" }} ->
 			(* we need to follow MacroType immediately since it might define other module types that we will load afterwards *)
 			if t.t_type == follow tt then raise_typing_error "Recursive typedef is not allowed" p;
 			tt
@@ -767,7 +767,7 @@ let type_types_into_module ctx m tdecls p =
 	if ctx.g.std != null_module then begin
 		add_dependency m ctx.g.std;
 		(* this will ensure both String and (indirectly) Array which are basic types which might be referenced *)
-		ignore(load_instance ctx (mk_type_path (["std"],"String"),null_pos) ParamNormal)
+		ignore(load_instance ctx (make_ptp (mk_type_path (["std"],"String")) null_pos) ParamNormal)
 	end;
 	ModuleLevel.init_type_params ctx decls;
 	(* setup module types *)

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -323,12 +323,12 @@ let parse_module ctx m p =
 							else
 								let params =
 									List.map (fun tp ->
-										TPType (CTPath (mk_type_path ([],fst tp.tp_name)),null_pos)
+										TPType (make_ptp_th_null (mk_type_path ([],fst tp.tp_name)))
 									) d.d_params
 								in
 								mk_type_path ~params (!remap,fst d.d_name)
 						in
-						CTPath (tp),null_pos;
+						make_ptp_th_null tp
 					end
 				},p) :: acc
 			in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -946,25 +946,28 @@ and type_object_decl ctx fl with_type p =
 		mk (TBlock (List.rev (e :: (List.rev evars)))) e.etype e.epos
 	)
 
-and type_new ctx (path,p_path) el with_type force_inline p =
-	let p_path =
-		if p_path <> null_pos then
-			p_path
+and type_new ctx ptp el with_type force_inline p =
+	let ptp =
+		if ptp.pos_full <> null_pos then
+			ptp
 		(*
 			Since macros don't have placed_type_path structure on Haxe side any ENew will have null_pos in `path`.
 			Try to calculate a better pos.
 		*)
 		else begin
-			match el with
-			| (_,p1) :: _ when p1.pfile = p.pfile && p.pmin < p1.pmin ->
-				let pmin = p.pmin + (String.length "new ")
-				and pmax = p1.pmin - 2 (* Additional "1" for an opening bracket *)
-				in
-				{ p with
-					pmin = if pmin < pmax then pmin else p.pmin;
-					pmax = pmax;
-				}
-			| _ -> p
+			let p = match el with
+				| (_,p1) :: _ when p1.pfile = p.pfile && p.pmin < p1.pmin ->
+					let pmin = p.pmin + (String.length "new ")
+					and pmax = p1.pmin - 2 (* Additional "1" for an opening bracket *)
+					in
+					{ p with
+						pmin = if pmin < pmax then pmin else p.pmin;
+						pmax = pmax;
+					}
+				| _ ->
+					p
+			in
+			make_ptp ptp.path p
 		end
 	in
 	let display_position_in_el () =
@@ -1022,14 +1025,14 @@ and type_new ctx (path,p_path) el with_type force_inline p =
 		)
 	in
 	let t = try
-		Typeload.load_instance ctx (path,p_path) (ParamCustom get_params)
+		Typeload.load_instance ctx ptp (ParamCustom get_params)
 	with exc ->
 		restore();
 		(* If we fail for some reason, process the arguments in case we want to display them (#7650). *)
 		if display_position_in_el () then List.iter (fun e -> ignore(type_expr ctx e WithType.value)) el;
 		raise exc
 	in
-	DisplayEmitter.check_display_type ctx t (path,p_path);
+	DisplayEmitter.check_display_type ctx t ptp;
 	let t = follow t in
 	let build_constructor_call ao c tl =
 		let fa = FieldAccess.get_constructor_access c tl p in
@@ -1099,7 +1102,7 @@ and type_try ctx e1 catches with_type p =
 		) params
 	in
 	let catches,el = List.fold_left (fun (acc1,acc2) ((v,pv),t,e_ast,pc) ->
-		let th = Option.default (CTPath { tpackage = ["haxe"]; tname = "Exception"; tsub = None; tparams = [] },null_pos) t in
+		let th = Option.default (make_ptp_th { tpackage = ["haxe"]; tname = "Exception"; tsub = None; tparams = [] } null_pos) t in
 		let t = Typeload.load_complex_type ctx true th in
 		let rec loop t = match follow t with
 			| TInst ({ cl_kind = KTypeParameter _} as c,_) when not (TypeloadCheck.is_generic_parameter ctx c) ->
@@ -1460,7 +1463,7 @@ and type_array_comprehension ctx e with_type p =
 			end
 		| EParenthesis e2 -> (EParenthesis (map_compr e2),p)
 		| EBinop(OpArrow,a,b) ->
-			et := (ENew(({tpackage=["haxe";"ds"];tname="Map";tparams=[];tsub=None},null_pos),[]),comprehension_pos);
+			et := (ENew(make_ptp {tpackage=["haxe";"ds"];tname="Map";tparams=[];tsub=None} null_pos,[]),comprehension_pos);
 			(ECall ((efield (e_ref,"set"),p),[a;b]),p)
 		| _ ->
 			et := (EArrayDecl [],comprehension_pos);
@@ -1807,7 +1810,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 	| EConst (Regexp (r,opt)) ->
 		let str = mk (TConst (TString r)) ctx.t.tstring p in
 		let opt = mk (TConst (TString opt)) ctx.t.tstring p in
-		let t = Typeload.load_instance ctx (mk_type_path (["std"],"EReg"),null_pos) ParamNormal in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (["std"],"EReg")) null_pos) ParamNormal in
 		mk (TNew ((match t with TInst (c,[]) -> c | _ -> die "" __LOC__),[],[str;opt])) t p
 	| EConst (String(s,SSingleQuotes)) when s <> "" ->
 		type_expr ctx (format_string ctx s p) with_type
@@ -1831,7 +1834,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 			let call     = ECall (field, [ arg_high; arg_low ]), p in
 			type_expr ctx call with_type
 		| "u32" ->
-			let check = ECheckType ((EConst (Int (s, None)), p), (CTPath (mk_type_path ([],"UInt")), p)), p in
+			let check = ECheckType ((EConst (Int (s, None)), p), (make_ptp_th (mk_type_path ([],"UInt")) p)), p in
 			type_expr ctx check with_type
 		| other -> raise_typing_error (other ^ " is not a valid integer suffix") p)
 	| EConst (Float (s, Some suffix) as c) ->
@@ -1902,7 +1905,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 			| TAbstract({a_path = (["haxe";"ds"],"Map")},[tk;tv]) ->
 				begin match el with
 				| [] ->
-					type_expr ctx (ENew(({tpackage=["haxe";"ds"];tname="Map";tparams=[];tsub=None},null_pos),[]),p) with_type
+					type_expr ctx (ENew(make_ptp {tpackage=["haxe";"ds"];tname="Map";tparams=[];tsub=None} null_pos,[]),p) with_type
 				| [(EDisplay _,_) as e1] ->
 					(* This must mean we're just typing the first key of a map declaration (issue #9133). *)
 					type_expr ctx e1 (WithType.with_type tk)
@@ -2008,9 +2011,9 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 	| EIs (e,(t,p_t)) ->
 		match t with
 		| CTPath tp ->
-			if tp.tparams <> [] then display_error ctx.com "Type parameters are not supported for the `is` operator" p_t;
+			if tp.path.tparams <> [] then display_error ctx.com "Type parameters are not supported for the `is` operator" p_t;
 			let e = type_expr ctx e WithType.value in
-			let mt = Typeload.load_type_def ctx p_t tp in
+			let mt = Typeload.load_type_def ctx p_t tp.path in
 			if ctx.in_display && DisplayPosition.display_position#enclosed_in p_t then
 				DisplayEmitter.display_module_type ctx mt p_t;
 			let e_t = type_module_type ctx mt p_t in

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -309,9 +309,9 @@ let rec handle_signature_display ctx e_ast with_type =
 				| _ -> [e1.etype,None,PMap.empty]
 			in
 			handle_call tl el e1.epos
-		| ENew(tpath,el) ->
-			let t = Abstract.follow_with_forward_ctor (Typeload.load_instance ctx tpath ParamSpawnMonos) in
-			handle_call (find_constructor_types t) el (pos tpath)
+		| ENew(ptp,el) ->
+			let t = Abstract.follow_with_forward_ctor (Typeload.load_instance ctx ptp ParamSpawnMonos) in
+			handle_call (find_constructor_types t) el ptp.pos_full
 		| EArray(e1,e2) ->
 			let e1 = type_expr ctx e1 WithType.value in
 			begin match follow e1.etype with

--- a/tests/misc/projects/Issue5644/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue5644/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-User.hx:1: characters 20-47 : Type not found : ThisObviouslyDoesntExist
+User.hx:1: characters 20-44 : Type not found : ThisObviouslyDoesntExist

--- a/tests/misc/projects/Issue5644/pretty-fail.hxml.stderr
+++ b/tests/misc/projects/Issue5644/pretty-fail.hxml.stderr
@@ -1,6 +1,6 @@
-[ERROR] User.hx:1: characters 20-47
+[ERROR] User.hx:1: characters 20-44
 
  1 | class User extends ThisObviouslyDoesntExist<T> {}
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
    | Type not found : ThisObviouslyDoesntExist
 

--- a/tests/server/src/cases/display/issues/Issue8687.hx
+++ b/tests/server/src/cases/display/issues/Issue8687.hx
@@ -1,4 +1,4 @@
-package cases.issues;
+package cases.display.issues;
 
 class Issue8687 extends TestCase {
 	function test(_) {

--- a/tests/server/src/cases/display/issues/Issue9705.hx
+++ b/tests/server/src/cases/display/issues/Issue9705.hx
@@ -1,0 +1,16 @@
+package cases.display.issues;
+
+import haxe.display.Diagnostic;
+
+class Issue9705 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue9705/Main.hx"));
+		var args = ["Main", "--interp"];
+		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+
+		var diag = parseDiagnostics();
+		var range = diag[0].range;
+		Assert.equals(DKUnresolvedIdentifier, diag[0].kind);
+		Assert.equals("Arrey".length, range.end.character - range.start.character);
+	}
+}

--- a/tests/server/test/templates/issues/Issue9705/Main.hx
+++ b/tests/server/test/templates/issues/Issue9705/Main.hx
@@ -1,0 +1,6 @@
+typedef Foo = Arrey<{
+	/**
+	 * test
+	 */
+	var test:Int;
+}>;


### PR DESCRIPTION
This may look a bit excessive but finally deals with annoying issue ~#7282~#9705. Type paths can now also store the actual dot path without the type parameters, which was impossible to determine before. 

Edit: I really like how obvious pretty errors make this change:

```
  1 | class User extends ThisObviouslyDoesntExist<T> {}
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
    | Type not found : ThisObviouslyDoesntExist
```