### PR TITLE
Valid redefinition rework

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -657,10 +657,10 @@ and assign_type_params uctx ttp1 ttp2 =
 			error []
 		| TpDefinition tctx ->
 			begin try
-				let ttp3 = List.assq ttp1 tctx.type_param_pairs in
-				if ttp2 != ttp3 then error []
+				let ttp3 = List.assq ttp2 tctx.type_param_pairs in
+				if ttp1 != ttp3 then error []
 			with Not_found ->
-				tctx.type_param_pairs <- (ttp1,ttp2) :: tctx.type_param_pairs
+				tctx.type_param_pairs <- (ttp2,ttp1) :: tctx.type_param_pairs
 			end
 	end
 

--- a/src/typing/tanon_identification.ml
+++ b/src/typing/tanon_identification.ml
@@ -69,7 +69,7 @@ object(self)
 			equality_kind = EqStricter;
 			equality_underlying = false;
 			strict_field_kind = true;
-			type_param_pairs = None;
+			type_param_mode = TpDefault;
 		} else {default_unification_context with equality_kind = EqDoNotFollowNull} in
 
 		let check () =

--- a/src/typing/tanon_identification.ml
+++ b/src/typing/tanon_identification.ml
@@ -69,6 +69,7 @@ object(self)
 			equality_kind = EqStricter;
 			equality_underlying = false;
 			strict_field_kind = true;
+			type_param_pairs = None;
 		} else {default_unification_context with equality_kind = EqDoNotFollowNull} in
 
 		let check () =

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -48,8 +48,9 @@ let is_generic_parameter ctx c =
 		false
 
 let valid_redefinition map1 map2 f1 t1 f2 t2 = (* child, parent *)
+	let uctx = {default_unification_context with type_param_pairs = Some (ref [])} in
 	let valid t1 t2 =
-		Type.unify t1 t2;
+		unify_custom uctx t1 t2;
 		if is_null t1 <> is_null t2 || ((follow t1) == t_dynamic && (follow t2) != t_dynamic) then raise (Unify_error [Cannot_unify (t1,t2)]);
 	in
 	begin match PurityState.get_purity_from_meta f2.cf_meta,PurityState.get_purity_from_meta f1.cf_meta with
@@ -57,7 +58,7 @@ let valid_redefinition map1 map2 f1 t1 f2 t2 = (* child, parent *)
 		| PurityState.ExpectPure p,PurityState.MaybePure -> f1.cf_meta <- (Meta.Pure,[EConst(Ident "expect"),p],null_pos) :: f1.cf_meta
 		| _ -> ()
 	end;
-	let t1, t2 = (match f1.cf_params, f2.cf_params with
+	(* let t1, t2 = (match f1.cf_params, f2.cf_params with
 		| [], [] -> t1, t2
 		| l1, l2 when List.length l1 = List.length l2 ->
 			let to_check = ref [] in
@@ -89,7 +90,7 @@ let valid_redefinition map1 map2 f1 t1 f2 t2 = (* child, parent *)
 		| _  ->
 			(* ignore type params, will create other errors later *)
 			t1, t2
-	) in
+	) in *)
 	match f1.cf_kind,f2.cf_kind with
 	| Method m1, Method m2 when not (m1 = MethDynamic) && not (m2 = MethDynamic) ->
 		begin match follow t1, follow t2 with

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -110,7 +110,7 @@ let valid_redefinition map1 map2 f1 t1 f2 t2 = (* child, parent *)
 			) ct2
 	in
 	List.iter (fun (ttp1,ttp2) ->
-		assign_ttp ttp1 ttp2
+		assign_ttp ttp2 ttp1
 	) tctx.type_param_pairs
 
 let copy_meta meta_src meta_target sl =

