### PR TITLE
[hxb] Add OFD and OBD chunks

### DIFF
--- a/src/compiler/hxb/hxbData.ml
+++ b/src/compiler/hxb/hxbData.ml
@@ -32,9 +32,10 @@ type chunk_kind =
 	| ENR (* enum references *)
 	| ABR (* abstract references *)
 	| TDR (* typedef references *)
-	(* Field references *)
+	(* Anonymous objects *)
 	| OFR (* object field references *)
 	| OFD (* object field definitions *)
+	| OBD (* object definitions *)
 	(* Own module type definitions *)
 	| CLD (* class definition *)
 	| END (* enum definition *)
@@ -74,6 +75,7 @@ let string_of_chunk_kind = function
 	| TDR -> "TDR"
 	| OFR -> "OFR"
 	| OFD -> "OFD"
+	| OBD -> "OBD"
 	| EFR -> "EFR"
 	| CFR -> "CFR"
 	| CLD -> "CLD"
@@ -100,6 +102,7 @@ let chunk_kind_of_string = function
 	| "TDR" -> TDR
 	| "OFR" -> OFR
 	| "OFD" -> OFD
+	| "OBD" -> OBD
 	| "EFR" -> EFR
 	| "CFR" -> CFR
 	| "CLD" -> CLD

--- a/src/compiler/hxb/hxbData.ml
+++ b/src/compiler/hxb/hxbData.ml
@@ -34,6 +34,7 @@ type chunk_kind =
 	| TDR (* typedef references *)
 	(* Field references *)
 	| AFR (* anon field references *)
+	| OFD (* object field definitions *)
 	(* Own module type definitions *)
 	| CLD (* class definition *)
 	| END (* enum definition *)
@@ -72,6 +73,7 @@ let string_of_chunk_kind = function
 	| ABR -> "ABR"
 	| TDR -> "TDR"
 	| AFR -> "AFR"
+	| OFD -> "OFD"
 	| EFR -> "EFR"
 	| CFR -> "CFR"
 	| CLD -> "CLD"
@@ -97,6 +99,7 @@ let chunk_kind_of_string = function
 	| "ABR" -> ABR
 	| "TDR" -> TDR
 	| "AFR" -> AFR
+	| "OFD" -> OFD
 	| "EFR" -> EFR
 	| "CFR" -> CFR
 	| "CLD" -> CLD

--- a/src/compiler/hxb/hxbData.ml
+++ b/src/compiler/hxb/hxbData.ml
@@ -10,10 +10,10 @@ exception HxbFailure of string
 	EN = enum
 	AB = abstract
 	TD = typedef
-	AN = anon
+	OB = anonymous object
 	CF = class field
 	EF = enum field
-	AF = anon field
+	OF = object field
 	EX = expression
 	EO = end of (Types | Fields | Module)
 	..F = forward definition
@@ -33,7 +33,7 @@ type chunk_kind =
 	| ABR (* abstract references *)
 	| TDR (* typedef references *)
 	(* Field references *)
-	| AFR (* anon field references *)
+	| OFR (* object field references *)
 	| OFD (* object field definitions *)
 	(* Own module type definitions *)
 	| CLD (* class definition *)
@@ -72,7 +72,7 @@ let string_of_chunk_kind = function
 	| ENR -> "ENR"
 	| ABR -> "ABR"
 	| TDR -> "TDR"
-	| AFR -> "AFR"
+	| OFR -> "OFR"
 	| OFD -> "OFD"
 	| EFR -> "EFR"
 	| CFR -> "CFR"
@@ -98,7 +98,7 @@ let chunk_kind_of_string = function
 	| "ENR" -> ENR
 	| "ABR" -> ABR
 	| "TDR" -> TDR
