### PR TITLE
[cpp] Fix abstract class functions with default values

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4760,7 +4760,18 @@ let gen_member_def ctx class_def is_static is_interface field =
          output "\n";
       | _ when has_class_field_flag field CfAbstract ->
          let ctx_arg_list ctx arg_list prefix =
-            String.concat "," (List.map (fun (n,o,t) -> (ctx_arg ctx n None t prefix) ) arg_list)
+            let get_default_value name =
+               try
+                  match Meta.get Meta.Value field.cf_meta with
+                  | (_,[ (EObjectDecl decls, _) ],_) ->
+                     Some ((List.find (fun ((n,_,_), _) -> n = name) decls) |> snd |> (type_constant_value ctx.ctx_common.basic));
+                  | _ ->
+                     None
+               with Not_found ->
+                  None
+            in
+
+            String.concat "," (List.map (fun (n,o,t) -> (ctx_arg ctx n (get_default_value n) t prefix) ) arg_list)
          in
          let tl,tr = match follow field.cf_type with
             | TFun(tl,tr) -> tl,tr

--- a/tests/unit/src/unit/issues/Issue11666.hx
+++ b/tests/unit/src/unit/issues/Issue11666.hx
@@ -1,0 +1,23 @@
+package unit.issues;
+
+private abstract class Foo {
+    abstract public function foo(v:Int = 20):Int;
+}
+
+private class ConcreteFoo extends Foo {
+    public function new() {}
+    
+    public function foo(v:Int = 20) {
+        return v;
+    }
+}
+
+class Issue11666 extends Test {
+    function test() {
+        final o = new ConcreteFoo();
+
+        eq(20, o.foo());
+        eq(12, o.foo(12));
+        eq(7, (o:Foo).foo(7));
+    }
+}


### PR DESCRIPTION
(Closes #11666) Don't always pass `None` into `ctx_arg` as thats the default value arg which we need to pull from `Meta.Value` for abstract class functions.