### PR TITLE
[hl] add element type to HArray

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2012,11 +2012,13 @@ and eval_expr ctx e =
 		| "$aalloc", [esize] ->
 			let et = (match follow e.etype with TAbstract ({ a_path = ["hl"],"NativeArray" },[t]) -> to_type ctx t | _ -> invalid()) in
 			let size = eval_to ctx esize HI32 in
-			let a = alloc_tmp ctx (HArray et) in
+			let a = alloc_tmp ctx (HArray HDyn) in
+			let b = alloc_tmp ctx (HArray et) in
 			let rt = alloc_tmp ctx HType in
 			op ctx (OType (rt,et));
-			op ctx (OCall2 (a,alloc_std ctx "alloc_array" [HType;HI32] (HArray et),rt,size));
-			a
+			op ctx (OCall2 (a,alloc_std ctx "alloc_array" [HType;HI32] (HArray HDyn),rt,size));
+			op ctx (OUnsafeCast(b,a));
+			b
 		| "$aget", [a; pos] ->
 			(*
 				read/write on arrays are unsafe : the type of NativeArray needs to be correcly set.

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -78,6 +78,7 @@ type array_impl = {
 	ai32 : tclass;
 	af32 : tclass;
 	af64 : tclass;
+	ai64 : tclass;
 }
 
 type constval =
@@ -151,7 +152,7 @@ let is_extern_field f =
 
 let is_array_class name =
 	match name with
-	| "hl.types.ArrayDyn" | "hl.types.ArrayBytes_Int" | "hl.types.ArrayBytes_Float" | "hl.types.ArrayObj" | "hl.types.ArrayBytes_hl_F32" | "hl.types.ArrayBytes_hl_UI16" -> true
+	| "hl.types.ArrayDyn" | "hl.types.ArrayBytes_Int" | "hl.types.ArrayBytes_Float" | "hl.types.ArrayObj" | "hl.types.ArrayBytes_hl_F32" | "hl.types.ArrayBytes_hl_UI16" | "hl.types.ArrayBytes_hl_I64" -> true
 	| _ -> false
 
 let is_array_type t =
@@ -287,6 +288,8 @@ let array_class ctx t =
 		ctx.array_impl.af32
 	| HF64 ->
 		ctx.array_impl.af64
+	| HI64 ->
+		ctx.array_impl.ai64
 	| HDyn ->
 		ctx.array_impl.adyn
 	| _ ->
@@ -1423,7 +1426,7 @@ and get_access ctx e =
 
 and array_read ctx ra (at,vt) ridx p =
 	match at with
-	| HUI8 | HUI16 | HI32 | HF32 | HF64 ->
+	| HUI8 | HUI16 | HI32 | HF32 | HF64 | HI64 ->
 		(* check bounds *)
 		hold ctx ridx;
 		let length = alloc_tmp ctx HI32 in
@@ -1432,7 +1435,7 @@ and array_read ctx ra (at,vt) ridx p =
 		let j = jump ctx (fun i -> OJULt (ridx,length,i)) in
 		let r = alloc_tmp ctx (match at with HUI8 | HUI16 -> HI32 | _ -> at) in
 		(match at with
-		| HUI8 | HUI16 | HI32 ->
+		| HUI8 | HUI16 | HI32 | HI64 ->
 			op ctx (OInt (r,alloc_i32 ctx 0l));
 		| HF32 | HF64 ->
 			op ctx (OFloat (r,alloc_float ctx 0.));
@@ -2554,7 +2557,7 @@ and eval_expr ctx e =
 					op ctx (OCall2 (alloc_tmp ctx HVoid, alloc_fun_path ctx (array_class ctx at).cl_path "__expand", ra, ridx));
 					j();
 					match at with
-					| HI32 | HF64 | HUI16 | HF32 ->
+					| HI32 | HF64 | HUI16 | HF32 | HI64 ->
 						let b = alloc_tmp ctx HBytes in
 						op ctx (OField (b,ra,1));
 						write_mem ctx b (shl ctx ridx (type_size_bits at)) at v
@@ -2830,6 +2833,8 @@ and eval_expr ctx e =
 			array_bytes 2 HF32 "F32" (fun b i r -> OSetMem (b,i,r))
 		| HF64 ->
 			array_bytes 3 HF64 "F64" (fun b i r -> OSetMem (b,i,r))
+		| HI64 ->
+			array_bytes 3 HI64 "I64" (fun b i r -> OSetMem (b,i,r))
 		| _ ->
 			let at = if is_dynamic et then et else HDyn in
 			let a = alloc_tmp ctx (HArray at) in
@@ -3143,7 +3148,7 @@ and gen_assign_op ctx acc e1 f =
 			op ctx (OCall2 (alloc_tmp ctx HVoid, alloc_fun_path ctx (array_class ctx at).cl_path "__expand", ra, ridx));
 			j();
 			match at with
-			| HUI8 | HUI16 | HI32 | HF32 | HF64 ->
+			| HUI8 | HUI16 | HI32 | HF32 | HF64 | HI64->
 				let hbytes = alloc_tmp ctx HBytes in
 				op ctx (OField (hbytes, ra, 1));
 				let ridx = shl ctx ridx (type_size_bits at) in
@@ -4152,6 +4157,7 @@ let create_context com dump =
 			ai32 = get_class "ArrayBytes_Int";
 			af32 = get_class "ArrayBytes_hl_F32";
 			af64 = get_class "ArrayBytes_Float";
+			ai64 = get_class "ArrayBytes_hl_I64";
 		};
 		base_class = get_class "Class";
 		base_enum = get_class "Enum";

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1181,6 +1181,8 @@ let make_types_idents htypes =
 			"t$nul_" ^ tstr t
 		| DSimple (HRef t) ->
 			"t$ref_" ^ (match make_desc t with DSimple _ -> tstr t | d -> desc_string d)
+		| DSimple (HArray t) ->
+			"t$array_" ^ (desc_string (make_desc t))
 		| DSimple t ->
 			"t$_" ^ tstr t
 		| DFun _ ->

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -117,7 +117,7 @@ let s_comp = function
 let core_types =
 	let vp = { vfields = [||]; vindex = PMap.empty } in
 	let ep = { ename = ""; eid = 0; eglobal = None; efields = [||] } in
-	[HVoid;HUI8;HUI16;HI32;HI64;HF32;HF64;HBool;HBytes;HDyn;HFun ([],HVoid);HObj null_proto;HArray;HType;HRef HVoid;HVirtual vp;HDynObj;HAbstract ("",0);HEnum ep;HNull HVoid;HMethod ([],HVoid);HStruct null_proto]
+	[HVoid;HUI8;HUI16;HI32;HI64;HF32;HF64;HBool;HBytes;HDyn;HFun ([],HVoid);HObj null_proto;HArray HDyn;HType;HRef HVoid;HVirtual vp;HDynObj;HAbstract ("",0);HEnum ep;HNull HVoid;HMethod ([],HVoid);HStruct null_proto]
 
 let tname str =
 	let n = String.concat "__" (ExtString.String.nsplit str ".") in
@@ -125,7 +125,7 @@ let tname str =
 
 let is_gc_ptr = function
 	| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool | HType | HRef _ | HMethod _ | HPacked _ -> false
-	| HBytes | HDyn | HFun _ | HObj _ | HArray | HVirtual _ | HDynObj | HAbstract _ | HEnum _ | HNull _ | HStruct _ -> true
+	| HBytes | HDyn | HFun _ | HObj _ | HArray _ | HVirtual _ | HDynObj | HAbstract _ | HEnum _ | HNull _ | HStruct _ -> true
 
 let is_ptr = function
 	| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool -> false
@@ -144,7 +144,7 @@ let rec ctype_no_ptr = function
 	| HDyn -> "vdynamic",1
 	| HFun _ -> "vclosure",1
 	| HObj p | HStruct p -> tname p.pname,0
-	| HArray -> "varray",1
+	| HArray _ -> "varray",1
 	| HType -> "hl_type",1
 	| HRef t -> let s,i = ctype_no_ptr t in s,i + 1
 	| HVirtual _ -> "vvirtual",1
@@ -192,7 +192,7 @@ let type_id t =
 	| HDyn -> "HDYN"
 	| HFun _ -> "HFUN"
 	| HObj _ -> "HOBJ"
-	| HArray -> "HARRAY"
+	| HArray _ -> "HARRAY"
 	| HType -> "HTYPE"
 	| HRef _ -> "HREF"
 	| HVirtual _ -> "HVIRTUAL"
@@ -237,7 +237,7 @@ let define ctx s =
 
 let rec define_type ctx t =
 	match t with
-	| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool | HBytes | HDyn | HArray | HType | HDynObj | HNull _ | HRef _ -> ()
+	| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool | HBytes | HDyn | HArray _ | HType | HDynObj | HNull _ | HRef _ -> ()
 	| HAbstract _ ->
 		define ctx "#include <hl/natives.h>";
 	| HFun (args,ret) | HMethod (args,ret) ->
@@ -744,7 +744,7 @@ let generate_function ctx f =
 			match rtype a, rtype b with
 			| (HUI8 | HUI16 | HI32 | HF32 | HF64 | HBool | HI64), (HUI8 | HUI16 | HI32 | HF32 | HF64 | HBool | HI64) ->
 				phys_compare()
-			| HBytes, HBytes | HArray,HArray ->
+			| HBytes, HBytes | HArray _,HArray _ ->
 				phys_compare()
 			| HType, HType ->
 				sexpr "if( hl_same_type(%s,%s) %s 0 ) {} else goto %s" (reg a) (reg b) (s_comp op) (label d)
@@ -1095,7 +1095,7 @@ let generate_function ctx f =
 			sexpr "hl_assert()"
 		| ORefData (r,d) ->
 			(match rtype d with
-			| HArray ->
+			| HArray _ ->
 				sexpr "%s = (%s)hl_aptr(%s,void*)" (reg r) (ctype (rtype r)) (reg d)
 			| _ ->
 				Globals.die "" __LOC__)
@@ -1138,7 +1138,7 @@ let make_types_idents htypes =
 	let types_descs = ref PMap.empty in
 	let rec make_desc t =
 		match t with
-		| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool | HBytes | HDyn | HArray | HType | HRef _ | HDynObj | HNull _ ->
+		| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool | HBytes | HDyn | HArray _ | HType | HRef _ | HDynObj | HNull _ ->
 			DSimple t
 		| HFun (tl,t) ->
 			DFun (List.map make_desc tl, make_desc t, true)

--- a/std/hl/NativeArray.hx
+++ b/std/hl/NativeArray.hx
@@ -94,5 +94,9 @@ package hl;
 		return null;
 	}
 
