### PR TITLE
Split 'hxb read' timers

### DIFF
--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -440,7 +440,7 @@ class hxb_reader_api_server
 			let is_display_file = DisplayPosition.display_position#is_in_file (Path.UniqueKey.lazy_key mc.mc_extra.m_file) in
 			let full_restore = com.is_macro_context || com.display.dms_full_typing || is_display_file in
 			let f_next chunks until =
-				let t_hxb = Timer.timer ["server";"module cache";"hxb read"] in
+				let t_hxb = Timer.timer ["server";"module cache";"hxb read";"until " ^ (string_of_chunk_kind until)] in
 				let r = reader#read_chunks_until (self :> HxbReaderApi.hxb_reader_api) chunks until (not full_restore) in
 				t_hxb();
 				r
@@ -590,7 +590,7 @@ and type_module sctx com delay mpath p =
 							api
 					in
 					let f_next chunks until =
-						let t_hxb = Timer.timer ["server";"module cache";"hxb read"] in
+						let t_hxb = Timer.timer ["server";"module cache";"hxb read";"until " ^ (string_of_chunk_kind until)] in
 						let r = reader#read_chunks_until api chunks until (not full_restore) in
 						t_hxb();
 						r


### PR DESCRIPTION
Current "hxb read" timer is triggered twice per hxb module restored.

The timer will still be triggered twice per module restored, but now will be split based on what is being restored, which can also be useful to know about:

```
  server 1.047s (98.66%) [8038]
    module cache 1.047s (98.66%) [8036]
      hxb read 1.017s (95.81%) [5514]
        until EOT 0.609s (57.41%) [2757]
        until EOF 0.214s (20.17%) [2459]
        until EOM 0.193s (18.22%) [298]
```