### PR TITLE
[macro] Don't choke on namePos for reification pattern matching

### DIFF
--- a/src/typing/matcher/exprToPattern.ml
+++ b/src/typing/matcher/exprToPattern.ml
@@ -365,10 +365,14 @@ let rec make pctx toplevel t e =
 			let is_matchable cf =
 				match cf.cf_kind with Method _ -> false | _ -> true
 			in
+			(* TODO: This needs a better check, but it's not obvious how to approach this. See #11433 *)
+			let is_probably_pos cf = match cf.cf_name with
+				| "pos" | "posPath" | "namePos" -> true
+				| _ -> false
+			in
 			let patterns,fields = List.fold_left (fun (patterns,fields) (cf,t) ->
 				try
-					if pctx.in_reification && cf.cf_name = "pos" then raise Not_found;
-					if pctx.in_reification && cf.cf_name = "namePos" then raise Not_found;
+					if pctx.in_reification && is_probably_pos cf then raise Not_found;
 					let e1 = Expr.field_assoc cf.cf_name fl in
 					make pctx false t e1 :: patterns,cf.cf_name :: fields
 				with Not_found ->

--- a/src/typing/matcher/exprToPattern.ml
+++ b/src/typing/matcher/exprToPattern.ml
@@ -368,6 +368,7 @@ let rec make pctx toplevel t e =
 			let patterns,fields = List.fold_left (fun (patterns,fields) (cf,t) ->
 				try
 					if pctx.in_reification && cf.cf_name = "pos" then raise Not_found;
+					if pctx.in_reification && cf.cf_name = "namePos" then raise Not_found;
 					let e1 = Expr.field_assoc cf.cf_name fl in
 					make pctx false t e1 :: patterns,cf.cf_name :: fields
 				with Not_found ->

--- a/tests/misc/projects/Issue11670/Main.hx
+++ b/tests/misc/projects/Issue11670/Main.hx
@@ -1,0 +1,16 @@
+class Main {
+	static function main() {
+		test(var foo:String);
+	}
+
+	static macro function test(e) {
+		switch e {
+			// Unrecognized pattern: untyped $__mk_pos__("Test.hx", 145, 150)
+			case macro var $name:$ct:
+			case _:
+		}
+
+		return macro {};
+	}
+}
+

--- a/tests/misc/projects/Issue11670/compile.hxml
+++ b/tests/misc/projects/Issue11670/compile.hxml
@@ -1,0 +1,1 @@
+-main Main


### PR DESCRIPTION
Regression caused by #11163 (included in 4.3 since 4.3.2)

Closes #11670 