### PR TITLE
[cpp] Absolute paths with absolute-path

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -1335,7 +1335,7 @@ let with_debug ctx metadata run =
 
 let hx_stack_push ctx output clazz func_name pos gc_stack =
    if ctx.ctx_debug_level > 0 then begin
-      let stripped_file = strip_file ctx.ctx_common pos.pfile in
+      let stripped_file = strip_file ctx.ctx_common (Path.get_real_path pos.pfile) in
       let esc_file = (StringHelper.s_escape stripped_file) in
       ctx.ctx_file_info := PMap.add stripped_file pos.pfile !(ctx.ctx_file_info);
       let full_name = clazz ^ "." ^ func_name ^ (

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -1321,7 +1321,7 @@ exception PathFound of string;;
 
 
 let strip_file ctx file = (match Common.defined ctx Common.Define.AbsolutePath with
-   | true -> file
+   | true -> Path.get_full_path file
    | false -> ctx.class_paths#relative_path file)
 ;;
 
@@ -1335,7 +1335,7 @@ let with_debug ctx metadata run =
 
 let hx_stack_push ctx output clazz func_name pos gc_stack =
    if ctx.ctx_debug_level > 0 then begin
-      let stripped_file = strip_file ctx.ctx_common (Path.get_real_path pos.pfile) in
+      let stripped_file = strip_file ctx.ctx_common pos.pfile in
       let esc_file = (StringHelper.s_escape stripped_file) in
       ctx.ctx_file_info := PMap.add stripped_file pos.pfile !(ctx.ctx_file_info);
       let full_name = clazz ^ "." ^ func_name ^ (


### PR DESCRIPTION
Using the `absolute-path` define doesn't result in absolute paths in hxcpp stackframes, you still get relative paths. With this change the paths will now actually be absolute.

![image](https://github.com/user-attachments/assets/cf89c48b-f30f-4623-9156-fe76f8fecee8)