-	| "AFR" -> AFR
+	| "OFR" -> OFR
 	| "OFD" -> OFD
 	| "EFR" -> EFR
 	| "CFR" -> CFR

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -1592,6 +1592,14 @@ class hxb_reader
 		let a = Array.init l (fun _ -> self#read_class_field_forward) in
 		anon_fields <- a
 
+	method read_ofd =
+		let l = read_uleb128 ch in
+		for i = 0 to l - 1 do
+			let index = read_uleb128 ch in
+			let cf = anon_fields.(index) in
+			self#read_class_field_and_overloads_data cf;
+		done
+
 	method read_cfr =
 		let l = read_uleb128 ch in
 		let a = Array.init l (fun i ->
@@ -1928,6 +1936,8 @@ class hxb_reader
 			self#read_tdr;
 		| AFR ->
 			self#read_afr;
+		| OFD ->
+			self#read_ofd;
 		| CLD ->
 			self#read_cld;
 		| END ->

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -301,7 +301,8 @@ class hxb_reader
 			anons.(read_uleb128 ch)
 		| 1 ->
 			let an = anons.(read_uleb128 ch) in
-			self#read_anon an
+			self#read_anon an;
+			an
 		| _ ->
 			assert false
 
@@ -1600,6 +1601,13 @@ class hxb_reader
 			self#read_class_field_and_overloads_data cf;
 		done
 
+	method read_obd =
+		let l = read_uleb128 ch in
+		for i = 0 to l - 1 do
+			let index = read_uleb128 ch in
+			self#read_anon anons.(index)
+		done
+
 	method read_cfr =
 		let l = read_uleb128 ch in
 		let a = Array.init l (fun i ->
@@ -1756,9 +1764,7 @@ class hxb_reader
 			an.a_status := Extend self#read_types;
 			read_fields ()
 		| _ -> assert false
-		end;
-
-		an
+		end
 
 	method read_tdd =
 		let l = read_uleb128 ch in
@@ -1938,6 +1944,8 @@ class hxb_reader
 			self#read_ofr;
 		| OFD ->
 			self#read_ofd;
+		| OBD ->
+			self#read_obd
 		| CLD ->
 			self#read_cld;
 		| END ->

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -1587,7 +1587,7 @@ class hxb_reader
 		) in
 		enum_fields <- a
 
-	method read_afr =
+	method read_ofr =
 		let l = read_uleb128 ch in
 		let a = Array.init l (fun _ -> self#read_class_field_forward) in
 		anon_fields <- a
@@ -1934,8 +1934,8 @@ class hxb_reader
 			self#read_abr;
 		| TDR ->
 			self#read_tdr;
-		| AFR ->
-			self#read_afr;
+		| OFR ->
+			self#read_ofr;
 		| OFD ->
 			self#read_ofd;
 		| CLD ->

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -486,7 +486,7 @@ module HxbWriter = struct
 			| EOT | EOF | EOM -> 0
 			| MDF -> 16
 			| MTF | MDR | CLR | END | ABD | ENR | ABR | TDR | EFR | CFR | AFD -> 64
-			| AFR | OFD | CLD | TDD | EFD -> 128
+			| OFR | OFD | CLD | TDD | EFD -> 128
 			| STR | DOC -> 256
 			| CFD | EXD -> 512
 		in
@@ -2141,7 +2141,7 @@ module HxbWriter = struct
 
 		let items = HashedIdentityPool.finalize writer.anon_fields in
 		if DynArray.length items > 0 then begin
-			start_chunk writer AFR;
+			start_chunk writer OFR;
 			Chunk.write_uleb128 writer.chunk (DynArray.length items);
 			DynArray.iter (fun (cf,_) ->
 				write_class_field_forward writer cf

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -454,7 +454,7 @@ type hxb_writer = {
 	typedefs : (path,tdef) Pool.t;
 	abstracts : (path,tabstract) Pool.t;
 	anons : (path,tanon) Pool.t;
-	anon_fields : (string,tclass_field,unit) HashedIdentityPool.t;
+	anon_fields : (string,tclass_field,bytes option) HashedIdentityPool.t;
 	tmonos : (tmono,unit) IdentityPool.t;
 
 	own_classes : (path,tclass) Pool.t;
@@ -468,6 +468,7 @@ type hxb_writer = {
 	mutable field_type_parameters : (typed_type_param,unit) IdentityPool.t;
 	mutable local_type_parameters : (typed_type_param,unit) IdentityPool.t;
 	mutable field_stack : unit list;
+	mutable wrote_local_type_param : bool;
 	unbound_ttp : (typed_type_param,unit) IdentityPool.t;
 	t_instance_chunk : Chunk.t;
 }
@@ -485,7 +486,7 @@ module HxbWriter = struct
 			| EOT | EOF | EOM -> 0
 			| MDF -> 16
 			| MTF | MDR | CLR | END | ABD | ENR | ABR | TDR | EFR | CFR | AFD -> 64
-			| AFR | CLD | TDD | EFD -> 128
+			| AFR | OFD | CLD | TDD | EFD -> 128
 			| STR | DOC -> 256
 			| CFD | EXD -> 512
 		in
@@ -1051,10 +1052,25 @@ module HxbWriter = struct
 			Chunk.write_u8 writer.chunk 0;
 			Chunk.write_uleb128 writer.chunk index
 		with Not_found ->
-			let index = HashedIdentityPool.add writer.anon_fields cf.cf_name cf () in
-			Chunk.write_u8 writer.chunk 1;
-			Chunk.write_uleb128 writer.chunk index;
-			ignore(write_class_field_and_overloads_data writer true cf)
+			let restore = start_temporary_chunk writer 256 in
+			let old = writer.wrote_local_type_param in
+			writer.wrote_local_type_param <- false;
+			ignore(write_class_field_and_overloads_data writer true cf);
+			let wrote_local_type_param = writer.wrote_local_type_param in
+			writer.wrote_local_type_param <- old;
+			let bytes = restore (fun new_chunk -> Chunk.get_bytes new_chunk) in
+			if wrote_local_type_param then begin
+				(* If we access something from the method scope, we have to write the anon field immediately.
+				   This should be fine because in such cases the field cannot be referenced elsewhere. *)
+				let index = HashedIdentityPool.add writer.anon_fields cf.cf_name cf None in
+				Chunk.write_u8 writer.chunk 1;
+				Chunk.write_uleb128 writer.chunk index;
+				Chunk.write_bytes writer.chunk bytes
+			end else begin
+				let index = HashedIdentityPool.add writer.anon_fields cf.cf_name cf (Some bytes) in
+				Chunk.write_u8 writer.chunk 0;
+				Chunk.write_uleb128 writer.chunk index;
+			end
 
 	(* Type instances *)
 
@@ -1063,14 +1079,18 @@ module HxbWriter = struct
 			begin match ttp.ttp_host with
 			| TPHType ->
 				let i = Pool.get writer.type_type_parameters ttp.ttp_name in
+				(* TODO: this isn't correct, but if we don't do this we'll have to communicate the current class *)
+				writer.wrote_local_type_param <- true;
 				Chunk.write_u8 writer.chunk 1;
 				Chunk.write_uleb128 writer.chunk i
 			| TPHMethod | TPHEnumConstructor | TPHAnonField | TPHConstructor ->
 				let i = IdentityPool.get writer.field_type_parameters ttp in
+				writer.wrote_local_type_param <- true;
 				Chunk.write_u8 writer.chunk 2;
 				Chunk.write_uleb128 writer.chunk i;
 			| TPHLocal ->
 				let index = IdentityPool.get writer.local_type_parameters ttp in
+				writer.wrote_local_type_param <- true;
 				Chunk.write_u8 writer.chunk 3;
 				Chunk.write_uleb128 writer.chunk index;
 		end with Not_found ->
@@ -2126,6 +2146,23 @@ module HxbWriter = struct
 			DynArray.iter (fun (cf,_) ->
 				write_class_field_forward writer cf
 			) items;
+
+			let anon_fields_with_expr = DynArray.create () in
+			DynArray.iteri (fun i (_,bytes) -> match bytes with
+				| None ->
+					()
+				| Some bytes ->
+					DynArray.add anon_fields_with_expr (i,bytes)
+			) items;
+			if DynArray.length anon_fields_with_expr > 0 then begin
+				start_chunk writer OFD;
+				Chunk.write_uleb128 writer.chunk (DynArray.length anon_fields_with_expr);
+				DynArray.iter (fun (index,bytes) ->
+					Chunk.write_uleb128 writer.chunk index;
+					Chunk.write_bytes writer.chunk bytes
+				) anon_fields_with_expr
+			end;
+
 		end;
 
 		let items = Pool.finalize writer.classes in
@@ -2244,6 +2281,7 @@ let create config warn anon_id =
 		field_type_parameters = IdentityPool.create ();
 		local_type_parameters = IdentityPool.create ();
 		field_stack = [];
+		wrote_local_type_param = false;
 		unbound_ttp = IdentityPool.create ();
 		t_instance_chunk = Chunk.create EOM cp 32;
 	}


### PR DESCRIPTION
We've come across a problem with the current way we handle anon fields and anons. Those are encoded on first use, which is convenient because in the general case anon fields might need type parameters from the local context. This works fine if the reader reads everything in order, but with delayed expression reading there can be the following situation:

1. An anon is first seen, and thus written, inside an expression
2. It is later seen in a different place, and written as a reference
3. The reader delays the expression reading, and then comes across the reference place before the definition place

It would be good to have an isolated test case for this, but it's not very easy to find one because this only occurred in a substantial codebase and is affected by the intricacies of type loading.

With this PR we now distinguish between anon fields that require a local context and those that don't. The former are still written immediately, which should work fine because such abstracts cannot appear elsewhere anyway. The latter are stored in the OFD chunk which is then read separately, which should always work because no local context is required. By extension, this applies to anons and the OBD chunk.