### PR TITLE
[make] Generate haxelib binary with `nekotools boot -c` on Mac/Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -544,7 +544,7 @@ jobs:
           set -ex
           eval $(opam env)
           opam config exec -- make -s -j`sysctl -n hw.ncpu` STATICLINK=1 "LIB_PARAMS=/usr/local/lib/libz.a /usr/local/lib/libpcre2-8.a /usr/local/lib/libmbedtls.a /usr/local/lib/libmbedcrypto.a /usr/local/lib/libmbedx509.a -cclib '-framework Security -framework CoreFoundation'" haxe
-          opam config exec -- make -s haxelib
+          opam config exec -- arch -x86_64 make -s haxelib
           make -s package_unix package_installer_mac
           ls -l out
           otool -L ./haxe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/include/*                      /usr/local/include/
           sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
           echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 
@@ -267,6 +268,7 @@ jobs:
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/include/*                      /usr/local/include/
           sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
           echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 
@@ -343,6 +345,7 @@ jobs:
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/include/*                      /usr/local/include/
           sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
           echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 
@@ -479,6 +482,7 @@ jobs:
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/include/*                      /usr/local/include/
           sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
           echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 
@@ -722,6 +726,7 @@ jobs:
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+          sudo ln -s $NEKOPATH/include/*                      /usr/local/include/
           sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
           echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,7 @@ jobs:
           tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
           NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
           sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/include
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
@@ -265,6 +266,7 @@ jobs:
           tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
           NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
           sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/include
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
@@ -342,6 +344,7 @@ jobs:
           tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
           NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
           sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/include
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
@@ -479,6 +482,7 @@ jobs:
           tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
           NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
           sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/include
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
@@ -723,6 +727,7 @@ jobs:
           tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
           NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
           sudo mkdir -p /usr/local/bin
+          sudo mkdir -p /usr/local/include
           sudo mkdir -p /usr/local/lib/neko
           sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
           sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/

--- a/Earthfile
+++ b/Earthfile
@@ -146,6 +146,7 @@ INSTALL_NEKO:
     ARG PREFIX=/usr/local
     RUN bash -c "ln -s \"$NEKOPATH\"/{neko,nekoc,nekoml,nekotools} \"$PREFIX/bin/\""
     RUN bash -c "ln -s \"$NEKOPATH\"/libneko.* \"$PREFIX/lib/\""
+    RUN bash -c "ln -s \"$NEKOPATH\"/*.h \"$PREFIX/include/\""
     RUN mkdir -p "$PREFIX/lib/neko/"
     RUN bash -c "ln -s \"$NEKOPATH\"/*.ndll \"$PREFIX/lib/neko/\""
     RUN ldconfig

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,11 @@ haxelib_unix:
 	(cd $(CURDIR)/extra/haxelib_src && $(CURDIR)/$(HAXE_OUTPUT) client.hxml && nekotools boot -c run.n)
 	${CC} $(CURDIR)/extra/haxelib_src/run.c -o $(HAXELIB_OUTPUT) -lneko
 
+ifeq ($(SYSTEM_NAME),Windows)
 haxelib: haxelib_$(PLATFORM)
+else
+haxelib: haxelib_unix
+endif
 
 tools: haxelib
 

--- a/Makefile
+++ b/Makefile
@@ -105,9 +105,11 @@ copy_haxetoolkit: /cygdrive/c/HaxeToolkit/haxe/haxe.exe
 endif
 
 # haxelib should depends on haxe, but we don't want to do that...
-haxelib:
-	(cd $(CURDIR)/extra/haxelib_src && $(CURDIR)/$(HAXE_OUTPUT) client.hxml && nekotools boot run.n)
-	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
+haxelib_unix:
+	(cd $(CURDIR)/extra/haxelib_src && $(CURDIR)/$(HAXE_OUTPUT) client.hxml && nekotools boot -c run.n)
+	${CC} $(CURDIR)/extra/haxelib_src/run.c -o $(HAXELIB_OUTPUT) -lneko
+
+haxelib: haxelib_$(PLATFORM)
 
 tools: haxelib
 

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,9 @@ endif
 
 # haxelib should depends on haxe, but we don't want to do that...
 haxelib_unix:
-	(cd $(CURDIR)/extra/haxelib_src && $(CURDIR)/$(HAXE_OUTPUT) client.hxml && nekotools boot -c run.n)
+	cd $(CURDIR)/extra/haxelib_src && \
+	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
+	nekotools boot -c run.n
 	${CC} $(CURDIR)/extra/haxelib_src/run.c -o $(HAXELIB_OUTPUT) -lneko
 
 ifeq ($(SYSTEM_NAME),Windows)

--- a/Makefile
+++ b/Makefile
@@ -104,13 +104,19 @@ copy_haxetoolkit: /cygdrive/c/HaxeToolkit/haxe/haxe.exe
 	cp $< $@
 endif
 
-# haxelib should depends on haxe, but we don't want to do that...
+ifeq ($(SYSTEM_NAME),Mac)
+# This assumes that haxelib and neko will both be installed into INSTALL_DIR,
+# which is the case when installing using the mac installer package
+HAXELIB_LFLAGS= -Wl,-rpath,$(INSTALL_DIR)/lib
+endif
+
 haxelib_unix:
 	cd $(CURDIR)/extra/haxelib_src && \
 	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
 	nekotools boot -c run.n
-	${CC} $(CURDIR)/extra/haxelib_src/run.c -o $(HAXELIB_OUTPUT) -lneko
+	$(CC) $(CURDIR)/extra/haxelib_src/run.c -o $(HAXELIB_OUTPUT) -lneko $(HAXELIB_LFLAGS)
 
+# haxelib should depends on haxe, but we don't want to do that...
 ifeq ($(SYSTEM_NAME),Windows)
 haxelib: haxelib_$(PLATFORM)
 else

--- a/Makefile.win
+++ b/Makefile.win
@@ -53,6 +53,11 @@ PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std \
 	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedtls.dll | sed -e 's/^\s*//')" \
 	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedx509.dll | sed -e 's/^\s*//')"
 
