### PR TITLE
Cleanup error positions

### DIFF
--- a/src/codegen/javaModern.ml
+++ b/src/codegen/javaModern.ml
@@ -754,11 +754,7 @@ module Converter = struct
 		tp
 
 	let convert_enum (jc : jclass) (file : string) =
-		let p = {
-			pfile = file;
-			pmin = 0;
-			pmax = 0
-		} in
+		let p = file_pos file in
 		let meta = ref [] in
 		let add_meta m = meta := m :: !meta in
 		let data = ref [] in
@@ -920,11 +916,7 @@ module Converter = struct
 		cff
 
 	let convert_class ctx (jc : jclass) (file : string) =
-		let p = {
-			pfile = file;
-			pmin = 0;
-			pmax = 0
-		} in
+		let p = file_pos file in
 		let flags = ref [HExtern] in
 		let meta = ref [] in
 		let add_flag f = flags := f :: !flags in

--- a/src/codegen/swfLoader.ml
+++ b/src/codegen/swfLoader.ml
@@ -147,7 +147,7 @@ let is_valid_path com pack name =
 
 let build_class com c file =
 	let path = (make_tpath c.hlc_name).path in
-	let pos = { pfile = file ^ "@" ^ s_type_path (path.tpackage,path.tname); pmin = 0; pmax = 0 } in
+	let pos = file_pos (file ^ "@" ^ s_type_path (path.tpackage,path.tname)) in
 	match path with
 	| { tpackage = ["flash";"utils"]; tname = ("Object"|"Function") } ->
 		let inf = {

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -293,7 +293,7 @@ let parse_args com =
 		),"<directory>","set current working directory");
 		("Compilation",["--haxelib-global"],[], Arg.Unit (fun () -> ()),"","pass --global argument to haxelib");
 		("Compilation",["-w"],[], Arg.String (fun s ->
-			let p = { pfile = "-w " ^ s; pmin = 0; pmax = 0 } in
+			let p = fake_pos ("-w " ^ s) in
 			let l = Warning.parse_options s p in
 			com.warning_options <- l :: com.warning_options
 		),"<warning list>","enable or disable specific warnings");

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -275,7 +275,7 @@ let check_defines com =
 		PMap.iter (fun k _ ->
 			try
 				let reason = Hashtbl.find Define.deprecation_lut k in
-				let p = { pfile = "-D " ^ k; pmin = -1; pmax = -1 } in
+				let p = fake_pos ("-D " ^ k) in
 				com.warning WDeprecatedDefine [] reason p
 			with Not_found ->
 				()

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -244,7 +244,7 @@ let load_display_file_standalone (ctx : Typecore.typer) file =
 let load_display_content_standalone (ctx : Typecore.typer) input =
 	let com = ctx.com in
 	let file = file_input_marker in
-	let p = {pfile = file; pmin = 0; pmax = 0} in
+	let p = file_pos file in
 	let parsed = TypeloadParse.parse_file_from_string com file p input in
 	let pack,decls = TypeloadParse.handle_parser_result com p parsed in
 	ignore(TypeloadModule.type_module ctx.com ctx.g (pack,"?DISPLAY") file ~dont_check_path:true decls p)

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -1122,7 +1122,7 @@ module HxbWriter = struct
 		end with Not_found ->
 			(try ignore(IdentityPool.get writer.unbound_ttp ttp) with Not_found -> begin
 				ignore(IdentityPool.add writer.unbound_ttp ttp ());
-				let p = { null_pos with pfile = (Path.UniqueKey.lazy_path writer.current_module.m_extra.m_file) } in
+				let p = file_pos (Path.UniqueKey.lazy_path writer.current_module.m_extra.m_file) in
 				let msg = Printf.sprintf "Unbound type parameter %s" (s_type_path ttp.ttp_class.cl_path) in
 				writer.warn WUnboundTypeParameter msg p
 			end);

--- a/src/context/commonCache.ml
+++ b/src/context/commonCache.ml
@@ -11,7 +11,7 @@ class lib_build_task cs file ftime lib = object(self)
 		let h = Hashtbl.create 0 in
 		List.iter (fun path ->
 			if not (Hashtbl.mem h path) then begin
-				let p = { pfile = file ^ " @ " ^ Globals.s_type_path path; pmin = 0; pmax = 0; } in
+				let p = file_pos (file ^ " @ " ^ Globals.s_type_path path) in
 				try begin match lib#build path p with
 				| Some r -> Hashtbl.add h path r
 				| None -> ()

--- a/src/context/display/displayPath.ml
+++ b/src/context/display/displayPath.ml
@@ -189,7 +189,7 @@ let handle_path_display ctx path p =
 			(* We assume that we want to go to the module file, not a specific type
 			   which might not even exist anyway. *)
 			let mt = ctx.g.do_load_module ctx (sl,s) p in
-			let p = { pfile = (Path.UniqueKey.lazy_path mt.m_extra.m_file); pmin = 0; pmax = 0} in
+			let p = file_pos (Path.UniqueKey.lazy_path mt.m_extra.m_file) in
 			raise_positions [p]
 		| (IDKModule(sl,s),_),DMHover ->
 			let m = ctx.g.do_load_module ctx (sl,s) p in

--- a/src/context/display/documentSymbols.ml
+++ b/src/context/display/documentSymbols.ml
@@ -114,7 +114,7 @@ let collect_module_symbols mname with_locals (pack,decls) =
 	) decls;
 	begin match mname with
 	| Some(file,mname) when not (Hashtbl.mem type_decls mname) ->
-		add mname Module {pfile = file; pmin = 0; pmax = 0} (String.concat "." pack) false
+		add mname Module (file_pos file) (String.concat "." pack) false
 	| _ ->
 		()
 	end;

--- a/src/core/globals.ml
+++ b/src/core/globals.ml
@@ -30,7 +30,9 @@ let version_minor = (version mod 1000) / 100
 let version_revision = (version mod 100)
 let version_pre = Some "alpha.1"
 
-let null_pos = { pfile = "?"; pmin = -1; pmax = -1 }
+let file_pos file = { pfile = file; pmin = 0; pmax = 0 }
+let fake_pos p = { pfile = p; pmin = -1; pmax = -1 }
+let null_pos = fake_pos "?"
 
 let no_color = false
 let c_reset = if no_color then "" else "\x1b[0m"

--- a/src/macro/eval/evalDebugSocket.ml
+++ b/src/macro/eval/evalDebugSocket.ml
@@ -473,7 +473,7 @@ module ValueCompletion = struct
 	exception JsonException of Json.t
 
 	let get_completion ctx text column env =
-		let p = { pmin = 0; pmax = 0; pfile = "" } in
+		let p = file_pos "" in
 		let save =
 			let old = !Parser.display_mode,DisplayPosition.display_position#get in
 			(fun () ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -993,7 +993,7 @@ let call_macro mctx args margs call p =
 	call (List.map (fun e -> try Interp.make_const e with Exit -> raise_typing_error "Argument should be a constant" e.epos) el)
 
 let resolve_init_macro com e =
-	let p = { pfile = "--macro " ^ e; pmin = -1; pmax = -1 } in
+	let p = fake_pos ("--macro " ^ e) in
 	let e = try
 		if String.get e (String.length e - 1) = ';' then raise_typing_error "Unexpected ;" p;
 		begin match ParserEntry.parse_expr_string com.defines e p raise_typing_error false with

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -39,7 +39,7 @@ let parse_file_from_lexbuf com file p lexbuf =
 	with
 		| Sedlexing.MalFormed ->
 			t();
-			raise_typing_error "Malformed file. Source files must be encoded with UTF-8." {pfile = file; pmin = 0; pmax = 0}
+			raise_typing_error "Malformed file. Source files must be encoded with UTF-8." (file_pos file)
 		| e ->
 			t();
 			raise e

--- a/tests/misc/projects/Issue8303/pretty-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8303/pretty-fail.hxml.stderr
@@ -2,10 +2,8 @@
 
    | Uncaught exception Stack overflow
 
-    ->  Main.hx:1: character 1
+    ->  Main.hx
 
-     1 | class Main {
-       | ^
        | Called from here
 
      8 |    log();


### PR DESCRIPTION
Fixes hxb's unbound type parameter warnings' position which was displayed as `(unknown)` in non-pretty message reporting modes. Not adding a test because those warnings should not happen so the test would start failing when we fix the underlying issue..

The actual fix here is using `pmin = 0; pmax = 0` instead of `pmin = -1; pmax = -1` in hxb writer, but this PR also:
* introduces `file_pos` and `fake_pos` functions to avoid `{ null_pos with ... }` / manual pos building with pmin/pmax = 0 / -1
* updates pretty errors to not display first line of a module when a position points to the whole module; I don't think this could have bad side effects as I can't really see errors which would point at first character (and not a range) of a module and for which printing that first line would be helpful

Before:
```
(unknown) : Warning : (WUnboundTypeParameter) Unbound type parameter foo.T
```

After:
```
src/Main.hx:1: character 1 : Warning : (WUnboundTypeParameter) Unbound type parameter foo.T
```

---

I'm still not sure how to handle "fake positions" in non-pretty message reporting modes, but that's not a new issue and should be addressed separately. For reference, this is about this:
```
❯ haxe user-defined-define-json-fail.hxml -D message.reporting=indent
(unknown) : Uncaught exception Could not read file define.jsno
  /opt/haxe/std/haxe/macro/Compiler.hx:393: characters 11-39 : Called from here
  (unknown) : Called from here
```
```
❯ haxe user-defined-define-json-fail.hxml -D message.reporting=classic
(unknown) : Uncaught exception Could not read file define.jsno
/opt/haxe/std/haxe/macro/Compiler.hx:393: characters 11-39 : Called from here
(unknown) : Called from here
```
vs:
```
❯ haxe user-defined-define-json-fail.hxml -D message.reporting=pretty -D message.no-color
[ERROR] --macro haxe.macro.Compiler.registerDefinesDescriptionFile('define.jsno', 'myapp')

   | Uncaught exception Could not read file define.jsno

    ->  /opt/haxe/std/haxe/macro/Compiler.hx:393: characters 11-39

    393 |   var f = sys.io.File.getContent(path);
        |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        | Called from here

        | Called from here
```