### PR TITLE
Add @:message.follow

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -727,6 +727,12 @@
 		"targets": ["TExpr"]
 	},
 	{
+		"name": "MessageFollow",
+		"metadata": ":message.follow",
+		"doc": "Follows a typedef when printing it.",
+		"targets": ["TTypedef"]
+	},
+	{
 		"name": "MultiReturn",
 		"metadata": ":multiReturn",
 		"doc": "Annotates an extern class as the result of multi-return function.",

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -68,6 +68,8 @@ let rec s_type ctx t =
 		| _ -> s_type_path c.cl_path ^ s_type_params ctx tl)
 	| TType ({ t_type = TAnon { a_status = { contents = ClassStatics { cl_kind = KAbstractImpl a }}}}, _) ->
 		"Abstract<" ^ (s_type_path a.a_path) ^ ">"
+	| TType (td,tl) when (Meta.has Meta.MessageFollow td.t_meta) ->
+		s_type ctx (apply_typedef td tl)
 	| TType (t,tl) ->
 		s_type_path t.t_path ^ s_type_params ctx tl
 	| TAbstract (a,tl) ->


### PR DESCRIPTION
I sometimes have some sort of helper typedefs that I don't actually want users to see in error messages and such. With this metadata, typedefs are followed away in the internal printing:

```haxe
@:message.follow
private typedef Apocalypse = String;

function main() {
	var a:Apocalypse = 1; // Int should be String
}
```