### PR TITLE
[hl] Ignore WANT_READ/WANT_WRITE errors when the socket is known to b…

### DIFF
--- a/std/hl/_std/sys/ssl/Socket.hx
+++ b/std/hl/_std/sys/ssl/Socket.hx
@@ -50,7 +50,10 @@ private class SocketInput extends haxe.io.Input {
 		__s.handshake();
 		var r = @:privateAccess __s.ssl.recv(buf, pos, len);
 		if (r == -1)
-			throw haxe.io.Error.Blocked;
+			if (@:privateAccess __s.isBlocking)
+				return 0
+			else
+				throw haxe.io.Error.Blocked;
 		else if (r <= 0)
 			throw new haxe.io.Eof();
 		return r;
@@ -85,7 +88,10 @@ private class SocketOutput extends haxe.io.Output {
 		__s.handshake();
 		var r = @:privateAccess __s.ssl.send(buf, pos, len);
 		if (r == -1)
-			throw haxe.io.Error.Blocked;
+			if (@:privateAccess __s.isBlocking)
+				return 0
+			else
+				throw haxe.io.Error.Blocked;
 		else if (r < 0)
 			throw new haxe.io.Eof();
 		return r;


### PR DESCRIPTION
…e blocking.

Sometimes mbedtls returns WANT_READ/WANT_WRITE errors (the case I encountered while working on https://github.com/HaxeFoundation/hashlink/pull/681 seems to be due to session tickets).
These should be interpreted as "retry when more data is known to be available", but there is no good way to express that in the current api when the socket is blocking other than returning zero.

Together with https://github.com/HaxeFoundation/hashlink/pull/681 this should be enough to get rid of the HL+macOS failures in https://github.com/HaxeFoundation/haxe/pull/11638.