### PR TITLE
[hl] Fix interface override function resolution

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -574,6 +574,8 @@ and class_type ?(tref=None) ctx c pl statics =
 			PMap.fold (fun cf acc -> cfield_type ctx cf :: acc) c.cl_fields fields
 		in
 		let fields = loop c in
+		(* remove fields from cl_implements having the same name. they might have different type but we only need the one in child *)
+		let fields = List.sort_uniq (fun (n1,_,_) (n2,_,_) -> compare n1 n2) fields in
 		vp.vfields <- Array.of_list fields;
 		Array.iteri (fun i (n,_,_) -> vp.vindex <- PMap.add n i vp.vindex) vp.vfields;
 		t

--- a/tests/unit/src/unit/issues/Issue11723.hx
+++ b/tests/unit/src/unit/issues/Issue11723.hx
@@ -1,0 +1,115 @@
+package unit.issues;
+
+@:keep
+private interface IEntity {
+	var id:Int;
+	function getVariable(varName:String):IVariable;
+	function containsVariable(varName:String):Bool;
+}
+
+@:keep
+private interface IUser extends IEntity {
+	var id:Int;
+	var name:String;
+	function getVariable(name:String):IUserVariable;
+	function setVariable(userVariable:IUserVariable):Void;
+}
+
+private class BasicUser implements IUser {
+	public var id:Int;
+	public var name:String;
+
+	private var _variables:haxe.ds.StringMap<IUserVariable>;
+
+	public function new(id:Int, name:String) {
+		this.id = id;
+		this.name = name;
+		_variables = new haxe.ds.StringMap();
+	}
+
+	public function getVariable(name:String):IUserVariable {
+		var get = _variables.get(name);
+		return cast(get, IUserVariable);
+	}
+
+	public function containsVariable(name:String):Bool {
+		var get = _variables.get(name);
+		return get != null;
+	}
+
+	public function setVariable(userVariable:IUserVariable):Void {
+		if (userVariable != null) {
+			_variables.set(userVariable.name, userVariable);
+		}
+	}
+}
+
+@:keep
+private interface IVariable {
+	var name:String;
+	var type:String;
+	function getValue():Dynamic;
+	function getIntValue():Int;
+	function getStringValue():String;
+}
+
+@:keep
+private interface IUserVariable extends IVariable {
+	var isPrivate:Bool;
+}
+
+private class BaseVariable implements IVariable {
+	public var name:String;
+	public var type:String;
+
+	private var _value:Any;
+
+	public function new(name:String, value:Any, type:String) {
+		this.name = name;
+		this.type = type;
+		_value = value;
+	}
+
+	public function getValue():Dynamic {
+		return _value;
+	}
+
+	public function getIntValue():Int {
+		return cast(_value, Int);
+	}
+
+	public function getStringValue():String {
+		return cast(_value, String);
+	}
+}
+
+private class BasicUserVariable extends BaseVariable implements IUserVariable {
+	public var isPrivate:Bool;
+
+	public function new(name:String, value:Any, type:String) {
+		super(name, value, type);
+	}
+}
+
+class Issue11723 extends Test {
+	public function test() {
+		var varname = "TestVar";
+		var myVariable = new BasicUserVariable(varname, "Testvalue", "String");
+		eq("Testvalue", myVariable.getStringValue());
+
+		var myUser = new BasicUser(1, "myUser");
+		myUser.setVariable(myVariable);
+		var formUser = myUser.getVariable(varname);
+		eq("Testvalue", formUser.getStringValue());
+
+		var bareEntity:IEntity = myUser;
+		var fromBareEntity = bareEntity.getVariable(varname);
+		eq("Testvalue", fromBareEntity.getStringValue());
+		t(bareEntity.containsVariable(varname));
+
+		var bareUser:IUser = myUser;
+		var fromBareUser = bareUser.getVariable(varname);
+		eq("Testvalue", fromBareUser.getStringValue());
+		t(bareUser.containsVariable(varname));
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/hashlink/issues/685

Happens when an interface extends another, and they have a same field (same name, but might have different type, in this case, return type extends parent's return type). Before the fix, tests will fail with `-D hl-check` then calls a different function / access violation when calling `fromBareUser.getStringValue()`.

~~I'm not sure if `List.sort_uniq` will always keep the first occurrence in the list, but this implementation rely on that. If that's not guaranteed I can implement my own version.~~
Implemented an uniq which keep child's fields before parent's. List.sort is not necessary here but it's used in vfields at other location.