### PR TITLE
Simplify type parameter typing

### DIFF
--- a/src/codegen/gencommon/closuresToClass.ml
+++ b/src/codegen/gencommon/closuresToClass.ml
@@ -393,7 +393,12 @@ let configure gen ft =
 		in
 
 		(*let cltypes = List.map (fun cl -> (snd cl.cl_path, TInst(map_param cl, []) )) tparams in*)
-		let cltypes = List.map (fun cl -> mk_type_param cl TPHType None None) tparams in
+		let cltypes = List.map (fun cl ->
+			let lol = cl.cl_kind in
+			let ttp = mk_type_param cl TPHType None None in
+			cl.cl_kind <- lol;
+			ttp
+		) tparams in
 
 		(* create a new class that extends abstract function class, with a ctor implementation that will setup all captured variables *)
 		let cfield = match gen.gcurrent_classfield with

--- a/src/codegen/gencommon/gencommon.ml
+++ b/src/codegen/gencommon/gencommon.ml
@@ -1142,9 +1142,7 @@ let clone_param ttp =
 	let ret = mk_class cl.cl_module (fst cl.cl_path, snd cl.cl_path ^ "_c") cl.cl_pos null_pos in
 	ret.cl_implements <- cl.cl_implements;
 	ret.cl_kind <- cl.cl_kind;
-	let ttp = mk_type_param ret ttp.ttp_host ttp.ttp_default ttp.ttp_constraints in
-	ret.cl_kind <- KTypeParameter ttp;
-	ttp
+	mk_type_param ret ttp.ttp_host ttp.ttp_default ttp.ttp_constraints
 
 let get_cl_t t =
 	match follow t with | TInst (cl,_) -> cl | _ -> die "" __LOC__

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -899,9 +899,7 @@ class hxb_reader
 				| i -> die (Printf.sprintf "Invalid type paramter host: %i" i) __LOC__
 			in
 			let c = mk_class current_module path pos pos in
-			let ttp = mk_type_param c host None None in
-			c.cl_kind <- KTypeParameter ttp;
-			ttp
+			mk_type_param c host None None
 		)
 
 	method read_type_parameters_data (a : typed_type_param array) =

--- a/src/context/display/displayTexpr.ml
+++ b/src/context/display/displayTexpr.ml
@@ -87,7 +87,7 @@ let check_display_class ctx decls c =
 		List.iter check_field c.cl_ordered_statics;
 	| _ ->
 		let sc = find_class_by_position decls c.cl_name_pos in
