### PR TITLE
[macro] Add modules created with defineType/defineModule as dependency of current module

### DIFF
--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -491,22 +491,22 @@ let rec add_modules sctx com delay (m : module_def) (from_binary : bool) (p : po
 	let rec add_modules tabs m0 m =
 		if m.m_extra.m_added < com.compilation_step then begin
 			let add_module mpath msign =
-					if msign = own_sign then begin
-						let m2 = try
-							com.module_lut#find mpath
-						with Not_found ->
-							match type_module sctx com delay mpath p with
-							| GoodModule m ->
-								m
-							| BinaryModule mc ->
-								failwith (Printf.sprintf "Unexpectedly found unresolved binary module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
-							| NoModule ->
-								failwith (Printf.sprintf "Unexpectedly could not find module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
-							| BadModule reason ->
-								failwith (Printf.sprintf "Unexpected bad module %s (%s) as a dependency of %s" (s_type_path mpath) (Printer.s_module_skip_reason reason) (s_type_path m0.m_path))
-						in
-						add_modules (tabs ^ "  ") m0 m2
-					end
+				if msign = own_sign then begin
+					let m2 = try
+						com.module_lut#find mpath
+					with Not_found ->
+						match type_module sctx com delay mpath p with
+						| GoodModule m ->
+							m
+						| BinaryModule mc ->
+							failwith (Printf.sprintf "Unexpectedly found unresolved binary module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
+						| NoModule ->
+							failwith (Printf.sprintf "Unexpectedly could not find module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
+						| BadModule reason ->
+							failwith (Printf.sprintf "Unexpected bad module %s (%s) as a dependency of %s" (s_type_path mpath) (Printer.s_module_skip_reason reason) (s_type_path m0.m_path))
+					in
+					add_modules (tabs ^ "  ") m0 m2
+				end
 			in
 
 			m.m_extra.m_added <- com.compilation_step;

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -491,22 +491,22 @@ let rec add_modules sctx com delay (m : module_def) (from_binary : bool) (p : po
 	let rec add_modules tabs m0 m =
 		if m.m_extra.m_added < com.compilation_step then begin
 			let add_module mpath msign =
-				if msign = own_sign then begin
-					let m2 = try
-						com.module_lut#find mpath
-					with Not_found ->
-						match type_module sctx com delay mpath p with
-						| GoodModule m ->
-							m
-						| BinaryModule mc ->
-							failwith (Printf.sprintf "Unexpectedly found unresolved binary module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
-						| NoModule ->
-							failwith (Printf.sprintf "Unexpectedly could not find module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
-						| BadModule reason ->
-							failwith (Printf.sprintf "Unexpected bad module %s (%s) as a dependency of %s" (s_type_path mpath) (Printer.s_module_skip_reason reason) (s_type_path m0.m_path))
-					in
-					add_modules (tabs ^ "  ") m0 m2
-				end
+					if msign = own_sign then begin
+						let m2 = try
+							com.module_lut#find mpath
+						with Not_found ->
+							match type_module sctx com delay mpath p with
+							| GoodModule m ->
+								m
+							| BinaryModule mc ->
+								failwith (Printf.sprintf "Unexpectedly found unresolved binary module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
+							| NoModule ->
+								failwith (Printf.sprintf "Unexpectedly could not find module %s as a dependency of %s" (s_type_path mpath) (s_type_path m0.m_path))
+							| BadModule reason ->
+								failwith (Printf.sprintf "Unexpected bad module %s (%s) as a dependency of %s" (s_type_path mpath) (Printer.s_module_skip_reason reason) (s_type_path m0.m_path))
+						in
+						add_modules (tabs ^ "  ") m0 m2
+					end
 			in
 
 			m.m_extra.m_added <- com.compilation_step;

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -472,8 +472,10 @@ class hxb_reader_api_server
 		com.display.dms_full_typing
 end
 
-let handle_cache_bound_objects com cbol =
+let handle_cache_bound_objects com cbol add_module =
 	DynArray.iter (function
+		| GeneratedModule(mpath,msign) ->
+			add_module mpath msign
 		| Resource(name,data) ->
 			Hashtbl.replace com.resources name data
 		| IncludeFile(file,position) ->
@@ -488,29 +490,8 @@ let rec add_modules sctx com delay (m : module_def) (from_binary : bool) (p : po
 	let own_sign = CommonCache.get_cache_sign com in
 	let rec add_modules tabs m0 m =
 		if m.m_extra.m_added < com.compilation_step then begin
-			m.m_extra.m_added <- com.compilation_step;
-			(match m0.m_extra.m_kind, m.m_extra.m_kind with
-			| MCode, MMacro | MMacro, MCode ->
-				(* this was just a dependency to check : do not add to the context *)
-				handle_cache_bound_objects com m.m_extra.m_cache_bound_objects;
-			| _ ->
-				ServerMessage.reusing com tabs m;
-				List.iter (fun t ->
-					(t_infos t).mt_restore()
-				) m.m_types;
-				(* The main module gets added when reading hxb already, so let's not add it again. Note that we
-				   can't set its m_added ahead of time because we want the rest of the logic here to run. *)
-				if not from_binary || m != m then
-					com.module_lut#add m.m_path m;
-				handle_cache_bound_objects com m.m_extra.m_cache_bound_objects;
-				let full_restore =
-					com.is_macro_context
-					|| com.display.dms_full_typing
-					|| DisplayPosition.display_position#is_in_file (Path.UniqueKey.lazy_key m.m_extra.m_file)
-				in
-				PMap.iter (fun _ mdep ->
-					let mpath = mdep.md_path in
-					if mdep.md_sign = own_sign then begin
+			let add_module mpath msign =
+					if msign = own_sign then begin
 						let m2 = try
 							com.module_lut#find mpath
 						with Not_found ->
@@ -526,7 +507,29 @@ let rec add_modules sctx com delay (m : module_def) (from_binary : bool) (p : po
 						in
 						add_modules (tabs ^ "  ") m0 m2
 					end
-				) (if full_restore then m.m_extra.m_deps else Option.default m.m_extra.m_deps m.m_extra.m_sig_deps)
+			in
+
+			m.m_extra.m_added <- com.compilation_step;
+			(match m0.m_extra.m_kind, m.m_extra.m_kind with
+			| MCode, MMacro | MMacro, MCode ->
+				(* this was just a dependency to check : do not add to the context *)
+				handle_cache_bound_objects com m.m_extra.m_cache_bound_objects add_module;
+			| _ ->
+				ServerMessage.reusing com tabs m;
+				List.iter (fun t ->
+					(t_infos t).mt_restore()
+				) m.m_types;
+				(* The main module gets added when reading hxb already, so let's not add it again. Note that we
+				   can't set its m_added ahead of time because we want the rest of the logic here to run. *)
+				if not from_binary || m != m then
+					com.module_lut#add m.m_path m;
+				handle_cache_bound_objects com m.m_extra.m_cache_bound_objects add_module;
+				let full_restore =
+					com.is_macro_context
+					|| com.display.dms_full_typing
+					|| DisplayPosition.display_position#is_in_file (Path.UniqueKey.lazy_key m.m_extra.m_file)
+				in
+				PMap.iter (fun _ mdep -> add_module mdep.md_path mdep.md_sign) (if full_restore then m.m_extra.m_deps else Option.default m.m_extra.m_deps m.m_extra.m_sig_deps)
 			)
 		end
 	in

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -618,7 +618,6 @@ module Printer = struct
 		| MDepFromTyping -> "MDepFromTyping"
 		| MDepFromMacro -> "MDepFromMacro"
 		| MDepFromMacroInclude -> "MDepFromMacroInclude"
-		| MDepFromMacroDefine -> "MDepFromMacroDefine"
 
 	let s_module_tainting_reason = function
 		| CheckDisplayFile -> "check_display_file"

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -618,6 +618,7 @@ module Printer = struct
 		| MDepFromTyping -> "MDepFromTyping"
 		| MDepFromMacro -> "MDepFromMacro"
 		| MDepFromMacroInclude -> "MDepFromMacroInclude"
+		| MDepFromMacroDefine -> "MDepFromMacroDefine"
 
 	let s_module_tainting_reason = function
 		| CheckDisplayFile -> "check_display_file"

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -57,6 +57,7 @@ type type_param_host =
 	| TPHUnbound
 
 type cache_bound_object =
+	| GeneratedModule of (string list * string) * Digest.t
 	| Resource of string * string
 	| IncludeFile of string * string
 	| Warning of WarningList.warning * string * pos
@@ -408,8 +409,6 @@ and module_dep_origin =
 	| MDepFromMacro
 	(* Compiler.include loads module with this special origin, which tells add_dependency not to add as a proper dependency. *)
 	| MDepFromMacroInclude
-	(* Modules created via Compiler.defineType or Compiler.defineModule will be added as dependency to their "parent" module with this origin. *)
-	| MDepFromMacroDefine
 
 and module_dep = {
 	md_sign : Digest.t;

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -57,7 +57,6 @@ type type_param_host =
 	| TPHUnbound
 
 type cache_bound_object =
-	| GeneratedModule of (string list * string) * Digest.t
 	| Resource of string * string
 	| IncludeFile of string * string
 	| Warning of WarningList.warning * string * pos
@@ -409,6 +408,8 @@ and module_dep_origin =
 	| MDepFromMacro
 	(* Compiler.include loads module with this special origin, which tells add_dependency not to add as a proper dependency. *)
 	| MDepFromMacroInclude
+	(* Modules created via Compiler.defineType or Compiler.defineModule will be added as dependency to their "parent" module with this origin. *)
+	| MDepFromMacroDefine
 
 and module_dep = {
 	md_sign : Digest.t;

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -406,7 +406,10 @@ and module_dep_origin =
 	| MDepFromTyping
 	| MDepFromImport
 	| MDepFromMacro
+	(* Compiler.include loads module with this special origin, which tells add_dependency not to add as a proper dependency. *)
 	| MDepFromMacroInclude
+	(* Modules created via Compiler.defineType or Compiler.defineModule will be added as dependency to their "parent" module with this origin. *)
+	| MDepFromMacroDefine
 
 and module_dep = {
 	md_sign : Digest.t;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -467,7 +467,7 @@ let make_macro_api ctx mctx p =
 			let mctx = (match ctx.g.macros with None -> die "" __LOC__ | Some (_,mctx) -> mctx) in
 			let ttype = Typeload.load_instance mctx (make_ptp cttype p) ParamNormal LoadNormal in
 			let f () = Interp.decode_type_def v in
-			let m, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
+			let mpath, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
 			let has_native_meta = match tdef with
 				| EClass d -> Meta.has Meta.Native d.d_meta
 				| EEnum d -> Meta.has Meta.Native d.d_meta
@@ -477,10 +477,10 @@ let make_macro_api ctx mctx p =
 			in
 			let add is_macro ctx =
 				let mdep = Option.map_default (fun s -> TypeloadModule.load_module ~origin:MDepFromMacro ctx (parse_path s) pos) ctx.m.curmod mdep in
-				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) m (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) [tdef,pos] pos in
+				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) mpath (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) [tdef,pos] pos in
 				mnew.m_extra.m_kind <- if is_macro then MMacro else MFake;
 				add_dependency mnew mdep MDepFromMacro;
-				add_dependency mdep mnew MDepFromMacroDefine;
+				DynArray.add mdep.m_extra.m_cache_bound_objects (GeneratedModule (mpath, mnew.m_extra.m_sign));
 				ctx.com.module_nonexistent_lut#clear;
 			in
 			add false ctx;
@@ -511,7 +511,7 @@ let make_macro_api ctx mctx p =
 				let mnew = TypeloadModule.type_module ctx.com ctx.g mpath (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) types pos in
 				mnew.m_extra.m_kind <- MFake;
 				add_dependency mnew ctx.m.curmod MDepFromMacro;
-				add_dependency ctx.m.curmod mnew MDepFromMacroDefine;
+				DynArray.add ctx.m.curmod.m_extra.m_cache_bound_objects (GeneratedModule (mpath, mnew.m_extra.m_sign));
 				ctx.com.module_nonexistent_lut#clear;
 			end
 		);

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -480,6 +480,7 @@ let make_macro_api ctx mctx p =
 				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) m (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) [tdef,pos] pos in
 				mnew.m_extra.m_kind <- if is_macro then MMacro else MFake;
 				add_dependency mnew mdep MDepFromMacro;
+				add_dependency mdep mnew MDepFromMacroDefine;
 				ctx.com.module_nonexistent_lut#clear;
 			in
 			add false ctx;
@@ -510,6 +511,7 @@ let make_macro_api ctx mctx p =
 				let mnew = TypeloadModule.type_module ctx.com ctx.g mpath (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) types pos in
 				mnew.m_extra.m_kind <- MFake;
 				add_dependency mnew ctx.m.curmod MDepFromMacro;
+				add_dependency ctx.m.curmod mnew MDepFromMacroDefine;
 				ctx.com.module_nonexistent_lut#clear;
 			end
 		);

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -467,7 +467,7 @@ let make_macro_api ctx mctx p =
 			let mctx = (match ctx.g.macros with None -> die "" __LOC__ | Some (_,mctx) -> mctx) in
 			let ttype = Typeload.load_instance mctx (make_ptp cttype p) ParamNormal LoadNormal in
 			let f () = Interp.decode_type_def v in
-			let mpath, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
+			let m, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
 			let has_native_meta = match tdef with
 				| EClass d -> Meta.has Meta.Native d.d_meta
 				| EEnum d -> Meta.has Meta.Native d.d_meta
@@ -477,10 +477,10 @@ let make_macro_api ctx mctx p =
 			in
 			let add is_macro ctx =
 				let mdep = Option.map_default (fun s -> TypeloadModule.load_module ~origin:MDepFromMacro ctx (parse_path s) pos) ctx.m.curmod mdep in
-				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) mpath (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) [tdef,pos] pos in
+				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) m (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) [tdef,pos] pos in
 				mnew.m_extra.m_kind <- if is_macro then MMacro else MFake;
 				add_dependency mnew mdep MDepFromMacro;
-				DynArray.add mdep.m_extra.m_cache_bound_objects (GeneratedModule (mpath, mnew.m_extra.m_sign));
+				add_dependency mdep mnew MDepFromMacroDefine;
 				ctx.com.module_nonexistent_lut#clear;
 			in
 			add false ctx;
@@ -511,7 +511,7 @@ let make_macro_api ctx mctx p =
 				let mnew = TypeloadModule.type_module ctx.com ctx.g mpath (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) types pos in
 				mnew.m_extra.m_kind <- MFake;
 				add_dependency mnew ctx.m.curmod MDepFromMacro;
-				DynArray.add ctx.m.curmod.m_extra.m_cache_bound_objects (GeneratedModule (mpath, mnew.m_extra.m_sign));
+				add_dependency ctx.m.curmod mnew MDepFromMacroDefine;
 				ctx.com.module_nonexistent_lut#clear;
 			end
 		);

--- a/tests/server/src/cases/issues/Issue11720.hx
+++ b/tests/server/src/cases/issues/Issue11720.hx
@@ -1,0 +1,22 @@
+package cases.issues;
+
+import haxe.display.Diagnostic;
+
+class Issue11720 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11720/Main.hx"));
+		vfs.putContent("Macro.hx", getTemplate("issues/Issue11720/Macro.hx"));
+		vfs.putContent("data/Weapon.hx", getTemplate("issues/Issue11720/data/Weapon.hx"));
+		vfs.putContent("col/Collection.hx", getTemplate("issues/Issue11720/col/Collection.hx"));
+		vfs.putContent("col/Item.hx", getTemplate("issues/Issue11720/col/Item.hx"));
+
+		var args = ["-main", "Main", "--macro", "include('data',true)", "--interp"];
+		runHaxe(args);
+		debugErrorMessages();
+		assertSuccess();
+
+		runHaxe(args);
+		assertSuccess();
+		assertHasPrint("Main.hx:4: data.WeaponCollection has been generated");
+	}
+}

--- a/tests/server/test/templates/issues/Issue11720/Macro.hx
+++ b/tests/server/test/templates/issues/Issue11720/Macro.hx
@@ -1,0 +1,23 @@
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.TypeTools;
+
+class Macro {
+	public static function build() {
+		var fields = Context.getBuildFields();
+		var cl = Context.getLocalClass().get();
+		var itemType = Context.getLocalType();
+		var itemComplexType = TypeTools.toComplexType(itemType);
+
+		var type:TypeDefinition = {
+			pos: Context.currentPos(),
+			name: cl.name + "Collection",
+			pack: cl.pack,
+			kind: TDClass({pack: ["col"], name: "Collection", params: [TPType(itemComplexType)]}),
+			fields: [],
+		}
+
+		Context.defineType(type);
+		return fields;
+	}
+}

--- a/tests/server/test/templates/issues/Issue11720/Main.hx
+++ b/tests/server/test/templates/issues/Issue11720/Main.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		var collectionType = Type.resolveClass("data.WeaponCollection");
+		if (collectionType != null) trace("data.WeaponCollection has been generated");
+	}
+}

--- a/tests/server/test/templates/issues/Issue11720/col/Collection.hx
+++ b/tests/server/test/templates/issues/Issue11720/col/Collection.hx
@@ -1,0 +1,7 @@
+package col;
+
+import col.Item;
+
+class Collection<T:Item> {
+	public var items:Array<T>;
+}

--- a/tests/server/test/templates/issues/Issue11720/col/Item.hx
+++ b/tests/server/test/templates/issues/Issue11720/col/Item.hx
@@ -1,0 +1,5 @@
+package col;
+@:autoBuild(Macro.build())
+abstract class Item {
+    
+}

--- a/tests/server/test/templates/issues/Issue11720/data/Weapon.hx
+++ b/tests/server/test/templates/issues/Issue11720/data/Weapon.hx
@@ -1,0 +1,7 @@
+package data;
+
+typedef Image = {}
+
+class Weapon extends col.Item {
+	public var picture:Image;
+}


### PR DESCRIPTION
This makes sure those modules will be pulled from cache when restoring current module.
I can't think of a problem that doing this could cause right now; hopefully I'm not missing something obvious :thinking: 

This was not a problem pre-hxb (in most cases at least?) because we were keeping modules in the cache even if not referenced from anywhere.