-	@:hlNative("std", "array_blit") public function blit(pos:Int, src:NativeArray<T>, srcPos:Int, srcLen:Int):Void {}
+	@:hlNative("std", "array_blit") static function real_blit(dest:NativeArray<Any>, pos:Int, src:NativeArray<Any>, srcPos:Int, srcLen:Int):Void {}
+
+	public inline function blit(pos:Int, src:NativeArray<T>, srcPos:Int, srcLen:Int):Void {
+		real_blit(cast this, pos, cast src, srcPos, srcLen);
+	}
 }

--- a/std/hl/types/ArrayBase.hx
+++ b/std/hl/types/ArrayBase.hx
@@ -148,4 +148,12 @@ class ArrayBase extends ArrayAccess {
 		a.size = length;
 		return a;
 	}
+
+	public static function allocI64(bytes:BytesAccess<I64>, length:Int) @:privateAccess {
+		var a:ArrayBytes.ArrayI64 = untyped $new(ArrayBytes.ArrayI64);
+		a.length = length;
+		a.bytes = bytes;
+		a.size = length;
+		return a;
+	}
 }

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -362,3 +362,4 @@ typedef ArrayI32 = ArrayBytes<Int>;
 typedef ArrayUI16 = ArrayBytes<UI16>;
 typedef ArrayF32 = ArrayBytes<F32>;
 typedef ArrayF64 = ArrayBytes<Float>;
