### PR TITLE
Do not store warnings as cache bound objects during display requests

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -436,7 +436,7 @@ let ignore_error com =
 	b
 
 let module_warning com m w options msg p =
-	DynArray.add m.m_extra.m_cache_bound_objects (Warning(w,msg,p));
+	if com.display.dms_full_typing then DynArray.add m.m_extra.m_cache_bound_objects (Warning(w,msg,p));
 	com.warning w options msg p
 
 (* Defines *)


### PR DESCRIPTION
See #11675 (not closing because I'd like to add a test first)