### PR TITLE
Add test for sys.FileSystem.readDirectory error

### DIFF
--- a/tests/sys/src/TestFileSystem.hx
+++ b/tests/sys/src/TestFileSystem.hx
@@ -60,6 +60,13 @@ class TestFileSystem extends utest.Test {
 			//read directory with complex path
 			Assert.isTrue(FileSystem.readDirectory("../sys/./.." + tailingSlash).indexOf("sys") > -1);
 		}
+		// should throw if directory doesn't exist
+		try {
+			FileSystem.readDirectory("non-existant");
+			Assert.isFalse(true);
+		} catch (_) {
+			Assert.isTrue(true);
+		}
 	}
 
 	function testCreateDirectory():Void {


### PR DESCRIPTION
According to the docs:
> If `path` does not denote a valid directory, an exception is thrown.

This wasn't the case on hxcpp on Windows, so I've added a test here and created a patch for hxcpp: https://github.com/HaxeFoundation/hxcpp/pull/1095

Also relevant: #8232