### PR TITLE
[hxb] declare module statics earlier

### DIFF
--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -1459,7 +1459,6 @@ class hxb_reader
 		in
 		loop CfrMember (read_uleb128 ch) c.cl_ordered_fields;
 		loop CfrStatic (read_uleb128 ch) c.cl_ordered_statics;
-		(match c.cl_kind with KModuleFields md -> md.m_statics <- Some c; | _ -> ());
 
 	method read_enum_fields (e : tenum) =
 		type_type_parameters <- Array.of_list e.e_params;
@@ -1516,6 +1515,9 @@ class hxb_reader
 		c.cl_implements <- self#read_list read_relation;
 		c.cl_dynamic <- self#read_option (fun () -> self#read_type_instance);
 		c.cl_array_access <- self#read_option (fun () -> self#read_type_instance);
+		(match c.cl_kind with
+			| KModuleFields md -> md.m_statics <- Some c;
+			| _ -> ());
 
 	method read_abstract (a : tabstract) =
 		self#read_common_module_type (Obj.magic a);

--- a/tests/server/src/cases/display/issues/Issue11678.hx
+++ b/tests/server/src/cases/display/issues/Issue11678.hx
@@ -1,0 +1,29 @@
+package cases.display.issues;
+
+import haxe.Json;
+import haxe.display.Display;
+
+typedef HoverResponse = {
+	?error:{code:Int, message:String},
+	?result:HoverResult
+}
+
+class Issue11678 extends DisplayTestCase {
+	function test(_) {
+		vfs.putContent("ModuleFields.js.hx", getTemplate("issues/Issue11678/ModuleFields.hx"));
+		var content = getTemplate("issues/Issue11678/Main.hx");
+		var transform = Marker.extractMarkers(content);
+		vfs.putContent("Main.hx", transform.source);
+
+		var args = ["-js", "test.js", "-main", "Main"];
+		runHaxe(["--no-output"].concat(args));
+		runHaxeJson(args, DisplayMethods.Hover, {
+			file: new FsPath("Main.hx"),
+			offset: transform.markers[1]
+		});
+
+		var response:HoverResponse = Json.parse(lastResult.stderr);
+		Assert.equals(null, response.error);
+		Assert.equals("foo", response.result.result.item.args.field.name);
+	}
+}

--- a/tests/server/src/cases/display/issues/Issue11678.hx
+++ b/tests/server/src/cases/display/issues/Issue11678.hx
@@ -10,12 +10,12 @@ typedef HoverResponse = {
 
 class Issue11678 extends DisplayTestCase {
 	function test(_) {
-		vfs.putContent("ModuleFields.js.hx", getTemplate("issues/Issue11678/ModuleFields.hx"));
+		vfs.putContent("ModuleFields.hx", getTemplate("issues/Issue11678/ModuleFields.hx"));
 		var content = getTemplate("issues/Issue11678/Main.hx");
 		var transform = Marker.extractMarkers(content);
 		vfs.putContent("Main.hx", transform.source);
 
-		var args = ["-js", "test.js", "-main", "Main"];
+		var args = ["-main", "Main"];
 		runHaxe(["--no-output"].concat(args));
 		runHaxeJson(args, DisplayMethods.Hover, {
 			file: new FsPath("Main.hx"),

--- a/tests/server/test/templates/issues/Issue11678/Main.hx
+++ b/tests/server/test/templates/issues/Issue11678/Main.hx
@@ -1,0 +1,5 @@
+import ModuleFields.foo;
+
+function main() {
+	{-1-}foo{-2-}();
+}

--- a/tests/server/test/templates/issues/Issue11678/ModuleFields.hx
+++ b/tests/server/test/templates/issues/Issue11678/ModuleFields.hx
@@ -1,0 +1,1 @@
+function foo() {}


### PR DESCRIPTION
Currently, this happens in `CFD`, which doesn't happen for most modules during display requests