### PR TITLE
Set --run args only when we're actually running

### DIFF
--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -54,6 +54,7 @@ and compilation_context = {
 	mutable has_next : bool;
 	mutable has_error : bool;
 	comm : communication;
+	mutable runtime_args : string list;
 }
 
 type compilation_callbacks = {

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -509,6 +509,7 @@ let create_context comm cs compilation_step params = {
 	has_next = false;
 	has_error = false;
 	comm = comm;
+	runtime_args = [];
 }
 
 module HighLevel = struct
@@ -614,7 +615,7 @@ module HighLevel = struct
 			| "--run" :: cl :: args ->
 				let acc = cl :: "-x" :: acc in
 				let ctx = create_context (List.rev acc) in
-				ctx.com.sys_args <- args;
+				ctx.runtime_args <- args;
 				[],Some ctx
 			| ("-L" | "--library" | "-lib") :: name :: args ->
 				let libs,args = find_subsequent_libs [name] args in

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -121,9 +121,16 @@ let generate ctx tctx ext actx =
 		| Java when not actx.jvm_flag -> Path.mkdir_from_path (com.file ^ "/.")
 		| _ -> Path.mkdir_from_path com.file
 	end;
-	if actx.interp then
-		Std.finally (Timer.timer ["interp"]) MacroContext.interpret tctx
-	else begin
+	if actx.interp then begin
+		let timer = Timer.timer ["interp"] in
+		let old = tctx.com.args in
+		tctx.com.args <- ctx.runtime_args;
+		let restore () =
+			tctx.com.args <- old;
+			timer ()
+		in
+		Std.finally restore MacroContext.interpret tctx
+	end else begin
 		let generate,name = match com.platform with
 		| Flash ->
 			let header = try

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -354,8 +354,7 @@ type context = {
 	mutable json_out : json_api option;
 	(* config *)
 	version : int;
-	args : string list;
-	mutable sys_args : string list;
+	mutable args : string list;
 	mutable display : DisplayTypes.DisplayMode.settings;
 	mutable debug : bool;
 	mutable verbose : bool;
@@ -810,7 +809,6 @@ let create compilation_step cs version args display_mode =
 			display_module_has_macro_defines = false;
 			module_diagnostics = [];
 		};
-		sys_args = args;
 		debug = false;
 		display = display_mode;
 		verbose = false;

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2569,7 +2569,7 @@ module StdSys = struct
 	open Common
 
 	let args = vfun0 (fun () ->
-		encode_array (List.map create_unknown ((get_ctx()).curapi.MacroApi.get_com()).sys_args)
+		encode_array (List.map create_unknown ((get_ctx()).curapi.MacroApi.get_com()).args)
 	)
 
 	let _command = vfun1 (fun cmd ->

--- a/tests/misc/projects/Issue11087/Main.hx
+++ b/tests/misc/projects/Issue11087/Main.hx
@@ -1,0 +1,9 @@
+macro function test() {
+	trace(Sys.args());
+	return macro null;
+}
+
+function main() {
+	test();
+	trace(Sys.args());
+}

--- a/tests/misc/projects/Issue11087/compile-interp.hxml
+++ b/tests/misc/projects/Issue11087/compile-interp.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue11087/compile-interp.hxml.stdout
+++ b/tests/misc/projects/Issue11087/compile-interp.hxml.stdout
@@ -1,0 +1,2 @@
+Main.hx:2: [--main,Main,--interp]
+Main.hx:8: []

--- a/tests/misc/projects/Issue11087/compile.hxml
+++ b/tests/misc/projects/Issue11087/compile.hxml
@@ -1,0 +1,2 @@
+--run Main
+arg

--- a/tests/misc/projects/Issue11087/compile.hxml.stdout
+++ b/tests/misc/projects/Issue11087/compile.hxml.stdout
@@ -1,0 +1,2 @@
+Main.hx:2: [-x,Main]
+Main.hx:8: [arg]


### PR DESCRIPTION
This changes the behavior of `Sys.args()` to what @tobil4sk suggests in https://github.com/HaxeFoundation/haxe/issues/11087#issuecomment-1917242911.

Doesn't add a test yet because our sys tests require a PHD.