### PR TITLE
Skip abstract impl classes when applying addGlobalMetadata

### DIFF
--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -377,7 +377,10 @@ module TypeLevel = struct
 	let init_class ctx_m c d p =
 		if ctx_m.m.is_display_file && DisplayPosition.display_position#enclosed_in (pos d.d_name) then
 			DisplayEmitter.display_module_type ctx_m (match c.cl_kind with KAbstractImpl a -> TAbstractDecl a | _ -> TClassDecl c) (pos d.d_name);
-		TypeloadCheck.check_global_metadata ctx_m c.cl_meta (fun m -> c.cl_meta <- m :: c.cl_meta) c.cl_module.m_path c.cl_path None;
+		(match c.cl_kind with
+			| KAbstractImpl _ -> ()
+			| _ -> TypeloadCheck.check_global_metadata ctx_m c.cl_meta (fun m -> c.cl_meta <- m :: c.cl_meta) c.cl_module.m_path c.cl_path None
+		);
 		let herits = d.d_flags in
 		List.iter (fun (m,_,p) ->
 			if m = Meta.Final then begin

--- a/tests/misc/projects/Issue11545/Macro.hx
+++ b/tests/misc/projects/Issue11545/Macro.hx
@@ -1,0 +1,30 @@
+#if macro
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+class Macro {
+	public static function initMacro() {
+		Compiler.addGlobalMetadata("Main", "@:build(Macro.instrumentFields())", true, true, false);
+	}
+
+	static function instrumentFields():Null<Array<Field>> {
+		var fields:Array<Field> = Context.getBuildFields();
+		for (field in fields) {
+			switch (field.kind) {
+				case FFun(f):
+					if (f.expr == null) {
+						continue;
+					}
+					switch (f.expr.expr) {
+						case EBlock(exprs):
+							exprs.unshift(macro trace($v{field.name}));
+						case _:
+					}
+				case _:
+			}
+		}
+		return fields;
+	}
+}
+#end

--- a/tests/misc/projects/Issue11545/Main.hx
+++ b/tests/misc/projects/Issue11545/Main.hx
@@ -1,0 +1,12 @@
+class Main {
+	static function main() {
+		var name = new ImageName("abc");
+		trace(name);
+	}
+}
+
+abstract ImageName(String) {
+	public function new(name:String) {
+		this = name;
+	}
+}

--- a/tests/misc/projects/Issue11545/compile.hxml
+++ b/tests/misc/projects/Issue11545/compile.hxml
@@ -1,0 +1,2 @@
+--macro Macro.initMacro()
+--run Main

--- a/tests/misc/projects/Issue11545/compile.hxml.stdout
+++ b/tests/misc/projects/Issue11545/compile.hxml.stdout
@@ -1,0 +1,3 @@
+Macro.hx:21: main
+Macro.hx:21: _new
+Main.hx:4: abc


### PR DESCRIPTION
Note that some metas will be forwarded, see https://github.com/HaxeFoundation/haxe/blob/development/src/typing/typeloadModule.ml#L572-L577

Closes #11545 