### PR TITLE
[hl] Fix do-while loop in genhl+hlopt

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2676,13 +2676,10 @@ and eval_expr ctx e =
 		ctx.m.mbreaks <- [];
 		ctx.m.mcontinues <- [];
 		ctx.m.mloop_trys <- ctx.m.mtrys;
-		let start = jump ctx (fun p -> OJAlways p) in
 		let continue_pos = current_pos ctx in
 		let ret = jump_back ctx in
-		let j = jump_expr ctx cond false in
-		start();
 		ignore(eval_expr ctx eloop);
-		set_curpos ctx (max_pos e);
+		let j = jump_expr ctx cond false in
 		ret();
 		j();
 		List.iter (fun f -> f (current_pos ctx)) ctx.m.mbreaks;

--- a/src/generators/hlopt.ml
+++ b/src/generators/hlopt.ml
@@ -936,8 +936,8 @@ let _optimize (f:fundecl) =
 				(* loop : first pass does not recurse, second pass uses cache *)
 				if b2.bloop && b2.bstart < b.bstart then (match b2.bneed_all with None -> acc | Some s -> ISet.union acc s) else
 				ISet.union acc (live b2)
-			) ISet.empty b.bnext in
-			let need_sub = ISet.filter (fun r ->
+			) ISet.empty in
+			let need_sub bl = ISet.filter (fun r ->
 				try
 					let w = PMap.find r b.bwrite in
 					set_live r (w + 1) b.bend;
@@ -945,8 +945,8 @@ let _optimize (f:fundecl) =
 				with Not_found ->
 					set_live r b.bstart b.bend;
 					true
-			) need_sub in
-			let need = ISet.union b.bneed need_sub in
+			) (need_sub bl) in
+			let need = ISet.union b.bneed (need_sub b.bnext) in
 			b.bneed_all <- Some need;
 			if b.bloop then begin
 				(*
@@ -963,8 +963,11 @@ let _optimize (f:fundecl) =
 				in
 				List.iter (fun b2 -> if b2.bstart > b.bstart then clear b2) b.bprev;
 				List.iter (fun b -> ignore(live b)) b.bnext;
+				(* do-while loop : recompute self after recompute all next *)
+				let need = ISet.union b.bneed (need_sub b.bnext) in
+				b.bneed_all <- Some need;
 			end;
-			need
+			Option.get b.bneed_all
 	in
 	ignore(live root);
 

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -1069,12 +1069,11 @@ module Cleanup = struct
 							| TLocal v when IntMap.mem v.v_id !locals -> true
 							| _ -> check_expr references_local e
 						in
-						let can_do = match com.platform with Hl -> false | _ -> true in
 						let rec loop2 el = match el with
-							| [{eexpr = TBreak}] when is_true_expr e1 && can_do && not has_continue ->
+							| [{eexpr = TBreak}] when is_true_expr e1 && not has_continue ->
 								do_while := Some (Texpr.Builder.make_bool com.basic true e1.epos);
 								[]
-							| [{eexpr = TIf(econd,{eexpr = TBlock[{eexpr = TBreak}]},None)}] when is_true_expr e1 && not (references_local econd) && can_do && not has_continue ->
+							| [{eexpr = TIf(econd,{eexpr = TBlock[{eexpr = TBreak}]},None)}] when is_true_expr e1 && not (references_local econd) && not has_continue ->
 								do_while := Some econd;
 								[]
 							| {eexpr = TBreak | TContinue | TReturn _ | TThrow _} as e :: el ->


### PR DESCRIPTION
This commit solve https://github.com/HaxeFoundation/haxe/issues/11037 by
- genhl.ml: Improve do-while loop generation, it now generate in a more nature way.
- hlopt.ml: Fix liveness computation with the new do-while loop structure.

Note:
It is also possible to do in a pure hlopt way (but I prefer the current solution), by adding the following code before live b return in hlopt.ml
```ocaml
 (* do-while loop :
	When a next node is a loop, and all prev of that loop node are after the loop,
	live is never called for that node. Call here.
*)
let is_bwdloop b = b.bloop && not (List.exists (fun p -> p.bstart < b.bstart) b.bprev) in
List.iter (fun b -> if is_bwdloop b then ignore(live b) else ()) b.bnext;
```

This commit, with `can_do` in `analyzerTexpr.ml` set to true, have passed the following test (which caused problems during my dev):

Simple do-while, from issue. Expected result: should not hang and output 0,3.
```haxe
static final global = true;
static function main() {
	var offset = 0;
	do {
		trace(offset);
		if (offset >= 3)
			break;
		offset = 3;
	} while (global);
}
```

Do-while in for. Expected result: should not throw outofbound exception, and output 0404040404040404.
```haxe
static var size : Int = 8;
static function main() {
	var buffer = haxe.io.Bytes.alloc(size);
	for(i in 0...size) {
		var rnd;
		do {
			rnd = 4;
		} while(rnd < 2);
		buffer.set(i, rnd);
	}
	trace(buffer.toHex());
}
```

Do-while with complex condition. Expected result: should not hang, and output 2 or 3.
```haxe
static var sample = 1;
static var max : Int = 3;
static function main() {
	var random;
	do {
		random = Std.random(max)+1;
	} while ( max > 1 && sample == random );
	trace(random);
}
```

Do-while with condition modified in loop. Expected result: should not hang and output 0.
```haxe
static function main() {
	var n = -460552;
	do {
		n >>>= 4;
	} while (n > 0);
	trace(n);
}
```
