### PR TITLE
Use VInlinedConstructorVariable to tag inlined but interesting variable for debug

### DIFF
--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -963,7 +963,7 @@ class hxb_reader
 			| 5 -> VUser TVOLocalFunction
 			| 6 -> VGenerated
 			| 7 -> VInlined
-			| 8 -> VInlinedConstructorVariable self#read_string
+			| 8 -> VInlinedConstructorVariable (self#read_list (fun () -> self#read_string))
 			| 9 -> VExtractorVariable
 			| 10 -> VAbstractThis
 			| _ -> assert false

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -963,7 +963,7 @@ class hxb_reader
 			| 5 -> VUser TVOLocalFunction
 			| 6 -> VGenerated
 			| 7 -> VInlined
-			| 8 -> VInlinedConstructorVariable
+			| 8 -> VInlinedConstructorVariable self#read_string
 			| 9 -> VExtractorVariable
 			| 10 -> VAbstractThis
 			| _ -> assert false

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -980,20 +980,22 @@ module HxbWriter = struct
 			Chunk.write_uleb128 writer.chunk (Pool.add writer.enum_fields key (en,ef))
 
 	let write_var_kind writer vk =
-		let b = match vk with
-			| VUser TVOLocalVariable -> 0
-			| VUser TVOArgument -> 1
-			| VUser TVOForVariable -> 2
-			| VUser TVOPatternVariable -> 3
-			| VUser TVOCatchVariable -> 4
-			| VUser TVOLocalFunction -> 5
-			| VGenerated -> 6
-			| VInlined -> 7
-			| VInlinedConstructorVariable -> 8
-			| VExtractorVariable -> 9
-			| VAbstractThis -> 10
-		in
-		Chunk.write_u8 writer.chunk b
+		let b,s = match vk with
+			| VUser TVOLocalVariable -> 0, ""
+			| VUser TVOArgument -> 1, ""
+			| VUser TVOForVariable -> 2, ""
+			| VUser TVOPatternVariable -> 3, ""
+			| VUser TVOCatchVariable -> 4, ""
+			| VUser TVOLocalFunction -> 5, ""
+			| VGenerated -> 6, ""
+			| VInlined -> 7, ""
+			| VInlinedConstructorVariable s -> 8, s
+			| VExtractorVariable -> 9, ""
+			| VAbstractThis -> 10, ""
+		in begin
+			Chunk.write_u8 writer.chunk b;
+			if (b == 8) then Chunk.write_string writer.chunk s;
+		end
 
 	let write_var writer fctx v =
 		Chunk.write_uleb128 writer.chunk v.v_id;

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -980,21 +980,21 @@ module HxbWriter = struct
 			Chunk.write_uleb128 writer.chunk (Pool.add writer.enum_fields key (en,ef))
 
 	let write_var_kind writer vk =
-		let b,s = match vk with
-			| VUser TVOLocalVariable -> 0, ""
-			| VUser TVOArgument -> 1, ""
-			| VUser TVOForVariable -> 2, ""
-			| VUser TVOPatternVariable -> 3, ""
-			| VUser TVOCatchVariable -> 4, ""
-			| VUser TVOLocalFunction -> 5, ""
-			| VGenerated -> 6, ""
-			| VInlined -> 7, ""
-			| VInlinedConstructorVariable s -> 8, s
-			| VExtractorVariable -> 9, ""
-			| VAbstractThis -> 10, ""
+		let b,sl = match vk with
+			| VUser TVOLocalVariable -> 0, []
+			| VUser TVOArgument -> 1, []
+			| VUser TVOForVariable -> 2, []
+			| VUser TVOPatternVariable -> 3, []
+			| VUser TVOCatchVariable -> 4, []
+			| VUser TVOLocalFunction -> 5, []
+			| VGenerated -> 6, []
+			| VInlined -> 7, []
+			| VInlinedConstructorVariable sl -> 8, sl
+			| VExtractorVariable -> 9, []
+			| VAbstractThis -> 10, []
 		in begin
 			Chunk.write_u8 writer.chunk b;
-			if (b == 8) then Chunk.write_string writer.chunk s;
+			if (b == 8) then Chunk.write_list writer.chunk sl (Chunk.write_string writer.chunk);
 		end
 
 	let write_var writer fctx v =

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -601,7 +601,7 @@ module Printer = struct
 			| TVOLocalFunction -> "TVOLocalFunction") ^ ")"
 		| VGenerated -> "VGenerated"
 		| VInlined -> "VInlined"
-		| VInlinedConstructorVariable -> "VInlinedConstructorVariable"
+		| VInlinedConstructorVariable s -> "VInlinedConstructorVariable" ^ "(" ^ s ^ ")"
 		| VExtractorVariable -> "VExtractorVariable"
 		| VAbstractThis -> "VAbstractThis"
 

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -601,7 +601,7 @@ module Printer = struct
 			| TVOLocalFunction -> "TVOLocalFunction") ^ ")"
 		| VGenerated -> "VGenerated"
 		| VInlined -> "VInlined"
