### PR TITLE
[make] Compile haxelib binary with hxcpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ haxelib_hxcpp: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
 	$(HAXELIB_INTERP) config > /dev/null || $(HAXELIB_INTERP) newrepo
 	$(HAXELIB_INTERP) path hxcpp > /dev/null || \
 		($(HAXELIB_INTERP) git hxcpp https://github.com/HaxeFoundation/hxcpp.git && \
-		hxcpp_path=`$(HAXELIB_INTERP) libpath hxcpp` && \
+		hxcpp_path=`$(HAXELIB_INTERP) libpath hxcpp | tr -d '\r'` && \
 		$(CURDIR)/$(HAXE_OUTPUT) --cwd $$hxcpp_path/tools/hxcpp compile.hxml)
 
 # haxelib should depends on haxe, but we don't want to do that...

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ HAXELIB_INTERP=HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) \
 # since haxelib isn't available in PATH yet, we have to pass -D no-compilation and build manually
 haxelib: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
 	$(HAXELIB_INTERP) config > /dev/null || $(HAXELIB_INTERP) newrepo
-	$(HAXELIB_INTERP) path hxcpp > /dev/null || $(HAXELIB_INTERP) install hxcpp
+	$(HAXELIB_INTERP) path hxcpp > /dev/null || $(HAXELIB_INTERP) install hxcpp --quiet
 	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
 		client_cpp.hxml -D destination=$(CURDIR)/$(HAXELIB_OUTPUT) -D no-compilation
 	$(HAXELIB_INTERP) --cwd $(HAXELIB_SRC_PATH)/bin/cpp run hxcpp Build.xml haxe

--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,14 @@ copy_haxetoolkit: /cygdrive/c/HaxeToolkit/haxe/haxe.exe
 	cp $< $@
 endif
 
+HAXE_STD_PATH=$(CURDIR)/std
 HAXELIB_SRC_PATH=$(CURDIR)/extra/haxelib_src
 
 $(HAXELIB_SRC_PATH)/haxelib_hxb.zip:
-	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
+	HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
 		each.hxml --interp haxelib.client.Main --hxb haxelib_hxb.zip
 
-HAXELIB_INTERP=HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) \
+HAXELIB_INTERP=HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) \
 	--hxb-lib $(HAXELIB_SRC_PATH)/haxelib_hxb.zip --run haxelib.client.Main
 
 # haxelib should depends on haxe, but we don't want to do that...
@@ -106,8 +107,8 @@ HAXELIB_INTERP=HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) \
 haxelib: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
 	$(HAXELIB_INTERP) config > /dev/null || $(HAXELIB_INTERP) newrepo
 	$(HAXELIB_INTERP) path hxcpp > /dev/null || $(HAXELIB_INTERP) install hxcpp --quiet
-	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
-		client_cpp.hxml -D destination=$(CURDIR)/$(HAXELIB_OUTPUT) -D no-compilation
+	HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
+		client_cpp.hxml -D destination=../../../../$(HAXELIB_OUTPUT) -D no-compilation
 	$(HAXELIB_INTERP) --cwd $(HAXELIB_SRC_PATH)/bin/cpp run hxcpp Build.xml haxe
 
 tools: haxelib

--- a/Makefile
+++ b/Makefile
@@ -93,13 +93,13 @@ copy_haxetoolkit: /cygdrive/c/HaxeToolkit/haxe/haxe.exe
 endif
 
 HAXE_STD_PATH=$(CURDIR)/std
-HAXELIB_SRC_PATH=$(CURDIR)/extra/haxelib_src
+HAXELIB_SRC_PATH=extra/haxelib_src
 
 $(HAXELIB_SRC_PATH)/haxelib_hxb.zip:
-	HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
+	HAXE_STD_PATH=$(HAXE_STD_PATH) ./$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
 		each.hxml --interp haxelib.client.Main --hxb haxelib_hxb.zip
 
-HAXELIB_INTERP=HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) \
+HAXELIB_INTERP=HAXE_STD_PATH=./std ./$(HAXE_OUTPUT) \
 	--hxb-lib $(HAXELIB_SRC_PATH)/haxelib_hxb.zip --run haxelib.client.Main
 
 haxelib_hxcpp: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
