### PR TITLE
Catch missing standard library in init macros

### DIFF
--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -328,6 +328,13 @@ let raise_msg ?(depth = 0) msg p = raise_error_msg ~depth (Custom msg) p
 let raise_typing_error ?(depth = 0) msg p = raise_msg ~depth msg p
 let raise_typing_error_ext err = raise_error err
 
+let raise_std_not_found () =
+	try
+		let std_path = Sys.getenv "HAXE_STD_PATH" in
+		raise_typing_error ("Standard library not found. Please check your `HAXE_STD_PATH` environment variable (current value: \"" ^ std_path ^ "\")") null_pos
+	with Not_found ->
+		raise_typing_error "Standard library not found. You may need to set your `HAXE_STD_PATH` environment variable" null_pos
+
 let error_require r p =
 	if r = "" then
 		raise_typing_error "This field is not available with the current compilation flags" p

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -697,7 +697,10 @@ let create_macro_context com =
 			[cp#clone]
 	) com.class_paths#as_list;
 	(* Eval _std must be in front so we don't look into hxnodejs or something. *)
-	com2.class_paths#add (Option.get !eval_std);
+	(* This can run before `TyperEntry.create`, so in order to display nice error when std is not found, this needs to be checked here too *)
+	(match !eval_std with
+	| Some std -> com2.class_paths#add std
+	| None -> Error.raise_std_not_found ());
 	let defines = adapt_defines_to_macro_context com2.defines; in
 	com2.defines.values <- defines.values;
 	com2.defines.defines_signature <- None;

--- a/src/typing/typerEntry.ml
+++ b/src/typing/typerEntry.ml
@@ -63,11 +63,7 @@ let create com macros =
 		TypeloadModule.load_module ctx ([],"StdTypes") null_pos
 	with
 		Error { err_message = Module_not_found ([],"StdTypes") } ->
-			try
-				let std_path = Sys.getenv "HAXE_STD_PATH" in
-				raise_typing_error ("Standard library not found. Please check your `HAXE_STD_PATH` environment variable (current value: \"" ^ std_path ^ "\")") null_pos
-			with Not_found ->
-				raise_typing_error "Standard library not found. You may need to set your `HAXE_STD_PATH` environment variable" null_pos
+			Error.raise_std_not_found ()
 	);
 	(* We always want core types to be available so we add them as default imports (issue #1904 and #3131). *)
 	List.iter (fun mt ->


### PR DESCRIPTION
Now that typer init happens later, macro context can be created with missing standard library without TyperEntry.create catching it. Added some detection there for nicer errors.