### PR TITLE
[hxb] Add define to opt out of hxb cache

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -67,6 +67,11 @@
 		"doc": "Activated when compiling with -debug."
 	},
 	{
+		"name": "DisableHxbCache",
+		"define": "disable-hxb-cache",
+		"doc": "Use in-memory cache instead of hxb powered cache."
+	},
+	{
 		"name": "DisableUnicodeStrings",
 		"define": "disable-unicode-strings",
 		"doc": "Disable Unicode support in `String` type.",

--- a/src/compiler/compilationCache.ml
+++ b/src/compiler/compilationCache.ml
@@ -81,7 +81,7 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 		try (Hashtbl.find modules path).m_extra
 		with Not_found -> (self#get_hxb_module path).mc_extra
 
-	method cache_module config warn anon_identification path m =
+	method cache_hxb_module config warn anon_identification path m =
 		match m.m_extra.m_kind with
 		| MImport ->
 			Hashtbl.add modules m.m_path m
@@ -95,6 +95,9 @@ class context_cache (index : int) (sign : Digest.t) = object(self)
 				mc_chunks = chunks;
 				mc_extra = { m.m_extra with m_cache_state = MSGood }
 			}
+
+	method cache_module_in_memory path m =
+		Hashtbl.replace modules path m
 
 	method clear_temp_cache =
 		Hashtbl.clear tmp_binary_cache

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -152,7 +152,7 @@ let get_signature def =
 			   Parser.parse_macro_ident as well (issue #5682).
 			   Note that we should removed flags like use_rtti_doc here.
 			*)
-			| "display" | "use_rtti_doc" | "macro_times" | "display_details" | "no_copt" | "display_stdin" | "hxb.stats" | "fail_fast"
+			| "display" | "use_rtti_doc" | "macro_times" | "display_details" | "no_copt" | "display_stdin" | "disable-hxb-cache" | "hxb.stats" | "fail_fast"
 			| "message.reporting" | "message.log_file" | "message.log_format" | "message.no_color"
 			| "dump" | "dump_dependencies" | "dump_ignore_var_ids" -> acc
 			| _ -> (k ^ "=" ^ v) :: acc

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -126,6 +126,8 @@ class Js {
 		changeDirectory(serverDir);
 		runCommand("haxe", ["build.hxml"]);
 		runCommand("node", ["test.js"]);
+		runCommand("haxe", ["build.hxml", "-D", "disable-hxb-cache"]);
+		runCommand("node", ["test.js"]);
 
 		changeDirectory(sysDir);
 		installNpmPackages(["deasync"]);

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -100,6 +100,7 @@ class TestCase implements ITest implements ITestCase {
 	}
 
 	function runHaxe(args:Array<String>, done:() -> Void) {
+		#if disable-hxb-cache args = ["-D", "disable-hxb-cache"].concat(args); #end
 		messages = [];
 		errorMessages = [];
 		server.rawRequest(args, null, function(result) {

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -112,16 +112,23 @@ class ServerTests extends TestCase {
 		assertSuccess();
 	}
 
-	function testDisplayModuleRecache() {
+	@:variant("InMemory", true)
+	@:variant("Hxb", false)
+	function testDisplayModuleRecache(inMemory:Bool) {
 		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
 		var args = ["--main", "HelloWorld", "--interp"];
+		if (inMemory) args = args.concat(["-D", "disable-hxb-cache"]);
+		else args = args.concat(["--undefine", "disable-hxb-cache"]);
+
 		runHaxe(args);
 		runHaxe(args);
 		assertReuse("HelloWorld");
 
 		var args2 = ["--main", "HelloWorld", "--interp", "--display", "HelloWorld.hx@64@type"];
-		runHaxe(args2);
+		if (inMemory) args2 = args2.concat(["-D", "disable-hxb-cache"]);
+		else args2 = args2.concat(["--undefine", "disable-hxb-cache"]);
 
+		runHaxe(args2);
 		runHaxe(args);
 		assertReuse("HelloWorld");
 
@@ -130,7 +137,9 @@ class ServerTests extends TestCase {
 		runHaxe(args2);
 
 		runHaxe(args);
-		assertSkipping("HelloWorld", Tainted("server/invalidate"));
+
+		if (inMemory) assertSkipping("HelloWorld", Tainted("check_display_file"));
+		else assertSkipping("HelloWorld", Tainted("server/invalidate"));
 	}
 
 	function testMutuallyDependent() {


### PR DESCRIPTION
While I do believe (and can see the results) hxb cache is the way forward for a stable compilation server, in projects where in-memory cache was working fine hxb cache makes display requests slower when in perfect conditions for in-memory cache (no invalidation, cache not getting corrupted).

This PR adds support for `-D disable-hxb-cache` which caches modules in memory rather than through hxb.

Please note that using this define means you're also opting out of several compilation server instability fixes, and future vshaxe optimizations (requests queue optimization, requests cancellation and potentially concurrent requests). But please do report issues that you cannot reproduce with Haxe 4.3.x.