### PR TITLE
Macro defined modules vs direct loading of types using it

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -310,7 +310,10 @@ let do_type ctx mctx actx display_file_dot_path =
 		com.callbacks#run com.error_ext com.callbacks#get_after_init_macros;
 		run_or_diagnose ctx (fun () ->
 			if com.display.dms_kind <> DMNone then DisplayTexpr.check_display_file tctx cs;
-			List.iter (fun cpath -> ignore(tctx.Typecore.g.Typecore.do_load_module tctx cpath null_pos)) (List.rev actx.classes);
+			List.iter (fun cpath ->
+				ignore(tctx.Typecore.g.Typecore.do_load_module tctx cpath null_pos);
+				Typecore.flush_pass tctx.g (PBuildClass:Typecore.typer_pass) "actx.classes"
+			) (List.rev actx.classes);
 			Finalization.finalize tctx;
 		);
 	end with TypeloadParse.DisplayInMacroBlock ->

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -312,7 +312,7 @@ let do_type ctx mctx actx display_file_dot_path =
 			if com.display.dms_kind <> DMNone then DisplayTexpr.check_display_file tctx cs;
 			List.iter (fun cpath ->
 				ignore(tctx.Typecore.g.Typecore.do_load_module tctx cpath null_pos);
-				Typecore.flush_pass tctx.g (PBuildClass:Typecore.typer_pass) "actx.classes"
+				Typecore.flush_pass tctx.g PBuildClass "actx.classes"
 			) (List.rev actx.classes);
 			Finalization.finalize tctx;
 		);

--- a/tests/misc/projects/Issue11004/build.hxml.stdout
+++ b/tests/misc/projects/Issue11004/build.hxml.stdout
@@ -1,1 +1,1 @@
-Bar.hx:27: @:storedTypedExpr 3 computed this_ident as: foo.bar
+Bar.hx:27: @:storedTypedExpr 1 computed this_ident as: foo.bar

--- a/tests/misc/projects/Issue11740/Baz.hx
+++ b/tests/misc/projects/Issue11740/Baz.hx
@@ -1,0 +1,6 @@
+import foo.Foo;
+
+class Baz {
+	function baz(data:foo.FooData) {}
+}
+

--- a/tests/misc/projects/Issue11740/Macro.macro.hx
+++ b/tests/misc/projects/Issue11740/Macro.macro.hx
@@ -1,0 +1,17 @@
+import haxe.macro.Context;
+
+class Macro {
+	public static function build() {
+		trace("build FooData");
+
+		Context.defineType({
+			pos : Context.currentPos(),
+			name : "FooData",
+			pack : ["foo"],
+			kind : TDClass(),
+			fields : [],
+		});
+
+		return null;
+	}
+}

--- a/tests/misc/projects/Issue11740/Main.hx
+++ b/tests/misc/projects/Issue11740/Main.hx
@@ -1,0 +1,5 @@
+import foo.Foo;
+
+function main() {
+	trace(Baz);
+}

--- a/tests/misc/projects/Issue11740/compile1.hxml
+++ b/tests/misc/projects/Issue11740/compile1.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp

--- a/tests/misc/projects/Issue11740/compile1.hxml.stdout
+++ b/tests/misc/projects/Issue11740/compile1.hxml.stdout
@@ -1,0 +1,2 @@
+Macro.macro.hx:5: build FooData
+Main.hx:4: Class<Baz>

--- a/tests/misc/projects/Issue11740/compile2.hxml
+++ b/tests/misc/projects/Issue11740/compile2.hxml
@@ -1,0 +1,3 @@
+-main Main
+Baz
+--interp

--- a/tests/misc/projects/Issue11740/compile2.hxml.stdout
+++ b/tests/misc/projects/Issue11740/compile2.hxml.stdout
@@ -1,0 +1,2 @@
+Macro.macro.hx:5: build FooData
+Main.hx:4: Class<Baz>

--- a/tests/misc/projects/Issue11740/foo/Foo.hx
+++ b/tests/misc/projects/Issue11740/foo/Foo.hx
@@ -1,0 +1,4 @@
+package foo;
+
+@:build(Macro.build())
+class Foo {}


### PR DESCRIPTION
While this looks like a very edge case / weird usage, this actually is easy to trigger in real use case because of diagnostics triggering similar behavior to `compile2.hxml`.

Not sure yet how to handle that, just pushing the repro for now.. 