### PR TITLE
[hlc] disable dump_types by default

### DIFF
--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1709,6 +1709,7 @@ let write_c com file (code:code) gnames =
 
 	line "";
 	line "static void dump_types( void (*fdump)( void *, int) ) {";
+	line "#ifdef HL_DUMP_TYPES";
 	block ctx;
 	sexpr "hl_type *t";
 	sexpr "int ntypes = %d" (Array.length all_types);
@@ -1728,6 +1729,9 @@ let write_c com file (code:code) gnames =
 			sexpr "t = (hl_type*)&%s.fun->closure_type; fdump(&t, sizeof(void*))" (type_name ctx t);
 		| _ -> ()
 	) all_types;
+	line "#else";
+	sexpr "hl_error(\"Requires compiling with HL_DUMP_TYPES defined\")";
+	line "#endif";
 	unblock ctx;
 	line "}";
 

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1709,8 +1709,8 @@ let write_c com file (code:code) gnames =
 
 	line "";
 	line "static void dump_types( void (*fdump)( void *, int) ) {";
-	line "#ifdef HL_DUMP_TYPES";
 	block ctx;
+	line "#ifdef HL_DUMP_TYPES";
 	sexpr "hl_type *t";
 	sexpr "int ntypes = %d" (Array.length all_types);
 	sexpr "fdump(&ntypes,4)";

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1730,7 +1730,7 @@ let write_c com file (code:code) gnames =
 		| _ -> ()
 	) all_types;
 	line "#else";
-	sexpr "hl_error(\"Requires compiling with HL_DUMP_TYPES defined\")";
+	sexpr "fprintf(stderr, \"Please compile with HL_DUMP_TYPES defined\\n\")";
 	line "#endif";
 	unblock ctx;
 	line "}";

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1730,7 +1730,7 @@ let write_c com file (code:code) gnames =
 		| _ -> ()
 	) all_types;
 	line "#else";
-	sexpr "fprintf(stderr, \"Please compile with HL_DUMP_TYPES defined\\n\")";
+	sexpr "printf(\"dump_types not available, please compile with HL_DUMP_TYPES defined\\n\")";
 	line "#endif";
 	unblock ctx;
 	line "}";


### PR DESCRIPTION
We found that the function `dump_types` introduced in https://github.com/HaxeFoundation/haxe/commit/9dcb694 makes the compilation very long on clang++ for a console target.
This PR disable `dump_types` by default by a `#ifdef` and show a runtime error if the dump function is called.