### PR TITLE
[4.3.5] Backport Json RPC diagnostics

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -312,7 +312,9 @@ let compile ctx actx =
 	let com = ctx.com in
 	(* Set up display configuration *)
 	DisplayProcessing.process_display_configuration ctx;
+	let restore = disable_report_mode com in
 	let display_file_dot_path = DisplayProcessing.process_display_file com actx in
+	restore ();
 	(* Initialize target: This allows access to the appropriate std packages and sets the -D defines. *)
 	let ext = Setup.initialize_target ctx com actx in
 	com.config <- get_config com; (* make sure to adapt all flags changes defined after platform *)

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -142,11 +142,11 @@ let process_display_file com actx =
 		| DFPOnly when (DisplayPosition.display_position#get).pfile = file_input_marker ->
 			actx.classes <- [];
 			com.main_class <- None;
-			begin match !TypeloadParse.current_stdin with
-			| Some input ->
-				TypeloadParse.current_stdin := None;
+			begin match com.file_contents with
+			| Some [_, Some input] ->
+				com.file_contents <- None;
 				DPKInput input
-			| None ->
+			| _ ->
 				DPKNone
 			end
 		| dfp ->

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -48,7 +48,7 @@ let handle_display_argument_old com file_pos actx =
 			| "diagnostics" ->
 				com.report_mode <- RMLegacyDiagnostics [file_unique];
 				let dm = create DMNone in
-				{dm with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display}
+				{dm with dms_display_file_policy = DFPAlso; dms_per_file = true}
 			| "statistics" ->
 				com.report_mode <- RMStatistics;
 				let dm = create DMNone in

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -154,36 +154,41 @@ let process_display_file com actx =
 				actx.classes <- [];
 				com.main_class <- None;
 			end;
-			let real = Path.get_real_path (DisplayPosition.display_position#get).pfile in
-			let path = match get_module_path_from_file_path com real with
-			| Some path ->
-				if com.display.dms_kind = DMPackage then DisplayException.raise_package (fst path);
-				let path = match ExtString.String.nsplit (snd path) "." with
-					| [name;"macro"] ->
-						(* If we have a .macro.hx path, don't add the file to classes because the compiler won't find it.
-						   This can happen if we're completing in such a file. *)
-						DPKMacro (fst path,name)
-					| [name] ->
-						actx.classes <- path :: actx.classes;
-						DPKNormal path
-					| [name;target] ->
-						let path = fst path, name in
-						actx.classes <- path :: actx.classes;
-						DPKNormal path
-					| e ->
-						die "" __LOC__
+			let dpk = List.map (fun file_key ->
+				let real = Path.get_real_path (Path.UniqueKey.to_string file_key) in
+				let dpk = match get_module_path_from_file_path com real with
+				| Some path ->
+					if com.display.dms_kind = DMPackage then DisplayException.raise_package (fst path);
+					let dpk = match ExtString.String.nsplit (snd path) "." with
+						| [name;"macro"] ->
+							(* If we have a .macro.hx path, don't add the file to classes because the compiler won't find it.
+								 This can happen if we're completing in such a file. *)
+							DPKMacro (fst path,name)
+						| [name] ->
+							actx.classes <- path :: actx.classes;
+							DPKNormal path
+						| [name;target] ->
+							let path = fst path, name in
+							actx.classes <- path :: actx.classes;
+							DPKNormal path
+						| _ ->
+							failwith ("Invalid display file '" ^ real ^ "'")
+					in
+					dpk
+				| None ->
+					if not (Sys.file_exists real) then failwith "Display file does not exist";
+					(match List.rev (ExtString.String.nsplit real Path.path_sep) with
+					| file :: _ when file.[0] >= 'a' && file.[0] <= 'z' -> failwith ("Display file '" ^ file ^ "' should not start with a lowercase letter")
+					| _ -> ());
+					DPKDirect real
 				in
-				path
-			| None ->
-				if not (Sys.file_exists real) then failwith "Display file does not exist";
-				(match List.rev (ExtString.String.nsplit real Path.path_sep) with
-				| file :: _ when file.[0] >= 'a' && file.[0] <= 'z' -> failwith ("Display file '" ^ file ^ "' should not start with a lowercase letter")
-				| _ -> ());
-				DPKDirect real
-			in
-			Common.log com ("Display file : " ^ real);
+				Common.log com ("Display file : " ^ real);
+				dpk
+			) DisplayPosition.display_position#get_files in
 			Common.log com ("Classes found : ["  ^ (String.concat "," (List.map s_type_path actx.classes)) ^ "]");
-			path
+			match dpk with
+				| [dfile] -> dfile
+				| _ -> DPKNone
 
 (* 3. Loaders for display file that might be called *)
 

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -22,7 +22,7 @@ let handle_display_argument_old com file_pos actx =
 		actx.did_something <- true;
 		(try Memory.display_memory com with e -> prerr_endline (Printexc.get_backtrace ()));
 	| "diagnostics" ->
-		com.report_mode <- RMDiagnostics []
+		com.report_mode <- RMLegacyDiagnostics []
 	| _ ->
 		let file, pos = try ExtString.String.split file_pos "@" with _ -> failwith ("Invalid format: " ^ file_pos) in
 		let file = Helper.unquote file in
@@ -46,7 +46,7 @@ let handle_display_argument_old com file_pos actx =
 			| "module-symbols" ->
 				create (DMModuleSymbols None)
 			| "diagnostics" ->
-				com.report_mode <- RMDiagnostics [file_unique];
+				com.report_mode <- RMLegacyDiagnostics [file_unique];
 				let dm = create DMNone in
 				{dm with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display}
 			| "statistics" ->
@@ -348,6 +348,8 @@ let handle_display_after_finalization ctx tctx display_file_dot_path =
 	end;
 	process_global_display_mode com tctx;
 	begin match com.report_mode with
+	| RMLegacyDiagnostics _ ->
+		DisplayOutput.emit_legacy_diagnostics com
 	| RMDiagnostics _ ->
 		DisplayOutput.emit_diagnostics com
 	| RMStatistics ->

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -143,8 +143,8 @@ let process_display_file com actx =
 			actx.classes <- [];
 			com.main_class <- None;
 			begin match com.file_contents with
-			| Some [_, Some input] ->
-				com.file_contents <- None;
+			| [_, Some input] ->
+				com.file_contents <- [];
 				DPKInput input
 			| _ ->
 				DPKNone

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -49,7 +49,7 @@ let parse_file cs com file p =
 	and fkey = com.file_keys#get file in
 	let is_display_file = DisplayPosition.display_position#is_in_file (com.file_keys#get ffile) in
 	match is_display_file, !current_stdin with
-	| true, Some stdin when (com.file_contents <> None || Common.defined com Define.DisplayStdin) ->
+	| true, Some stdin when (com.file_contents <> [] || Common.defined com Define.DisplayStdin) ->
 		TypeloadParse.parse_file_from_string com file p stdin
 	| _ ->
 		let ftime = file_time ffile in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -49,7 +49,7 @@ let parse_file cs com file p =
 	and fkey = com.file_keys#get file in
 	let is_display_file = DisplayPosition.display_position#is_in_file (com.file_keys#get ffile) in
 	match is_display_file, !current_stdin with
-	| true, Some stdin when Common.defined com Define.DisplayStdin ->
+	| true, Some stdin when (com.file_contents <> None || Common.defined com Define.DisplayStdin) ->
 		TypeloadParse.parse_file_from_string com file p stdin
 	| _ ->
 		let ftime = file_time ffile in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -18,15 +18,7 @@ let has_error ctx =
 	ctx.has_error || ctx.com.Common.has_error
 
 let check_display_flush ctx f_otherwise = match ctx.com.json_out with
-	| None ->
-		if is_diagnostics ctx.com then begin
-			List.iter (fun cm ->
-				add_diagnostics_message ~depth:cm.cm_depth ctx.com (located cm.cm_message cm.cm_pos) cm.cm_kind cm.cm_severity
-			) (List.rev ctx.messages);
-			raise (Completion (Diagnostics.print ctx.com))
-		end else
-			f_otherwise ()
-	| Some api ->
+	| Some api when not (is_diagnostics ctx.com) ->
 		if has_error ctx then begin
 			let errors = List.map (fun cm ->
 				JObject [
@@ -37,6 +29,17 @@ let check_display_flush ctx f_otherwise = match ctx.com.json_out with
 			) (List.rev ctx.messages) in
 			api.send_error errors
 		end
+	| _ ->
+		if is_diagnostics ctx.com then begin
+			List.iter (fun cm ->
+				add_diagnostics_message ~depth:cm.cm_depth ctx.com (located cm.cm_message cm.cm_pos) cm.cm_kind cm.cm_severity
+			) (List.rev ctx.messages);
+			(match ctx.com.report_mode with
+			| RMDiagnostics _ -> ()
+			| RMLegacyDiagnostics _ -> raise (Completion (Diagnostics.print ctx.com))
+			| _ -> die "" __LOC__)
+		end else
+			f_otherwise ()
 
 let current_stdin = ref None
 

--- a/src/compiler/serverConfig.ml
+++ b/src/compiler/serverConfig.ml
@@ -1,3 +1,2 @@
 let do_not_check_modules = ref false
-let populate_cache_from_display = ref true
 let legacy_completion = ref false

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -383,7 +383,7 @@ type context = {
 	display_information : display_information;
 	file_lookup_cache : (string,string option) lookup;
 	file_keys : file_keys;
-	mutable file_contents : (Path.UniqueKey.t * string option) list option;
+	mutable file_contents : (Path.UniqueKey.t * string option) list;
 	readdir_cache : (string * string,(string array) option) lookup;
 	parser_cache : (string,(type_def * pos) list) lookup;
 	module_to_file : (path,string) lookup;
@@ -854,7 +854,7 @@ let create compilation_step cs version args =
 		};
 		file_lookup_cache = new hashtbl_lookup;
 		file_keys = new file_keys;
-		file_contents = None;
+		file_contents = [];
 		readdir_cache = new hashtbl_lookup;
 		module_to_file = new hashtbl_lookup;
 		stored_typed_exprs = new hashtbl_lookup;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -272,7 +272,8 @@ type compiler_stage =
 
 type report_mode =
 	| RMNone
-	| RMDiagnostics of Path.UniqueKey.t list
+	| RMLegacyDiagnostics of Path.UniqueKey.t list
+	| RMDiagnostics of (Path.UniqueKey.t * string option (* file contents *)) list
 	| RMStatistics
 
 class virtual ['key,'value] lookup = object(self)
@@ -867,7 +868,7 @@ let create compilation_step cs version args =
 	com
 
 let is_diagnostics com = match com.report_mode with
-	| RMDiagnostics _ -> true
+	| RMLegacyDiagnostics _ | RMDiagnostics _ -> true
 	| _ -> false
 
 let disable_report_mode com =

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -272,8 +272,8 @@ type compiler_stage =
 
 type report_mode =
 	| RMNone
-	| RMLegacyDiagnostics of Path.UniqueKey.t list
-	| RMDiagnostics of (Path.UniqueKey.t * string option (* file contents *)) list
+	| RMLegacyDiagnostics of (Path.UniqueKey.t list)
+	| RMDiagnostics of (Path.UniqueKey.t list)
 	| RMStatistics
 
 class virtual ['key,'value] lookup = object(self)
@@ -383,6 +383,7 @@ type context = {
 	display_information : display_information;
 	file_lookup_cache : (string,string option) lookup;
 	file_keys : file_keys;
+	mutable file_contents : (Path.UniqueKey.t * string option) list option;
 	readdir_cache : (string * string,(string array) option) lookup;
 	parser_cache : (string,(type_def * pos) list) lookup;
 	module_to_file : (path,string) lookup;
@@ -853,6 +854,7 @@ let create compilation_step cs version args =
 		};
 		file_lookup_cache = new hashtbl_lookup;
 		file_keys = new file_keys;
+		file_contents = None;
 		readdir_cache = new hashtbl_lookup;
 		module_to_file = new hashtbl_lookup;
 		stored_typed_exprs = new hashtbl_lookup;

--- a/src/context/display/diagnostics.ml
+++ b/src/context/display/diagnostics.ml
@@ -20,7 +20,7 @@ let find_unused_variables com e =
 	let vars = Hashtbl.create 0 in
 	let pmin_map = Hashtbl.create 0 in
 	let rec loop e = match e.eexpr with
-		| TVar({v_kind = VUser _} as v,eo) when v.v_name <> "_" ->
+		| TVar({v_kind = VUser _} as v,eo) when v.v_name <> "_" && not (has_var_flag v VUsedByTyper) ->
 			Hashtbl.add pmin_map e.epos.pmin v;
 			let p = match eo with
 				| None -> e.epos
@@ -178,11 +178,6 @@ let prepare com =
 	dctx.diagnostics_messages <- com.shared.shared_display_information.diagnostics_messages;
 	dctx.unresolved_identifiers <- com.display_information.unresolved_identifiers;
 	dctx
-
-let secure_generated_code ctx e =
-	(* This causes problems and sucks in general... need a different solution. But I forgot which problem this solved anyway. *)
-	(* mk (TMeta((Meta.Extern,[],e.epos),e)) e.etype e.epos *)
-	e
 
 let print com =
 	let dctx = prepare com in

--- a/src/context/display/diagnostics.ml
+++ b/src/context/display/diagnostics.ml
@@ -20,13 +20,14 @@ let find_unused_variables com e =
 	let vars = Hashtbl.create 0 in
 	let pmin_map = Hashtbl.create 0 in
 	let rec loop e = match e.eexpr with
-		| TVar({v_kind = VUser _} as v,eo) when v.v_name <> "_" && not (has_var_flag v VUsedByTyper) ->
+		| TVar({v_kind = VUser origin} as v,eo) when v.v_name <> "_" && not (has_var_flag v VUsedByTyper) ->
 			Hashtbl.add pmin_map e.epos.pmin v;
 			let p = match eo with
-				| None -> e.epos
-				| Some e1 ->
-					loop e1;
-					{ e.epos with pmax = e1.epos.pmin }
+			| Some e1 when origin <> TVOPatternVariable ->
+				loop e1;
+				{ e.epos with pmax = e1.epos.pmin }
+			| _ ->
+				e.epos
 			in
 			Hashtbl.replace vars v.v_id (v,p);
 		| TLocal ({v_kind = VUser _} as v) ->

--- a/src/context/display/diagnosticsPrinter.ml
+++ b/src/context/display/diagnosticsPrinter.ml
@@ -26,8 +26,7 @@ let make_diagnostic kd p sev args = {
 let is_diagnostics_file com file_key =
 	match com.report_mode with
 	| RMLegacyDiagnostics [] | RMDiagnostics [] -> true
-	| RMLegacyDiagnostics file_keys -> List.exists (fun key' -> file_key = key') file_keys
-	| RMDiagnostics file_keys -> List.exists (fun (key',_) -> file_key = key') file_keys
+	| RMLegacyDiagnostics file_keys | RMDiagnostics file_keys -> List.mem file_key file_keys
 	| _ -> false
 
 module UnresolvedIdentifierSuggestion = struct

--- a/src/context/display/diagnosticsPrinter.ml
+++ b/src/context/display/diagnosticsPrinter.ml
@@ -25,8 +25,9 @@ let make_diagnostic kd p sev args = {
 
 let is_diagnostics_file com file_key =
 	match com.report_mode with
-	| RMDiagnostics [] -> true
-	| RMDiagnostics file_keys -> List.exists (fun key' -> file_key = key') file_keys
+	| RMLegacyDiagnostics [] | RMDiagnostics [] -> true
+	| RMLegacyDiagnostics file_keys -> List.exists (fun key' -> file_key = key') file_keys
+	| RMDiagnostics file_keys -> List.exists (fun (key',_) -> file_key = key') file_keys
 	| _ -> false
 
 module UnresolvedIdentifierSuggestion = struct

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -100,7 +100,7 @@ class display_handler (jsonrpc : jsonrpc_handler) com (cs : CompilationCache.t) 
 			com.file_contents <- file_contents;
 
 			match files with
-			| [] | [_] -> DisplayPosition.display_position#set { pfile = file; pmin = pos; pmax = pos; };
+			| [] -> DisplayPosition.display_position#set { pfile = file; pmin = pos; pmax = pos; };
 			| _ -> DisplayPosition.display_position#set_files files;
 		end
 end
@@ -160,12 +160,8 @@ let handler =
 		"display/diagnostics", (fun hctx ->
 			hctx.display#set_display_file false false;
 			hctx.display#enable_display DMNone;
+			hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = true };
 			hctx.com.report_mode <- RMDiagnostics (List.map (fun (f,_) -> f) hctx.com.file_contents);
-
-			(match hctx.com.file_contents with
-			| [file, None] ->
-				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = true };
-			| _ -> ());
 		);
 		"display/implementation", (fun hctx ->
 			hctx.display#set_display_file false true;

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -126,6 +126,55 @@ let handler =
 			hctx.display#set_display_file false true;
 			hctx.display#enable_display DMDefinition;
 		);
+		"display/diagnostics", (fun hctx ->
+			hctx.display#enable_display DMNone;
+
+			let file = hctx.jsonrpc#get_opt_param (fun () ->
+				let file = hctx.jsonrpc#get_string_param "file" in
+				Path.get_full_path file
+			) file_input_marker in
+
+			if file <> file_input_marker then begin
+				let file_unique = hctx.com.file_keys#get file in
+
+				let contents = hctx.jsonrpc#get_opt_param (fun () ->
+					let s = hctx.jsonrpc#get_string_param "contents" in
+					Some s
+				) None in
+
+				DisplayPosition.display_position#set {
+					pfile = file;
+					pmin = -1;
+					pmax = -1;
+				};
+
+				hctx.com.report_mode <- RMDiagnostics [file_unique, contents];
+				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display};
+			end else begin
+				let file_contents = hctx.jsonrpc#get_opt_param (fun () ->
+					hctx.jsonrpc#get_opt_param (fun () -> hctx.jsonrpc#get_array_param "fileContents") []
+				) [] in
+
+				if (List.length file_contents) = 0 then begin
+					hctx.com.report_mode <- RMDiagnostics []
+				end else
+					let file_contents = List.map (fun fc -> match fc with
+						| JObject fl ->
+							let file = hctx.jsonrpc#get_string_field "fileContents" "file" fl in
+							let file = Path.get_full_path file in
+							let file_unique = hctx.com.file_keys#get file in
+							let contents = hctx.jsonrpc#get_opt_param (fun () ->
+								let s = hctx.jsonrpc#get_string_field "fileContents" "contents" fl in
+								Some s
+							) None in
+							(file_unique, contents)
+						| _ -> invalid_arg "fileContents"
+					) file_contents in
+
+					DisplayPosition.display_position#set_files (List.map (fun (k, _) -> k) file_contents);
+					hctx.com.report_mode <- RMDiagnostics file_contents
+			end
+		);
 		"display/implementation", (fun hctx ->
 			hctx.display#set_display_file false true;
 			hctx.display#enable_display (DMImplementation);

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -164,7 +164,7 @@ let handler =
 
 			(match hctx.com.file_contents with
 			| [file, None] ->
-				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display};
+				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = true };
 			| _ -> ());
 		);
 		"display/implementation", (fun hctx ->
@@ -401,12 +401,6 @@ let handler =
 				let b = hctx.jsonrpc#get_bool_param "legacyCompletion" in
 				ServerConfig.legacy_completion := b;
 				l := jstring ("Legacy completion " ^ (if b then "enabled" else "disabled")) :: !l;
-				()
-			) ();
-			hctx.jsonrpc#get_opt_param (fun () ->
-				let b = hctx.jsonrpc#get_bool_param "populateCacheFromDisplay" in
-				ServerConfig.populate_cache_from_display := b;
-				l := jstring ("Compilation cache refill from display " ^ (if b then "enabled" else "disabled")) :: !l;
 				()
 			) ();
 			hctx.send_result (jarray !l)

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -61,12 +61,11 @@ class display_handler (jsonrpc : jsonrpc_handler) com (cs : CompilationCache.t) 
 			Path.get_full_path file
 		) file_input_marker in
 		let pos = if requires_offset then jsonrpc#get_int_param "offset" else (-1) in