-		ignore(Typeload.type_type_params ctx TPHType c.cl_path (fun() -> c.cl_params) null_pos sc.d_params);
+		ignore(Typeload.type_type_params ctx TPHType c.cl_path null_pos sc.d_params);
 		List.iter (function
 			| (HExtends ptp | HImplements ptp) when display_position#enclosed_in ptp.pos_full ->
 				ignore(Typeload.load_instance ~allow_display:true ctx ptp ParamNormal)
@@ -101,7 +101,7 @@ let check_display_class ctx decls c =
 
 let check_display_enum ctx decls en =
 	let se = find_enum_by_position decls en.e_name_pos in
-	ignore(Typeload.type_type_params ctx TPHType en.e_path (fun() -> en.e_params) null_pos se.d_params);
+	ignore(Typeload.type_type_params ctx TPHType en.e_path null_pos se.d_params);
 	PMap.iter (fun _ ef ->
 		if display_position#enclosed_in ef.ef_pos then begin
 			let sef = find_enum_field_by_position se ef.ef_name_pos in
@@ -111,12 +111,12 @@ let check_display_enum ctx decls en =
 
 let check_display_typedef ctx decls td =
 	let st = find_typedef_by_position decls td.t_name_pos in
-	ignore(Typeload.type_type_params ctx TPHType td.t_path (fun() -> td.t_params) null_pos st.d_params);
+	ignore(Typeload.type_type_params ctx TPHType td.t_path null_pos st.d_params);
 	ignore(Typeload.load_complex_type ctx true st.d_data)
 
 let check_display_abstract ctx decls a =
 	let sa = find_abstract_by_position decls a.a_name_pos in
-	ignore(Typeload.type_type_params ctx TPHType a.a_path (fun() -> a.a_params) null_pos sa.d_params);
+	ignore(Typeload.type_type_params ctx TPHType a.a_path null_pos sa.d_params);
 	List.iter (function
 		| (AbOver(ct,p) | AbFrom(ct,p) | AbTo(ct,p)) when display_position#enclosed_in p ->
 			ignore(Typeload.load_complex_type ctx true (ct,p))

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -517,9 +517,7 @@ let clone_type_parameter map path ttp =
 		| None -> None
 		| Some constraints -> Some (lazy (List.map map (Lazy.force constraints)))
 	in
-	let ttp' = mk_type_param c ttp.ttp_host def constraints in
-	c.cl_kind <- KTypeParameter ttp';
-	ttp'
+	mk_type_param c ttp.ttp_host def constraints
 
 (** checks if we can access to a given class field using current context *)
 let can_access ctx c cf stat =

--- a/src/core/tFunctions.ml
+++ b/src/core/tFunctions.ml
@@ -722,14 +722,17 @@ let lookup_param n l =
 	in
 	loop l
 
-let mk_type_param c host def constraints = {
-	ttp_name = snd c.cl_path;
-	ttp_type = TInst(c,[]);
-	ttp_class = c;
-	ttp_host = host;
-	ttp_constraints = constraints;
-	ttp_default = def;
-}
+let mk_type_param c host def constraints =
+	let ttp = {
+		ttp_name = snd c.cl_path;
+		ttp_type = TInst(c,[]);
+		ttp_class = c;
+		ttp_host = host;
+		ttp_constraints = constraints;
+		ttp_default = def;
+	} in
+	c.cl_kind <- KTypeParameter ttp;
+	ttp
 
 let type_of_module_type = function
 	| TClassDecl c -> TInst (c,extract_param_types c.cl_params)

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -726,10 +726,10 @@ let load_type_hint ?(opt=false) ctx pcur t =
 (* ---------------------------------------------------------------------- *)
 (* PASS 1 & 2 : Module and Class Structure *)
 
-let rec type_type_param ctx host path get_params p tp =
+let rec type_type_param ctx host path p tp =
 	let n = fst tp.tp_name in
 	let c = mk_class ctx.m.curmod (fst path @ [snd path],n) (pos tp.tp_name) (pos tp.tp_name) in
-	c.cl_params <- type_type_params ctx host c.cl_path get_params p tp.tp_params;
+	c.cl_params <- type_type_params ctx host c.cl_path p tp.tp_params;
 	c.cl_meta <- tp.Ast.tp_meta;
 	if host = TPHEnumConstructor then c.cl_meta <- (Meta.EnumConstructorParam,[],null_pos) :: c.cl_meta;
 	let t = TInst (c,extract_param_types c.cl_params) in
@@ -755,13 +755,25 @@ let rec type_type_param ctx host path get_params p tp =
 			) "default" in
 			Some (TLazy r)
 	in
-	let ttp = match tp.tp_constraints with
+	let ttp = mk_type_param c host default None in
+	c.cl_kind <- KTypeParameter ttp;
+	ttp
+
+and type_type_params ctx host path p tpl =
+	let names = ref [] in
+	let param_pairs = List.map (fun tp ->
+		if List.exists (fun name -> name = fst tp.tp_name) !names then display_error ctx.com ("Duplicate type parameter name: " ^ fst tp.tp_name) (pos tp.tp_name);
+		names := (fst tp.tp_name) :: !names;
+		tp,type_type_param ctx host path p tp
+	) tpl in
+	let params = List.map snd param_pairs in
+	let ctx = { ctx with type_params = params @ ctx.type_params } in
+	List.iter (fun (tp,ttp) ->
+		match tp.tp_constraints with
 		| None ->
-			mk_type_param c host default None
+			()
 		| Some th ->
-			let current_type_params = ctx.type_params in
 			let constraints = lazy (
-				let ctx = { ctx with type_params = get_params() @ current_type_params } in
 				let rec loop th = match fst th with
 					| CTIntersection tl -> List.map (load_complex_type ctx true) tl
 					| CTParent ct -> loop ct
@@ -771,7 +783,7 @@ let rec type_type_param ctx host path get_params p tp =
 				(* check against direct recursion *)
 				let rec loop t =
 					match follow t with
-					| TInst (c2,_) when c == c2 ->
+					| TInst (c2,_) when ttp.ttp_class == c2 ->
 						raise_typing_error "Recursive constraint parameter is not allowed" p
 					| TInst ({ cl_kind = KTypeParameter ttp },_) ->
 						List.iter loop (get_constraints ttp)
@@ -782,18 +794,9 @@ let rec type_type_param ctx host path get_params p tp =
 				constr
 			) in
 			delay ctx PConnectField (fun () -> ignore (Lazy.force constraints));
-			mk_type_param c host default (Some constraints)
-	in
-	c.cl_kind <- KTypeParameter ttp;
-	ttp
-
-and type_type_params ctx host path get_params p tpl =
-	let names = ref [] in
-	List.map (fun tp ->
-		if List.exists (fun name -> name = fst tp.tp_name) !names then display_error ctx.com ("Duplicate type parameter name: " ^ fst tp.tp_name) (pos tp.tp_name);
-		names := (fst tp.tp_name) :: !names;
-		type_type_param ctx host path get_params p tp
-	) tpl
+			ttp.ttp_constraints <- Some constraints;
+	) param_pairs;
+	params
 
 let load_core_class ctx c =
 	let ctx2 = (match ctx.g.core_api with

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -733,7 +733,6 @@ let rec type_type_param ctx host path p tp =
 	c.cl_meta <- tp.Ast.tp_meta;
 	if host = TPHEnumConstructor then c.cl_meta <- (Meta.EnumConstructorParam,[],null_pos) :: c.cl_meta;
 	let ttp = mk_type_param c host None None in
-	c.cl_kind <- KTypeParameter ttp;
 	if ctx.is_display_file && DisplayPosition.display_position#enclosed_in (pos tp.tp_name) then
 		DisplayEmitter.display_type ctx ttp.ttp_type (pos tp.tp_name);
 	ttp

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -44,9 +44,7 @@ let save_field_state ctx =
 	)
 
 let type_function_params ctx fd host fname p =
-	let params = ref [] in
-	params := Typeload.type_type_params ctx host ([],fname) (fun() -> !params) p fd.f_params;
-	!params
+	Typeload.type_type_params ctx host ([],fname) p fd.f_params
 
 let type_function ctx (args : function_arguments) ret fmode e do_display p =
 	ctx.in_function <- true;

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -320,7 +320,7 @@ module ModuleLevel = struct
 		 List.iter (fun d ->
 			match d with
 			| (TClassDecl c, (EClass d, p)) ->
-				c.cl_params <- type_type_params ctx TPHType c.cl_path (fun() -> c.cl_params) p d.d_params;
+				c.cl_params <- type_type_params ctx TPHType c.cl_path p d.d_params;
 				if Meta.has Meta.Generic c.cl_meta && c.cl_params <> [] then c.cl_kind <- KGeneric;
 				if Meta.has Meta.GenericBuild c.cl_meta then begin
 					if ctx.com.is_macro_context then raise_typing_error "@:genericBuild cannot be used in macros" c.cl_pos;
@@ -328,11 +328,11 @@ module ModuleLevel = struct
 				end;
 				if c.cl_path = (["haxe";"macro"],"MacroType") then c.cl_kind <- KMacroType;
 			| (TEnumDecl e, (EEnum d, p)) ->
-				e.e_params <- type_type_params ctx TPHType e.e_path (fun() -> e.e_params) p d.d_params;
+				e.e_params <- type_type_params ctx TPHType e.e_path p d.d_params;
 			| (TTypeDecl t, (ETypedef d, p)) ->
-				t.t_params <- type_type_params ctx TPHType t.t_path (fun() -> t.t_params) p d.d_params;
+				t.t_params <- type_type_params ctx TPHType t.t_path p d.d_params;
 			| (TAbstractDecl a, (EAbstract d, p)) ->
-				a.a_params <- type_type_params ctx TPHType a.a_path (fun() -> a.a_params) p d.d_params;
+				a.a_params <- type_type_params ctx TPHType a.a_path p d.d_params;
 			| _ ->
 				die "" __LOC__
 		) decls
@@ -341,9 +341,7 @@ end
 module TypeLevel = struct
 	let load_enum_field ctx e et is_flat index c =
 		let p = c.ec_pos in
-		let params = ref [] in
-		params := type_type_params ctx TPHEnumConstructor ([],fst c.ec_name) (fun() -> !params) c.ec_pos c.ec_params;
-		let params = !params in
+		let params = type_type_params ctx TPHEnumConstructor ([],fst c.ec_name) c.ec_pos c.ec_params in
 		let ctx = { ctx with type_params = params @ ctx.type_params } in
 		let rt = (match c.ec_type with
 			| None -> et


### PR DESCRIPTION
Instead of doing whatever it is we're doing right now, the process of typing a list of type parameters is now simplified:

1. Create all ttp instances
2. Create a context which has them in `type_params`
3. Type all their defaults and constraints

Should not break anything, so it probably will.