### PR TITLE
[hl] Add hl.Bytes.fromNativeArray

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2056,6 +2056,11 @@ and eval_expr ctx e =
 				op ctx (ONullCheck a);
 				op ctx (OField (r,a,1));
 				r
+			| TAbstract ({ a_path = ["hl"],"NativeArray" },[t]) when is_number (to_type ctx t) ->
+				let a = eval_expr ctx a in
+				let r = alloc_tmp ctx HBytes in
+				op ctx (OUnsafeCast(r,a));
+				r
 			| t ->
 				abort ("Invalid array type " ^ s_type (print_context()) t) a.epos)
 		| "$ref", [v] ->

--- a/std/haxe/ds/Vector.hx
+++ b/std/haxe/ds/Vector.hx
@@ -232,7 +232,7 @@ abstract Vector<T>(VectorData<T>) {
 		#else
 		var a = new Array();
 		var len = length;
-		#if (neko)
+		#if (neko || hl)
 		// prealloc good size
 		if (len > 0)
 			a[len - 1] = get(0);

--- a/std/hl/Bytes.hx
+++ b/std/hl/Bytes.hx
@@ -211,6 +211,10 @@ package hl;
 		return untyped $abytes(a);
 	}
 
+	extern public static inline function getNativeArray<T>(a:hl.NativeArray<T>):Bytes {
+		return untyped $abytes(a);
+	}
+
 	@:from
 	public static inline function fromBytes(bytes:haxe.io.Bytes) {
 		return @:privateAccess bytes.b;


### PR DESCRIPTION
Trying to address heap issues in https://github.com/HaxeFoundation/haxe/pull/11568
It compile now but is still getting runtime access violation in game.

Here is heaps patch

```diff
diff --git a/h3d/impl/GlDriver.hx b/h3d/impl/GlDriver.hx
index 697672fc..3223e975 100644
--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -596,7 +596,8 @@ class GlDriver extends Driver {
 		case Globals:
 			if( s.globals != null ) {
 				#if hl
-				gl.uniform4fv(s.globals, streamData(hl.Bytes.getArray(buf.globals.toData()), 0, s.shader.globalsSize * 16), 0, s.shader.globalsSize * 4);
+				var bytes = #if (haxe_ver < 5.0) hl.Bytes.getArray(buf.globals.toData()) #else hl.Bytes.getNativeArray(buf.globals.toData()) #end;
+				gl.uniform4fv(s.globals, streamData(bytes, 0, s.shader.globalsSize * 16), 0, s.shader.globalsSize * 4);
 				#else
 				var a = buf.globals.subarray(0, s.shader.globalsSize * 4);
 				gl.uniform4fv(s.globals, a);
@@ -605,7 +606,8 @@ class GlDriver extends Driver {
 		case Params:
 			if( s.params != null ) {
 				#if hl
-				gl.uniform4fv(s.params, streamData(hl.Bytes.getArray(buf.params.toData()), 0, s.shader.paramsSize * 16), 0, s.shader.paramsSize * 4);
+				var bytes = #if (haxe_ver < 5.0) hl.Bytes.getArray(buf.params.toData()) #else hl.Bytes.getNativeArray(buf.params.toData()) #end;
+				gl.uniform4fv(s.params, streamData(bytes, 0, s.shader.paramsSize * 16), 0, s.shader.paramsSize * 4);
 				#else
 				var a = buf.params.subarray(0, s.shader.paramsSize * 4);
 				gl.uniform4fv(s.params, a);
diff --git a/h3d/impl/RenderContext.hx b/h3d/impl/RenderContext.hx
index a8751e06..50c92873 100644
--- a/h3d/impl/RenderContext.hx
+++ b/h3d/impl/RenderContext.hx
@@ -178,8 +178,10 @@ class RenderContext {
 	}
 
 	inline function getPtr( data : h3d.shader.Buffers.ShaderBufferData ) {
-		#if hl
+		#if (hl && haxe_ver < 5.0)
 		return (hl.Bytes.getArray((cast data : Array<Single>)) : hl.BytesAccess<hl.F32>);
+		#elseif hl
+		return (hl.Bytes.getNativeArray(data.toData()) : hl.BytesAccess<hl.F32>);
 		#else
 		return data;
 		#end
diff --git a/hxd/fmt/hmd/Library.hx b/hxd/fmt/hmd/Library.hx
index 80148527..14293ab8 100644
--- a/hxd/fmt/hmd/Library.hx
+++ b/hxd/fmt/hmd/Library.hx
@@ -257,7 +257,7 @@ class Library {
 				}
 				buf.indexes[i] = rid - 1;
 			}
-			#if neko
+			#if (neko || (hl && haxe_ver >= 5.0 ))
 			buf.vertexes = haxe.ds.Vector.fromArrayCopy(vertexes.getNative());
 			#else
 			buf.vertexes = haxe.ds.Vector.fromData(vertexes.getNative());
```