### PR TITLE
Macro build order

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -92,6 +92,13 @@
 		"links": ["https://haxe.org/manual/macro-type-building.html"]
 	},
 	{
+		"name": "BuildOrder",
+		"metadata": ":buildOrder",
+		"doc": "Specify that a build macro should run Early or Late (in relation to other build macros for current type)",
+		"params": ["Build order"],
+		"targets": ["TClassField"]
+	},
+	{
 		"name": "BuildXml",
 		"metadata": ":buildXml",
 		"doc": "Specify XML data to be injected into `Build.xml`.",

--- a/tests/misc/projects/Issue11582/Macro2.macro.hx
+++ b/tests/misc/projects/Issue11582/Macro2.macro.hx
@@ -1,0 +1,72 @@
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+using StringTools;
+
+class Macro2 {
+	static var id = 0;
+
+	static function registerBuild(i:String, fields:Array<Field>) {
+		if (Context.getLocalClass().get().isInterface) return null;
+
+		var hasMacros = false;
+		for (f in fields) {
+			if (f.name == "macros") {
+				hasMacros = true;
+				break;
+			}
+		}
+
+		if (!hasMacros)
+			fields = (macro class A {
+				public static var macros = [];
+			}).fields.concat(fields);
+
+		var id = '_' + id++;
+		fields.push((macro class A {
+			 static var $id = {macros.push($v{i}); 0;};
+		}).fields[0]);
+
+		return fields;
+	}
+
+	static function isAsync(f:Field):Bool {
+		return Lambda.exists(f.meta, m -> m.name == ":async");
+	}
+
+	@:buildOrder(Late)
+	public static function buildTest() {
+		var fields = haxe.macro.Context.getBuildFields();
+		var asyncArg = {name: "async", type: macro :Async};
+
+		// Add `async` arg to tests with `@:async` metadata
+		for (f in fields) {
+			if (!f.name.startsWith("test")) continue;
+
+			switch f.kind {
+				case FFun({args: [], ret: ret, expr: expr, params: []}) if (isAsync(f)):
+					f.kind = FFun({args: [asyncArg], ret: ret, expr: expr, params: []});
+
+				case _:
+			}
+		}
+
+		return registerBuild("Base Test", fields);
+	}
+
+	public static function autoAsync() {
+		var fields = haxe.macro.Context.getBuildFields();
+
+		// Add `@:async` to all tests
+		for (f in fields) {
+			if (!f.name.startsWith("test")) continue;
+
+			switch f.kind {
+				case FFun(_): f.meta.push({name: ":async", params: [], pos: f.pos});
+				case _:
+			}
+		}
+
+		return registerBuild("Auto async", fields);
+	}
+}

--- a/tests/misc/projects/Issue11582/Macro3.macro.hx
+++ b/tests/misc/projects/Issue11582/Macro3.macro.hx
@@ -1,0 +1,72 @@
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+using StringTools;
+
+class Macro3 {
+	static var id = 0;
+
+	static function registerBuild(i:String, fields:Array<Field>) {
+		if (Context.getLocalClass().get().isInterface) return null;
+
+		var hasMacros = false;
+		for (f in fields) {
+			if (f.name == "macros") {
+				hasMacros = true;
+				break;
+			}
+		}
+
+		if (!hasMacros)
+			fields = (macro class A {
+				public static var macros = [];
+			}).fields.concat(fields);
+
+		var id = '_' + id++;
+		fields.push((macro class A {
+			 static var $id = {macros.push($v{i}); 0;};
+		}).fields[0]);
+
+		return fields;
+	}
+
+	static function isAsync(f:Field):Bool {
+		return Lambda.exists(f.meta, m -> m.name == ":async");
+	}
+
+	public static function buildTest() {
+		var fields = haxe.macro.Context.getBuildFields();
+		var asyncArg = {name: "async", type: macro :Async};
+
+		// Add `async` arg to tests with `@:async` metadata
+		for (f in fields) {
+			if (!f.name.startsWith("test")) continue;
+
+			switch f.kind {
+				case FFun({args: [], ret: ret, expr: expr, params: []}) if (isAsync(f)):
+					f.kind = FFun({args: [asyncArg], ret: ret, expr: expr, params: []});
+
+				case _:
+			}
+		}
+
+		return registerBuild("Base Test", fields);
+	}
+
+	@:buildOrder(Early)
+	public static function autoAsync() {
+		var fields = haxe.macro.Context.getBuildFields();
+
+		// Add `@:async` to all tests
+		for (f in fields) {
+			if (!f.name.startsWith("test")) continue;
+
+			switch f.kind {
+				case FFun(_): f.meta.push({name: ":async", params: [], pos: f.pos});
+				case _:
+			}
+		}
+
+		return registerBuild("Auto async", fields);
+	}
+}

--- a/tests/misc/projects/Issue11582/Main2.hx
+++ b/tests/misc/projects/Issue11582/Main2.hx
@@ -1,0 +1,25 @@
+class Main2 {
+	static function main() {
+		trace("TestFoo", TestFoo.macros);
+		trace("TestBar", TestBar.macros);
+	}
+}
+
+class Async {
+	public function done() {}
+}
+
+@:autoBuild(Macro2.buildTest())
+class BaseTest {}
+
+class TestFoo extends BaseTest {
+	@:async
+	function test() async.done();
+}
+
+@:autoBuild(Macro2.autoAsync())
+class AsyncTest extends BaseTest {}
+
+class TestBar extends AsyncTest {
+	function test() async.done();
+}

--- a/tests/misc/projects/Issue11582/Main3.hx
+++ b/tests/misc/projects/Issue11582/Main3.hx
@@ -1,0 +1,25 @@
+class Main3 {
+	static function main() {
+		trace("TestFoo", TestFoo.macros);
+		trace("TestBar", TestBar.macros);
+	}
+}
+
+class Async {
+	public function done() {}
+}
+
+@:autoBuild(Macro3.buildTest())
+class BaseTest {}
+
+class TestFoo extends BaseTest {
+	@:async
+	function test() async.done();
+}
+
+@:autoBuild(Macro3.autoAsync())
+class AsyncTest extends BaseTest {}
+
+class TestBar extends AsyncTest {
+	function test() async.done();
+}

--- a/tests/misc/projects/Issue11582/compile-early.hxml
+++ b/tests/misc/projects/Issue11582/compile-early.hxml
@@ -1,0 +1,2 @@
+-main Main3
+--interp

--- a/tests/misc/projects/Issue11582/compile-early.hxml.stdout
+++ b/tests/misc/projects/Issue11582/compile-early.hxml.stdout
@@ -1,0 +1,2 @@
+Main3.hx:3: TestFoo,[Base Test]
+Main3.hx:4: TestBar,[Auto async,Base Test]

--- a/tests/misc/projects/Issue11582/compile-late.hxml
+++ b/tests/misc/projects/Issue11582/compile-late.hxml
@@ -1,0 +1,2 @@
+-main Main2
+--interp

--- a/tests/misc/projects/Issue11582/compile-late.hxml.stdout
+++ b/tests/misc/projects/Issue11582/compile-late.hxml.stdout
@@ -1,0 +1,2 @@
+Main2.hx:3: TestFoo,[Base Test]
+Main2.hx:4: TestBar,[Auto async,Base Test]


### PR DESCRIPTION
As an alternative to #11622, adds support for `@:buildOrder(Late)` and `@:buildOrder(Early)` on build macros, letting those specify if what they're doing requires running before or after other build macros for current type.

Added tests pass with 4.3.x but not with current nightlies (compilation error).

~~_Also, windows CI is broken again for some reason..._~~ works again this morning :shrug: 

Closes #11194 