### PR TITLE
fix cast error if Std.string fails

### DIFF
--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -217,8 +217,10 @@ class Boot {
 	@:ifFeature("typed_cast") private static function __cast(o:Dynamic, t:Dynamic) {
 		if (o == null || __instanceof(o, t))
 			return o;
-		else
-			throw "Cannot cast " + Std.string(o) + " to " + Std.string(t);
+		else {
+			var str = try Std.string(o) catch( e : Dynamic ) (cast o : String);
+			throw "Cannot cast " + str + " to " + Std.string(t);
+		}
 	}
 
 	static var __toStr:js.lib.Function;


### PR DESCRIPTION
This fixes an error when a toString() raises an error, this can be reproduced with the following sample: 

```haxe
class Foo {
   var o : Map<String, Foo> = [];
   public function new() {
      o.set("x", this);
   }
   public function toString() {
		return "Foo:"+o; // will stack overflow
   }
}
class Main {
    static function main() {
        cast(new Foo(), Main); // should raise cast error
    }
}
```

Should be tested and fixed on other platforms as well.
