### PR TITLE
[hlc] Use uint64 instead of uint64_t for shift cast

### DIFF
--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -846,7 +846,7 @@ let generate_function ctx f =
 			sexpr "%s = %s >> %s" (reg r) (reg a) (reg b)
 		| OUShr (r,a,b) ->
 			(match rtype r with
-			| HI64 -> sexpr "%s = ((uint64_t)%s) >> %s" (reg r) (reg a) (reg b)
+			| HI64 -> sexpr "%s = ((uint64)%s) >> %s" (reg r) (reg a) (reg b)
 			| _ -> sexpr "%s = ((unsigned)%s) >> %s" (reg r) (reg a) (reg b)
 			);
 		| OAnd (r,a,b) ->


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/haxe/issues/11718

`uint64` is defined in `hl.h` for all platforms as `typedef unsigned long long uint64;`, and `hl.h` is included everywhere, so I think it's safe to just generate based on `uint64`.