### PR TITLE
[hl] Fix NotEq compare nullInt with Int

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -1491,6 +1491,11 @@ and jump_expr ctx e jcond =
 			| OpNotEq -> if jcond then OJNotEq (r1,r2,i) else OJEq (r1,r2,i)
 			| _ -> die "" __LOC__
 		) in
+		let nullisfalse = match jop with
+			| OpEq -> jcond
+			| OpNotEq -> not jcond
+			| _ -> die "" __LOC__
+		in
 		let t1 = to_type ctx e1.etype in
 		let t2 = to_type ctx e2.etype in
 		(match t1, t2 with
@@ -1510,8 +1515,8 @@ and jump_expr ctx e jcond =
 			free ctx a;
 			free ctx r1;
 			let j = jumpeq a b in
-			if jcond then (jnull(););
-			(fun() -> if not jcond then (jnull();); j());
+			if nullisfalse then (jnull(););
+			(fun() -> if not nullisfalse then (jnull();); j());
 		| _ ->
 			let t = common_type ctx e1 e2 true e.epos in
 			let a = eval_to ctx e1 t in

--- a/tests/unit/src/unit/TestOps.hx
+++ b/tests/unit/src/unit/TestOps.hx
@@ -1,5 +1,6 @@
 package unit;
 
+@:analyzer(ignore)
 class TestOps extends Test {
 
 	public function testOps()

--- a/tests/unit/src/unit/TestOps.hx
+++ b/tests/unit/src/unit/TestOps.hx
@@ -1,6 +1,5 @@
 package unit;
 
-@:analyzer(ignore)
 class TestOps extends Test {
 
 	public function testOps()
@@ -104,6 +103,7 @@ class TestOps extends Test {
 
 	#if target.static
 
+	@:analyzer(ignore)
 	function testNullOps() {
 		var a:Null<Int> = 10;
 		// arithmetic
@@ -164,6 +164,7 @@ class TestOps extends Test {
 
 	#if !flash // Will not fix for flash
 
+	@:analyzer(ignore)
 	function testNadakoOps() {
 		// bool
 		var nullBool:Null<Bool> = null;
@@ -258,6 +259,7 @@ class TestOps extends Test {
 
 	#end
 
+	@:analyzer(ignore)
 	function testDynamicOps() {
 		var a:Dynamic = 10;
 		// arithmetic


### PR DESCRIPTION
The following code does not return the expected result on local (it print false, false), and this PR fix it.

```haxe
static function main() {
	var nullInt:Null<Int> = null;
	trace(nullInt != 0); // expect: true
	trace(nullInt != 6); // expect: true
}
```

However, CI is green and place this code in TestOps.hx does not cause any problem (it print true, true but it shouldn't); try.haxe does not fail either. That's very strange and I don't understand why :(