### PR TITLE
Add load_instance_mode

### DIFF
--- a/src/context/display/displayTexpr.ml
+++ b/src/context/display/displayTexpr.ml
@@ -90,7 +90,7 @@ let check_display_class ctx decls c =
 		ignore(Typeload.type_type_params ctx TPHType c.cl_path null_pos sc.d_params);
 		List.iter (function
 			| (HExtends ptp | HImplements ptp) when display_position#enclosed_in ptp.pos_full ->
-				ignore(Typeload.load_instance ~allow_display:true ctx ptp ParamNormal)
+				ignore(Typeload.load_instance ~allow_display:true ctx ptp ParamNormal LoadNormal)
 			| _ ->
 				()
 		) sc.d_flags;
@@ -112,14 +112,14 @@ let check_display_enum ctx decls en =
 let check_display_typedef ctx decls td =
 	let st = find_typedef_by_position decls td.t_name_pos in
 	ignore(Typeload.type_type_params ctx TPHType td.t_path null_pos st.d_params);
-	ignore(Typeload.load_complex_type ctx true st.d_data)
+	ignore(Typeload.load_complex_type ctx true LoadNormal st.d_data)
 
 let check_display_abstract ctx decls a =
 	let sa = find_abstract_by_position decls a.a_name_pos in
 	ignore(Typeload.type_type_params ctx TPHType a.a_path null_pos sa.d_params);
 	List.iter (function
 		| (AbOver(ct,p) | AbFrom(ct,p) | AbTo(ct,p)) when display_position#enclosed_in p ->
-			ignore(Typeload.load_complex_type ctx true (ct,p))
+			ignore(Typeload.load_complex_type ctx true LoadNormal (ct,p))
 		| _ ->
 			()
 	) sa.d_flags

--- a/src/core/inheritDoc.ml
+++ b/src/core/inheritDoc.ml
@@ -34,8 +34,8 @@ let rec get_class_field c field_name =
 		| None -> raise Not_found
 		| Some (csup, _) -> get_class_field csup field_name
 
-let find_type ctx (tp,p) =
-	try Typeload.load_instance' ctx (make_ptp tp p) ParamSpawnMonos
+let find_type ctx mode (tp,p) =
+	try Typeload.load_instance' ctx (make_ptp tp p) ParamSpawnMonos mode
 	with _ -> raise Not_found
 
 (**
@@ -160,7 +160,7 @@ and get_target_doc ctx e_target =
 			| _ ->
 				mk_type_path path
 		in
-		let t = (find_type ctx (tp,snd e_target)) in
+		let t = (find_type ctx LoadNormal (tp,snd e_target)) in
 		try
 			match follow t with
 			| TInst (c, _) ->
@@ -207,11 +207,11 @@ and get_target_doc ctx e_target =
 	in
 	let resolve_type () =
 		let tp = mk_type_path path, snd e_target in
-		resolve_type_t (find_type ctx tp)
+		resolve_type_t (find_type ctx LoadNormal tp)
 	in
 	let resolve_sub_type sub =
 		let tp = mk_type_path ~sub path, snd e_target in
-		resolve_type_t (find_type ctx tp)
+		resolve_type_t (find_type ctx LoadNormal tp)
 	in
 	try
 		match sub with

--- a/src/filters/exceptions.ml
+++ b/src/filters/exceptions.ml
@@ -511,23 +511,23 @@ let filter tctx =
 			make_ptp tp null_pos
 		in
 		let wildcard_catch_type =
-			let t = Typeload.load_instance tctx (tp config.ec_wildcard_catch) ParamSpawnMonos in
+			let t = Typeload.load_instance tctx (tp config.ec_wildcard_catch) ParamSpawnMonos LoadNormal in
 			if is_dynamic t then t_dynamic
 			else t
 		and base_throw_type =
-			let t = Typeload.load_instance tctx (tp config.ec_base_throw) ParamSpawnMonos in
+			let t = Typeload.load_instance tctx (tp config.ec_base_throw) ParamSpawnMonos LoadNormal in
 			if is_dynamic t then t_dynamic
 			else t
 		and haxe_exception_type, haxe_exception_class =
-			match Typeload.load_instance tctx (tp haxe_exception_type_path) ParamSpawnMonos with
+			match Typeload.load_instance tctx (tp haxe_exception_type_path) ParamSpawnMonos LoadNormal with
 			| TInst(cls,_) as t -> t,cls
 			| _ -> raise_typing_error "haxe.Exception is expected to be a class" null_pos
 		and value_exception_type, value_exception_class =
-			match Typeload.load_instance tctx (tp value_exception_type_path) ParamSpawnMonos with
+			match Typeload.load_instance tctx (tp value_exception_type_path) ParamSpawnMonos LoadNormal with
 			| TInst(cls,_) as t -> t,cls
 			| _ -> raise_typing_error "haxe.ValueException is expected to be a class" null_pos
 		and haxe_native_stack_trace =
-			match Typeload.load_instance tctx (tp (["haxe"],"NativeStackTrace")) ParamSpawnMonos with
+			match Typeload.load_instance tctx (tp (["haxe"],"NativeStackTrace")) ParamSpawnMonos LoadNormal with
 			| TInst(cls,_) -> cls
 			| TAbstract({ a_impl = Some cls },_) -> cls
 			| _ -> raise_typing_error "haxe.NativeStackTrace is expected to be a class or an abstract" null_pos
@@ -644,7 +644,7 @@ let insert_save_stacks tctx =
 *)
 let patch_constructors tctx =
 	let tp = make_ptp (mk_type_path haxe_exception_type_path) null_pos in