-		ignore(jsonrpc#get_opt_param (fun () ->
+		com.file_contents <- jsonrpc#get_opt_param (fun () ->
 			let s = jsonrpc#get_string_param "contents" in
 			let file_unique = com.file_keys#get file in
-			com.file_contents <- Some [file_unique, Some s];
-			Some s
-		) None);
+			Some [file_unique, Some s]
+		) None;
 		Parser.was_auto_triggered := was_auto_triggered;
 		DisplayPosition.display_position#set {
 			pfile = file;

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -60,18 +60,49 @@ class display_handler (jsonrpc : jsonrpc_handler) com (cs : CompilationCache.t) 
 			let file = jsonrpc#get_string_param "file" in
 			Path.get_full_path file
 		) file_input_marker in
-		let pos = if requires_offset then jsonrpc#get_int_param "offset" else (-1) in
-		com.file_contents <- jsonrpc#get_opt_param (fun () ->
+		let contents = jsonrpc#get_opt_param (fun () ->
 			let s = jsonrpc#get_string_param "contents" in
-			let file_unique = com.file_keys#get file in
-			Some [file_unique, Some s]
-		) None;
+			Some s
+		) None in
+
+		let pos = if requires_offset then jsonrpc#get_int_param "offset" else (-1) in
 		Parser.was_auto_triggered := was_auto_triggered;
