### PR TITLE
[display] Do not silently replace missing types with Dynamic

### DIFF
--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -644,9 +644,7 @@ and load_complex_type ctx allow_display mode (t,pn) =
 		if Diagnostics.error_in_diagnostics_run ctx.com err.err_pos then begin
 			delay ctx.g PForce (fun () -> DisplayToplevel.handle_unresolved_identifier ctx name err.err_pos true);
 			t_dynamic
-		end else if ignore_error ctx.com && not (DisplayPosition.display_position#enclosed_in pn) then
-			t_dynamic
-		else
+		end else
 			raise (Error err)
 
 and init_meta_overloads ctx co cf =

--- a/tests/display/src/cases/InMacro.hx
+++ b/tests/display/src/cases/InMacro.hx
@@ -4,6 +4,7 @@ class InMacro extends DisplayTestCase {
 	/**
 
 		import haxe.macro.Context;
+		import haxe.macro.Expr;
 
 		class Main {
 

--- a/tests/display/src/cases/Issue6399.hx
+++ b/tests/display/src/cases/Issue6399.hx
@@ -5,7 +5,7 @@ class Issue6399 extends DisplayTestCase {
 		class Main {
 			public static function main() {}
 
-			macro function foo({-1-}name{-2-}:String, {-3-}struct{-4-}:Expr, {-5-}defaults{-6-}:Expr) {
+			macro function foo({-1-}name{-2-}:String, {-3-}struct{-4-}:haxe.macro.Expr, {-5-}defaults{-6-}:haxe.macro.Expr) {
 				return macro {
 					if ($str{-7-}uct.$n{-8-}ame == null) $str{-9-}uct.$n{-10-}ame = $defa{-11-}ults.$n{-12-}ame;
 				}
@@ -20,10 +20,10 @@ class Issue6399 extends DisplayTestCase {
 
 		for (i in [7, 9]) {
 			eq(range(3, 4), position(pos(i)));
-			eq("Dynamic", type(pos(i)));
+			eq("haxe.macro.Expr", type(pos(i)));
 		}
 
 		eq(range(5, 6), position(pos(11)));
-		eq("Dynamic", type(pos(11)));
+		eq("haxe.macro.Expr", type(pos(11)));
 	}
 }

--- a/tests/display/src/cases/Issue6417.hx
+++ b/tests/display/src/cases/Issue6417.hx
@@ -5,13 +5,13 @@ class Issue6417 extends DisplayTestCase {
 		class Main {
 			static function main() {}
 
-			macro function foo({-1-}body{-2-}:Expr) {
+			macro function foo({-1-}body{-2-}:haxe.macro.Expr) {
 				macro function() $bo{-3-}dy;
 			}
 		}
 	**/
 	function test() {
 		eq(range(1, 2), position(pos(3)));
-		eq("Dynamic", type(pos(3)));
+		eq("haxe.macro.Expr", type(pos(3)));
 	}
 }


### PR DESCRIPTION
This is mostly an issue when using `Context.resolveType` in macros to determine if a type still exists in the cache. Also is responsible for Expr being typed as Dynamic in macros (when not imported)

This will "break" a lot of things..
I'm not sure what it was supposed to be helping with, as tests are ok with that change :/ 
