### PR TITLE
[hxb] Ignore invalidations during display requests 

### DIFF
--- a/src/compiler/compilationCache.ml
+++ b/src/compiler/compilationCache.ml
@@ -35,6 +35,7 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 	val files : (Path.UniqueKey.t,cached_file) Hashtbl.t = Hashtbl.create 0
 	val modules : (path,module_def) Hashtbl.t = Hashtbl.create 0
 	val binary_cache : (path,HxbData.module_cache) Hashtbl.t = Hashtbl.create 0
+	val tmp_binary_cache : (path,HxbData.module_cache) Hashtbl.t = Hashtbl.create 0
 	val string_pool  = StringPool.create ()
 	val removed_files = Hashtbl.create 0
 	val mutable json = JNull
@@ -67,8 +68,18 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 	method find_module_opt path =
 		Hashtbl.find_opt modules path
 
+	method get_hxb_module path =
+		try Hashtbl.find tmp_binary_cache path
+		with Not_found ->
+			let mc = Hashtbl.find binary_cache path in
+			let m_extra = { mc.mc_extra with m_deps = mc.mc_extra.m_deps } in
+			let mc = { mc with mc_extra = m_extra } in
+			Hashtbl.add tmp_binary_cache path mc;
+			mc
+
 	method find_module_extra path =
-		try (Hashtbl.find modules path).m_extra with Not_found -> (Hashtbl.find binary_cache path).mc_extra
+		try (Hashtbl.find modules path).m_extra
+		with Not_found -> (self#get_hxb_module path).mc_extra
 
 	method cache_module config warn anon_identification path m =
 		match m.m_extra.m_kind with
@@ -86,7 +97,11 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 			}
 
 	method clear_cache =
-		Hashtbl.clear modules
+		Hashtbl.clear modules;
+		Hashtbl.clear tmp_binary_cache
+
+	method reset =
+		Hashtbl.clear tmp_binary_cache
 
 	(* initialization *)
 
@@ -101,7 +116,6 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 	method get_hxb = binary_cache
 	method get_string_pool = string_pool
 	method get_string_pool_arr = string_pool.items.arr
-	method get_hxb_module path = Hashtbl.find binary_cache path
 
 	(* TODO handle hxb cache there too *)
 	method get_removed_files = removed_files
@@ -154,6 +168,9 @@ class cache = object(self)
 		tasks <- PriorityQueue.Empty
 
 	(* contexts *)
+
+	method reset =
+		Hashtbl.iter (fun _ ctx -> ctx#reset) contexts
 
 	method get_context sign =
 		try

--- a/src/compiler/compilationCache.ml
+++ b/src/compiler/compilationCache.ml
@@ -96,12 +96,12 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 				mc_extra = { m.m_extra with m_cache_state = MSGood }
 			}
 
-	method clear_cache =
-		Hashtbl.clear modules;
+	method clear_temp_cache =
 		Hashtbl.clear tmp_binary_cache
 
-	method reset =
-		Hashtbl.clear tmp_binary_cache
+	method clear_cache =
+		Hashtbl.clear modules;
+		self#clear_temp_cache
 
 	(* initialization *)
 
@@ -169,8 +169,8 @@ class cache = object(self)
 
 	(* contexts *)
 
