### PR TITLE
Don't bind foreign type parameters in definition mode

### DIFF
--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -50,6 +50,7 @@ let is_generic_parameter ctx c =
 let valid_redefinition map1 map2 f1 t1 f2 t2 = (* child, parent *)
 	let tctx = {
 		type_param_pairs = [];
+		known_type_params = f1.cf_params
 	} in
 	let uctx = {default_unification_context with type_param_mode = TpDefinition tctx} in
 	let valid t1 t2 =

--- a/tests/misc/projects/Issue11624/MainBar.hx
+++ b/tests/misc/projects/Issue11624/MainBar.hx
@@ -1,0 +1,9 @@
+interface Foo {
+	function bar<T>():T;
+}
+
+class Bar implements Foo {
+	public function bar<T>() return null; // Error: write_full_path hxb writer failure
+}
+
+function main() {}

--- a/tests/misc/projects/Issue11624/MainBaz.hx
+++ b/tests/misc/projects/Issue11624/MainBaz.hx
@@ -1,0 +1,9 @@
+interface Foo {
+	function baz<T>():T;
+}
+
+class Bar implements Foo {
+	public function baz<T>():T return null; // this is fine
+}
+
+function main() {}

--- a/tests/misc/projects/Issue11624/MainFoo.hx
+++ b/tests/misc/projects/Issue11624/MainFoo.hx
@@ -1,0 +1,9 @@
+interface Foo {
+	function foo<T>():T;
+}
+
+class Bar implements Foo {
+	public function foo() return null; // Warning: Unbound type parameter foo.T
+}
+
+function main() {}

--- a/tests/misc/projects/Issue11624/compile-bar-fail.hxml
+++ b/tests/misc/projects/Issue11624/compile-bar-fail.hxml
@@ -1,0 +1,2 @@
+--main MainBar
+--interp

--- a/tests/misc/projects/Issue11624/compile-bar-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11624/compile-bar-fail.hxml.stderr
@@ -1,0 +1,5 @@
+MainBar.hx:6: characters 18-21 : Field bar has different type than in Foo
+MainBar.hx:2: characters 11-14 : ... Interface field is defined here
+MainBar.hx:6: characters 18-21 : ... error: Null<Unknown<0>> should be bar.T
+MainBar.hx:6: characters 18-21 : ... have: (...) -> Null<...>
+MainBar.hx:6: characters 18-21 : ... want: (...) -> bar.T

--- a/tests/misc/projects/Issue11624/compile-baz.hxml
+++ b/tests/misc/projects/Issue11624/compile-baz.hxml
@@ -1,0 +1,2 @@
+--main MainBaz
+--interp

--- a/tests/misc/projects/Issue11624/compile-foo-fail.hxml
+++ b/tests/misc/projects/Issue11624/compile-foo-fail.hxml
@@ -1,0 +1,2 @@
+--main MainFoo
+--interp

--- a/tests/misc/projects/Issue11624/compile-foo-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11624/compile-foo-fail.hxml.stderr
@@ -1,0 +1,5 @@
+MainFoo.hx:6: characters 18-21 : Field foo has different type than in Foo
+MainFoo.hx:2: characters 11-14 : ... Interface field is defined here
+MainFoo.hx:6: characters 18-21 : ... error: Null<Unknown<0>> should be foo.T
+MainFoo.hx:6: characters 18-21 : ... have: (...) -> Null<...>
+MainFoo.hx:6: characters 18-21 : ... want: (...) -> foo.T


### PR DESCRIPTION
This changes `link` so that it no longer binds monomorphs to type parameters that are not known in the current context. For now we're only doing this in the new definition mode.

This likely breaks some code.

Closes #11624