### PR TITLE
[Diagnostics] Fix compiler failure when report mode disabled

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -374,6 +374,7 @@ type context = {
 	main : context_main;
 	mutable package_rules : (string,package_rule) PMap.t;
 	mutable report_mode : report_mode;
+	mutable report_mode_disabled : bool;
 	(* communication *)
 	mutable print : string -> unit;
 	mutable error : ?depth:int -> string -> pos -> unit;
@@ -855,6 +856,7 @@ let create compilation_step cs version args display_mode =
 		json_out = None;
 		has_error = false;
 		report_mode = RMNone;
+		report_mode_disabled = false;
 		is_macro_context = false;
 		functional_interface_lut = new Lookup.hashtbl_lookup;
 		hxb_reader_api = None;
@@ -863,16 +865,19 @@ let create compilation_step cs version args display_mode =
 	} in
 	com
 
-let is_diagnostics com = match com.report_mode with
+let is_diagnostics com = not com.report_mode_disabled && match com.report_mode with
 	| RMLegacyDiagnostics _ | RMDiagnostics _ -> true
 	| _ -> false
 
 let is_compilation com = com.display.dms_kind = DMNone && not (is_diagnostics com)
 
 let disable_report_mode com =
-	let old = com.report_mode in
-	com.report_mode <- RMNone;
-	(fun () -> com.report_mode <- old)
+	if com.report_mode_disabled || com.report_mode = RMNone then
+		(fun () -> ())
+	else begin
+		com.report_mode_disabled <- true;
+		(fun () -> com.report_mode_disabled <- false)
+	end
 
 let log com str =
 	if com.verbose then com.print (str ^ "\n")

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -62,10 +62,7 @@ let macro_timer com l =
 
 let typing_timer ctx need_type f =
 	let t = Timer.timer ["typing"] in
-	let old = ctx.com.error_ext in
-	let restore_report_mode = disable_report_mode ctx.com in
 	let restore_field_state = TypeloadFunction.save_field_state ctx in
-	ctx.com.error_ext <- (fun err -> raise_error { err with err_from_macro = true });
 
 	let ctx = if need_type && ctx.pass < PTypeField then begin
 		enter_field_typing_pass ctx.g ("typing_timer",[]);
@@ -73,6 +70,11 @@ let typing_timer ctx need_type f =
 	end else
 		ctx
 	in
+
+	let old = ctx.com.error_ext in
+	let restore_report_mode = disable_report_mode ctx.com in
+	ctx.com.error_ext <- (fun err -> raise_error { err with err_from_macro = true });
+
 	let exit() =
 		t();
 		ctx.com.error_ext <- old;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -62,8 +62,6 @@ let macro_timer com l =
 
 let typing_timer ctx need_type f =
 	let t = Timer.timer ["typing"] in
-	let restore_field_state = TypeloadFunction.save_field_state ctx in
-
 	let ctx = if need_type && ctx.pass < PTypeField then begin
 		enter_field_typing_pass ctx.g ("typing_timer",[]);
 		TyperManager.clone_for_expr ctx ctx.e.curfun false
@@ -73,6 +71,7 @@ let typing_timer ctx need_type f =
 
 	let old = ctx.com.error_ext in
 	let restore_report_mode = disable_report_mode ctx.com in
+	let restore_field_state = TypeloadFunction.save_field_state ctx in
 	ctx.com.error_ext <- (fun err -> raise_error { err with err_from_macro = true });
 
 	let exit() =


### PR DESCRIPTION
Started with a workaround, but ended up finding the real issue so reverted the workaround; keeping it in history just in case it's needed again later on.

This fixes an "old" (from january) issue that I could only get a clean repro for today:
```
File "src/core/globals.ml", line 175, characters 1-7: Assertion failed
Compiler failure
Please submit an issue at https://github.com/HaxeFoundation/haxe/issues/new
Attach the following information:
Haxe: 5.0.0-alpha.1+15731ea67; OS type: windows;
File "src/compiler/compiler.ml", line 26, characters 17-24
Called from file "src/compiler/compiler.ml", line 298, characters 2-275
Called from file "src/compiler/compiler.ml", line 365, characters 37-100
Called from file "src/compiler/compiler.ml", line 394, characters 1-5
Called from file "src/compiler/compiler.ml", line 471, characters 2-135
Called from file "src/compiler/compiler.ml", line 445, characters 2-9
Called from file "src/compiler/compiler.ml", line 668, characters 5-43
Called from file "src/compiler/compiler.ml", line 680, characters 13-22
Called from file "src/compiler/server.ml", line 633, characters 1-39
Called from file "src/compiler/server.ml", line 694, characters 3-30
Called from file "src/compiler/compiler.ml", line 668, characters 5-43
Called from file "src/compiler/compiler.ml", line 680, characters 13-22
Called from file "src/compiler/server.ml", line 633, characters 1-39
Called from file "src/compiler/haxe.ml", line 53, characters 0-56
```