### PR TITLE
Type operator lhs against expected type

### DIFF
--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -630,6 +630,10 @@ let type_non_assign_op ctx op e1 e2 is_assign_op abstract_overload_only with_typ
 			WithType.value
 	in
 	let e1 = type_expr ctx e1 wt in
+	let e1 = match wt with
+		| WithType.WithType(t,_) -> AbstractCast.cast_or_unify ctx t e1 e1.epos
+		| _ -> e1
+	in
 	let result = if abstract_overload_only then begin
 		let e2 = type_binop_rhs ctx op e1 e2 is_assign_op with_type p in
 		try_abstract_binop_overloads ctx op e1 e2 is_assign_op p

--- a/tests/unit/src/unit/issues/Issue10981.hx
+++ b/tests/unit/src/unit/issues/Issue10981.hx
@@ -1,0 +1,15 @@
+package unit.issues;
+
+import haxe.EnumFlags;
+
+private enum E {
+	A;
+	B;
+}
+
+class Issue10981 extends Test {
+	function test() {
+		var flags:EnumFlags<E> = A | B;
+		eq(3, flags.toInt());
+	}
+}


### PR DESCRIPTION
For #10981

I don't know if this is acceptable behavior, but I'm already not sure if #2786 was acceptable behavior (and we subsequently ran into problems in #4914).

It just seems quite random to type the operands against the expected _return_ type. I'd kind of understand typing them against the argument types of the `@:op` function, but that wouldn't work for the `EnumFlags` case because there the lhs is the underlying type, `Int`. 