### PR TITLE
Delay macro build order change

### DIFF
--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -512,7 +512,7 @@ module Inheritance = struct
 				match m with
 				| Meta.AutoBuild, el, p -> c.cl_meta <- (Meta.Build,el,{ c.cl_pos with pmax = c.cl_pos.pmin }(* prevent display metadata *)) :: m :: c.cl_meta
 				| _ -> ()
-			) (List.rev csup.cl_meta);
+			) (if (is_next ctx.com) then (List.rev csup.cl_meta) else csup.cl_meta);
 			if has_class_flag csup CFinal && not (((has_class_flag csup CExtern) && Meta.has Meta.Hack c.cl_meta) || (match c.cl_kind with KTypeParameter _ -> true | _ -> false)) then
 				raise_typing_error ("Cannot extend a final " ^ if (has_class_flag c CInterface) then "interface" else "class") p;
 		in

--- a/tests/misc/projects/Issue11582/compile.hxml
+++ b/tests/misc/projects/Issue11582/compile.hxml
@@ -1,2 +1,3 @@
 -main Main
+-D haxe-next
 --interp

--- a/tests/server/build.hxml
+++ b/tests/server/build.hxml
@@ -5,6 +5,7 @@
 -lib hxnodejs
 -lib utest
 -lib haxeserver
+-D haxe-next
 -D analyzer-optimize
 -D UTEST-PRINT-TESTS
 #-D UTEST_PATTERN=ServerTests


### PR DESCRIPTION
While I still think #11582 is needed in some way, it currently breaks many established macro-heavy projects that were built with the previous messed up build order.

I would like to work more on that at some point, if only to help with migrating such macros.

As it is, I fear it's too much of a breaking change and could drive people away from 5.0 nightlies so I would like to keep it under `-D haxe-next` for a bit.