-		| VInlinedConstructorVariable s -> "VInlinedConstructorVariable" ^ "(" ^ s ^ ")"
+		| VInlinedConstructorVariable sl -> "VInlinedConstructorVariable" ^ "(" ^ (String.concat ", " sl) ^ ")"
 		| VExtractorVariable -> "VExtractorVariable"
 		| VAbstractThis -> "VAbstractThis"
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -144,7 +144,7 @@ and tvar_kind =
 	| VUser of tvar_origin
 	| VGenerated
 	| VInlined
-	| VInlinedConstructorVariable of string
+	| VInlinedConstructorVariable of string list
 	| VExtractorVariable
 	| VAbstractThis
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -144,7 +144,7 @@ and tvar_kind =
 	| VUser of tvar_origin
 	| VGenerated
 	| VInlined
-	| VInlinedConstructorVariable
+	| VInlinedConstructorVariable of string
 	| VExtractorVariable
 	| VAbstractThis
 

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -103,7 +103,7 @@ let check_local_vars_init ctx e =
 		| TVar (v,eo) ->
 			begin
 				match eo with
-				| None when v.v_kind = VInlinedConstructorVariable ->
+				| None when (match v.v_kind with VInlinedConstructorVariable _ -> true | _ -> false) ->
 					()
 				| None ->
 					declared := v.v_id :: !declared;

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -992,16 +992,16 @@ let real_name v =
 	match loop v.v_meta with
 	| "_gthis" -> "this"
 	| name -> match v.v_kind with
-		| VInlinedConstructorVariable s -> s
+		| VInlinedConstructorVariable sl -> String.concat "." sl
 		| _ -> name
 
-let is_gen_local ctx v = match v.v_kind with
+let not_debug_var ctx v = match v.v_kind with
 	| VUser _ -> false
 	| VInlinedConstructorVariable _ -> false
 	| _ -> true
 
 let add_assign ctx v =
-	if is_gen_local ctx v then () else
+	if not_debug_var ctx v then () else
 	let name = real_name v in
 	ctx.m.massign <- (alloc_string ctx name, current_pos ctx - 1) :: ctx.m.massign
 

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -995,6 +995,7 @@ let real_name v =
 
 let is_gen_local ctx v = match v.v_kind with
 	| VUser _ -> false
+	| VInlinedConstructorVariable -> false
 	| _ -> true
 
 let add_assign ctx v =

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -991,11 +991,13 @@ let real_name v =
 	in
 	match loop v.v_meta with
 	| "_gthis" -> "this"
-	| name -> name
+	| name -> match v.v_kind with
+		| VInlinedConstructorVariable s -> s
+		| _ -> name
 
 let is_gen_local ctx v = match v.v_kind with
 	| VUser _ -> false
-	| VInlinedConstructorVariable -> false
+	| VInlinedConstructorVariable _ -> false
 	| _ -> true
 
 let add_assign ctx v =

--- a/src/macro/eval/evalJit.ml
+++ b/src/macro/eval/evalJit.ml
@@ -655,7 +655,7 @@ and jit_expr jit return e =
 				wrap()
 			| TUnop((Increment | Decrement),_,e1) | TBinop((OpAssign | OpAssignOp _),e1,_) ->
 				begin match (Texpr.skip e1).eexpr with
-				| TLocal {v_kind = VGenerated | VInlined | VInlinedConstructorVariable | VExtractorVariable} ->
+				| TLocal {v_kind = VGenerated | VInlined | VInlinedConstructorVariable _ | VExtractorVariable} ->
 					f
 				| _ ->
 					wrap()

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -664,7 +664,7 @@ module LocalDce = struct
 			has_var_flag v VAnalyzed
 		in
 		let keep v =
-			is_used v || ((match v.v_kind with VUser _ | VInlined -> true | _ -> false) && not ctx.config.local_dce) || ExtType.has_reference_semantics v.v_type || has_var_flag v VCaptured || Meta.has Meta.This v.v_meta
+			is_used v || ((match v.v_kind with VUser _ | VInlined | VInlinedConstructorVariable -> true | _ -> false) && not ctx.config.local_dce) || ExtType.has_reference_semantics v.v_type || has_var_flag v VCaptured || Meta.has Meta.This v.v_meta
 		in
 		let rec use v =
 			if not (is_used v) then begin

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -664,7 +664,7 @@ module LocalDce = struct
 			has_var_flag v VAnalyzed
 		in
 		let keep v =