@@ -107,12 +107,12 @@ haxelib_hxcpp: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
 	$(HAXELIB_INTERP) path hxcpp > /dev/null || \
 		($(HAXELIB_INTERP) git hxcpp https://github.com/HaxeFoundation/hxcpp.git && \
 		hxcpp_path=`$(HAXELIB_INTERP) libpath hxcpp | tr -d '\r'` && \
-		$(CURDIR)/$(HAXE_OUTPUT) --cwd $$hxcpp_path/tools/hxcpp compile.hxml)
+		./$(HAXE_OUTPUT) --cwd $$hxcpp_path/tools/hxcpp compile.hxml)
 
 # haxelib should depends on haxe, but we don't want to do that...
 # since haxelib isn't available in PATH yet, we have to pass -D no-compilation and build manually
 haxelib: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip haxelib_hxcpp
-	HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
+	HAXE_STD_PATH=$(HAXE_STD_PATH) ./$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
 		client_cpp.hxml -D destination=../../../../$(HAXELIB_OUTPUT) -D no-compilation
 	$(HAXELIB_INTERP) --cwd $(HAXELIB_SRC_PATH)/bin/cpp run hxcpp Build.xml haxe
 

--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,16 @@ $(HAXELIB_SRC_PATH)/haxelib_hxb.zip:
 HAXELIB_INTERP=HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) \
 	--hxb-lib $(HAXELIB_SRC_PATH)/haxelib_hxb.zip --run haxelib.client.Main
 
+haxelib_hxcpp: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
+	$(HAXELIB_INTERP) config > /dev/null || $(HAXELIB_INTERP) newrepo
+	$(HAXELIB_INTERP) path hxcpp > /dev/null || \
+		($(HAXELIB_INTERP) git hxcpp https://github.com/HaxeFoundation/hxcpp.git && \
+		hxcpp_path=`$(HAXELIB_INTERP) libpath hxcpp` && \
+		$(CURDIR)/$(HAXE_OUTPUT) --cwd $$hxcpp_path/tools/hxcpp compile.hxml)
+
 # haxelib should depends on haxe, but we don't want to do that...
 # since haxelib isn't available in PATH yet, we have to pass -D no-compilation and build manually
-haxelib: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
-	$(HAXELIB_INTERP) config > /dev/null || $(HAXELIB_INTERP) newrepo
-	$(HAXELIB_INTERP) path hxcpp > /dev/null || $(HAXELIB_INTERP) install hxcpp --quiet
+haxelib: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip haxelib_hxcpp
 	HAXE_STD_PATH=$(HAXE_STD_PATH) $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
 		client_cpp.hxml -D destination=../../../../$(HAXELIB_OUTPUT) -D no-compilation
 	$(HAXELIB_INTERP) --cwd $(HAXELIB_SRC_PATH)/bin/cpp run hxcpp Build.xml haxe

--- a/Makefile
+++ b/Makefile
@@ -92,24 +92,23 @@ copy_haxetoolkit: /cygdrive/c/HaxeToolkit/haxe/haxe.exe
 	cp $< $@
 endif
 
-ifeq ($(SYSTEM_NAME),Mac)
-# This assumes that haxelib and neko will both be installed into INSTALL_DIR,
-# which is the case when installing using the mac installer package
-HAXELIB_LFLAGS= -Wl,-rpath,$(INSTALL_DIR)/lib
-endif
+HAXELIB_SRC_PATH=$(CURDIR)/extra/haxelib_src
 
-haxelib_unix:
-	cd $(CURDIR)/extra/haxelib_src && \
-	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
-	nekotools boot -c run.n
-	$(CC) $(CURDIR)/extra/haxelib_src/run.c -o $(HAXELIB_OUTPUT) -lneko $(HAXELIB_LFLAGS)
+$(HAXELIB_SRC_PATH)/haxelib_hxb.zip:
+	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
+		each.hxml --interp haxelib.client.Main --hxb haxelib_hxb.zip
+
+HAXELIB_INTERP=HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) \
+	--hxb-lib $(HAXELIB_SRC_PATH)/haxelib_hxb.zip --run haxelib.client.Main
 
 # haxelib should depends on haxe, but we don't want to do that...
-ifeq ($(SYSTEM_NAME),Windows)
-haxelib: haxelib_$(PLATFORM)
-else
-haxelib: haxelib_unix
-endif
+# since haxelib isn't available in PATH yet, we have to pass -D no-compilation and build manually
+haxelib: $(HAXELIB_SRC_PATH)/haxelib_hxb.zip
+	$(HAXELIB_INTERP) config > /dev/null || $(HAXELIB_INTERP) newrepo
+	$(HAXELIB_INTERP) path hxcpp > /dev/null || $(HAXELIB_INTERP) install hxcpp
+	HAXE_STD_PATH=$(CURDIR)/std $(CURDIR)/$(HAXE_OUTPUT) --cwd $(HAXELIB_SRC_PATH) \
+		client_cpp.hxml -D destination=$(CURDIR)/$(HAXELIB_OUTPUT) -D no-compilation
+	$(HAXELIB_INTERP) --cwd $(HAXELIB_SRC_PATH)/bin/cpp run hxcpp Build.xml haxe
 
 tools: haxelib
 
