### PR TITLE
Fix haxe.macro.Printer ("class MyClass<T:(A, B)>" => "class MyClass<T:(A & B)>")

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -200,7 +200,7 @@ class Printer {
 		return (tpd.meta != null && tpd.meta.length > 0 ? tpd.meta.map(printMetadata).join(" ") + " " : "")
 			+ tpd.name
 			+ (tpd.params != null && tpd.params.length > 0 ? "<" + tpd.params.map(printTypeParamDecl).join(", ") + ">" : "")
-			+ (tpd.constraints != null && tpd.constraints.length > 0 ? ":(" + tpd.constraints.map(printComplexType).join(", ") + ")" : "")
+			+ (tpd.constraints != null && tpd.constraints.length > 0 ? ":(" + tpd.constraints.map(printComplexType).join(" & ") + ")" : "")
 			+ (tpd.defaultType != null ? "=" + printComplexType(tpd.defaultType) : "");
 
 	public function printFunctionArg(arg:FunctionArg)


### PR DESCRIPTION
Old version generate code:
```
class MyClass<T:(A, B)>
```
Compiling that code produce error "unexpected >".

New version produce
```
class MyClass<T:(A & B)>
```
which compile OK