-		DisplayPosition.display_position#set {
-			pfile = file;
-			pmin = pos;
-			pmax = pos;
-		}
+
+		if file <> file_input_marker then begin
+			let file_unique = com.file_keys#get file in
+
+			DisplayPosition.display_position#set {
+				pfile = file;
+				pmin = pos;
+				pmax = pos;
+			};
+
+			com.file_contents <- [file_unique, contents];
+		end else begin
+			let file_contents = jsonrpc#get_opt_param (fun () ->
+				jsonrpc#get_opt_param (fun () -> jsonrpc#get_array_param "fileContents") []
+			) [] in
+
+			let file_contents = List.map (fun fc -> match fc with
+				| JObject fl ->
+					let file = jsonrpc#get_string_field "fileContents" "file" fl in
+					let file = Path.get_full_path file in
+					let file_unique = com.file_keys#get file in
+					let contents = jsonrpc#get_opt_param (fun () ->
+						let s = jsonrpc#get_string_field "fileContents" "contents" fl in
+						Some s
+					) None in
+					(file_unique, contents)
+				| _ -> invalid_arg "fileContents"
+			) file_contents in
+
+			let files = (List.map (fun (k, _) -> k) file_contents) in
+			com.file_contents <- file_contents;
+
+			match files with
+			| [] | [_] -> DisplayPosition.display_position#set { pfile = file; pmin = pos; pmax = pos; };
+			| _ -> DisplayPosition.display_position#set_files files;
+		end
 end
 
 type handler_context = {
@@ -127,56 +158,14 @@ let handler =
 			hctx.display#enable_display DMDefinition;
 		);
 		"display/diagnostics", (fun hctx ->
+			hctx.display#set_display_file false false;
 			hctx.display#enable_display DMNone;
+			hctx.com.report_mode <- RMDiagnostics (List.map (fun (f,_) -> f) hctx.com.file_contents);
 
-			let file = hctx.jsonrpc#get_opt_param (fun () ->
-				let file = hctx.jsonrpc#get_string_param "file" in
-				Path.get_full_path file
-			) file_input_marker in
-
-			if file <> file_input_marker then begin
-				let file_unique = hctx.com.file_keys#get file in
-
-				let contents = hctx.jsonrpc#get_opt_param (fun () ->
-					let s = hctx.jsonrpc#get_string_param "contents" in
-					Some s
-				) None in
-
-				DisplayPosition.display_position#set {
-					pfile = file;
-					pmin = -1;
-					pmax = -1;
-				};
-
-				hctx.com.file_contents <- Some [file_unique, contents];
-				hctx.com.report_mode <- RMDiagnostics [file_unique];
+			(match hctx.com.file_contents with
+			| [file, None] ->
 				hctx.com.display <- { hctx.com.display with dms_display_file_policy = DFPAlso; dms_per_file = true; dms_populate_cache = !ServerConfig.populate_cache_from_display};
-			end else begin
-				let file_contents = hctx.jsonrpc#get_opt_param (fun () ->
-					hctx.jsonrpc#get_opt_param (fun () -> hctx.jsonrpc#get_array_param "fileContents") []
-				) [] in
-
-				if (List.length file_contents) = 0 then begin
-					hctx.com.report_mode <- RMDiagnostics []
-				end else
-					let file_contents = List.map (fun fc -> match fc with
-						| JObject fl ->
-							let file = hctx.jsonrpc#get_string_field "fileContents" "file" fl in
-							let file = Path.get_full_path file in
-							let file_unique = hctx.com.file_keys#get file in
-							let contents = hctx.jsonrpc#get_opt_param (fun () ->
-								let s = hctx.jsonrpc#get_string_field "fileContents" "contents" fl in
-								Some s
-							) None in
-							(file_unique, contents)
-						| _ -> invalid_arg "fileContents"
-					) file_contents in
-
-					let files = (List.map (fun (k, _) -> k) file_contents) in
-					DisplayPosition.display_position#set_files files;
-					hctx.com.file_contents <- Some file_contents;
-					hctx.com.report_mode <- RMDiagnostics files
-			end
+			| _ -> ());
 		);
 		"display/implementation", (fun hctx ->
 			hctx.display#set_display_file false true;

--- a/src/core/display/displayPosition.ml
+++ b/src/core/display/displayPosition.ml
@@ -23,9 +23,15 @@ class display_position_container =
 		method set p =
 			pos <- p;
 			last_pos <- p;
-			file_key <- None
+			file_key <- None;
+			file_keys <- if p.pfile = DisplayProcessingGlobals.file_input_marker then [] else [Path.UniqueKey.create p.pfile]
+
 		method set_files files =
 			file_keys <- files
+
+		method get_files =
+			file_keys
+
 		(**
 			Get current display position
 		*)

--- a/src/core/display/displayPosition.ml
+++ b/src/core/display/displayPosition.ml
@@ -11,6 +11,7 @@ class display_position_container =
 		(** Current display position *)
 		val mutable pos = null_pos
 		val mutable file_key = None
+		val mutable file_keys = []
 		(**
 			Display position value which was set with the latest `display_position#set p` call.
 			Kept even after `display_position#reset` call.
@@ -23,6 +24,8 @@ class display_position_container =
 			pos <- p;
 			last_pos <- p;
 			file_key <- None
+		method set_files files =
+			file_keys <- files
 		(**
 			Get current display position
 		*)
@@ -43,7 +46,8 @@ class display_position_container =
 		*)
 		method reset =
 			pos <- null_pos;
-			file_key <- None
+			file_key <- None;
+			file_keys <- []
 		(**
 			Check if `p` contains current display position
 		*)
@@ -53,8 +57,13 @@ class display_position_container =
 			Check if a file with `file_key` contains current display position
 		*)
 		method is_in_file file_key =
