### PR TITLE
[hl] Fix debug info missing for catch e:String, arg with unify error

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -3025,6 +3025,7 @@ and eval_expr ctx e =
 					op ctx (OCall2 (rb, alloc_fun_path ctx (["hl"],"BaseType") "check",r,rtrap));
 					let jnext = jump ctx (fun n -> OJFalse (rb,n)) in
 					op ctx (OMov (rv, unsafe_cast_to ~debugchk:false ctx rtrap (to_type ctx v.v_type) ec.epos));
+					add_assign ctx v;
 					jnext
 				in
 				let r = eval_expr ctx ec in

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -1006,8 +1006,8 @@ let not_debug_var ctx v = match v.v_kind with
 	| VInlinedConstructorVariable _ -> false
 	| _ -> true
 
-let add_assign ctx v =
-	if not_debug_var ctx v then () else
+let add_assign ?(force=false) ctx v =
+	if not force && not_debug_var ctx v then () else
 	let name = real_name v in
 	ctx.m.massign <- (alloc_string ctx name, current_pos ctx - 1) :: ctx.m.massign
 
@@ -3291,7 +3291,7 @@ and make_fun ?gen_content ctx name fidx f cthis cparent =
 	let args = List.map (fun (v,o) ->
 		let t = to_type ctx v.v_type in
 		let r = alloc_var ctx (if o = None then v else { v with v_type = if not (is_nullable t) then TAbstract(ctx.ref_abstract,[v.v_type]) else v.v_type }) true in
-		add_assign ctx v; (* record var name *)
+		add_assign ~force:true ctx v; (* record var name *)
 		rtype ctx r
 	) f.tf_args in
 


### PR DESCRIPTION
Improve hl debug info for the debugger in the following cases:

- When break in `catch(e:String)`, e is not displayed in debugger
```haxe
class Test {
	static function doThrow() {
		throw "from doThrow";
	}
	static function main() {
		try {
			doThrow();
		} catch(e:String) {
			trace(e); // break here does not diaplay e
		}
	}
}
```

- When break in a override function and the type cannot be unified (`item` in args becomes `VGenerated _tmp_item`), related: https://github.com/vshaxe/hashlink-debugger/issues/75
```haxe
class Test { 
	static function main() {
		var iig = new InventoryItemGroup();
		var it = new Item();
		var data = {count : 1, k : it};
		var icon = iig.makeIcon(data);
		trace(icon);
	}
}
class SlotGroup<T> {
	public function new() {}
	public function makeIcon( item : SlotItem<T> ) : String {
		return "" + item;
	}
}
class InventoryItemGroup extends SlotGroup<Item> {
	override function makeIcon(item : SlotItem<Item>) {
		trace(item); // break here does not diaplay item, only visible in next line
		return super.makeIcon(item);
	}
}
class Item {
	public function new() {}
}
abstract SlotItem<T>({ count : Int, k : T }) {
	@:from public inline static function from<T>( data : { count : Int, k : T } ) : SlotItem<T> {
		return cast data;
	}
}
```
