### PR TITLE
[ci] Specify macOS runner versions instead of using macos-latest.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -448,7 +448,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-14]
+        os: [macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     env:
       PLATFORM: mac
@@ -543,14 +543,14 @@ jobs:
           otool -L ./haxelib
 
       - name: Upload artifact (x64)
-        if: matrix.os == 'macos-latest'
+        if: runner.arch == 'X64'
         uses: actions/upload-artifact@v4
         with:
           name: macX64Binaries
           path: out
 
       - name: Upload artifact (arm)
-        if: matrix.os == 'macos-14'
+        if: runner.arch == 'ARM64'
         uses: actions/upload-artifact@v4
         with:
           name: macArmBinaries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -689,7 +689,7 @@ jobs:
 
   mac-test:
     needs: mac-build-universal
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       PLATFORM: mac
       TEST: ${{matrix.target}}

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -56,14 +56,14 @@
     otool -L ./haxelib
 
 - name: Upload artifact (x64)
-  if: matrix.os == 'macos-latest'
+  if: runner.arch == 'X64'
   uses: actions/upload-artifact@v4
   with:
     name: macX64Binaries
     path: out
 
 - name: Upload artifact (arm)
-  if: matrix.os == 'macos-14'
+  if: runner.arch == 'ARM64'
   uses: actions/upload-artifact@v4
   with:
     name: macArmBinaries

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -393,7 +393,7 @@ jobs:
 
   mac-test:
     needs: mac-build-universal
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       PLATFORM: mac
       TEST: ${{matrix.target}}

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -308,7 +308,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-14]
+        os: [macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     env:
       PLATFORM: mac


### PR DESCRIPTION
Use `runner.arch` to decide where to upload the macOS artifacts.