### PR TITLE
Turn cl_init into a class field

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -307,7 +307,7 @@ module Dump = struct
 				| Some f -> print_field false f);
 				List.iter (print_field false) c.cl_ordered_fields;
 				List.iter (print_field true) c.cl_ordered_statics;
-				(match c.cl_init with
+				(match TClass.get_cl_init c with
 				| None -> ()
 				| Some e ->
 					print "\n\tstatic function __init__() ";
@@ -490,14 +490,9 @@ let map_source_header com f =
 
 (* Static extensions for classes *)
 module ExtClass = struct
-
-	let add_cl_init c e = match c.cl_init with
-			| None -> c.cl_init <- Some e
-			| Some e' -> c.cl_init <- Some (concat e' e)
-
 	let add_static_init c cf e p =
 		let ethis = Texpr.Builder.make_static_this c p in
 		let ef1 = mk (TField(ethis,FStatic(c,cf))) cf.cf_type p in
 		let e_assign = mk (TBinop(OpAssign,ef1,e)) e.etype p in
-		add_cl_init c e_assign
+		TClass.add_cl_init c e_assign
 end

--- a/src/codegen/gencommon/gencommon.ml
+++ b/src/codegen/gencommon/gencommon.ml
@@ -723,8 +723,8 @@ let run_filters_from gen t filters =
 		gen.gcurrent_classfield <- None;
 		(match c.cl_init with
 		| None -> ()
-		| Some e ->
-			c.cl_init <- Some (List.fold_left (fun e f -> f e) e filters));
+		| Some f ->
+			process_field f);
 	| TClassDecl _ | TEnumDecl _ | TTypeDecl _ | TAbstractDecl _ ->
 		()
 

--- a/src/codegen/gencommon/initFunction.ml
+++ b/src/codegen/gencommon/initFunction.ml
@@ -71,7 +71,7 @@ let handle_override_dynfun acc e this field =
 
 let handle_class gen cl =
 	let com = gen.gcon in
-	let init = match cl.cl_init with
+	let init = match TClass.get_cl_init cl with
 		| None -> []
 		| Some i -> [i]
 	in