-			is_used v || ((match v.v_kind with VUser _ | VInlined | VInlinedConstructorVariable -> true | _ -> false) && not ctx.config.local_dce) || ExtType.has_reference_semantics v.v_type || has_var_flag v VCaptured || Meta.has Meta.This v.v_meta
+			is_used v || ((match v.v_kind with VUser _ | VInlined | VInlinedConstructorVariable _ -> true | _ -> false) && not ctx.config.local_dce) || ExtType.has_reference_semantics v.v_type || has_var_flag v VCaptured || Meta.has Meta.This v.v_meta
 		in
 		let rec use v =
 			if not (is_used v) then begin

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -790,7 +790,7 @@ module Fusion = struct
 			let num_uses = state#get_reads v in
 			let num_writes = state#get_writes v in
 			let can_be_used_as_value = can_be_used_as_value com e in
-			let is_compiler_generated = match v.v_kind with VUser _ | VInlined | VInlinedConstructorVariable -> false | _ -> true in
+			let is_compiler_generated = match v.v_kind with VUser _ | VInlined | VInlinedConstructorVariable _ -> false | _ -> true in
 			let has_type_params = match v.v_extra with Some ve when ve.v_params <> [] -> true | _ -> false in
 			let rec is_impure_extern e = match e.eexpr with
 				| TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf))) when has_class_flag cl CExtern ->

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -790,7 +790,7 @@ module Fusion = struct
 			let num_uses = state#get_reads v in
 			let num_writes = state#get_writes v in
 			let can_be_used_as_value = can_be_used_as_value com e in
-			let is_compiler_generated = match v.v_kind with VUser _ | VInlined -> false | _ -> true in
+			let is_compiler_generated = match v.v_kind with VUser _ | VInlined | VInlinedConstructorVariable -> false | _ -> true in
 			let has_type_params = match v.v_extra with Some ve when ve.v_params <> [] -> true | _ -> false in
 			let rec is_impure_extern e = match e.eexpr with
 				| TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf))) when has_class_flag cl CExtern ->

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -184,7 +184,7 @@ let inline_constructors ctx original_e =
 		PMap.find s io.io_fields
 	in
 	let alloc_io_field_full (io:inline_object) (fname:string) (constexpr_option:texpr option) (t:t) (p:pos) : inline_var =
-		let v = alloc_var (VInlinedConstructorVariable "") fname t p in
+		let v = alloc_var VInlined fname t p in
 		let iv = add v (IVKField (io,fname,constexpr_option)) in
 		io.io_fields <- PMap.add fname iv io.io_fields;
 		iv
@@ -759,7 +759,7 @@ let inline_constructors ctx original_e =
 				v.v_id <- -v.v_id;
 				let vnames = List.rev (get_pretty_name iv) in
 				v.v_name <- String.concat "_" vnames;
-				v.v_kind <- if (was_user iv) then VInlinedConstructorVariable (String.concat "." vnames) else VInlined;
+				if (was_user iv) then v.v_kind <- VInlinedConstructorVariable (String.concat "." vnames);
 			end
 		) !vars;
 		e

--- a/src/optimization/inlineConstructors.ml
+++ b/src/optimization/inlineConstructors.ml
@@ -759,7 +759,7 @@ let inline_constructors ctx original_e =
 				v.v_id <- -v.v_id;
 				let vnames = List.rev (get_pretty_name iv) in
 				v.v_name <- String.concat "_" vnames;
-				if (was_user iv) then v.v_kind <- VInlinedConstructorVariable (String.concat "." vnames);
+				if (was_user iv) then v.v_kind <- VInlinedConstructorVariable vnames;
 			end
 		) !vars;
 		e


### PR DESCRIPTION
This PR try to address https://github.com/vshaxe/hashlink-debugger/issues/91 (ping @ncannasse) : When performing inline constructor optimization, the original variable is lost and cannot be reconstructed at the debugger side. In this original example, `pt` is replaced by `pt_x`, `pt_y` (with `v_kind` of `VInlined`).

```haxe
static function foo(x,y) {
	var pt = new h2d.col.Point(x,y);
	return pt.length();
}
```

At the same time, other inlined variable should not appear in debugger, such as `z2` in the `foo2()` function below (`z2` appear also as `VInlined` in `foo2()`)

```haxe
static inline function boo(z1:Float) {
	var z2 = Math.abs(z1);
	return z2 * z2;
}
static function foo2() {
	var w = boo(13.5);
	return w;
}
```

This PR do the following:
- Use the never used `v_kind` `VInlinedConstructorVariable`, and add a `string` parameter to it, in order to keep information about the original variable path (`pt.x`, `pt.y` in the first example).
  - This information can also be carried in `v_name`, but I think it might damage source code generation so I finally choose to pass it in `v_kind`.
- Tag a inlined variable with `VInlinedConstructorVariable` instead of `VInlined`, when the variable is replacing a VUser variable.
  - Also valid when inline constructor is inside another inline constructor. It will show something like `pp.pt.x`
- Send original variable path to HL if applicable (need to adapt the debugger later to parse this information correctly).

I have done some tests in local, and my HL debugger can see those variables that I'd like to have (it can't parse the value correctly with the "." but I would like to validate the haxe change in a first place).