-	method reset =
-		Hashtbl.iter (fun _ ctx -> ctx#reset) contexts
+	method clear_temp_cache =
+		Hashtbl.iter (fun _ ctx -> ctx#clear_temp_cache) contexts
 
 	method get_context sign =
 		try

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -448,10 +448,14 @@ class hxb_reader_api_server
 			GoodModule (com.module_lut#find m_path)
 		with Not_found -> try
 			let mc = cc#get_hxb_module m_path in
-			begin match mc.mc_extra.m_cache_state with
-				| MSBad reason -> BadModule reason
-				| _ -> BinaryModule mc
-			end
+			if not com.is_macro_context && not com.display.dms_full_typing && not (DisplayPosition.display_position#is_in_file (Path.UniqueKey.lazy_key mc.mc_extra.m_file)) then begin
+				mc.mc_extra.m_cache_state <- MSGood;
+				BinaryModule mc
+			end else
+				begin match mc.mc_extra.m_cache_state with
+					| MSBad reason -> BadModule reason
+					| _ -> BinaryModule mc
+				end
 		with Not_found ->
 			NoModule
 
@@ -550,15 +554,20 @@ and type_module sctx com delay mpath p =
 		try
 			let m = cc#find_module m_path in
 			begin match m.m_extra.m_cache_state with
-				| MSBad reason -> BadModule reason
+				| MSBad reason ->
+					BadModule reason
 				| _ -> GoodModule m
 			end;
 		with Not_found -> try
 			let mc = cc#get_hxb_module m_path in
-			begin match mc.mc_extra.m_cache_state with
-				| MSBad reason -> BadModule reason
-				| _ -> BinaryModule mc
-			end
+			if not com.is_macro_context && not com.display.dms_full_typing && not (DisplayPosition.display_position#is_in_file (Path.UniqueKey.lazy_key mc.mc_extra.m_file)) then begin
+				mc.mc_extra.m_cache_state <- MSGood;
+				BinaryModule mc
+			end else
+				begin match mc.mc_extra.m_cache_state with
+					| MSBad reason -> BadModule reason
+					| _ -> BinaryModule mc
+				end
 		with Not_found ->
 			NoModule
 	in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -640,6 +640,7 @@ let after_save sctx ctx =
 		maybe_cache_context sctx ctx.com
 
 let after_compilation sctx ctx =
+	sctx.cs#reset;
 	()
 
 let mk_length_prefixed_communication allow_nonblock chin chout =

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -649,7 +649,7 @@ let after_save sctx ctx =
 		maybe_cache_context sctx ctx.com
 
 let after_compilation sctx ctx =
-	sctx.cs#reset;
+	sctx.cs#clear_temp_cache;
 	()
 
 let mk_length_prefixed_communication allow_nonblock chin chout =

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -439,7 +439,7 @@ class hxb_reader_api_server
 			else delay (fun () -> ignore(f_next chunks EOF));
 			m
 		| BadModule reason ->
-			die (Printf.sprintf "Unexpected BadModule %s" (s_type_path path)) __LOC__
+			die (Printf.sprintf "Unexpected BadModule %s (%s)" (s_type_path path) (Printer.s_module_skip_reason reason)) __LOC__
 		| NoModule ->
 			die (Printf.sprintf "Unexpected NoModule %s" (s_type_path path)) __LOC__
 


### PR DESCRIPTION
* ~~Built on top of #11659 for now~~
* Make sure display requests don't alter cached data (`binary_cache` in `compilationCache.ml`)
* Restore all (except current display file) hxb modules as `MSGood` during display requests
* This does _not_ break workflow of working on several files without compiling, but changes will only be available in other files if you save your changes (file time changes still invalidates the module)
* Nightlies can be downloaded there https://github.com/HaxeFoundation/haxe/actions/runs/9014655440?pr=11660

I tested this branch with all projects I had available, without detecting any issue (at least not any new issue) and got very promising results (see below). 

Notes:
* my computer is a bit slow, so mostly look at timing differences and not raw numbers
* some framework/user code still need some tweaks to reduce invalidation / macro work
* most if not all heaps games tested needed a small patch to `hxbit` letting it run its macros during display requests (but that's also true for other nightlies)

## [Shiro project]
  * 4.3.4: not compiling
  * `5.0.0-alpha.1+c325889`: 
    * hover without invalidation 1~2s
    * completion 4~6s
    * hover with invalidation 4~5s
  * this branch:
    * all requests under 1s

## [Shiro project]
  * 4.3.4
    * hover request without invalidation 0.1s
    * completion 5s
    * hover request with invalidation 4s
  * `5.0.0-alpha.1+c325889`: 
    * hover request without invalidation 1~1.2s
    * completion 4~6s
    * hover request with invalidation 4~5s
  * this branch:
    * all requests under 1s

## [Shiro project]
  * 4.3.4: not compiling
  * `5.0.0-alpha.1+c325889`: 
    * hover request on Game.hx without invalidation 400~700ms
    * completion on Game.hx **broken**
    * hover request on Game.hx with invalidation **broken**
  * this branch:
    * hover request on Game.hx without invalidation 160~300ms
    * completion on Game.hx 200~300ms
    * hover request on Game.hx with invalidation 160~300ms

## [Personal heaps game] (very similar results on other small[ish] scale projects)
  * 4.3.4
    * hover request without invalidation 30~50ms
    * completion 120~140ms
    * hover request with invalidation 120~160ms
  * `5.0.0-alpha.1+c325889`: 
    * hover request without invalidation  170~280ms
    * completion 270~380ms
    * hover request with invalidation 250~350ms
  * this branch:
    * hover request without invalidation 80~90ms
    * completion 90~140ms
    * hover request with invalidation 90~140ms

## Other "small scale" projects

Smaller projects that tend to have no issues with Haxe 4 and are running diagnostics still have much faster display requests when cache has just been filled (after compilation or diagnostics), though even those can have slightly better timings (with diagnostics disabled at least) when files start to be invalidated.

## Misc

* [Shiro project] - 4.3.4: 20+ seconds; `5.0.0-alpha.1+c325889` and this branch ~15sec including 12+ seconds of macros and rest in typing; something is wrong on user code there
* [Shiro project] currently not getting completion with nightlies for unrelated issues (and not compiling with 4.3.4)