-	match Typeload.load_instance tctx tp ParamSpawnMonos with
+	match Typeload.load_instance tctx tp ParamSpawnMonos LoadNormal with
 	(* Add only if `__shiftStack` method exists *)
 	| TInst(cls,_) when PMap.mem "__shiftStack" cls.cl_fields ->
 		(fun mt ->

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -171,7 +171,7 @@ let static_method_container gctx c cf p =
 	let pack = fst c.cl_path in
 	let name = (snd c.cl_path) ^ "_" ^ cf.cf_name ^ "_" ^ gctx.name in
 	try
-		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (pack,name)) p) ParamSpawnMonos in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (pack,name)) p) ParamSpawnMonos LoadNormal in
 		match t with
 		| TInst(cg,_) -> cg
 		| _ -> raise_typing_error ("Cannot specialize @:generic static method because the generated type name is already used: " ^ name) p
@@ -271,7 +271,7 @@ let build_generic_class ctx c p tl =
 	let gctx = make_generic ctx c.cl_params tl (Meta.has (Meta.Custom ":debug.generic") c.cl_meta) p in
 	let name = (snd c.cl_path) ^ "_" ^ gctx.name in
 	try
-		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (pack,name)) p) ParamNormal in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (pack,name)) p) ParamNormal LoadNormal in
 		match t with
 		| TInst({ cl_kind = KGenericInstance (csup,_) },_) when c == csup -> t
 		| _ -> raise_typing_error ("Cannot specialize @:generic because the generated type name is already used: " ^ name) p

--- a/src/typing/matcher/exprToPattern.ml
+++ b/src/typing/matcher/exprToPattern.ml
@@ -58,7 +58,7 @@ let get_general_module_type ctx mt p =
 			end
 		| _ -> raise_typing_error "Cannot use this type as a value" p
 	in
-	Typeload.load_instance ctx (make_ptp {tname=loop mt;tpackage=[];tsub=None;tparams=[]} p) ParamSpawnMonos
+	Typeload.load_instance ctx (make_ptp {tname=loop mt;tpackage=[];tsub=None;tparams=[]} p) ParamSpawnMonos LoadNormal
 
 let unify_type_pattern ctx mt t p =
 	let tcl = get_general_module_type ctx mt p in

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -386,7 +386,7 @@ let make_binop ctx op e1 e2 is_assign_op p =
 		unify ctx e2.etype b p;
 		mk_op e1 e2 b
 	| OpInterval ->
