### PR TITLE
Don't populate cache from legacy diagnostics

### DIFF
--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -48,7 +48,7 @@ let handle_display_argument_old com file_pos actx =
 			| "diagnostics" ->
 				com.report_mode <- RMLegacyDiagnostics [file_unique];
 				let dm = create DMNone in
-				{dm with dms_display_file_policy = DFPOnly; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display}
+				{dm with dms_display_file_policy = DFPOnly; dms_per_file = true; dms_populate_cache = false}
 			| "statistics" ->
 				com.report_mode <- RMStatistics;
 				let dm = create DMNone in

--- a/src/compiler/serverConfig.ml
+++ b/src/compiler/serverConfig.ml
@@ -1,11 +1,9 @@
 let do_not_check_modules = ref false
-let populate_cache_from_display = ref true
 let legacy_completion = ref false
 
 let max_completion_items = ref 0
 
 let reset () =
 	do_not_check_modules := false;
-	populate_cache_from_display := true;
 	legacy_completion := false;
 	max_completion_items := 0

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -214,7 +214,7 @@ let handler =
 
 			(match hctx.com.file_contents with
 			| [file, None] ->
-				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display};
+				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = true };
 			| _ -> ());
 		);
 		"display/implementation", (fun hctx ->
@@ -462,12 +462,6 @@ let handler =
 				let b = hctx.jsonrpc#get_bool_param "legacyCompletion" in
 				ServerConfig.legacy_completion := b;
 				l := jstring ("Legacy completion " ^ (if b then "enabled" else "disabled")) :: !l;
-				()
-			) ();
-			hctx.jsonrpc#get_opt_param (fun () ->
-				let b = hctx.jsonrpc#get_bool_param "populateCacheFromDisplay" in
-				ServerConfig.populate_cache_from_display := b;
-				l := jstring ("Compilation cache refill from display " ^ (if b then "enabled" else "disabled")) :: !l;
 				()
 			) ();
 			hctx.send_result (jarray !l)

--- a/std/haxe/display/Server.hx
+++ b/std/haxe/display/Server.hx
@@ -73,7 +73,6 @@ typedef ConfigurePrintParams = {
 
 typedef ConfigureParams = {
 	final ?noModuleChecks:Bool;
-	final ?populateCacheFromDisplay:Bool;
 	final ?legacyCompletion:Bool;
 	final ?print:ConfigurePrintParams;
 }

--- a/tests/server/src/cases/issues/Issue11177.hx
+++ b/tests/server/src/cases/issues/Issue11177.hx
@@ -17,20 +17,16 @@ class Issue11177 extends TestCase {
 		});
 	}
 
-	function testWithoutCacheFromDisplay(_) {
+	function testLegacyDiagnostics(_) {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
 		vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
 		vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
 		var args = ["-main", "Main", "--interp"];
-		runHaxeJson([], ServerMethods.Configure, {populateCacheFromDisplay: false});
-		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
-			Assert.equals(0, res.length);
-		});
+		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
 		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxe(args);
-		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
-			Assert.equals(0, res.length);
-		});
+		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+		Assert.isTrue(lastResult.stderr.length == 2);
 	}
 }

--- a/tests/server/src/cases/issues/Issue11184.hx
+++ b/tests/server/src/cases/issues/Issue11184.hx
@@ -17,15 +17,12 @@ class Issue11184 extends TestCase {
 		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
 	}
 
-	function testWithoutCacheFromDisplay(_) {
+	function testLegacyDiagnostics(_) {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
 		var args = ["-main", "Main", "-js", "bin/test.js"];
-		runHaxeJson([], ServerMethods.Configure, {populateCacheFromDisplay: false});
-		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
-			Assert.equals(1, res.length);
-			Assert.equals(1, res[0].diagnostics.length);
-			Assert.equals(res[0].diagnostics[0].args, "Cannot use Void as value");
-		});
+		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+		final diagnostics = haxe.Json.parse(lastResult.stderr)[0].diagnostics;
+		Assert.equals(diagnostics[0].args, "Cannot use Void as value");
 		runHaxe(args);
 		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
 		runHaxe(args);

--- a/tests/server/src/cases/issues/Issue11695.hx
+++ b/tests/server/src/cases/issues/Issue11695.hx
@@ -1,0 +1,39 @@
+package cases.issues;
+
+class Issue11695 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11695/Main.hx"));
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro1.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: before");
+
+		// Note: this is needed because modification time is currently checked with second precision
+		Sys.sleep(1);
+
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro2.hx"));
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Macro.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
+
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: after");
+	}
+
+	function testLegacyDiagnostics(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11695/Main.hx"));
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro1.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: before");
+
+		// Note: this is needed because modification time is currently checked with second precision
+		Sys.sleep(1);
+
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro2.hx"));
+		runHaxe(args.concat(["--display", "Macro.hx@0@diagnostics"]));
+
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: after");
+	}
+}

--- a/tests/server/test/templates/issues/Issue11695/Macro1.hx
+++ b/tests/server/test/templates/issues/Issue11695/Macro1.hx
@@ -1,0 +1,1 @@
+macro function test() return macro trace("before");

--- a/tests/server/test/templates/issues/Issue11695/Macro2.hx
+++ b/tests/server/test/templates/issues/Issue11695/Macro2.hx
@@ -1,0 +1,1 @@
+macro function test() return macro trace("after");

--- a/tests/server/test/templates/issues/Issue11695/Main.hx
+++ b/tests/server/test/templates/issues/Issue11695/Main.hx
@@ -1,0 +1,3 @@
+function main() {
+	Macro.test();
+}


### PR DESCRIPTION
Closes #11695

Note that vshaxe is still using legacy diagnostics, will need to update it to json RPC diagnostics.