### PR TITLE
[cpp] Null Check Interfaces

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4715,7 +4715,7 @@ let gen_member_def ctx class_def is_static is_interface field =
             let cast = "::hx::interface_cast< ::" ^ join_class_path_remap class_def.cl_path "::" ^ "_obj *>" in
             output ("		" ^ returnType ^ " (::hx::Object :: *_hx_" ^ remap_name ^ ")(" ^ argList ^ "); \n");
             output ("		static inline " ^ returnType ^ " " ^ remap_name ^ "( ::Dynamic _hx_" ^ commaArgList ^ ") {\n");
-            output ("         if (::hx::IsNull(::Dynamic(_hx_))) ::hx::NullReference("Object", false);");
+            output ("         if (::hx::IsNull(::Dynamic(_hx_))) ::hx::NullReference(\"Object\", false);");
             output ("			" ^ returnStr ^ "(_hx_.mPtr->*( " ^ cast ^ "(_hx_.mPtr->_hx_getInterface(" ^ (cpp_class_hash class_def) ^ ")))->_hx_" ^ remap_name ^ ")(" ^ cpp_arg_names args ^ ");\n		}\n" );
          end
       | _  ->  ( )

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4715,7 +4715,7 @@ let gen_member_def ctx class_def is_static is_interface field =
             let cast = "::hx::interface_cast< ::" ^ join_class_path_remap class_def.cl_path "::" ^ "_obj *>" in
             output ("		" ^ returnType ^ " (::hx::Object :: *_hx_" ^ remap_name ^ ")(" ^ argList ^ "); \n");
             output ("		static inline " ^ returnType ^ " " ^ remap_name ^ "( ::Dynamic _hx_" ^ commaArgList ^ ") {\n");
-            output ("         if (::hx::IsNull(::Dynamic(_hx_))) ::hx::NullReference(\"Object\", false);");
+            output ("         if (::hx::IsNull(_hx_)) ::hx::NullReference(\"Object\", false); \n");
             output ("			" ^ returnStr ^ "(_hx_.mPtr->*( " ^ cast ^ "(_hx_.mPtr->_hx_getInterface(" ^ (cpp_class_hash class_def) ^ ")))->_hx_" ^ remap_name ^ ")(" ^ cpp_arg_names args ^ ");\n		}\n" );
          end
       | _  ->  ( )

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4715,7 +4715,12 @@ let gen_member_def ctx class_def is_static is_interface field =
             let cast = "::hx::interface_cast< ::" ^ join_class_path_remap class_def.cl_path "::" ^ "_obj *>" in
             output ("		" ^ returnType ^ " (::hx::Object :: *_hx_" ^ remap_name ^ ")(" ^ argList ^ "); \n");
             output ("		static inline " ^ returnType ^ " " ^ remap_name ^ "( ::Dynamic _hx_" ^ commaArgList ^ ") {\n");
-            output ("         if (::hx::IsNull(_hx_)) ::hx::NullReference(\"Object\", false); \n");
+            output ("			#ifdef HXCPP_CHECK_POINTER\n");
+            output ("			if (::hx::IsNull(_hx_)) ::hx::NullReference(\"Object\", false);\n");
+            output ("			#ifdef HXCPP_GC_CHECK_POINTER\n");
+            output ("				GCCheckPointer(_hx_.mPtr);\n");
+            output ("			#endif\n");
+            output ("			#endif\n");
             output ("			" ^ returnStr ^ "(_hx_.mPtr->*( " ^ cast ^ "(_hx_.mPtr->_hx_getInterface(" ^ (cpp_class_hash class_def) ^ ")))->_hx_" ^ remap_name ^ ")(" ^ cpp_arg_names args ^ ");\n		}\n" );
          end
       | _  ->  ( )

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -4715,6 +4715,7 @@ let gen_member_def ctx class_def is_static is_interface field =
             let cast = "::hx::interface_cast< ::" ^ join_class_path_remap class_def.cl_path "::" ^ "_obj *>" in
             output ("		" ^ returnType ^ " (::hx::Object :: *_hx_" ^ remap_name ^ ")(" ^ argList ^ "); \n");
             output ("		static inline " ^ returnType ^ " " ^ remap_name ^ "( ::Dynamic _hx_" ^ commaArgList ^ ") {\n");
+            output ("         if (::hx::IsNull(::Dynamic(_hx_))) ::hx::NullReference("Object", false);");
             output ("			" ^ returnStr ^ "(_hx_.mPtr->*( " ^ cast ^ "(_hx_.mPtr->_hx_getInterface(" ^ (cpp_class_hash class_def) ^ ")))->_hx_" ^ remap_name ^ ")(" ^ cpp_arg_names args ^ ");\n		}\n" );
          end
       | _  ->  ( )

--- a/tests/unit/src/unit/issues/Issue11743.hx
+++ b/tests/unit/src/unit/issues/Issue11743.hx
@@ -1,0 +1,17 @@
+package unit.issues;
+
+#if cpp
+import utest.Assert;
+
+private interface IFoo {
+    function foo():Void;
+}
+
+class Issue11743 extends Test {
+    function test() {
+        final o : IFoo = null;
+
+        Assert.raises(() -> o.foo());
+    }
+}
+#end

--- a/tests/unit/src/unit/issues/Issue11743.hx
+++ b/tests/unit/src/unit/issues/Issue11743.hx
@@ -1,6 +1,5 @@
 package unit.issues;
 
-#if cpp
 import utest.Assert;
 
 private interface IFoo {
@@ -8,10 +7,12 @@ private interface IFoo {
 }
 
 class Issue11743 extends Test {
+
+    #if cpp
     function test() {
         final o : IFoo = null;
 
         Assert.raises(() -> o.foo());
     }
+    #end
 }
-#end


### PR DESCRIPTION
Adds a null check to the interface object before we start casting, dereferencing, and doing anything which will cause an access violation.

```haxe
interface IFoo {
    function foo():Void;
}

function main() {
    final o : IFoo = null;

    try {
        o.foo();
    catch (exn:Any) {
        trace(exn);
    }

    o.foo();
}
```

With the current behaviour null interface access cannot be caught and you will not get stack traces, adding the null check means it can now be caught and you will get stack traces. The used `NullReference` function is also used by the hxcpp debugger, so null interfaces will no longer crash the debugger.