### PR TITLE
[typer] Monomorph vs Null<T> inference

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -401,7 +401,7 @@ let rec type_ident_raise ctx i p mode with_type =
 					| TMono r when not (is_nullable t) ->
 						(* If our expected type is a monomorph, bind it to Null<?>. The is_nullable check is here because
 							the expected type could already be Null<?>, in which case we don't want to double-wrap (issue #11286). *)
-						Monomorph.do_bind r (tnull())
+						Monomorph.bind r (tnull())
 					| _ ->
 						(* Otherwise there's no need to create a monomorph, we can just type the null literal
 						the way we expect it. *)

--- a/tests/misc/projects/Issue11753/Main.hx
+++ b/tests/misc/projects/Issue11753/Main.hx
@@ -1,0 +1,31 @@
+class Main {
+	static var doThings : Foo -> Void;
+
+	static function main() {
+		var foo = new Foo();
+		doThings = (foo -> doThingsImpl(foo));
+		doThings(foo);
+	}
+
+	static function doThingsImpl(foo) {
+		foo.doWithBar();
+		$type(foo);
+		$type(foo.doWithBar);
+
+		if (foo != null) trace(foo);
+		$type(foo);
+		$type(foo.doWithBar);
+	}
+}
+
+class Foo {
+	public function new() {}
+	public function doWithBar(?bar:Bar) {
+		trace(bar);
+	}
+}
+
+@:keep
+class Bar {
+	public function new() {}
+}

--- a/tests/misc/projects/Issue11753/compile-fail.hxml
+++ b/tests/misc/projects/Issue11753/compile-fail.hxml
@@ -1,3 +1,4 @@
 -main Main
 --hl bin/main.hl
+-D message.reporting=pretty
 -D message.no-color

--- a/tests/misc/projects/Issue11753/compile-fail.hxml
+++ b/tests/misc/projects/Issue11753/compile-fail.hxml
@@ -1,0 +1,3 @@
+-main Main
+--hl bin/main.hl
+-D message.no-color

--- a/tests/misc/projects/Issue11753/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11753/compile-fail.hxml.stderr
@@ -1,0 +1,32 @@
+[WARNING] Main.hx:12: characters 9-12
+
+ 12 |   $type(foo);
+    |         ^^^
+    | Unknown<0> : { doWithBar : () -> Unknown<1> }
+
+[WARNING] Main.hx:13: characters 9-22
+
+ 13 |   $type(foo.doWithBar);
+    |         ^^^^^^^^^^^^^
+    | () -> Unknown<0>
+
+[WARNING] Main.hx:16: characters 9-12
+
+ 16 |   $type(foo);
+    |         ^^^
+    | Null<{ doWithBar : () -> Unknown<0> }>
+
+[WARNING] Main.hx:17: characters 9-22
+
+ 17 |   $type(foo.doWithBar);
+    |         ^^^^^^^^^^^^^
+    | () -> Unknown<0>
+
+[ERROR] Main.hx:6: characters 35-38
+
+  6 |   doThings = (foo -> doThingsImpl(foo));
+    |                                   ^^^
+    | error: (?bar : Null<Bar>) -> Void should be () -> Unknown<0>
+    | have: { doWithBar: (?...) -> ... }
+    | want: { doWithBar: () -> ... }
+


### PR DESCRIPTION
This is a regression introduced in 4.3.0 with https://github.com/HaxeFoundation/haxe/commit/02a7f9834b1327507eb9b6f646697960a0ec657f

This can also lead to `Fatal error: exception Invalid_argument("List.map2")` in genhl with a slightly different example.
Also allows this kind of things https://try.haxe.org/#05A1D90d

### 4.2.5

```
Main.hx:12: characters 9-12 : Warning : Unknown<0> : { doWithBar : () -> Unknown<1> }
Main.hx:13: characters 9-22 : Warning : () -> Unknown<0>
Main.hx:16: characters 9-12 : Warning : Unknown<0> : { doWithBar : () -> Unknown<1> }
Main.hx:17: characters 9-22 : Warning : () -> Unknown<0>
Main.hx:6: characters 35-38 : error: (?bar : Null<Bar>) -> Void should be () -> Unknown<0>
Main.hx:6: characters 35-38 : ... have: { doWithBar: (?...) -> ... }
Main.hx:6: characters 35-38 : ... want: { doWithBar: () -> ... }
Main.hx:6: characters 35-38 : ... For function argument 'foo'
```

### Since 4.3.0

Notice how we lose the `doWithBar` typing:

```
Main.hx:12: characters 9-12 : Warning : Unknown<0> : { doWithBar : () -> Unknown<1> }
Main.hx:13: characters 9-22 : Warning : () -> Unknown<0>
Main.hx:16: characters 9-12 : Warning : Null<Unknown<0>>
Main.hx:17: characters 9-22 : Warning : Unknown<0>
Main.hx:11: characters 3-16 : Don't know how to cast (Bar):void to ():dyn
```

### With this PR

```
[WARNING] Main.hx:12: characters 9-12

 12 |   $type(foo);
    |         ^^^
    | Unknown<0> : { doWithBar : () -> Unknown<1> }

[WARNING] Main.hx:13: characters 9-22

 13 |   $type(foo.doWithBar);
    |         ^^^^^^^^^^^^^
    | () -> Unknown<0>

[WARNING] Main.hx:16: characters 9-12

 16 |   $type(foo);
    |         ^^^
    | Null<{ doWithBar : () -> Unknown<0> }>

[WARNING] Main.hx:17: characters 9-22

 17 |   $type(foo.doWithBar);
    |         ^^^^^^^^^^^^^
    | () -> Unknown<0>

[ERROR] Main.hx:6: characters 35-38

  6 |   doThings = (foo -> doThingsImpl(foo));
    |                                   ^^^
    | error: (?bar : Null<Bar>) -> Void should be () -> Unknown<0>
    | have: { doWithBar: (?...) -> ... }
    | want: { doWithBar: () -> ... }
```