### PR TITLE
[display] Insert EDisplay in the proper position when parsing a call …

### DIFF
--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -1715,8 +1715,24 @@ and parse_call_params f p1 s =
 				let e = check_signature_mark e p1 p2 in
 				f (List.rev (e :: acc)) p2
 			| [< '(Comma,p2); '(PClose,p3) >] ->
-				let e = check_signature_mark e p1 p3 in
-				f (List.rev (e :: acc)) p3
+				if (is_signature_display()) then begin
+					let prev_arg_pos = punion p1 p2 in
+					let comma_paren_pos = punion p2 p3 in
+					(* first check wether the display position is within the previous argument *)
+					if encloses_position_gt display_position#get prev_arg_pos then begin
+						(* wrap the argument that was just parsed *)
+						let e = mk_display_expr e DKMarked in
+						f (List.rev (e :: acc)) p3
+					(* then check wether the display position is between the comma and the closing parenthesis *)
+					end else if encloses_position_gt display_position#get comma_paren_pos then begin
+						(* add a dummy final argument *)
+						let e2 = mk_display_expr (mk_null_expr comma_paren_pos) DKMarked in
+						f (List.rev (e2 :: e :: acc)) p3
+					end else f (List.rev (e :: acc)) p3
+				end else begin
+				(* if not in signature display mode don't check anything *)
+					f (List.rev (e :: acc)) p3
+				end
 			| [< '(Comma,p2) >] ->
 				let e = check_signature_mark e p1 p2 in
 				parse_next_param (e :: acc) p2

--- a/tests/display/src/cases/Signature.hx
+++ b/tests/display/src/cases/Signature.hx
@@ -282,4 +282,20 @@ class Signature extends DisplayTestCase {
 	function testStaticVisibility() {
 		sigEq(0, [["s:String"]], signature(pos(1)));
 	}
+
+	/**
+		class Foo {
+			public static function foo(a:Int, b:Int) {}
+		}
+
+		class Main {
+			static function main() {
+				Foo.foo(1{-1-},{-2-});
+			}
+		}
+	**/
+	function testTrailingCommaEdgeCase() {
+		sigEq(0, [["a:Int","b:Int"]], signature(pos(1)));
+		sigEq(1, [["a:Int","b:Int"]], signature(pos(2)));
+	}
 }


### PR DESCRIPTION
…expression.

Currently when the display position is between the final comma and the closing parenthesis signature help won't report the correct active argument.