### PR TITLE
Only write default Connection header to HTTP requests if needed

### DIFF
--- a/std/sys/Http.hx
+++ b/std/sys/Http.hx
@@ -223,7 +223,8 @@ class Http extends haxe.http.HttpBase {
 			else
 				b.writeString("Content-Length: " + uri.length + "\r\n");
 		}
-		b.writeString("Connection: close\r\n");
+		if( !Lambda.exists(headers, function(h) return h.name == "Connection") )
+			b.writeString("Connection: close\r\n");
 		for (h in headers) {
 			b.writeString(h.name);
 			b.writeString(": ");


### PR DESCRIPTION
Currently sys/Http writes "Connection: Close" to all requests, but this should not be done if, for example, the headers provided for a given request include a "Connection: Keep-Alive" header.