### PR TITLE
Use structural equality in generic_substitute_type'.

### DIFF
--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -91,7 +91,7 @@ let rec generic_substitute_type' gctx allow_expr t =
 		t
 	| _ ->
 		try
-			let t,eo = List.assq t gctx.subst in
+			let t,eo = List.assoc t gctx.subst in
 			(* Somewhat awkward: If we allow expression types, use the original KExpr one. This is so
 			   recursing into further KGeneric expands correctly. *)
 			begin match eo with


### PR DESCRIPTION
This fixes a bug where typed exprs coming from macros won't have their types properly substituted in generic functions.
A simple example is
```hx
function main() {
	foo(0);
}

@:generic function foo<T>(val:T):T {
	return bar(val);
}

macro function bar(expr) {
	var typedExpr = haxe.macro.Context.typeExpr(expr);
	return haxe.macro.Context.storeTypedExpr(typedExpr);
}
```
AST dump for `foo<Int>` without this change:
```hx
	@:noCompletion @:noUsing @:genericInstance
	public static function foo_Int[Function:(val : Int) -> Int]
		[Arg val<5480>:Int]
		[Block:Dynamic] [Return:Dynamic] [Local val(5480):Int:foo.T]
```
Note there is still a `foo.T` left.
AST dump for `foo<Int>` with this change:
```hx
	@:noCompletion @:noUsing @:genericInstance
	public static function foo_Int[Function:(val : Int) -> Int]
		[Arg val<5480>:Int]
		[Block:Dynamic] [Return:Dynamic] [Local val(5480):Int:Int]
```
Now all occurences of `foo.T` have been replaced by `Int`.