-		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (["std"],"IntIterator")) null_pos) ParamNormal in
+		let t = Typeload.load_instance ctx (make_ptp (mk_type_path (["std"],"IntIterator")) null_pos) ParamNormal LoadNormal in
 		let e1 = AbstractCast.cast_or_unify_raise ctx tint e1 e1.epos in
 		let e2 = AbstractCast.cast_or_unify_raise ctx tint e2 e2.epos in
 		BinopSpecial (mk (TNew ((match t with TInst (c,[]) -> c | _ -> die "" __LOC__),[],[e1;e2])) t p,false)

--- a/src/typing/strictMeta.ml
+++ b/src/typing/strictMeta.ml
@@ -174,7 +174,7 @@ let get_strict_meta ctx meta params pos =
 			display_error ctx.com "A @:strict metadata must contain exactly one parameter. Please check the documentation for more information" pos;
 			raise Exit
 	in
-	let t = Typeload.load_complex_type ctx false (ctype,pos) in
+	let t = Typeload.load_complex_type ctx false LoadNormal (ctype,pos) in
 	flush_pass ctx.g PBuildClass "get_strict_meta";
 	let texpr = type_expr ctx changed_expr NoValue in
 	let with_type_expr = (ECheckType( (EConst (Ident "null"), pos), (ctype,null_pos) ), pos) in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -293,6 +293,11 @@ type load_instance_param_mode =
 	| ParamSpawnMonos
 	| ParamCustom of (build_info -> Type.t list option -> Type.t list)
 
