### PR TITLE
Unify help messages handling

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -154,8 +154,7 @@ let parse_args com =
 			com.debug <- true;
 		),"","add debug information to the compiled code");
 		("Miscellaneous",["--version"],["-version"],Arg.Unit (fun() ->
-			com.info s_version_full null_pos;
-			actx.did_something <- true;
+			raise (Helper.HelpMessage s_version_full);
 		),"","print version and exit");
 		("Miscellaneous", ["-h";"--help"], ["-help"], Arg.Unit (fun () ->
 			raise (Arg.Help "")
@@ -163,31 +162,27 @@ let parse_args com =
 		("Miscellaneous",["--help-defines"],[], Arg.Unit (fun() ->
 			let all,max_length = Define.get_documentation_list com.user_defines in
 			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-			List.iter (fun msg -> com.print (msg ^ "\n")) all;
-			actx.did_something <- true
+			raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
 		),"","print help for all compiler specific defines");
 		("Miscellaneous",["--help-user-defines"],[], Arg.Unit (fun() ->
 			actx.did_something <- true;
 			com.callbacks#add_after_init_macros (fun() ->
 				let all,max_length = Define.get_user_documentation_list com.user_defines in
 				let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-				List.iter (fun msg -> com.print (msg ^ "\n")) all;
-				raise Abort
+				raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
 			)
 		),"","print help for all user defines");
 		("Miscellaneous",["--help-metas"],[], Arg.Unit (fun() ->
 			let all,max_length = Meta.get_documentation_list com.user_metas in
 			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-			List.iter (fun msg -> com.print (msg ^ "\n")) all;
-			actx.did_something <- true
+			raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
 		),"","print help for all compiler metadatas");
 		("Miscellaneous",["--help-user-metas"],[], Arg.Unit (fun() ->
 			actx.did_something <- true;
 			com.callbacks#add_after_init_macros (fun() ->
 				let all,max_length = Meta.get_user_documentation_list com.user_metas in
 				let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-				List.iter (fun msg -> com.print (msg ^ "\n")) all;
-				raise Abort
+				raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
 			)
 		),"","print help for all user metadatas");
 	] in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -440,7 +440,7 @@ with
 	| Failure msg when not Helper.is_debug_run ->
 		error ctx ("Error: " ^ msg) null_pos
 	| Helper.HelpMessage msg ->
-		com.info msg null_pos
+		print_endline msg
 	| Parser.TypePath (p,c,is_import,pos) ->
 		DisplayOutput.handle_type_path_exception ctx p c is_import pos
 	| Parser.SyntaxCompletion(kind,subj) ->

--- a/tests/misc/projects/Issue8471/Macro.hx
+++ b/tests/misc/projects/Issue8471/Macro.hx
@@ -2,6 +2,7 @@ import haxe.macro.Context;
 
 class Macro {
 	public static function init() {
+		Context.info("Info", Context.currentPos());
 		Context.warning("This warning will disappear", Context.currentPos());
 
 		Context.onAfterTyping(afterTyping);

--- a/tests/misc/projects/Issue8471/Macro2.hx
+++ b/tests/misc/projects/Issue8471/Macro2.hx
@@ -9,6 +9,7 @@ class Macro2 {
 	}
 
 	static function afterTyping(_) {
+		Context.info("Info", Context.currentPos());
 		Context.warning(("1" :DeprecatedType), Context.currentPos());
 		Context.warning("2", Context.currentPos());
 		Context.warning("3", Context.currentPos());

--- a/tests/misc/projects/Issue8471/compile.hxml
+++ b/tests/misc/projects/Issue8471/compile.hxml
@@ -1,2 +1,1 @@
---version
 --macro Macro.init()

--- a/tests/misc/projects/Issue8471/compile2-pretty.hxml.stderr
+++ b/tests/misc/projects/Issue8471/compile2-pretty.hxml.stderr
@@ -1,6 +1,6 @@
-[WARNING] (macro) Macro2.hx:12: characters 25-39
+[WARNING] (macro) Macro2.hx:13: characters 25-39
 
- 12 |   Context.warning(("1" :DeprecatedType), Context.currentPos());
+ 13 |   Context.warning(("1" :DeprecatedType), Context.currentPos());
     |                         ^^^^^^^^^^^^^^
     | (WDeprecated) This typedef is deprecated in favor of String
 

--- a/tests/misc/projects/Issue8471/compile2.hxml
+++ b/tests/misc/projects/Issue8471/compile2.hxml
@@ -1,2 +1,1 @@
---version
 --macro Macro2.init()

--- a/tests/misc/projects/Issue8471/compile2.hxml.stderr
+++ b/tests/misc/projects/Issue8471/compile2.hxml.stderr
@@ -1,4 +1,4 @@
-Macro2.hx:12: characters 25-39 : Warning : (WDeprecated) This typedef is deprecated in favor of String
+Macro2.hx:13: characters 25-39 : Warning : (WDeprecated) This typedef is deprecated in favor of String
 Warning : 1
 Warning : 2
 Warning : 3


### PR DESCRIPTION
Current situation is a bit weird, with different behavior:
* `--help` aborts immediately and goes through message reporting (and can use pretty errors etc)
* `--version` goes through message reporting (and can use pretty errors etc) and lets compilation continue (so it's added as a "normal" info message)
* `--help-metas` and `--help-define` directly print to stdout (kinda same for user variants)

<details>
<summary>Which means we can have these (click to expand)</summary>

![image](https://github.com/HaxeFoundation/haxe/assets/6101998/6e83fcf4-6f43-436f-8d25-379c4542d5b7)

But also this:
![image](https://github.com/HaxeFoundation/haxe/assets/6101998/7ae42f6a-b3c4-471b-808e-e4236c59b706)

vs this:
![image](https://github.com/HaxeFoundation/haxe/assets/6101998/3a3aa624-dffa-4e4c-89ac-48ee08748dbf)

And things like mix between raw stdout from --help-metas and message reporting from --version
</details>

With this PR, all of the above go through the same path, meaning:
* None of these would go through message reporting (bye "pretty" --version and --help)
* They will all abort after printing their content