+typedef ArrayI64 = ArrayBytes<I64>;

--- a/tests/unit/src/unit/issues/Issue11734.hx
+++ b/tests/unit/src/unit/issues/Issue11734.hx
@@ -1,0 +1,19 @@
+package unit.issues;
+
+import unit.Test;
+#if hl
+import hl.NativeArray;
+#end
+
+class Issue11734 extends Test {
+	#if hl
+	function test() {
+		var a = new hl.NativeArray<Float>(1);
+		a[0] = 0.0;
+		var b:NativeArray<Float> = new hl.NativeArray<Float>(1);
+		b[0] = 1.0;
+		a.blit(0, b, 0, 1);
+		feq(1.0, a[0]);
+	}
+	#end
+}


### PR DESCRIPTION
This changes HL's `HArray` to carry an element type, which I want to use to deal with the problems described in #11568.

At the moment we're getting some hl-check failures in the unit tests that all look like this:

```
  78 |   eq(arr[0].high, 0);
     |      ^^^
     | Check failure at fun@1660 @1B - array(dyn) should be array(i64)

 ERROR  src/unit/TestInt64.hx:79: characters 6-9

  79 |   eq(arr[0].low, 1);
     |      ^^^
     | Check failure at fun@1660 @35 - array(dyn) should be array(i64)
```