@@ -237,7 +236,7 @@ clean_haxe:
 	rm -f -r _build $(HAXE_OUTPUT) $(PREBUILD_OUTPUT)
 
 clean_tools:
-	rm -f $(HAXE_OUTPUT) $(PREBUILD_OUTPUT) $(HAXELIB_OUTPUT)
+	rm -rf $(HAXE_OUTPUT) $(PREBUILD_OUTPUT) $(HAXELIB_OUTPUT) $(HAXELIB_SRC_PATH)/haxelib_hxb.zip $(HAXELIB_SRC_PATH)/bin/cpp
 
 clean_package:
 	rm -rf $(PACKAGE_OUT_DIR)

--- a/Makefile.win
+++ b/Makefile.win
@@ -3,6 +3,8 @@ MAKEFILENAME=Makefile.win
 include Makefile
 HAXE_OUTPUT=haxe.exe
 HAXELIB_OUTPUT=haxelib.exe
+HAXE_STD_PATH=$(shell cygpath -m "$(CURDIR)/std")
+HAXELIB_SRC_PATH=$(shell cygpath -m "$(CURDIR)/extra/haxelib_src")
 PREBUILD_OUTPUT=prebuild.exe
 EXTENSION=.exe
 PACKAGE_SRC_EXTENSION=.zip

--- a/Makefile.win
+++ b/Makefile.win
@@ -4,7 +4,6 @@ include Makefile
 HAXE_OUTPUT=haxe.exe
 HAXELIB_OUTPUT=haxelib.exe
 HAXE_STD_PATH=$(shell cygpath -m "$(CURDIR)/std")
-HAXELIB_SRC_PATH=$(shell cygpath -m "$(CURDIR)/extra/haxelib_src")
 PREBUILD_OUTPUT=prebuild.exe
 EXTENSION=.exe
 PACKAGE_SRC_EXTENSION=.zip

--- a/Makefile.win
+++ b/Makefile.win
@@ -49,13 +49,6 @@ PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std \
 	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedtls.dll | sed -e 's/^\s*//')" \
 	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedx509.dll | sed -e 's/^\s*//')"
 
-# haxelib should depends on haxe, but we don't want to do that...
-haxelib_win:
-	cd $(CURDIR)/extra/haxelib_src && \
-	HAXE_STD_PATH=$$(cygpath -m $(CURDIR)/std) $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
-	nekotools boot run.n
-	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
-
 echo_package_files:
 	echo $(PACKAGE_FILES)
 

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -170,10 +170,12 @@ let write_build_options common_ctx filename defines =
    PMap.iter ( fun name value -> match name with
       | "true" | "sys" | "dce" | "cpp" | "debug" -> ()
       | _ ->  write_define name (escape_command value)) defines;
-   let pin,pid = Process_helper.open_process_args_in_pid "haxelib" [|"haxelib"; "path"; "hxcpp"|] in
-   set_binary_mode_in pin false;
-   write_define "hxcpp" (Stdlib.input_line pin);
-   Stdlib.ignore (Process_helper.close_process_in_pid (pin,pid));
+   if not (PMap.exists "no_compilation" defines) then begin
+      let pin,pid = Process_helper.open_process_args_in_pid "haxelib" [|"haxelib"; "path"; "hxcpp"|] in
+      set_binary_mode_in pin false;
+      write_define "hxcpp" (Stdlib.input_line pin);
+      Stdlib.ignore (Process_helper.close_process_in_pid (pin,pid));
+   end;
    writer#close
 
 let create_member_types common_ctx =


### PR DESCRIPTION
This avoids the dependency on neko, which means that haxe no longer has to be packaged with neko as a mandatory dependency.

Haxelib has to be run through eval first in order to install (and run) hxcpp. Due to ssl issues on eval, hxcpp has to be installed via git rather than from lib.haxe.org.

Possible since HaxeFoundation/haxelib#643 has been merged.

gencpp no longer puts `hxcpp=...` into Options.txt if `-D no-compilation` is set because that requires a `haxelib path` call, which is not possible if the haxelib binary hasn't been built yet. Hxcpp never uses this value anyway and it is not very useful to store it if gencpp didn't run hxcpp.

Closes #8155.