@@ -109,7 +109,7 @@ let handle_class gen cl =
 	let init = List.rev init in
 	(match init with
 	| [] -> cl.cl_init <- None
-	| _ -> cl.cl_init <- Some (mk (TBlock init) com.basic.tvoid cl.cl_pos));
+	| _ -> TClass.set_cl_init cl (mk (TBlock init) com.basic.tvoid cl.cl_pos));
 
 	(* FIXME: find a way to tell OverloadingConstructor to execute this code even with empty constructors *)
 	let vars, funs = List.fold_left (fun (acc_vars,acc_funs) cf ->

--- a/src/context/display/deprecationCheck.ml
+++ b/src/context/display/deprecationCheck.ml
@@ -107,7 +107,7 @@ let run com =
 		| TClassDecl c when not (Meta.has Meta.Deprecated c.cl_meta) ->
 			let dctx = {dctx with class_meta = c.cl_meta; curmod = c.cl_module} in
 			(match c.cl_constructor with None -> () | Some cf -> run_on_field dctx cf);
-			(match c.cl_init with None -> () | Some e -> run_on_expr dctx e);
+			(match TClass.get_cl_init c with None -> () | Some e -> run_on_expr dctx e);
 			List.iter (run_on_field dctx) c.cl_ordered_statics;
 			List.iter (run_on_field dctx) c.cl_ordered_fields;
 		| _ ->

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -621,7 +621,7 @@ let generate_class ctx c =
 		"fields",jlist (generate_class_field ctx CFSMember) c.cl_ordered_fields;
 		"statics",jlist (generate_class_field ctx CFSStatic) c.cl_ordered_statics;
 		"constructor",jopt (generate_class_field ctx CFSConstructor) c.cl_constructor;
-		"init",jopt (generate_texpr ctx) c.cl_init;
+		"init",jopt (generate_texpr ctx) (TClass.get_cl_init c);
 		"overrides",jlist (classfield_ref ctx) (List.filter (fun cf -> has_class_field_flag cf CfOverride) c.cl_ordered_fields);
 		"isExtern",jbool (has_class_flag c CExtern);
 		"isFinal",jbool (has_class_flag c CFinal);

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -211,6 +211,8 @@ let find_field c name kind =
 		PMap.find name c.cl_statics
 	| CfrMember ->
 		PMap.find name c.cl_fields
+	| CfrInit ->
+		begin match c.cl_init with Some cf -> cf | None -> raise Not_found end
 
 let null_module = {
 	m_id = alloc_mid();

--- a/src/core/tOther.ml
+++ b/src/core/tOther.ml
@@ -412,6 +412,30 @@ module TClass = struct
 		in
 		let apply = apply_params c.cl_params tl in
 		loop apply c
+
+
+	let get_cl_init c = match c.cl_init with
+		| Some {cf_expr = Some e} -> Some e
+		| _ -> None
+
+	let modify_cl_init c e append = match c.cl_init with
+		| Some cf ->
+			begin match cf.cf_expr with
+				| Some e' when append ->
+					cf.cf_expr <- Some (concat e' e)
+				| _ ->
+					cf.cf_expr <- Some e
+			end
+		| None ->
+			let cf = mk_field "__init__" t_dynamic null_pos null_pos in
+			cf.cf_expr <- Some e;
+			c.cl_init <- Some cf
+
+	let add_cl_init c e =
+		modify_cl_init c e true
+
+	let set_cl_init c e =
+		modify_cl_init c e false
 end
 
 let s_class_path c =

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -506,7 +506,7 @@ module Printer = struct
 			"cl_super",s_opt (fun (c,tl) -> s_type (TInst(c,tl))) c.cl_super;
 			"cl_implements",s_list ", " (fun (c,tl) -> s_type (TInst(c,tl))) c.cl_implements;
 			"cl_array_access",s_opt s_type c.cl_array_access;
-			"cl_init",s_opt (s_expr_ast true "" s_type) c.cl_init;
+			"cl_init",s_opt (s_expr_ast true "" s_type) (TOther.TClass.get_cl_init c);
 			"cl_constructor",s_opt (s_tclass_field (tabs ^ "\t")) c.cl_constructor;
 			"cl_ordered_fields",s_list "\n\t" (s_tclass_field (tabs ^ "\t")) c.cl_ordered_fields;
 			"cl_ordered_statics",s_list "\n\t" (s_tclass_field (tabs ^ "\t")) c.cl_ordered_statics;

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -413,6 +413,7 @@ let s_class_field_ref_kind = function
 	| CfrStatic -> "CfrStatic"
 	| CfrMember -> "CfrMember"
 	| CfrConstructor -> "CfrConstructor"
+	| CfrInit -> "CfrInit"
 
 module Printer = struct
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -300,7 +300,7 @@ and tclass = {
 	mutable cl_dynamic : t option;
 	mutable cl_array_access : t option;
 	mutable cl_constructor : tclass_field option;
-	mutable cl_init : texpr option;
+	mutable cl_init : tclass_field option;
 
 	mutable cl_build : unit -> build_state;
 	(*

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -421,6 +421,7 @@ and class_field_ref_kind =
 	| CfrStatic
 	| CfrMember
 	| CfrConstructor
+	| CfrInit
 
 and class_field_ref = {
 	cfr_sign : string;

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -666,15 +666,14 @@ let save_class_state com t =
 		let csr = Option.map (mk_field_restore) c.cl_constructor in
 		let ofr = List.map (mk_field_restore) c.cl_ordered_fields in
 		let osr = List.map (mk_field_restore) c.cl_ordered_statics in
-		let init = c.cl_init in
-		Option.may save_vars init;
+		let init = Option.map mk_field_restore c.cl_init in
 		c.cl_restore <- (fun() ->
 			c.cl_super <- sup;
 			c.cl_implements <- impl;
 			c.cl_meta <- meta;
 			if ext then add_class_flag c CExtern else remove_class_flag c CExtern;
 			c.cl_path <- path;
-			c.cl_init <- init;
+			c.cl_init <- Option.map restore_field init;
 			c.cl_ordered_fields <- List.map restore_field ofr;
 			c.cl_ordered_statics <- List.map restore_field osr;
 			c.cl_fields <- mk_pmap c.cl_ordered_fields;

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -81,11 +81,11 @@ let run_expression_filters ?(ignore_processed_status=false) ctx detail_times fil
 		(match c.cl_constructor with
 		| None -> ()
 		| Some f -> process_field f);
-		(match c.cl_init with
+		(match TClass.get_cl_init c with
 		| None -> ()
 		| Some e ->
 			let identifier = Printf.sprintf "%s.__init__" (s_type_path c.cl_path) in
-			c.cl_init <- Some (run (Some identifier) e));
+			TClass.set_cl_init c (run (Some identifier) e))
 	| TEnumDecl _ -> ()
 	| TTypeDecl _ -> ()
 	| TAbstractDecl _ -> ()

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -5003,7 +5003,7 @@ let find_referenced_types_flags ctx obj field_name super_deps constructor_deps h
    (* Body of main function *)
    (match obj with
    | TClassDecl class_def -> visit_class class_def;
-      (match class_def.cl_init with Some expression -> visit_params expression | _ -> ())
+      (match TClass.get_cl_init class_def with Some expression -> visit_params expression | _ -> ())
    | TEnumDecl enum_def -> visit_enum enum_def
    | TTypeDecl _ | TAbstractDecl _ -> (* These are expanded *) ());
 
@@ -5455,7 +5455,7 @@ let rec find_next_super_iteration ctx class_def =
 ;;
 
 let has_init_field class_def =
-   match class_def.cl_init with
+   match TClass.get_cl_init class_def with
    | Some _ -> true
    | _ -> false;;
 
@@ -5533,7 +5533,7 @@ let has_compare_field class_def =
 
 
 let has_boot_field class_def =
-   match class_def.cl_init with
+   match TClass.get_cl_init class_def with
    | None -> List.exists has_field_init (List.filter should_implement_field class_def.cl_ordered_statics)
    | _ -> true
 ;;
@@ -6094,7 +6094,7 @@ let generate_class_files baseCtx super_deps constructor_deps class_def inScripta
       end;
    end;
 
-   (match class_def.cl_init with
+   (match TClass.get_cl_init class_def with
    | Some expression ->
       let ctx = file_context baseCtx cpp_file debug false in
       output_cpp ("void " ^ class_name^ "::__init__()");
@@ -8379,7 +8379,7 @@ let generate_script_class common_ctx script class_def =
    script#write ((string_of_int ( (List.length ordered_fields) +
                                  (List.length ordered_statics) +
                                  (match class_def.cl_constructor with Some _ -> 1 | _ -> 0 ) +
-                                 (match class_def.cl_init with Some _ -> 1 | _ -> 0 ) ) )
+                                 (match TClass.get_cl_init class_def with Some _ -> 1 | _ -> 0 ) ) )
                                  ^ "\n");
 
    let generate_field isStatic field =
@@ -8412,7 +8412,7 @@ let generate_script_class common_ctx script class_def =
    (match class_def.cl_constructor with
       | Some field  -> generate_field true field
       | _ -> () );
-   (match class_def.cl_init with
+   (match TClass.get_cl_init class_def with
       | Some expression  -> script#voidFunc true false "__init__" expression
       | _ -> () );
 

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -3696,7 +3696,7 @@ let generate_static_init ctx types main =
 	(* init class statics *)
 	let init_exprs = ref [] in
 	List.iter (fun t ->
-		(match t with TClassDecl { cl_init = Some e } -> init_exprs := e :: !init_exprs | _ -> ());
+		(match t with TClassDecl { cl_init = Some {cf_expr = Some e} } -> init_exprs := e :: !init_exprs | _ -> ());
 		match t with
 		| TClassDecl c when not (has_class_flag c CExtern) ->
 			List.iter (fun f ->

--- a/src/generators/genjava.ml
+++ b/src/generators/genjava.ml
@@ -2201,7 +2201,7 @@ let generate con =
 			newline w
 		| _ -> ());
 
-		(match cl.cl_init with
+		(match TClass.get_cl_init cl with
 			| None -> ()
 			| Some init ->
 				write w "static";
@@ -2298,14 +2298,13 @@ let generate con =
 	let super_map (cl,tl) = (cl, List.map run_follow_gen tl) in
 	List.iter (function
 		| TClassDecl cl ->
-				let all_fields = (Option.map_default (fun cf -> [cf]) [] cl.cl_constructor) @ cl.cl_ordered_fields @ cl.cl_ordered_statics in
+				let all_fields = (Option.map_default (fun cf -> [cf]) [] cl.cl_constructor) @ cl.cl_ordered_fields @ cl.cl_ordered_statics @ (Option.map_default (fun cf -> [cf]) [] cl.cl_init)in
 				List.iter (fun cf ->
 					cf.cf_type <- run_follow_gen cf.cf_type;
 					cf.cf_expr <- Option.map type_map cf.cf_expr
 				) all_fields;
 			 cl.cl_dynamic <- Option.map run_follow_gen cl.cl_dynamic;
 			 cl.cl_array_access <- Option.map run_follow_gen cl.cl_array_access;
-			 cl.cl_init <- Option.map type_map cl.cl_init;
 			 cl.cl_super <- Option.map super_map cl.cl_super;
 			 cl.cl_implements <- List.map super_map cl.cl_implements
 		| _ -> ()

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -1623,7 +1623,7 @@ let need_to_generate_interface ctx cl_iface =
 
 let generate_type ctx = function
 	| TClassDecl c ->
-		(match c.cl_init with
+		(match TClass.get_cl_init c with
 		| None -> ()
 		| Some e ->
 			ctx.inits <- e :: ctx.inits);

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -2532,10 +2532,7 @@ class tclass_to_jvm gctx c = object(self)
 			let p = null_pos in
 			let efield = Texpr.Builder.make_static_field c cf p in
 			let eop = mk (TBinop(OpAssign,efield,e)) cf.cf_type p in
-			begin match c.cl_init with
-			| None -> c.cl_init <- Some eop
-			| Some e -> c.cl_init <- Some (concat e eop)
-			end
+			TClass.add_cl_init c eop
 		in
 		begin match cf.cf_expr with
 			| None ->
@@ -2618,7 +2615,7 @@ class tclass_to_jvm gctx c = object(self)
 			| Some cf,None -> field MConstructor cf
 			| None,_ -> ()
 		end;
-		begin match c.cl_init with
+		begin match TClass.get_cl_init c with
 			| None ->
 				()
 			| Some e ->

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1840,7 +1840,7 @@ let generate_require ctx path meta =
 
 let generate_type ctx = function
     | TClassDecl c ->
-        (match c.cl_init with
+        (match TClass.get_cl_init c with
          | None -> ()
          | Some e ->
              ctx.inits <- e :: ctx.inits);

--- a/src/generators/genneko.ml
+++ b/src/generators/genneko.ml
@@ -555,7 +555,7 @@ let gen_enum ctx e =
 let gen_type ctx t acc =
 	match t with
 	| TClassDecl c ->
-		(match c.cl_init with
+		(match TClass.get_cl_init c with
 		| None -> ()
 		| Some e -> ctx.inits <- (c,e) :: ctx.inits);
 		if (has_class_flag c CExtern) then

--- a/src/generators/genphp7.ml
+++ b/src/generators/genphp7.ml
@@ -959,7 +959,7 @@ class class_wrapper (cls) =
 			if (has_class_flag cls CInterface) then
 				false
 			else
-				match cls.cl_init with
+				match TClass.get_cl_init cls with
 					| Some _ -> true
 					| None ->
 						List.exists
@@ -978,7 +978,7 @@ class class_wrapper (cls) =
 			Returns expression of a user-defined static __init__ method
 			@see http://old.haxe.org/doc/advanced/magic#initialization-magic
 		*)
-		method! get_magic_init = cls.cl_init
+		method! get_magic_init = TClass.get_cl_init cls
 		(**
 			Returns hx source file name where this type was declared
 		*)
@@ -994,7 +994,7 @@ class class_wrapper (cls) =
 			if not (has_class_flag cls CExtern) then
 				None
 			else
-				match cls.cl_init with
+				match TClass.get_cl_init cls with
 					| None -> None
 					| Some body ->
 						let path =
@@ -1009,8 +1009,8 @@ class class_wrapper (cls) =
 								cl_ordered_fields  = [];
 								cl_ordered_statics  = [];
 								cl_constructor = None;
-								cl_init = Some body
 						} in
+						TClass.set_cl_init additional_cls body;
 						remove_class_flag additional_cls CExtern;
 						Some (TClassDecl additional_cls)
 	end

--- a/src/generators/genpy.ml
+++ b/src/generators/genpy.ml
@@ -2001,7 +2001,7 @@ module Generator = struct
 		!has_static_methods || !has_empty_static_vars
 
 	let gen_class_init ctx c =
-		match c.cl_init with
+		match TClass.get_cl_init c with
 			| None ->
 				()
 			| Some e ->

--- a/src/generators/genswf.ml
+++ b/src/generators/genswf.ml
@@ -142,7 +142,7 @@ let build_dependencies t =
 			add_field f;
 			if c.cl_path <> (["flash"],"Boot") then add_path (["flash"],"Boot") DKExpr;
 		);
-		(match c.cl_init with
+		(match TClass.get_cl_init c with
 		| None -> ()
 		| Some e -> add_expr e);
 		(match c.cl_super with

--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -1982,7 +1982,7 @@ let generate_extern_inits ctx =
 	List.iter (fun t ->
 		match t with
 		| TClassDecl c when (has_class_flag c CExtern) ->
-			(match c.cl_init with
+			(match TClass.get_cl_init c with
 			| None -> ()
 			| Some e -> gen_expr ctx false e);
 		| _ -> ()
@@ -2035,7 +2035,7 @@ let generate_class_init ctx c hc =
 	if not (has_class_flag c CInterface) then write ctx HPopScope;
 	write ctx (HInitProp (type_path ctx c.cl_path));
 	if ctx.swc && c.cl_path = ctx.boot then generate_extern_inits ctx;
-	(match c.cl_init with
+	(match TClass.get_cl_init c with
 	| None -> ()
 	| Some e ->
 		gen_expr ctx false e;

--- a/src/macro/eval/evalPrototype.ml
+++ b/src/macro/eval/evalPrototype.ml
@@ -211,7 +211,7 @@ let create_static_prototype ctx mt =
 			|  _ ->
 				()
 		) fields;
-		begin match c.cl_init with
+		begin match TClass.get_cl_init c with
 			| None -> ()
 			| Some e -> DynArray.add delays (false,(fun _ -> ignore(eval_expr ctx (EKMethod(key,key___init__)) e)))
 		end;

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -1169,7 +1169,7 @@ and encode_tclass c =
 		"fields", encode_ref c.cl_ordered_fields (encode_and_map_array encode_cfield) (fun() -> "class fields");
 		"statics", encode_ref c.cl_ordered_statics (encode_and_map_array encode_cfield) (fun() -> "class fields");
 		"constructor", (match c.cl_constructor with None -> vnull | Some cf -> encode_cfref cf);
-		"init", (match c.cl_init with None -> vnull | Some e -> encode_texpr e);
+		"init", (match TClass.get_cl_init c with None -> vnull | Some e -> encode_texpr e);
 		"overrides", (encode_array (List.map encode_cfref (List.filter (fun cf -> has_class_field_flag cf CfOverride) c.cl_ordered_fields)))
 	]
 

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -1126,7 +1126,7 @@ module Run = struct
 			| None -> ()
 			| Some f -> process_field false f;
 		end;
-		begin match c.cl_init with
+		begin match TClass.get_cl_init c with
 			| None ->
 				()
 			| Some e ->
@@ -1138,7 +1138,7 @@ module Run = struct
 					| TFunction tf -> tf.tf_expr
 					| _ -> die "" __LOC__
 				in
-				c.cl_init <- Some e
+				TClass.set_cl_init c e
 		end
 
 	let run_on_type com config t =

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -186,6 +186,11 @@ and mark_field dce c cf kind =
 			| None -> ()
 		in
 		loop c
+	| CfrInit ->
+		begin match c.cl_init with
+			| Some cf -> add c cf
+			| None -> ()
+		end
 	| CfrStatic | CfrMember ->
 		let stat = kind = CfrStatic in
 		if not (PMap.mem cf.cf_name (if stat then c.cl_statics else c.cl_fields)) then begin
@@ -764,7 +769,7 @@ let collect_entry_points dce com =
 			end;
 			begin match c.cl_init with
 				| Some cf when keep_class || Meta.has Meta.KeepInit c.cl_meta ->
-					loop CfrStatic cf
+					loop CfrInit cf
 				| _ ->
 					()
 			end;

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -209,7 +209,7 @@ let rec update_marked_class_fields dce c =
 		if has_class_field_flag cf CfMaybeUsed then mark_field dce c cf CfrMember
 	) c.cl_ordered_fields;
 	(* we always have to keep super classes and implemented interfaces *)
-	(match c.cl_init with None -> () | Some init -> dce.follow_expr dce init);
+	(match TClass.get_cl_init c with None -> () | Some init -> dce.follow_expr dce init);
 	List.iter (fun (c,_) -> mark_class dce c) c.cl_implements;
 	(match c.cl_super with None -> () | Some (csup,pl) -> mark_class dce csup);
 	pop()
@@ -763,10 +763,7 @@ let collect_entry_points dce com =
 				| None -> ()
 			end;
 			begin match c.cl_init with
-				| Some e when keep_class || Meta.has Meta.KeepInit c.cl_meta ->
-					(* create a fake field to deal with our internal logic (issue #3286) *)
-					let cf = mk_field "__init__" e.etype e.epos null_pos in
-					cf.cf_expr <- Some e;
+				| Some cf when keep_class || Meta.has Meta.KeepInit c.cl_meta ->
 					loop CfrStatic cf
 				| _ ->
 					()
@@ -874,7 +871,7 @@ let sweep dce com =
 			let has_non_extern_fields = List.exists inef c.cl_ordered_fields || List.exists inef c.cl_ordered_statics in
 			(* we keep a class if it was used or has a used field *)
 			if has_class_flag c CUsed || has_non_extern_fields then loop (mt :: acc) l else begin
-				(match c.cl_init with
+				(match TClass.get_cl_init c with
 				| Some f when Meta.has Meta.KeepInit c.cl_meta ->
 					(* it means that we only need the __init__ block *)
 					add_class_flag c CExtern;

--- a/src/typing/finalization.ml
+++ b/src/typing/finalization.ml
@@ -179,7 +179,7 @@ let sort_types com (modules : module_lut) =
 	and walk_class p c =
 		(match c.cl_super with None -> () | Some (c,_) -> loop_class p c);
 		List.iter (fun (c,_) -> loop_class p c) c.cl_implements;
-		(match c.cl_init with
+		(match TClass.get_cl_init c with
 		| None -> ()
 		| Some e -> walk_expr p e);
 		PMap.iter (fun _ f ->

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -364,7 +364,7 @@ let build_generic_class ctx c p tl =
 			cf_new.cf_type <- TLazy r;
 			cf_new
 		in
-		if c.cl_init <> None then raise_typing_error "This class can't be generic" p;
+		if TClass.get_cl_init c <> None then raise_typing_error "This class can't be generic" p;
 		List.iter (fun cf -> match cf.cf_kind with
 			| Method MethMacro when not ctx.com.is_macro_context -> ()
 			| _ -> raise_typing_error "A generic class can't have static fields" cf.cf_pos

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1513,7 +1513,7 @@ class class_checker cls immediate_execution report =
 						self#check_accessors is_static f
 			end in
 			if is_safe_class then
-				Option.may ((self#get_checker (safety_mode cls_meta))#check_root_expr) cls.cl_init;
+				Option.may ((self#get_checker (safety_mode cls_meta))#check_root_expr) (TClass.get_cl_init cls);
 			Option.may (check_field false) cls.cl_constructor;
 			List.iter (check_field false) cls.cl_ordered_fields;
 			List.iter (check_field true) cls.cl_ordered_statics;

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -979,7 +979,7 @@ module TypeBinding = struct
 					if fctx.field_kind = FKInit then
 						(match e.eexpr with
 						| TBlock [] | TBlock [{ eexpr = TConst _ }] | TConst _ | TObjectDecl [] -> ()
-						| _ -> c.cl_init <- Some e);
+						| _ -> TClass.set_cl_init c e);
 					cf.cf_expr <- Some (mk (TFunction tf) t p);
 					cf.cf_type <- t;
 					check_field_display ctx fctx c cf;


### PR DESCRIPTION
We have various parts of the compiler which are field-based and then struggle a bit when dealing with the expression-based `cl_init`. This PR changes the representation to use a `tclass_field` for these as well, but hides the class-field-ness behind a small API.