### PR TITLE
[CI] Fix mac/lua CI

### DIFF
--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -21,7 +21,6 @@ class Lua {
 				else
 					runNetworkCommand("brew", ["install", "python3"]);
 
-				attemptCommand("brew", ["install", "pcre2"]);
 				runCommand("pip3", ["install", "hererocks"]);
 				runCommand("brew", ["install", "openssl"]);
 			}


### PR DESCRIPTION
Reinstalling pcre2 with `brew` during lua CI now causes issues (and pcre2 is already installed during `mac-build` anyway)