### PR TITLE
Only set cf_expr_unoptimized if we think we need it

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -99,6 +99,11 @@
 		"parent": "WTyper"
 	},
 	{
+		"name": "WInlineOptimizedField",
+		"doc": "A cached field which was optimized might lead to different output when inlined",
+		"parent": "WTyper"
+	},
+	{
 		"name": "WPatternMatcher",
 		"doc": "Warnings related to the pattern matcher",
 		"parent": "WTyper"

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -213,6 +213,10 @@ class TestCase implements ITest {
 		}
 	}
 
+	function assertSilence() {
+		return Assert.isTrue(lastResult.stderr == "");
+	}
+
 	function assertSuccess(?p:haxe.PosInfos) {
 		return Assert.isTrue(0 == errorMessages.length, p);
 	}

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -150,10 +150,9 @@ class ServerTests extends TestCase {
 		vfs.putContent("Other.hx", getTemplate("issues/Issue9134/Other.hx"));
 		var args = ["-main", "Main", "Other"];
 
-		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [
-			{file: new FsPath("Other.hx")},
-			{file: new FsPath("Main.hx")},
-		]}, res -> {
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {
+			fileContents: [{file: new FsPath("Other.hx")}, {file: new FsPath("Main.hx")},]
+		}, res -> {
 			Assert.equals(1, res.length);
 			Assert.equals(1, res[0].diagnostics.length);
 			var arg = res[0].diagnostics[0].args;
@@ -164,10 +163,12 @@ class ServerTests extends TestCase {
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Other.hx")});
 
-		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [
-			{file: new FsPath("Main.hx"), contents: getTemplate("issues/Issue9134/Main2.hx")},
-			{file: new FsPath("Other.hx"), contents: getTemplate("issues/Issue9134/Other2.hx")}
-		]}, res -> {
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {
+			fileContents: [
+				{file: new FsPath("Main.hx"), contents: getTemplate("issues/Issue9134/Main2.hx")},
+				{file: new FsPath("Other.hx"), contents: getTemplate("issues/Issue9134/Other2.hx")}
+			]
+		}, res -> {
 			Assert.equals(1, res.length);
 			Assert.equals(1, res[0].diagnostics.length);
 			var arg = res[0].diagnostics[0].args;
@@ -178,10 +179,12 @@ class ServerTests extends TestCase {
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Other.hx")});
 
-		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [
-			{file: new FsPath("Main.hx"), contents: getTemplate("issues/Issue9134/Main.hx")},
-			{file: new FsPath("Other.hx"), contents: getTemplate("issues/Issue9134/Other2.hx")}
-		]}, res -> {
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {
+			fileContents: [
+				{file: new FsPath("Main.hx"), contents: getTemplate("issues/Issue9134/Main.hx")},
+				{file: new FsPath("Other.hx"), contents: getTemplate("issues/Issue9134/Other2.hx")}
+			]
+		}, res -> {
 			Assert.equals(2, res.length);
 
 			for (i in 0...2) {
@@ -206,9 +209,12 @@ class ServerTests extends TestCase {
 
 			for (result in res) {
 				var file = result.file.toString();
-				if (StringTools.endsWith(file, "Main.hx")) hasMain = true;
-				else if (StringTools.endsWith(file, "Other.hx")) hasOther = true;
-				else continue;
+				if (StringTools.endsWith(file, "Main.hx"))
+					hasMain = true;
+				else if (StringTools.endsWith(file, "Other.hx"))
+					hasOther = true;
+				else
+					continue;
 
 				var arg = result.diagnostics[0].args;
 				Assert.equals("Unused variable", (cast arg).description);
@@ -427,7 +433,7 @@ class ServerTests extends TestCase {
 		vfs.putContent("haxe/ds/Vector.hx", getTemplate("issues/Issue10986/Vector.hx"));
 		var args = ["-main", "Main", "--jvm", "Main.jar"];
 		runHaxe(args);
-		vfs.touchFile("haxe/ds/Vector.hx");
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("haxe/ds/Vector.hx")});
 		runHaxe(args);
 		assertSuccess();
 	}
@@ -459,16 +465,18 @@ class ServerTests extends TestCase {
 		var transform = Marker.extractMarkers(getTemplate("issues/Issue8368/MyMacro2.macro.hx"));
 		var args = ["-main", "Main", "--macro", "define('whatever')"];
 
-		vfs.putContent(
-			"MyMacro.macro.hx",
-			transform.source.substr(0, transform.markers[1])
-			+ transform.source.substr(transform.markers[2], transform.source.length)
-		);
+		vfs.putContent("MyMacro.macro.hx",
+			transform.source.substr(0, transform.markers[1]) + transform.source.substr(transform.markers[2], transform.source.length));
 
 		runHaxe(args);
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("MyMacro.macro.hx")});
 
-		var completionRequest = {file: new FsPath("MyMacro.macro.hx"), contents: transform.source, offset: transform.markers[2], wasAutoTriggered: false};
+		var completionRequest = {
+			file: new FsPath("MyMacro.macro.hx"),
+			contents: transform.source,
+			offset: transform.markers[2],
+			wasAutoTriggered: false
+		};
 		runHaxeJson(args, DisplayMethods.Completion, completionRequest);
 		Assert.isTrue(parseCompletion().result.items.length == 23);
 		runHaxeJson(args, DisplayMethods.Completion, completionRequest);
@@ -488,8 +496,10 @@ class ServerTests extends TestCase {
 		function runLoop() {
 			runHaxeJson(args, DisplayMethods.Diagnostics, {file: new FsPath("Empty.hx")}, () -> {
 				runHaxe(args.concat(["-D", "compile-only-define"]), () -> {
-					if (assertSuccess() && ++runs < 20) runLoop();
-					else async.done();
+					if (assertSuccess() && ++runs < 20)
+						runLoop();
+					else
+						async.done();
 				});
 			});
 		}

--- a/tests/server/src/cases/issues/Issue11460.hx
+++ b/tests/server/src/cases/issues/Issue11460.hx
@@ -1,0 +1,48 @@
+package cases.issues;
+
+using StringTools;
+
+class Issue11460 extends TestCase {
+	function testClass(_) {
+		var mainContent = getTemplate("issues/Issue11460/Main.hx");
+		vfs.putContent("Main.hx", mainContent);
+		vfs.putContent("C.hx", getTemplate("issues/Issue11460/C.hx"));
+		var args = ["Main", "--interp"];
+
+		// initial cache
+		runHaxe(args);
+		assertSilence();
+
+		// touching Main doesn't do anything
+		vfs.touchFile("Main.hx");
+		runHaxe(args);
+		assertSilence();
+
+		// touching both doesn't do anything
+		vfs.touchFile("Main.hx");
+		vfs.touchFile("C.hx");
+		runHaxe(args);
+		assertSilence();
+
+		// removing the inline is fine
+		vfs.putContent("Main.hx", mainContent.replace("inline", ""));
+		runHaxe(args);
+		assertSilence();
+
+		// adding it back is fine too because C is still cached
+		vfs.putContent("Main.hx", mainContent);
+		runHaxe(args);
+		assertSilence();
+
+		// removing the inline and changing C is still fine
+		vfs.putContent("Main.hx", mainContent.replace("inline", ""));
+		vfs.touchFile("C.hx");
+		runHaxe(args);
+		assertSilence();
+
+		// but adding it now gives us the warning
+		vfs.putContent("Main.hx", mainContent);
+		runHaxe(args);
+		utest.Assert.match(~/WInlineOptimizedField/, lastResult.stderr);
+	}
+}

--- a/tests/server/src/cases/issues/Issue11460.hx
+++ b/tests/server/src/cases/issues/Issue11460.hx
@@ -14,13 +14,13 @@ class Issue11460 extends TestCase {
 		assertSilence();
 
 		// touching Main doesn't do anything
-		vfs.touchFile("Main.hx");
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxe(args);
 		assertSilence();
 
 		// touching both doesn't do anything
-		vfs.touchFile("Main.hx");
-		vfs.touchFile("C.hx");
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("C.hx")});
 		runHaxe(args);
 		assertSilence();
 
@@ -36,7 +36,7 @@ class Issue11460 extends TestCase {
 
 		// removing the inline and changing C is still fine
 		vfs.putContent("Main.hx", mainContent.replace("inline", ""));
-		vfs.touchFile("C.hx");
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("C.hx")});
 		runHaxe(args);
 		assertSilence();
 

--- a/tests/server/src/cases/issues/Issue11460.hx
+++ b/tests/server/src/cases/issues/Issue11460.hx
@@ -4,8 +4,9 @@ using StringTools;
 
 class Issue11460 extends TestCase {
 	function testClass(_) {
-		var mainContent = getTemplate("issues/Issue11460/Main.hx");
-		vfs.putContent("Main.hx", mainContent);
+		var mainContentWithInline = getTemplate("issues/Issue11460/Main.hx");
+		var mainContentWithoutInline = mainContentWithInline.replace("inline", "");
+		vfs.putContent("Main.hx", mainContentWithInline);
 		vfs.putContent("C.hx", getTemplate("issues/Issue11460/C.hx"));
 		var args = ["Main", "--interp"];
 
@@ -25,23 +26,27 @@ class Issue11460 extends TestCase {
 		assertSilence();
 
 		// removing the inline is fine
-		vfs.putContent("Main.hx", mainContent.replace("inline", ""));
+		vfs.putContent("Main.hx", mainContentWithoutInline);
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxe(args);
 		assertSilence();
 
 		// adding it back is fine too because C is still cached
-		vfs.putContent("Main.hx", mainContent);
+		vfs.putContent("Main.hx", mainContentWithInline);
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxe(args);
 		assertSilence();
 
 		// removing the inline and changing C is still fine
-		vfs.putContent("Main.hx", mainContent.replace("inline", ""));
+		vfs.putContent("Main.hx", mainContentWithoutInline);
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("C.hx")});
 		runHaxe(args);
 		assertSilence();
 
 		// but adding it now gives us the warning
-		vfs.putContent("Main.hx", mainContent);
+		vfs.putContent("Main.hx", mainContentWithInline);
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxe(args);
 		utest.Assert.match(~/WInlineOptimizedField/, lastResult.stderr);
 	}

--- a/tests/server/src/cases/issues/Issue9358.hx
+++ b/tests/server/src/cases/issues/Issue9358.hx
@@ -6,7 +6,7 @@ class Issue9358 extends TestCase {
 		vfs.putContent("StateHandler.hx", getTemplate("issues/Issue9358/StateHandler.hx"));
 		var args = ["-cp", "src", "-m", "Main", "-hl", "hl.hl"];
 		runHaxe(args);
-		vfs.touchFile("Main.hx");
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Dependency.hx")});
 		runHaxe(args);
 		assertSuccess();
 	}

--- a/tests/server/src/utils/Vfs.hx
+++ b/tests/server/src/utils/Vfs.hx
@@ -17,16 +17,6 @@ class Vfs {
 		FileSystem.createDirectory(physicalPath);
 	}
 
-	public function touchFile(path:String) {
-		var path = getPhysicalPath(path);
-		FileSystem.createDirectory(path.dir);
-		var file = Fs.openSync(path.dir + "/" + path.file + "." + path.ext, 'a');
-		var last = Fs.fstatSync(file).mtime;
-		var notNow = last.delta(1000);
-		Fs.futimesSync(file, notNow, notNow);
-		Fs.closeSync(file);
-	}
-
 	public function overwriteContent(path:String, content:String) {
 		var path = getPhysicalPath(path).toString();
 		if (!FileSystem.exists(path)) {

--- a/tests/server/test/templates/issues/Issue11460/C.hx
+++ b/tests/server/test/templates/issues/Issue11460/C.hx
@@ -1,0 +1,5 @@
+class C {
+	static public function doSomething() {
+		trace("Ok I did something");
+	}
+}

--- a/tests/server/test/templates/issues/Issue11460/Main.hx
+++ b/tests/server/test/templates/issues/Issue11460/Main.hx
@@ -1,0 +1,3 @@
+function main() {
+	inline C.doSomething();
+}


### PR DESCRIPTION
See #11460

I opted to simply emit a warning if this goes wrong. The issue seems to narrow for me to consider things like restarting current compilation (although it would be nice if this worked). 