+type load_instance_mode =
+	| LoadNormal
+	| LoadReturn
+	| LoadAny (* We don't necessarily know why we're loading, so let's just load anything *)
+
 let rec maybe_build_instance ctx t0 get_params p =
 	let rec loop t = match t with
 		| TInst({cl_kind = KGeneric} as c,tl) ->
@@ -332,7 +337,8 @@ let rec load_params ctx info params p =
 			let c = mk_class ctx.m.curmod ([],name) p (pos e) in
 			c.cl_kind <- KExpr e;
 			TInst (c,[]),pos e
-		| TPType t -> load_complex_type ctx true t,pos t
+		| TPType t ->
+			load_complex_type ctx true LoadNormal t,pos t
 	in
 	let checks = DynArray.create () in
 	let rec loop tl1 tl2 is_rest = match tl1,tl2 with
@@ -400,7 +406,7 @@ let rec load_params ctx info params p =
 	params
 
 (* build an instance from a full type *)
-and load_instance' ctx ptp get_params =
+and load_instance' ctx ptp get_params mode =
 	let t = ptp.path in
 	try
 		if t.tpackage <> [] || t.tsub <> None then raise Not_found;
@@ -412,7 +418,7 @@ and load_instance' ctx ptp get_params =
 		let info = ctx.g.get_build_info ctx mt ptp.pos_full in
 		if info.build_path = ([],"Dynamic") then match t.tparams with
 			| [] -> t_dynamic
-			| [TPType t] -> TDynamic (Some (load_complex_type ctx true t))
+			| [TPType t] -> TDynamic (Some (load_complex_type ctx true LoadNormal t))
 			| _ -> raise_typing_error "Too many parameters for Dynamic" ptp.pos_full
 		else if info.build_params = [] then begin match t.tparams with
 			| [] ->
@@ -440,9 +446,9 @@ and load_instance' ctx ptp get_params =
 			maybe_build_instance ctx t get_params ptp.pos_full
 		end
 
-and load_instance ctx ?(allow_display=false) ptp get_params =
+and load_instance ctx ?(allow_display=false) ptp get_params mode =
 	try
-		let t = load_instance' ctx ptp get_params in
+		let t = load_instance' ctx ptp get_params mode in
 		if allow_display then DisplayEmitter.check_display_type ctx t ptp;
 		t
 	with Error { err_message = Module_not_found path } when ctx.e.macro_depth <= 0 && (ctx.com.display.dms_kind = DMDefault) && DisplayPosition.display_position#enclosed_in ptp.pos_path ->
@@ -452,17 +458,17 @@ and load_instance ctx ?(allow_display=false) ptp get_params =
 (*
 	build an instance from a complex type
 *)
-and load_complex_type' ctx allow_display (t,p) =
+and load_complex_type' ctx allow_display mode (t,p) =
 	match t with
-	| CTParent t -> load_complex_type ctx allow_display t
+	| CTParent t -> load_complex_type ctx allow_display mode t
 	| CTPath { path = {tpackage = ["$"]; tname = "_hx_mono" }} -> spawn_monomorph ctx.e p
-	| CTPath ptp -> load_instance ~allow_display ctx ptp ParamNormal
+	| CTPath ptp -> load_instance ~allow_display ctx ptp ParamNormal mode
 	| CTOptional _ -> raise_typing_error "Optional type not allowed here" p
 	| CTNamed _ -> raise_typing_error "Named type not allowed here" p
 	| CTIntersection tl ->
 		let tl = List.map (fun (t,pn) ->
 			try
-				(load_complex_type ctx allow_display (t,pn),pn)
+				(load_complex_type ctx allow_display LoadNormal (t,pn),pn)
 			with DisplayException(DisplayFields ({fkind = CRTypeHint} as r)) ->
 				let l = List.filter (fun item -> match item.ci_kind with
 					| ITType({kind = Struct},_) -> true
@@ -479,7 +485,7 @@ and load_complex_type' ctx allow_display (t,p) =
 		) "constraint" in
 		TLazy r
 	| CTExtend (tl,l) ->
-		begin match load_complex_type ctx allow_display (CTAnonymous l,p) with
+		begin match load_complex_type ctx allow_display LoadNormal (CTAnonymous l,p) with
 		| TAnon a as ta ->
 			let mk_extension (t,p) =
 				match follow t with
@@ -503,7 +509,7 @@ and load_complex_type' ctx allow_display (t,p) =
 			in
 			let il = List.map (fun ptp ->
 				try
-					(load_instance ctx ~allow_display ptp ParamNormal,ptp.pos_full)
+					(load_instance ctx ~allow_display ptp ParamNormal LoadNormal,ptp.pos_full)
 				with DisplayException(DisplayFields ({fkind = CRTypeHint} as r)) ->
 					let l = List.filter (fun item -> match item.ci_kind with
 						| ITType({kind = Struct},_) -> true
@@ -533,9 +539,9 @@ and load_complex_type' ctx allow_display (t,p) =
 			let pf = snd f.cff_name in
 			let p = f.cff_pos in
 			if PMap.mem n acc then raise_typing_error ("Duplicate field declaration : " ^ n) pf;
-			let topt = function
+			let topt mode = function
 				| None -> raise_typing_error ("Explicit type required for field " ^ n) p
-				| Some t -> load_complex_type ctx allow_display t
+				| Some t -> load_complex_type ctx allow_display mode t
 			in
 			if n = "new" then warning ctx WDeprecated "Structures with new are deprecated, use haxe.Constraints.Constructible instead" p;
 			let no_expr = function
@@ -563,19 +569,19 @@ and load_complex_type' ctx allow_display (t,p) =
 				| FVar(t,e) when !final ->
 					no_expr e;
 					let t = (match t with None -> raise_typing_error "Type required for structure property" p | Some t -> t) in
-					load_complex_type ctx allow_display t, Var { v_read = AccNormal; v_write = AccNever }
+					load_complex_type ctx allow_display LoadNormal t, Var { v_read = AccNormal; v_write = AccNever }
 				| FVar (Some (CTPath({path = {tpackage=[];tname="Void"}}),_), _)  | FProp (_,_,Some (CTPath({path = {tpackage=[];tname="Void"}}),_),_) ->
 					raise_typing_error "Fields of type Void are not allowed in structures" p
 				| FVar (t, e) ->
 					no_expr e;
-					topt t, Var { v_read = AccNormal; v_write = AccNormal }
+					topt LoadNormal t, Var { v_read = AccNormal; v_write = AccNormal }
 				| FFun fd ->
 					params := (!type_function_params_ref) ctx fd TPHAnonField (fst f.cff_name) p;
 					no_expr fd.f_expr;
 					let old = ctx.type_params in
 					ctx.type_params <- !params @ old;
-					let args = List.map (fun ((name,_),o,_,t,e) -> no_expr e; name, o, topt t) fd.f_args in
-					let t = TFun (args,topt fd.f_type), Method (if !dyn then MethDynamic else MethNormal) in
+					let args = List.map (fun ((name,_),o,_,t,e) -> no_expr e; name, o, topt LoadNormal t) fd.f_args in
+					let t = TFun (args,topt LoadReturn fd.f_type), Method (if !dyn then MethDynamic else MethNormal) in
 					ctx.type_params <- old;
 					t
 				| FProp (i1,i2,t,e) ->
@@ -594,7 +600,7 @@ and load_complex_type' ctx allow_display (t,p) =
 							raise_typing_error "Custom property access is no longer supported in Haxe 3" f.cff_pos;
 					in
 					let t = (match t with None -> raise_typing_error "Type required for structure property" p | Some t -> t) in
-					load_complex_type ctx allow_display t, Var { v_read = access i1 true; v_write = access i2 false }
+					load_complex_type ctx allow_display LoadNormal t, Var { v_read = access i1 true; v_write = access i2 false }
 			) in
 			let t = if Meta.has Meta.Optional f.cff_meta then ctx.t.tnull t else t in
 			let cf = {
@@ -623,17 +629,17 @@ and load_complex_type' ctx allow_display (t,p) =
 	| CTFunction (args,r) ->
 		match args with
 		| [CTPath { path = {tpackage = []; tparams = []; tname = "Void" }},_] ->
-			TFun ([],load_complex_type ctx allow_display r)
+			TFun ([],load_complex_type ctx allow_display  LoadReturn r)
 		| _ ->
 			TFun (List.map (fun t ->
 				let t, opt = (match fst t with CTOptional t | CTParent((CTOptional t,_)) -> t, true | _ -> t,false) in
 				let n,t = (match fst t with CTNamed (n,t) -> (fst n), t | _ -> "", t) in
-				n,opt,load_complex_type ctx allow_display t
-			) args,load_complex_type ctx allow_display r)
+				n,opt,load_complex_type ctx allow_display LoadNormal t
+			) args,load_complex_type ctx allow_display LoadReturn r)
 
-and load_complex_type ctx allow_display (t,pn) =
+and load_complex_type ctx allow_display mode (t,pn) =
 	try
-		load_complex_type' ctx allow_display (t,pn)
+		load_complex_type' ctx allow_display mode (t,pn)
 	with Error ({ err_message = Module_not_found(([],name)) } as err) ->
 		if Diagnostics.error_in_diagnostics_run ctx.com err.err_pos then begin
 			delay ctx.g PForce (fun () -> DisplayToplevel.handle_unresolved_identifier ctx name err.err_pos true);
@@ -669,17 +675,17 @@ and init_meta_overloads ctx co cf =
 			end;
 			let params : type_params = (!type_function_params_ref) ctx f TPHMethod cf.cf_name p in
 			ctx.type_params <- params @ ctx.type_params;
-			let topt = function None -> raise_typing_error "Explicit type required" p | Some t -> load_complex_type ctx true t in
+			let topt mode = function None -> raise_typing_error "Explicit type required" p | Some t -> load_complex_type ctx true mode t in
 			let args =
 				List.map
 					(fun ((a,_),opt,_,t,cto) ->
-						let t = if opt then ctx.t.tnull (topt t) else topt t in
+						let t = if opt then ctx.t.tnull (topt LoadNormal t) else topt LoadNormal t in
 						let opt = opt || cto <> None in
 						a,opt,t
 					)
 					f.f_args
 			in
-			let cf = { cf with cf_type = TFun (args,topt f.f_type); cf_params = params; cf_meta = cf_meta} in
+			let cf = { cf with cf_type = TFun (args,topt LoadReturn f.f_type); cf_params = params; cf_meta = cf_meta} in
 			generate_args_meta ctx.com co (fun meta -> cf.cf_meta <- meta :: cf.cf_meta) f.f_args;
 			overloads := cf :: !overloads;
 			ctx.type_params <- old;
@@ -712,10 +718,10 @@ let t_iterator ctx p =
 (*
 	load either a type t or Null<Unknown> if not defined
 *)
-let load_type_hint ?(opt=false) ctx pcur t =
+let load_type_hint ?(opt=false) ctx pcur mode t =
 	let t = match t with
 		| None -> spawn_monomorph ctx.e pcur
-		| Some (t,p) ->	load_complex_type ctx true (t,p)
+		| Some (t,p) ->	load_complex_type ctx true mode (t,p)
 	in
 	if opt then ctx.t.tnull t else t
 
@@ -747,7 +753,7 @@ and type_type_params ctx host path p tpl =
 				()
 			| Some ct ->
 				let r = make_lazy ctx.g ttp.ttp_type (fun r ->
-					let t = load_complex_type ctx true ct in
+					let t = load_complex_type ctx true LoadNormal ct in
 					begin match host with
 					| TPHType ->
 						()
@@ -768,9 +774,9 @@ and type_type_params ctx host path p tpl =
 		| Some th ->
 			let constraints = lazy (
 				let rec loop th = match fst th with
-					| CTIntersection tl -> List.map (load_complex_type ctx true) tl
+					| CTIntersection tl -> List.map (load_complex_type ctx true LoadNormal) tl
 					| CTParent ct -> loop ct
-					| _ -> [load_complex_type ctx true th]
+					| _ -> [load_complex_type ctx true LoadNormal th]
 				in
 				let constr = loop th in
 				(* check against direct recursion *)

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -595,7 +595,7 @@ module Inheritance = struct
 		let fl = ExtList.List.filter_map (fun (is_extends,ptp) ->
 			try
 				let t = try
-					Typeload.load_instance ~allow_display:true ctx ptp ParamNormal
+					Typeload.load_instance ~allow_display:true ctx ptp ParamNormal LoadNormal
 				with DisplayException(DisplayFields ({fkind = CRTypeHint} as r)) ->
 					(* We don't allow `implements` on interfaces. Just raise fields completion with no fields. *)
 					if not is_extends && (has_class_flag c CInterface) then raise_fields [] CRImplements r.fsubject;

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -280,9 +280,6 @@ let transform_abstract_field com this_t a_t a f =
 	| _ ->
 		f
 
-let lazy_display_type ctx f =
-	f ()
-
 type enum_abstract_mode =
 	| EAString
 	| EAInt of int ref
@@ -891,7 +888,7 @@ let load_variable_type_hint ctx fctx eo p = function
 	| None ->
 		mk_mono()
 	| Some t ->
-		lazy_display_type ctx (fun () -> load_type_hint ctx p (Some t))
+		load_type_hint ctx p LoadNormal (Some t)
 
 let create_variable (ctx,cctx,fctx) c f t eo p =
 	let is_abstract_enum_field = List.mem_assoc AEnum f.cff_access in
@@ -1105,7 +1102,7 @@ let check_abstract (ctx,cctx,fctx) a c cf fd t ret p =
 		end
 	end
 
-let type_opt (ctx,cctx,fctx) p t =
+let type_opt (ctx,cctx,fctx) p mode t =
 	let c = cctx.tclass in
 	let is_truly_extern =
 		(has_class_flag c CExtern || fctx.is_extern)
@@ -1122,7 +1119,7 @@ let type_opt (ctx,cctx,fctx) p t =
 		display_error ctx.com "Type required for abstract functions" p;
 		t_dynamic
 	| _ ->
-		Typeload.load_type_hint ctx p t
+		Typeload.load_type_hint ctx p mode t
 
 let setup_args_ret ctx cctx fctx name fd p =
 	let c = cctx.tclass in
@@ -1163,7 +1160,7 @@ let setup_args_ret ctx cctx fctx name fd p =
 		ctx.t.tvoid
 	else begin
 		let def () =
-			type_opt (ctx,cctx,fctx) p fd.f_type
+			type_opt (ctx,cctx,fctx) p LoadReturn fd.f_type
 		in
 		maybe_use_property_type fd.f_type (fun () -> match Lazy.force mk with MKGetter | MKSetter -> true | _ -> false) def
 	end in
@@ -1176,7 +1173,7 @@ let setup_args_ret ctx cctx fctx name fd p =
 	let is_extern = fctx.is_extern || has_class_flag ctx.c.curclass CExtern in
 	let type_arg i opt cto p =
 		let def () =
-			type_opt (ctx,cctx,fctx) p cto
+			type_opt (ctx,cctx,fctx) p LoadNormal cto
 		in
 		if i = 0 then maybe_use_property_type cto (fun () -> match Lazy.force mk with MKSetter -> true | _ -> false) def else def()
 	in
@@ -1241,7 +1238,7 @@ let create_method (ctx,cctx,fctx) c f fd p =
 				| None -> ()
 				| Some (CTPath ({ path = {tpackage = []; tname = "Void" } as tp}),p) ->
 					if ctx.m.is_display_file && DisplayPosition.display_position#enclosed_in p then
-						ignore(load_instance ~allow_display:true ctx (make_ptp tp p) ParamNormal);
+						ignore(load_instance ~allow_display:true ctx (make_ptp tp p) ParamNormal LoadReturn); (* VOIDTODO *)
 				| _ -> raise_typing_error "A class constructor can't have a return type" p;
 			end
 		| false,_ ->
@@ -1356,7 +1353,7 @@ let create_property (ctx,cctx,fctx) c f (get,set,t,eo) p =
 	let ret = (match t, eo with
 		| None, None -> raise_typing_error "Property requires type-hint or initialization" p;
 		| None, _ -> mk_mono()
-		| Some t, _ -> lazy_display_type ctx (fun () -> load_type_hint ctx p (Some t))
+		| Some t, _ -> load_type_hint ctx p LoadNormal (Some t)
 	) in
 	let t_get,t_set = match cctx.abstract with
 		| Some a when fctx.is_abstract_member ->

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -310,7 +310,7 @@ let rec handle_signature_display ctx e_ast with_type =
 			in
 			handle_call tl el e1.epos
 		| ENew(ptp,el) ->
-			let t = Abstract.follow_with_forward_ctor (Typeload.load_instance ctx ptp ParamSpawnMonos) in
+			let t = Abstract.follow_with_forward_ctor (Typeload.load_instance ctx ptp ParamSpawnMonos LoadNormal) in
 			handle_call (find_constructor_types t) el ptp.pos_full
 		| EArray(e1,e2) ->
 			let e1 = type_expr ctx e1 WithType.value in


### PR DESCRIPTION
This passes an additional argument to all type instance loading operations, which currently has three possible values:

```ocaml
type load_instance_mode =
	| LoadNormal
	| LoadReturn
	| LoadAny (* We don't necessarily know why we're loading, so let's just load anything *)
```

I primarily want to use it to disallow loading `Void` in places that aren't return types, but there might be some other applications for this as well. Shouldn't have any observable impact.