### PR TITLE
Fix -D dump-dependencies

### DIFF
--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -398,14 +398,18 @@ module Dump = struct
 				| Some (com, macro_sign) when sign = macro_sign -> com
 				| _ -> raise Not_found
 			in
-			com.module_lut#find path
+			(com, com.module_lut#find path)
 		in
 		List.iter (fun m ->
 			print "%s:\n" (Path.UniqueKey.lazy_path m.m_extra.m_file);
 			PMap.iter (fun _ mdep ->
-				let m2 = find_module mdep.md_path mdep.md_sign in
+				let (com, m2) = find_module mdep.md_path mdep.md_sign in
 				let file = Path.UniqueKey.lazy_path m2.m_extra.m_file in
-				print "\t%s\n" file;
+				let ctx = match platform_name_macro com with
+					| p when p <> target_name -> Printf.sprintf "[%s] " p
+					| _ -> ""
+				in
+				print "\t%s%s\n" ctx file;
 				let l = try Hashtbl.find dep file with Not_found -> [] in
 				Hashtbl.replace dep file (m :: l)
 			) m.m_extra.m_deps;

--- a/src/codegen/codegen.ml
+++ b/src/codegen/codegen.ml
@@ -386,29 +386,16 @@ module Dump = struct
 		let buf,close = create_dumpfile [] dump_dependencies_path in
 		let print fmt = Printf.kprintf (fun s -> Buffer.add_string buf s) fmt in
 		let dep = Hashtbl.create 0 in
-
-		let com_sign = Define.get_signature com.defines in
-		let macro_sign =
-			if com.is_macro_context then None
-			else Option.map (fun com -> (com, Define.get_signature com.defines)) (com.get_macros())
-		in
-		let find_module path sign =
-			let com = match macro_sign with
-				| _ when sign = com_sign -> com
-				| Some (com, macro_sign) when sign = macro_sign -> com
-				| _ -> raise Not_found
-			in
-			(com, com.module_lut#find path)
-		in
 		List.iter (fun m ->
 			print "%s:\n" (Path.UniqueKey.lazy_path m.m_extra.m_file);
 			PMap.iter (fun _ mdep ->
-				let (com, m2) = find_module mdep.md_path mdep.md_sign in
-				let file = Path.UniqueKey.lazy_path m2.m_extra.m_file in
-				let ctx = match platform_name_macro com with
-					| p when p <> target_name -> Printf.sprintf "[%s] " p
-					| _ -> ""
+				let (ctx,m2) = match mdep.md_kind with
+					| MMacro when not com.is_macro_context ->
+						("[macro] ", (Option.get (com.get_macros())).module_lut#find mdep.md_path)
+					| _ ->
+						("", com.module_lut#find mdep.md_path)
 				in
+				let file = Path.UniqueKey.lazy_path m2.m_extra.m_file in
 				print "\t%s%s\n" ctx file;
 				let l = try Hashtbl.find dep file with Not_found -> [] in
 				Hashtbl.replace dep file (m :: l)


### PR DESCRIPTION
`-D dump-dependencies` has been crashing with `Not_found` for a while (since hxb, probably) when we have dependencies from another context.

This PR also adds `[macro]` at the beginning of the line when dependency is from another context (not working for dependants)