### PR TITLE
hlopt: do not opt mov if destination is an haxe variable

### DIFF
--- a/src/generators/hlopt.ml
+++ b/src/generators/hlopt.ml
@@ -970,9 +970,10 @@ let _optimize (f:fundecl) =
 
 	(* nop *)
 
+	let is_assign i = Array.exists (fun (var,pos) -> pos = i) f.assigns in
 	for i=0 to Array.length f.code - 1 do
 		(match op i with
-		| OMov (d,r) when not (is_live d (i + 1)) ->
+		| OMov (d,r) when not (is_live d (i + 1)) && not (is_assign i) ->
 			let n = read_counts.(r) - 1 in
 			read_counts.(r) <- n;
 			write_counts.(d) <- write_counts.(d) - 1;


### PR DESCRIPTION
This commit solve https://github.com/vshaxe/hashlink-debugger/issues/111 by remove optimization on unused mov, when the dest register is an haxe variable.
It should not have a big impact on the overall optimization, as it only impact the case "assign a variable but never use it later".