### PR TITLE
[lua] Fix bug in genlua causing significant slowdown in all loops.

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -582,9 +582,10 @@ and gen_loop ctx cond do_while e =
     if do_while then
         print ctx " or _hx_do_first_%i" ctx.break_depth;
     print ctx " do ";
-    if do_while then
+    if do_while then begin
         newline ctx;
         println ctx "_hx_do_first_%i = false;" ctx.break_depth;
+    end;
     if will_continue then print ctx "repeat ";
     gen_block_element ctx e;
     if will_continue then begin


### PR DESCRIPTION
The condition on line 585 was missing a begin/end block so the generator was unconditionally modifying a variable named `_hx_do_first_*` which was supposed to only exist for do-while loops. 

Since the code that initializes `_hx_do_first_*` doesn't have this problem, no local variable is created, which means that this bug causes a global variable access for every iteration of every non do-while loop (very bad for performance). Fixing this improved the performance of loops by about 30% in my limited testing. They are now the same speed as writing a loop in Lua by hand.