I suspect that there's some bad typing going on here involving unapplied type parameters, which lead to the unwanted `array(dyn)`.

Compiling a standalone

```haxe
function main() {
	var a = new haxe.atomic.AtomicInt(0);
}
```

on the other hand gives some very suspicious errors like these:

```
 ERROR  C:\git\haxe\std/hl/_std/String.hx:101: characters 13-15

 101 |   var out = [];
     |             ^^
     | Check failure at fun@7 @2 - array(i32) should be array(String)

 ERROR  C:\git\haxe\std/hl/_std/haxe/NativeStackTrace.hx:23: characters 29-34

  23 |   var arr = new NativeArray(count);
     |                             ^^^^^
     | Check failure at fun@258 @3 - array(i32) should be array(abstract(hl_symbol))
```

I currently have no idea where the `array(i32)` comes from. The dump looks normal:

```
	public static function exceptionStack[Function:() -> hl.NativeArray<haxe.Symbol>]
		[Block:Dynamic]
			[Var count<0>(VUsedByTyper):Int]
				[Call:Int]
					[Field:(arr : hl.NativeArray<haxe.Symbol>) -> Int]
						[TypeExpr haxe.NativeStackTrace:Class<haxe.NativeStackTrace>]
						[FStatic:(arr : hl.NativeArray<haxe.Symbol>) -> Int]
							haxe.NativeStackTrace
							exceptionStackRaw:(arr : hl.NativeArray<haxe.Symbol>) -> Int
					[Const:hl.NativeArray<haxe.Symbol>] null
			[Var arr<0>(VUsedByTyper):hl.NativeArray<haxe.Symbol>]
				[Call:hl.NativeArray<haxe.Symbol>]
					[Ident:Int -> Unknown<0>] $aalloc
					[Local count(0):Int:Int]
			[Call:Int]
				[Field:(arr : hl.NativeArray<haxe.Symbol>) -> Int]
					[TypeExpr haxe.NativeStackTrace:Class<haxe.NativeStackTrace>]
					[FStatic:(arr : hl.NativeArray<haxe.Symbol>) -> Int]
						haxe.NativeStackTrace
						exceptionStackRaw:(arr : hl.NativeArray<haxe.Symbol>) -> Int
				[Local arr(0):hl.NativeArray<haxe.Symbol>:hl.NativeArray<haxe.Symbol>]
			[Return:Dynamic] [Local arr(0):hl.NativeArray<haxe.Symbol>:hl.NativeArray<haxe.Symbol>]
```

Note how all occurrences of `hl.NativeArray` have `haxe.Symbol` as type parameter. This makes me think that there's an unrelated bug in genhl here.