--- a/tests/misc/projects/Issue11411/MainArgumentVarianceBad.hx
+++ b/tests/misc/projects/Issue11411/MainArgumentVarianceBad.hx
@@ -1,0 +1,14 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T:Parent>(t:T):Void;
+}
+
+class C implements I {
+    public function test<T:Child>(t:T) { }
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainArgumentVarianceGood.hx
+++ b/tests/misc/projects/Issue11411/MainArgumentVarianceGood.hx
@@ -1,0 +1,14 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T:Child>(t:T):Void;
+}
+
+class C implements I {
+    public function test<T:Parent>(t:T) { }
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainArgumentVarianceMissingBad.hx
+++ b/tests/misc/projects/Issue11411/MainArgumentVarianceMissingBad.hx
@@ -1,0 +1,14 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T>(t:T):Void;
+}
+
+class C implements I {
+    public function test<T:Child>(t:T) { }
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainArgumentVarianceMissingGood.hx
+++ b/tests/misc/projects/Issue11411/MainArgumentVarianceMissingGood.hx
@@ -1,0 +1,14 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T:Child>(t:T):Void;
+}
+
+class C implements I {
+    public function test<T>(t:T) { }
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainInterfaceUnion.hx
+++ b/tests/misc/projects/Issue11411/MainInterfaceUnion.hx
@@ -1,0 +1,13 @@
+interface A {}
+interface B {}
+class C implements A implements B {}
+
+class Parent {
+	function f<TC:C>(a:TC, b:TC) {}
+}
+
+class Child extends Parent {
+	override function f<TA:A, TB:B>(a:TA, b:TB) {}
+}
+
+function main() {}

--- a/tests/misc/projects/Issue11411/MainNoVariance.hx
+++ b/tests/misc/projects/Issue11411/MainNoVariance.hx
@@ -1,0 +1,11 @@
+interface I {
+    public function test<T>():Void;
+}
+
+class C implements I {
+    public function test<T:String>() { }
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainReturnVarianceBad.hx
+++ b/tests/misc/projects/Issue11411/MainReturnVarianceBad.hx
@@ -1,0 +1,16 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T:Child>():T;
+}
+
+class C implements I {
+    public function test<T:Parent>():T {
+		return null;
+	}
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainReturnVarianceGood.hx
+++ b/tests/misc/projects/Issue11411/MainReturnVarianceGood.hx
@@ -1,0 +1,16 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T:Parent>():T;
+}
+
+class C implements I {
+    public function test<T:Child>():T {
+		return null;
+	}
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainReturnVarianceMissingBad.hx
+++ b/tests/misc/projects/Issue11411/MainReturnVarianceMissingBad.hx
@@ -1,0 +1,16 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T:Child>():T;
+}
+
+class C implements I {
+    public function test<T>():T {
+		return null;
+	}
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/MainReturnVarianceMissingGood.hx
+++ b/tests/misc/projects/Issue11411/MainReturnVarianceMissingGood.hx
@@ -1,0 +1,16 @@
+class Parent {}
+class Child extends Parent {}
+
+interface I {
+    public function test<T>():T;
+}
+
+class C implements I {
+    public function test<T:Child>():T {
+		return null;
+	}
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/Issue11411/compile-argument-variance-bad-fail.hxml
+++ b/tests/misc/projects/Issue11411/compile-argument-variance-bad-fail.hxml
@@ -1,0 +1,2 @@
+--main MainArgumentVarianceBad
+--interp

--- a/tests/misc/projects/Issue11411/compile-argument-variance-good.hxml
+++ b/tests/misc/projects/Issue11411/compile-argument-variance-good.hxml
@@ -1,0 +1,2 @@
+--main MainArgumentVarianceGood
+--interp

--- a/tests/misc/projects/Issue11411/compile-argument-variance-missing-bad-fail.hxml
+++ b/tests/misc/projects/Issue11411/compile-argument-variance-missing-bad-fail.hxml
@@ -1,0 +1,2 @@
+--main MainArgumentVarianceMissingBad
+--interp

--- a/tests/misc/projects/Issue11411/compile-argument-variance-missing-good.hxml
+++ b/tests/misc/projects/Issue11411/compile-argument-variance-missing-good.hxml
@@ -1,0 +1,2 @@
+--main MainArgumentVarianceMissingGood
+--interp

--- a/tests/misc/projects/Issue11411/compile-interface-union.hxml
+++ b/tests/misc/projects/Issue11411/compile-interface-union.hxml
@@ -1,0 +1,2 @@
+--main MainInterfaceUnion
+--interp

--- a/tests/misc/projects/Issue11411/compile-no-variance.hxml
+++ b/tests/misc/projects/Issue11411/compile-no-variance.hxml
@@ -1,0 +1,2 @@
+--main MainNoVariance
+--interp

--- a/tests/misc/projects/Issue11411/compile-return-variance-bad-fail.hxml
+++ b/tests/misc/projects/Issue11411/compile-return-variance-bad-fail.hxml
@@ -1,0 +1,2 @@
+--main MainReturnVarianceBad
+--interp

--- a/tests/misc/projects/Issue11411/compile-return-variance-good.hxml
+++ b/tests/misc/projects/Issue11411/compile-return-variance-good.hxml
@@ -1,0 +1,2 @@
+--main MainReturnVarianceGood
+--interp

--- a/tests/misc/projects/Issue11411/compile-return-variance-missing-bad-fail.hxml
+++ b/tests/misc/projects/Issue11411/compile-return-variance-missing-bad-fail.hxml
@@ -1,0 +1,2 @@
+--main MainReturnVarianceMissingBad
+--interp

--- a/tests/misc/projects/Issue11411/compile-return-variance-missing-good.hxml
+++ b/tests/misc/projects/Issue11411/compile-return-variance-missing-good.hxml
@@ -1,0 +1,2 @@
+--main MainReturnVarianceMissingGood
+--interp


### PR DESCRIPTION
This changes how `valid_redefinition` deals with type parameters by introducing `type_param_mode` to unification and using a special `TpDefinition` mode. When encountering a type parameter to type parameter assignment in that mode, we pair the two up and admit the unification. Once we're done with that, we check that the constraints.

Constraint checks now use unification instead of type equality, which means that they respect variance. See the tests for examples, I hope I got everything right.

This shouldn't outright break anything but there's a chance we're adding type holes.

Closes #11411. 