### PR TITLE
[cpp] Prevent AtomicObject use cpp

### DIFF
--- a/std/haxe/atomic/AtomicObject.hx
+++ b/std/haxe/atomic/AtomicObject.hx
@@ -4,7 +4,7 @@ package haxe.atomic;
 #error "This target does not support atomic operations."
 #end
 
-#if (js || hxcpp)
+#if (js || cpp)
 #error "JavaScript and Hxcpp do not support AtomicObject"
 #end
 


### PR DESCRIPTION
I tried to use `AtomicObject` on the cpp target and ran into some very weird runtime null function errors. After much head scratching I discovered that `AtomicObject` is not actually implemented for hxcpp and the reason the `#error` wasn't stopping the compilation is that it was guarded with `hxcpp` instead of `cpp`.