-			pos.pfile <> "?"
-			&& self#get_file_key = file_key
+			(pos.pfile <> "?" && self#get_file_key = file_key) || self#has_file file_key
+		(**
+			This is a hack; currently used by Diagnostics.collect_diagnostics when sending multiple files
+			to run diagnostics on via json rpc
+		*)
+		method has_file file_key =
+			List.mem file_key file_keys
 		(**
 			Cut `p` at the position of the latest `display_position#set pos` call.
 		*)

--- a/src/core/displayTypes.ml
+++ b/src/core/displayTypes.ml
@@ -235,7 +235,6 @@ module DisplayMode = struct
 		| DMDefault | DMDefinition | DMTypeDefinition | DMPackage | DMHover | DMSignature -> settings
 		| DMUsage _ | DMImplementation -> { settings with
 				dms_full_typing = true;
-				dms_populate_cache = !ServerConfig.populate_cache_from_display;
 				dms_force_macro_typing = true;
 				dms_display_file_policy = DFPAlso;
 				dms_exit_during_typing = false

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -442,7 +442,12 @@ let flag_tclass_field_names = [
 type flag_tvar =
 	| VCaptured
 	| VFinal
-	| VUsed (* used by the analyzer *)
+	| VAnalyzed
 	| VAssigned
 	| VCaught
 	| VStatic
+	| VUsedByTyper (* Set if the typer looked up this variable *)
+
+let flag_tvar_names = [
+	"VCaptured";"VFinal";"VAnalyzed";"VAssigned";"VCaught";"VStatic";"VUsedByTyper"
+]

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -916,7 +916,8 @@ let save_class_state ctx t =
 			a.a_meta <- List.filter (fun (m,_,_) -> m <> Meta.ValueUsed) a.a_meta
 		)
 
-let run com tctx main =
+let run tctx main before_destruction =
+	let com = tctx.com in
 	let detail_times = Common.defined com DefineList.FilterTimes in
 	let new_types = List.filter (fun t ->
 		let cached = is_cached com t in
@@ -1025,4 +1026,5 @@ let run com tctx main =
 	let t = filter_timer detail_times ["callbacks"] in
 	com.callbacks#run com.callbacks#get_after_save; (* macros onGenerate etc. *)
 	t();
+	before_destruction();
 	destruction tctx detail_times main locals

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -661,14 +661,14 @@ module LocalDce = struct
 
 	let rec apply ctx =
 		let is_used v =
-			has_var_flag v VUsed
+			has_var_flag v VAnalyzed
 		in
 		let keep v =
 			is_used v || ((match v.v_kind with VUser _ | VInlined -> true | _ -> false) && not ctx.config.local_dce) || ExtType.has_reference_semantics v.v_type || has_var_flag v VCaptured || Meta.has Meta.This v.v_meta
 		in
 		let rec use v =
 			if not (is_used v) then begin
-				add_var_flag v VUsed;
+				add_var_flag v VAnalyzed;
 				(try expr (get_var_value ctx.graph v) with Not_found -> ());
 				begin match Ssa.get_reaching_def ctx.graph v with
 					| None ->
@@ -676,7 +676,7 @@ module LocalDce = struct
 						   reaching definition (issue #10972). Simply marking it as being used should be sufficient. *)
 						let v' = get_var_origin ctx.graph v in
 						if not (is_used v') then
-							add_var_flag v' VUsed
+							add_var_flag v' VAnalyzed
 					| Some v ->
 						use v;
 				end

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -589,7 +589,6 @@ class inline_state ctx ethis params cf f p = object(self)
 				mk (TBlock (DynArray.to_list el)) tret e.epos
 		in
 		let e = inline_metadata e cf.cf_meta in
-		let e = Diagnostics.secure_generated_code ctx e in
 		if has_params then begin
 			let mt = map_type cf.cf_type in
 			let unify_func () = unify_raise mt (TFun (tl,tret)) p in

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -488,7 +488,6 @@ object(self)
 			!ethis_f();
 			raise exc
 		in
-		let e = Diagnostics.secure_generated_code ctx e in
 		ctx.com.located_error <- old;
 		!ethis_f();
 		e

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -62,14 +62,14 @@ let parse_file_from_string com file p string =
 let parse_file com file p =
 	let file_key = com.file_keys#get file in
 	let contents = match com.file_contents with
-		| Some files ->
-			(try List.assoc file_key files with Not_found -> None)
-		| None when (Common.defined com Define.DisplayStdin) && DisplayPosition.display_position#is_in_file file_key ->
+		| [] when (Common.defined com Define.DisplayStdin) && DisplayPosition.display_position#is_in_file file_key ->
 			let s = Std.input_all stdin in
 			close_in stdin;
-			com.file_contents <- Some [file_key, Some s];
+			com.file_contents <- [file_key, Some s];
 			Some s
-		| None -> None
+		| [] -> None
+		| files ->
+			(try List.assoc file_key files with Not_found -> None)
 	in
 
 	match contents with

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -60,9 +60,15 @@ let parse_file_from_string com file p string =
 	parse_file_from_lexbuf com file p (Sedlexing.Utf8.from_string string)
 
 let parse_file com file p =
+	let file_key = com.file_keys#get file in
 	let contents = match com.file_contents with
 		| Some files ->
-			(try List.assoc (com.file_keys#get file) files with Not_found -> None)
+			(try List.assoc file_key files with Not_found -> None)
+		| None when (Common.defined com Define.DisplayStdin) && DisplayPosition.display_position#is_in_file file_key ->
+			let s = Std.input_all stdin in
+			close_in stdin;
+			com.file_contents <- Some [file_key, Some s];
+			Some s
 		| None -> None
 	in
 

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -59,23 +59,11 @@ let parse_file_from_lexbuf com file p lexbuf =
 let parse_file_from_string com file p string =
 	parse_file_from_lexbuf com file p (Sedlexing.Utf8.from_string string)
 
-let current_stdin = ref None (* TODO: we're supposed to clear this at some point *)
-
 let parse_file com file p =
-	let contents = match com.report_mode with
-		| RMDiagnostics files ->
+	let contents = match com.file_contents with
+		| Some files ->
 			(try List.assoc (com.file_keys#get file) files with Not_found -> None)
-		| _ when (Common.defined com Define.DisplayStdin) && DisplayPosition.display_position#is_in_file (com.file_keys#get file) ->
-			Some (match !current_stdin with
-				| Some s ->
-					s
-				| None ->
-					let s = Std.input_all stdin in
-					close_in stdin;
-					current_stdin := Some s;
-					s
-			)
-		| _ -> None
+		| None -> None
 	in
 
 	match contents with

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -62,20 +62,26 @@ let parse_file_from_string com file p string =
 let current_stdin = ref None (* TODO: we're supposed to clear this at some point *)
 
 let parse_file com file p =
-	let use_stdin = (Common.defined com Define.DisplayStdin) && DisplayPosition.display_position#is_in_file (com.file_keys#get file) in
-	if use_stdin then
-		let s =
-			match !current_stdin with
-			| Some s ->
-				s
-			| None ->
-				let s = Std.input_all stdin in
-				close_in stdin;
-				current_stdin := Some s;
-				s
-		in
+	let contents = match com.report_mode with
+		| RMDiagnostics files ->
+			(try List.assoc (com.file_keys#get file) files with Not_found -> None)
+		| _ when (Common.defined com Define.DisplayStdin) && DisplayPosition.display_position#is_in_file (com.file_keys#get file) ->
+			Some (match !current_stdin with
+				| Some s ->
+					s
+				| None ->
+					let s = Std.input_all stdin in
+					close_in stdin;
+					current_stdin := Some s;
+					s
+			)
+		| _ -> None
+	in
+
+	match contents with
+	| Some s ->
 		parse_file_from_string com file p s
-	else
+	| _ ->
 		let ch = try open_in_bin file with _ -> typing_error ("Could not open " ^ file) p in
 		Std.finally (fun() -> close_in ch) (parse_file_from_lexbuf com file p) (Sedlexing.Utf8.from_channel ch)
 

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -350,6 +350,7 @@ let rec type_ident_raise ctx i p mode with_type =
 	| _ ->
 	try
 		let v = PMap.find i ctx.locals in
+		add_var_flag v VUsedByTyper;
 		(match v.v_extra with
 		| Some ve ->
 			let (params,e) = (ve.v_params,ve.v_expr) in
@@ -1130,7 +1131,7 @@ and type_new ctx path el with_type force_inline p =
 		typing_error (s_type (print_context()) t ^ " cannot be constructed") p
 	end with Error(No_constructor _ as err,p,depth) when ctx.com.display.dms_kind <> DMNone ->
 		located_display_error ~depth ctx.com (error_msg p err);
-		Diagnostics.secure_generated_code ctx (mk (TConst TNull) t p)
+		mk (TConst TNull) t p
 
 and type_try ctx e1 catches with_type p =
 	let e1 = type_expr ctx (Expr.ensure_block e1) with_type in
@@ -1796,7 +1797,6 @@ and type_call_builtin ctx e el mode with_type p =
 		| _ ->
 			let e = type_expr ctx e WithType.value in
 			warning ctx WInfo (s_type (print_context()) e.etype) e.epos;
-			let e = Diagnostics.secure_generated_code ctx e in
 			e
 		end
 	| (EField(e,"match",efk_todo),p), [epat] ->

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -155,9 +155,11 @@ let get_this ctx p =
 	| FunMemberClassLocal | FunMemberAbstractLocal ->
 		let v = match ctx.vthis with
 			| None ->
-				let v = if ctx.curfun = FunMemberAbstractLocal then
-					PMap.find "this" ctx.locals
-				else
+				let v = if ctx.curfun = FunMemberAbstractLocal then begin
+					let v = PMap.find "this" ctx.locals in
+					add_var_flag v VUsedByTyper;
+					v
+				end else
 					add_local ctx VGenerated "`this" ctx.tthis p
 				in
 				ctx.vthis <- Some v;

--- a/std/haxe/display/Display.hx
+++ b/std/haxe/display/Display.hx
@@ -35,7 +35,7 @@ import haxe.ds.ReadOnlyArray;
 class DisplayMethods {
 
 	/**
-		TODO documentation
+		The request is sent from the client to Haxe to get diagnostics for a specific file, a list of files or the whole project.
 	**/
 	static inline var Diagnostics = new HaxeRequestMethod<DiagnosticsParams, DiagnosticsResult>("display/diagnostics");
 
@@ -99,7 +99,6 @@ class DisplayMethods {
 		TODO:
 
 		- finish completion
-		- diagnostics
 		- codeLens
 		- workspaceSymbols ("project/symbol"?)
 	 */

--- a/std/haxe/display/Display.hx
+++ b/std/haxe/display/Display.hx
@@ -25,6 +25,7 @@ package haxe.display;
 import haxe.display.JsonModuleTypes;
 import haxe.display.Position;
 import haxe.display.Protocol;
+import haxe.ds.ReadOnlyArray;
 
 /**
 	Methods of the JSON-RPC-based `--display` protocol in Haxe 4.
@@ -32,6 +33,12 @@ import haxe.display.Protocol;
 **/
 @:publicFields
 class DisplayMethods {
+
+	/**
+		TODO documentation
+	**/
+	static inline var Diagnostics = new HaxeRequestMethod<DiagnosticsParams, DiagnosticsResult>("display/diagnostics");
+
 	/**
 		The completion request is sent from the client to Haxe to request code completion.
 		Haxe automatically determines the type of completion to use based on the passed position, see `CompletionResultKind`.
@@ -437,6 +444,17 @@ typedef StructExtensionCompletion = {
 typedef PatternCompletion<T> = ToplevelCompletion<T> & {
 	var isOutermostPattern:Bool;
 }
+
+typedef DiagnosticsParams = {
+	var ?file:FsPath;
+	var ?contents:String;
+	var ?fileContents:Array<{file:FsPath, ?contents:String}>;
+}
+
+typedef DiagnosticsResult = Response<ReadOnlyArray<{
+	var file:FsPath;
+	var diagnostics:ReadOnlyArray<Diagnostic<Any>>;
+}>>
 
 enum abstract CompletionModeKind<T>(Int) {
 	var Field:CompletionModeKind<FieldCompletionSubject<Dynamic>>;

--- a/std/haxe/display/Server.hx
+++ b/std/haxe/display/Server.hx
@@ -73,7 +73,6 @@ typedef ConfigurePrintParams = {
 
 typedef ConfigureParams = {
 	final ?noModuleChecks:Bool;
-	final ?populateCacheFromDisplay:Bool;
 	final ?legacyCompletion:Bool;
 	final ?print:ConfigurePrintParams;
 }

--- a/tests/display/build.hxml
+++ b/tests/display/build.hxml
@@ -5,4 +5,4 @@
 -lib haxeserver
 --interp
 -D use-rtti-doc
--D test=11285
+# -D test=11285

--- a/tests/display/src/cases/Issue5306.hx
+++ b/tests/display/src/cases/Issue5306.hx
@@ -7,8 +7,8 @@ class Issue5306 extends DisplayTestCase {
 		class Main {
 			static function main() {
 				var ib:Array<Int>;
-				ib[0] = 0; ib[1] = 1; ib[2]
-				{-5-}trace{-6-}("test");
+				{-5-}ib{-6-}[0] = 0; ib[1] = 1; ib[2]
+				{-7-}trace{-8-}("test");
 			}
 		}
 	**/
@@ -22,7 +22,7 @@ class Issue5306 extends DisplayTestCase {
 			// },
 			{
 				kind: DKParserError,
-				range: diagnosticsRange(pos(5), pos(6)),
+				range: diagnosticsRange(pos(7), pos(8)),
 				severity: Error,
 				relatedInformation: [],
 				args: "Missing ;"
@@ -33,6 +33,14 @@ class Issue5306 extends DisplayTestCase {
 				severity: Error,
 				relatedInformation: [],
 				args: "Type not found : InvalidType"
+			},
+			{
+				kind: DKCompilerError,
+				range: diagnosticsRange(pos(5), pos(6)),
+				severity: Error,
+				code: null,
+				relatedInformation: [],
+				args: "Local variable ib used without being initialized"
 			}
 		];
 		arrayEq(expected, diagnostics());

--- a/tests/display/src/cases/Issue5306.hx
+++ b/tests/display/src/cases/Issue5306.hx
@@ -38,7 +38,6 @@ class Issue5306 extends DisplayTestCase {
 				kind: DKCompilerError,
 				range: diagnosticsRange(pos(5), pos(6)),
 				severity: Error,
-				code: null,
 				relatedInformation: [],
 				args: "Local variable ib used without being initialized"
 			}

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -62,22 +62,26 @@ class TestCase implements ITest {
 		server.stop();
 	}
 
+	function handleResult(result) {
+		lastResult = result;
+		debugLastResult = {
+			hasError: lastResult.hasError,
+			prints: lastResult.prints,
+			stderr: lastResult.stderr,
+			stdout: lastResult.stdout
+		}
+		sendLogMessage(result.stdout);
+		for (print in result.prints) {
+			var line = print.trim();
+			messages.push('Haxe print: $line');
+		}
+	}
+
 	function runHaxe(args:Array<String>, done:() -> Void) {
 		messages = [];
 		errorMessages = [];
 		server.rawRequest(args, null, function(result) {
-			lastResult = result;
-			debugLastResult = {
-				hasError: lastResult.hasError,
-				prints: lastResult.prints,
-				stderr: lastResult.stderr,
-				stdout: lastResult.stdout
-			}
-			sendLogMessage(result.stdout);
-			for (print in result.prints) {
-				var line = print.trim();
-				messages.push('Haxe print: $line');
-			}
+			handleResult(result);
 			if (result.hasError) {
 				sendErrorMessage(result.stderr);
 			}
@@ -95,7 +99,10 @@ class TestCase implements ITest {
 			callback:TResponse->Void, done:() -> Void) {
 		var methodArgs = {method: method, id: 1, params: methodArgs};
 		args = args.concat(['--display', Json.stringify(methodArgs)]);
+		messages = [];
+		errorMessages = [];
 		server.rawRequest(args, null, function(result) {
+			handleResult(result);
 			callback(Json.parse(result.stderr).result.result);
 			done();
 		}, function(msg) {

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -96,14 +96,20 @@ class TestCase implements ITest {
 	}
 
 	function runHaxeJsonCb<TParams, TResponse>(args:Array<String>, method:HaxeRequestMethod<TParams, Response<TResponse>>, methodArgs:TParams,
-			callback:TResponse->Void, done:() -> Void) {
+			callback:TResponse->Void, done:() -> Void, ?pos:PosInfos) {
 		var methodArgs = {method: method, id: 1, params: methodArgs};
 		args = args.concat(['--display', Json.stringify(methodArgs)]);
 		messages = [];
 		errorMessages = [];
 		server.rawRequest(args, null, function(result) {
 			handleResult(result);
-			callback(Json.parse(result.stderr).result.result);
+			var json = try Json.parse(result.stderr) catch(e) {result: null, error: e.message};
+
+			if (json.result != null) {
+				callback(json.result?.result);
+			} else {
+				Assert.fail('Error: ' + json.error, pos);
+			}
 			done();
 		}, function(msg) {
 			sendErrorMessage(msg);

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -1,7 +1,9 @@
 package cases;
 
+import haxe.display.Diagnostic;
 import haxe.display.Display;
 import haxe.display.FsPath;
+import haxe.display.Position.Range;
 import haxe.display.Server;
 import haxe.io.Path;
 import utest.Assert;
@@ -257,6 +259,48 @@ class ServerTests extends TestCase {
 		});
 		runHaxe(args.concat(["--display", "HelloWorld.hx@0@hover"]));
 		assertReuse("HelloWorld");
+	}
+
+	function testDiagnosticsMultipleOpenFiles() {
+		vfs.putContent("Main.hx", getTemplate("diagnostics/multi-files/Main.hx"));
+		vfs.putContent("File1.hx", getTemplate("diagnostics/multi-files/File1.hx"));
+		vfs.putContent("File2.hx", getTemplate("diagnostics/multi-files/File2.hx"));
+		vfs.putContent("File3.hx", getTemplate("diagnostics/multi-files/File3.hx"));
+
+		var args = ["--main", "Main", "--interp"];
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [
+			{file: new FsPath("Main.hx")},
+			{file: new FsPath("File1.hx")},
+			{file: new FsPath("File2.hx")},
+		]}, res -> {
+			Assert.equals(3, res.length); // Asked diagnostics for 3 files
+
+			for (fileDiagnostics in res) {
+				final path = ~/[\/|\\]/g.split(fileDiagnostics.file.toString()).pop();
+
+				switch (path) {
+					case "Main.hx":
+						Assert.equals(3, fileDiagnostics.diagnostics.length);
+						for (diag in fileDiagnostics.diagnostics) {
+							Assert.equals(diag.kind, DKUnusedImport);
+						}
+
+					case "File1.hx" | "File2.hx":
+						Assert.equals(1, fileDiagnostics.diagnostics.length);
+						var diag:Diagnostic<{description:String, range:Range}> = fileDiagnostics.diagnostics[0];
+						Assert.equals(diag.kind, DKRemovableCode);
+						Assert.equals(diag.args.description, "Unused variable");
+
+					case _: throw 'Did not expect diagnostics for $path';
+				}
+			}
+		});
+
+		// Check that File3 was reached
+		var context = null;
+		runHaxeJsonCb(args, ServerMethods.Contexts, null, res -> context = res.find(ctx -> ctx.desc == "after_init_macros"));
+		runHaxeJsonCb(args, ServerMethods.Type, {signature: context.signature, modulePath: "File3", typeName: "File3"}, res -> Assert.equals(res.pos.file, "File3.hx"));
+		assertSuccess();
 	}
 
 	function testSyntaxCache() {

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -237,6 +237,22 @@ class ServerTests extends TestCase {
 		assertReuse("HelloWorld");
 	}
 
+	function testDiagnosticsRecache1() {
+		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
+		var args = ["--main", "HelloWorld", "--interp"];
+		runHaxe(args);
+		runHaxe(args);
+		assertReuse("HelloWorld");
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("HelloWorld.hx")});
+		runHaxe(args);
+		assertSkipping("HelloWorld", Tainted("server/invalidate"));
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [{file: new FsPath("HelloWorld.hx")}]}, res -> {
+			Assert.equals(0, res.length);
+		});
+		runHaxe(args);
+		assertReuse("HelloWorld");
+	}
+
 	function testDiagnosticsRecache2() {
 		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
 		var args = ["--main", "HelloWorld", "--interp"];
@@ -270,22 +286,21 @@ class ServerTests extends TestCase {
 		var args = ["--main", "Main", "--interp"];
 		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [
 			{file: new FsPath("Main.hx")},
-			{file: new FsPath("File1.hx")},
-			{file: new FsPath("File2.hx")},
+			{file: new FsPath("File1.hx")}
 		]}, res -> {
-			Assert.equals(3, res.length); // Asked diagnostics for 3 files
+			Assert.equals(2, res.length); // Asked diagnostics for 2 files
 
 			for (fileDiagnostics in res) {
 				final path = ~/[\/|\\]/g.split(fileDiagnostics.file.toString()).pop();
 
 				switch (path) {
 					case "Main.hx":
-						Assert.equals(3, fileDiagnostics.diagnostics.length);
+						Assert.equals(2, fileDiagnostics.diagnostics.length);
 						for (diag in fileDiagnostics.diagnostics) {
 							Assert.equals(diag.kind, DKUnusedImport);
 						}
 
-					case "File1.hx" | "File2.hx":
+					case "File1.hx":
 						Assert.equals(1, fileDiagnostics.diagnostics.length);
 						var diag:Diagnostic<{description:String, range:Range}> = fileDiagnostics.diagnostics[0];
 						Assert.equals(diag.kind, DKRemovableCode);
@@ -296,11 +311,37 @@ class ServerTests extends TestCase {
 			}
 		});
 
-		// Check that File3 was reached
+		// Check that File2 was reached
 		var context = null;
 		runHaxeJsonCb(args, ServerMethods.Contexts, null, res -> context = res.find(ctx -> ctx.desc == "after_init_macros"));
-		runHaxeJsonCb(args, ServerMethods.Type, {signature: context.signature, modulePath: "File3", typeName: "File3"}, res -> Assert.equals(res.pos.file, "File3.hx"));
-		assertSuccess();
+		runHaxeJsonCb(args, ServerMethods.Type, {signature: context.signature, modulePath: "File2", typeName: "File2"}, res -> Assert.equals(res.pos.file, "File2.hx"));
+
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {fileContents: [
+			{file: new FsPath("Main.hx")},
+			{file: new FsPath("File3.hx")}, // Not reached by normal compilation
+		]}, res -> {
+			Assert.equals(2, res.length); // Asked diagnostics for 2 files
+
+			for (fileDiagnostics in res) {
+				final path = ~/[\/|\\]/g.split(fileDiagnostics.file.toString()).pop();
+
+				switch (path) {
+					case "Main.hx":
+						Assert.equals(2, fileDiagnostics.diagnostics.length);
+						for (diag in fileDiagnostics.diagnostics) {
+							Assert.equals(diag.kind, DKUnusedImport);
+						}
+
+					case "File3.hx":
+						Assert.equals(1, fileDiagnostics.diagnostics.length);
+						var diag:Diagnostic<{description:String, range:Range}> = fileDiagnostics.diagnostics[0];
+						Assert.equals(diag.kind, DKRemovableCode);
+						Assert.equals(diag.args.description, "Unused variable");
+
+					case _: throw 'Did not expect diagnostics for $path';
+				}
+			}
+		});
 	}
 
 	function testSyntaxCache() {

--- a/tests/server/src/cases/display/issues/Issue10635.hx
+++ b/tests/server/src/cases/display/issues/Issue10635.hx
@@ -14,12 +14,15 @@ class Issue10635 extends DisplayTestCase {
 		}
 	**/
 	function test(_) {
-		var args = ["-main", "Main", "--display", "Main.hx@0@diagnostics"];
+		var args = ["-main", "Main"];
 		vfs.putContent("Something.hx", getTemplate("issues/Issue10635/Something.hx"));
-		runHaxe(args);
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-		runHaxe(args);
-		Assert.isTrue(lastResult.stderr.length == 2); // dumb, but we don't have a proper diagnostics structure in these tests
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
 	}
 
 	/**
@@ -32,12 +35,15 @@ class Issue10635 extends DisplayTestCase {
 		}
 	**/
 	function testGenericClassPerMethod(_) {
-		var args = ["-main", "Main", "--display", "Main.hx@0@diagnostics"];
+		var args = ["-main", "Main"];
 		vfs.putContent("Something.hx", "@:genericClassPerMethod " + getTemplate("issues/Issue10635/Something.hx"));
-		runHaxe(args);
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-		runHaxe(args);
-		Assert.isTrue(lastResult.stderr.length == 2); // dumb, but we don't have a proper diagnostics structure in these tests
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
 	}
 
 	function testGenericAddition(_) {

--- a/tests/server/src/cases/issues/Issue10653.hx
+++ b/tests/server/src/cases/issues/Issue10653.hx
@@ -8,9 +8,12 @@ class Issue10653 extends TestCase {
 		runHaxe(args);
 		vfs.putContent("Main.hx", getTemplate("issues/Issue10653/MainAfter.hx"));
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
-		Assert.isTrue(lastResult.stderr.length == 2);
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
 	}
 }

--- a/tests/server/src/cases/issues/Issue11177.hx
+++ b/tests/server/src/cases/issues/Issue11177.hx
@@ -7,25 +7,14 @@ class Issue11177 extends TestCase {
 	// 	vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
 	// 	vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
 	// 	var args = ["-main", "Main", "--interp"];
-	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
+	// 		Assert.equals(0, res.length);
+	// 	});
 	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
 	// 	runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 	// 	runHaxe(args);
-	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
-	// 	Assert.isTrue(lastResult.stderr.length == 2);
+	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
+	// 		Assert.equals(0, res.length);
+	// 	});
 	// }
-
-	function testWithoutCacheFromDisplay(_) {
-		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
-		vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
-		vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
-		var args = ["-main", "Main", "--interp"];
-		runHaxeJson([], ServerMethods.Configure, {populateCacheFromDisplay: false});
-		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
-		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
-		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-		runHaxe(args);
-		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
-		Assert.isTrue(lastResult.stderr.length == 2);
-	}
 }

--- a/tests/server/src/cases/issues/Issue11177.hx
+++ b/tests/server/src/cases/issues/Issue11177.hx
@@ -1,33 +1,32 @@
 package cases.issues;
 
 class Issue11177 extends TestCase {
-	// Disabled for now until #11177 is actually fixed, likely by #11220
-	// function test(_) {
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
-	// 	vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
-	// 	vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
-	// 	var args = ["-main", "Main", "--interp"];
-	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
-	// 		Assert.equals(0, res.length);
-	// 	});
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
-	// 	runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-	// 	runHaxe(args);
-	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
-	// 		Assert.equals(0, res.length);
-	// 	});
-	// }
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
+		vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
+		vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+		runHaxe(args);
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Buttons.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
+	}
 
-	// function testLegacyDiagnostics(_) {
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
-	// 	vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
-	// 	vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
-	// 	var args = ["-main", "Main", "--interp"];
-	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
-	// 	runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
-	// 	runHaxe(args);
-	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
-	// 	Assert.isTrue(lastResult.stderr.length == 2);
-	// }
+	function testLegacyDiagnostics(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
+		vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
+		vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+		runHaxe(args);
+		runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+		Assert.isTrue(lastResult.stderr.length == 2);
+	}
 }

--- a/tests/server/src/cases/issues/Issue11177.hx
+++ b/tests/server/src/cases/issues/Issue11177.hx
@@ -17,4 +17,17 @@ class Issue11177 extends TestCase {
 	// 		Assert.equals(0, res.length);
 	// 	});
 	// }
+
+	// function testLegacyDiagnostics(_) {
+	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main.hx"));
+	// 	vfs.putContent("Buttons.hx", getTemplate("issues/Issue11177/Buttons.hx"));
+	// 	vfs.putContent("KeyCode.hx", getTemplate("issues/Issue11177/KeyCode.hx"));
+	// 	var args = ["-main", "Main", "--interp"];
+	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11177/Main2.hx"));
+	// 	runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+	// 	runHaxe(args);
+	// 	runHaxe(args.concat(["--display", "Buttons.hx@0@diagnostics"]));
+	// 	Assert.isTrue(lastResult.stderr.length == 2);
+	// }
 }

--- a/tests/server/src/cases/issues/Issue11184.hx
+++ b/tests/server/src/cases/issues/Issue11184.hx
@@ -5,21 +5,14 @@ class Issue11184 extends TestCase {
 	// function test(_) {
 	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
 	// 	var args = ["-main", "Main", "-js", "bin/test.js"];
-	// 	runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+	// 		Assert.equals(1, res.length);
+	// 		Assert.equals(1, res[0].diagnostics.length);
+	// 		Assert.equals(res[0].diagnostics[0].args, "Cannot use Void as value");
+	// 	});
 	// 	runHaxe(args);
 	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
 	// 	runHaxe(args);
 	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
 	// }
-
-	function testWithoutCacheFromDisplay(_) {
-		vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
-		var args = ["-main", "Main", "-js", "bin/test.js"];
-		runHaxeJson([], ServerMethods.Configure, {populateCacheFromDisplay: false});
-		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
-		runHaxe(args);
-		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
-		runHaxe(args);
-		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
-	}
 }

--- a/tests/server/src/cases/issues/Issue11184.hx
+++ b/tests/server/src/cases/issues/Issue11184.hx
@@ -1,32 +1,31 @@
 package cases.issues;
 
 class Issue11184 extends TestCase {
-	// Disabled for now until #11184 is actually fixed, likely by #11220
-	// function testDiagnostics(_) {
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
-	// 	var args = ["-main", "Main", "-js", "bin/test.js"];
+	function testDiagnostics(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
+		var args = ["-main", "Main", "-js", "bin/test.js"];
 
-	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
-	// 		Assert.equals(1, res.length);
-	// 		Assert.equals(1, res[0].diagnostics.length);
-	// 		Assert.equals(res[0].diagnostics[0].args, "Cannot use Void as value");
-	// 	});
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(1, res.length);
+			Assert.equals(1, res[0].diagnostics.length);
+			Assert.equals(res[0].diagnostics[0].args, "Cannot use Void as value");
+		});
 
-	// 	runHaxe(args);
-	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
-	// 	runHaxe(args);
-	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
-	// }
+		runHaxe(args);
+		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+		runHaxe(args);
+		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	}
 
-	// function testLegacyDiagnostics(_) {
-	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
-	// 	var args = ["-main", "Main", "-js", "bin/test.js"];
-	// 	runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
-	// 	final diagnostics = haxe.Json.parse(lastResult.stderr)[0].diagnostics;
-	// 	Assert.equals(diagnostics[0].args, "Cannot use Void as value");
-	// 	runHaxe(args);
-	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
-	// 	runHaxe(args);
-	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
-	// }
+	function testLegacyDiagnostics(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
+		var args = ["-main", "Main", "-js", "bin/test.js"];
+		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+		final diagnostics = haxe.Json.parse(lastResult.stderr)[0].diagnostics;
+		Assert.equals(diagnostics[0].args, "Cannot use Void as value");
+		runHaxe(args);
+		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+		runHaxe(args);
+		Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	}
 }

--- a/tests/server/src/cases/issues/Issue11184.hx
+++ b/tests/server/src/cases/issues/Issue11184.hx
@@ -2,14 +2,28 @@ package cases.issues;
 
 class Issue11184 extends TestCase {
 	// Disabled for now until #11184 is actually fixed, likely by #11220
-	// function test(_) {
+	// function testDiagnostics(_) {
 	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
 	// 	var args = ["-main", "Main", "-js", "bin/test.js"];
+
 	// 	runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
 	// 		Assert.equals(1, res.length);
 	// 		Assert.equals(1, res[0].diagnostics.length);
 	// 		Assert.equals(res[0].diagnostics[0].args, "Cannot use Void as value");
 	// 	});
+
+	// 	runHaxe(args);
+	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	// 	runHaxe(args);
+	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
+	// }
+
+	// function testLegacyDiagnostics(_) {
+	// 	vfs.putContent("Main.hx", getTemplate("issues/Issue11184/Main.hx"));
+	// 	var args = ["-main", "Main", "-js", "bin/test.js"];
+	// 	runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+	// 	final diagnostics = haxe.Json.parse(lastResult.stderr)[0].diagnostics;
+	// 	Assert.equals(diagnostics[0].args, "Cannot use Void as value");
 	// 	runHaxe(args);
 	// 	Assert.isTrue(hasErrorMessage("Cannot use Void as value"));
 	// 	runHaxe(args);

--- a/tests/server/src/cases/issues/Issue11203.hx
+++ b/tests/server/src/cases/issues/Issue11203.hx
@@ -1,0 +1,23 @@
+package cases.issues;
+
+class Issue11203 extends TestCase {
+	function testClass(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11203/MainClass.hx"));
+		var args = ["Main", "--interp"];
+		runHaxe(args);
+		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+
+		var diag = parseDiagnostics();
+		Assert.isTrue(diag.length == 0);
+	}
+
+	function testAbstract(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11203/MainAbstract.hx"));
+		var args = ["Main", "--interp"];
+		runHaxe(args);
+		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
+
+		var diag = parseDiagnostics();
+		Assert.isTrue(diag.length == 0);
+	}
+}

--- a/tests/server/src/cases/issues/Issue11695.hx
+++ b/tests/server/src/cases/issues/Issue11695.hx
@@ -1,0 +1,39 @@
+package cases.issues;
+
+class Issue11695 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11695/Main.hx"));
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro1.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: before");
+
+		// Note: this is needed because modification time is currently checked with second precision
+		Sys.sleep(1);
+
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro2.hx"));
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Macro.hx")}, res -> {
+			Assert.equals(0, res.length);
+		});
+
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: after");
+	}
+
+	function testLegacyDiagnostics(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11695/Main.hx"));
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro1.hx"));
+		var args = ["-main", "Main", "--interp"];
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: before");
+
+		// Note: this is needed because modification time is currently checked with second precision
+		Sys.sleep(1);
+
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11695/Macro2.hx"));
+		runHaxe(args.concat(["--display", "Macro.hx@0@diagnostics"]));
+
+		runHaxe(args);
+		assertHasPrint("Macro.hx:1: after");
+	}
+}

--- a/tests/server/src/cases/issues/Issue7282.hx
+++ b/tests/server/src/cases/issues/Issue7282.hx
@@ -1,0 +1,22 @@
+package cases.issues;
+
+import haxe.display.Diagnostic;
+import haxe.display.Position.Range;
+
+class Issue7282 extends TestCase {
+	function test(_) {
+		var content = getTemplate("issues/Issue7282/Main.hx");
+		var transform = Markers.parse(content);
+
+		vfs.putContent("Main.hx", transform.source);
+		var args = ["-main", "Main"];
+		runHaxe(args);
+		assertSuccess();
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			var arg:{description:String, range:Range} = res[0].diagnostics[0].args;
+			Assert.equals("Unused variable", arg.description);
+			Assert.same(transform.range(1,2), res[0].diagnostics[0].range);
+			Assert.same(transform.range(1,2), arg.range);
+		});
+	}
+}

--- a/tests/server/src/cases/issues/Issue7931.hx
+++ b/tests/server/src/cases/issues/Issue7931.hx
@@ -1,0 +1,13 @@
+package cases.issues;
+
+class Issue7931 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue7931/Main.hx"));
+		var args = ["-main", "Main"];
+		runHaxe(args);
+		assertErrorMessage("Local variable s used without being initialized");
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals("Local variable s used without being initialized", res[0].diagnostics[0].args);
+		});
+	}
+}

--- a/tests/server/src/cases/issues/Issue8687.hx
+++ b/tests/server/src/cases/issues/Issue8687.hx
@@ -4,9 +4,10 @@ class Issue8687 extends TestCase {
 	function test(_) {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue8687/Main.hx"));
 		var args = ["-main", "Main", "--interp"];
-		runHaxe(args.concat(["--display", "Main.hx@0@diagnostics"]));
-
-		var diag = parseDiagnostics();
-		Assert.equals("Invalid version string \"foo\". Should follow SemVer.", diag[0].args);
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(1, res.length);
+			Assert.equals(1, res[0].diagnostics.length);
+			Assert.equals(res[0].diagnostics[0].args, "Invalid version string \"foo\". Should follow SemVer.");
+		});
 	}
 }

--- a/tests/server/test/templates/diagnostics/multi-files/File1.hx
+++ b/tests/server/test/templates/diagnostics/multi-files/File1.hx
@@ -1,0 +1,5 @@
+class File1 {
+	static function test() {
+		var foo = 42;
+	}
+}

--- a/tests/server/test/templates/diagnostics/multi-files/File2.hx
+++ b/tests/server/test/templates/diagnostics/multi-files/File2.hx
@@ -1,0 +1,5 @@
+class File2 {
+	static function test() {
+		var foo = 42;
+	}
+}

--- a/tests/server/test/templates/diagnostics/multi-files/File3.hx
+++ b/tests/server/test/templates/diagnostics/multi-files/File3.hx
@@ -1,0 +1,5 @@
+class File3 {
+	static function test() {
+		var foo = 42;
+	}
+}

--- a/tests/server/test/templates/diagnostics/multi-files/Main.hx
+++ b/tests/server/test/templates/diagnostics/multi-files/Main.hx
@@ -1,5 +1,4 @@
 import File1;
 import File2;
-import File3;
 
 function main() {}

--- a/tests/server/test/templates/diagnostics/multi-files/Main.hx
+++ b/tests/server/test/templates/diagnostics/multi-files/Main.hx
@@ -1,0 +1,5 @@
+import File1;
+import File2;
+import File3;
+
+function main() {}

--- a/tests/server/test/templates/issues/Issue11203/MainAbstract.hx
+++ b/tests/server/test/templates/issues/Issue11203/MainAbstract.hx
@@ -1,0 +1,16 @@
+class Main {
+	static function main() {
+		var future = new Future();
+		future.eager();
+	}
+}
+
+abstract Future({}) from {} {
+	public function new()
+		this = {};
+
+	public inline function eager():Future {
+		trace("much side effect!");
+		return this;
+	}
+}

--- a/tests/server/test/templates/issues/Issue11203/MainClass.hx
+++ b/tests/server/test/templates/issues/Issue11203/MainClass.hx
@@ -1,0 +1,15 @@
+class Main {
+	static function main() {
+		var future = new Future();
+		future.eager();
+	}
+}
+
+class Future {
+	public function new() {}
+
+	public inline function eager():Future {
+		trace("much side effect!");
+		return this;
+	}
+}

--- a/tests/server/test/templates/issues/Issue11695/Macro1.hx
+++ b/tests/server/test/templates/issues/Issue11695/Macro1.hx
@@ -1,0 +1,1 @@
+macro function test() return macro trace("before");

--- a/tests/server/test/templates/issues/Issue11695/Macro2.hx
+++ b/tests/server/test/templates/issues/Issue11695/Macro2.hx
@@ -1,0 +1,1 @@
+macro function test() return macro trace("after");

--- a/tests/server/test/templates/issues/Issue11695/Main.hx
+++ b/tests/server/test/templates/issues/Issue11695/Main.hx
@@ -1,0 +1,3 @@
+function main() {
+	Macro.test();
+}

--- a/tests/server/test/templates/issues/Issue7282/Main.hx
+++ b/tests/server/test/templates/issues/Issue7282/Main.hx
@@ -1,0 +1,10 @@
+import haxe.ds.Option;
+
+class Main {
+	public static function main() {
+		switch ((null:Option<Int>)) {
+			case Some({-1-}value{-2-}):
+			case None:
+		}
+	}
+}

--- a/tests/server/test/templates/issues/Issue7931/Main.hx
+++ b/tests/server/test/templates/issues/Issue7931/Main.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		var s:String;
+		s += "test";
+	}
+}

--- a/tests/server/test/templates/issues/Issue9134/Main.hx
+++ b/tests/server/test/templates/issues/Issue9134/Main.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main() {
+		var unused = null;
+	}
+}

--- a/tests/server/test/templates/issues/Issue9134/Main2.hx
+++ b/tests/server/test/templates/issues/Issue9134/Main2.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		var unused = null;
+		if (unused != null) trace("wat");
+	}
+}

--- a/tests/server/test/templates/issues/Issue9134/Other.hx
+++ b/tests/server/test/templates/issues/Issue9134/Other.hx
@@ -1,0 +1,2 @@
+class Other {
+}

--- a/tests/server/test/templates/issues/Issue9134/Other2.hx
+++ b/tests/server/test/templates/issues/Issue9134/Other2.hx
@@ -1,0 +1,6 @@
+class Other {
+	static function foo() {
+		// var foo = trace("wat");
+		var unused = null;
+	}
+}


### PR DESCRIPTION
* [x] Backport https://github.com/HaxeFoundation/haxe/pull/11412
* [x] Backport test changes from https://github.com/HaxeFoundation/haxe/pull/11412 ([running CI](https://github.com/HaxeFoundation/haxe/actions/runs/9772499931) on legacy diagnostics first :heavy_check_mark:)
* [x] Track and add other diagnostics related tests from `development`
  * [x] #7282
  * [x] #7931
  * [x] ~~#9705~~
  * [x] #11177
  * [x] #11184
  * [x] #11203
  * [x] ~~#11516~~ doesn't apply to `4.3_bugfix` (tests pass just fine but are useless there)
  * [x] #11695
* [x] Backport other diagnostics related fixes
  * [x] #11220
  * [x] Kinda related: https://github.com/HaxeFoundation/haxe/commit/19cc8a50d3f90d1afa0452e7cf5ae0867106fc37
  * [x] https://github.com/HaxeFoundation/haxe/commit/160a49095d5e54fe65345c896c7d02d18369b9ce for #7282 
  * [x] ddef63886e69bb78e7623820a20b5b06fc49ba50, e4ca1c81f00082a22caa3fcde4663bd822caf2fb, 19cc8a50d3f90d1afa0452e7cf5ae0867106fc37
  * [x] Remove `populateCacheFromDisplay` https://github.com/HaxeFoundation/haxe/pull/11696/commits/0f40f12d46ab33b19eedd070084e4f80f7fae1b2
  * [x] #11709
* [x] Add doc to `DisplayMethods.Diagnostics`... (same in `development`)