+# haxelib should depends on haxe, but we don't want to do that...
+haxelib_win:
+	(cd $(CURDIR)/extra/haxelib_src && $(CURDIR)/$(HAXE_OUTPUT) client.hxml && nekotools boot run.n)
+	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
+
 echo_package_files:
 	echo $(PACKAGE_FILES)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -55,7 +55,9 @@ PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std \
 
 # haxelib should depends on haxe, but we don't want to do that...
 haxelib_win:
-	(cd $(CURDIR)/extra/haxelib_src && $(CURDIR)/$(HAXE_OUTPUT) client.hxml && nekotools boot run.n)
+	cd $(CURDIR)/extra/haxelib_src && \
+	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
+	nekotools boot run.n
 	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
 
 echo_package_files:

--- a/Makefile.win
+++ b/Makefile.win
@@ -56,7 +56,7 @@ PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std \
 # haxelib should depends on haxe, but we don't want to do that...
 haxelib_win:
 	cd $(CURDIR)/extra/haxelib_src && \
-	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
+	$(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
 	nekotools boot run.n
 	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -56,7 +56,7 @@ PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std \
 # haxelib should depends on haxe, but we don't want to do that...
 haxelib_win:
 	cd $(CURDIR)/extra/haxelib_src && \
-	$(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
+	HAXE_STD_PATH=$$(cygpath -m $(CURDIR)/std) $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
 	nekotools boot run.n
 	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
 

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -49,7 +49,7 @@
     set -ex
     eval $(opam env)
     opam config exec -- make -s -j`sysctl -n hw.ncpu` STATICLINK=1 "LIB_PARAMS=/usr/local/lib/libz.a /usr/local/lib/libpcre2-8.a /usr/local/lib/libmbedtls.a /usr/local/lib/libmbedcrypto.a /usr/local/lib/libmbedx509.a -cclib '-framework Security -framework CoreFoundation'" haxe
-    opam config exec -- make -s haxelib
+    opam config exec -- arch -x86_64 make -s haxelib
     make -s package_unix package_installer_mac
     ls -l out
     otool -L ./haxe

--- a/extra/github-actions/install-neko-unix.yml
+++ b/extra/github-actions/install-neko-unix.yml
@@ -6,6 +6,7 @@
     tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
     NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
     sudo mkdir -p /usr/local/bin
+    sudo mkdir -p /usr/local/include
     sudo mkdir -p /usr/local/lib/neko
     sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
     sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/

--- a/extra/github-actions/install-neko-unix.yml
+++ b/extra/github-actions/install-neko-unix.yml
@@ -9,6 +9,7 @@
     sudo mkdir -p /usr/local/lib/neko
     sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
     sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+    sudo ln -s $NEKOPATH/include/*                      /usr/local/include/
     sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
     echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
 


### PR DESCRIPTION
`nekotools boot` is a bit of a hack because it simply copies the neko exectuable and injects in the neko bytecode. This can cause issues with some tools that deal with executables on Linux/Mac. https://github.com/HaxeFoundation/neko/issues/130#issuecomment-218610395

This started happening on Arch linux, where the bytecode somehow gets stripped away during packaging so haxelib becomes unusable because it is reverted to the regular neko binary. See: #11652.

`nekotools boot -c` will instead generate a .c file which can then be compiled manually. I've changed this for Mac and Linux, but for Windows it will continue to use `nekotools boot` as it is simpler and doesn't cause issues there as far as I'm aware.

I'm not sure if this may have packaging implications now that a c compiler is used directly in the make file?