### PR TITLE
[tests] Enable hlc tests on windows and mac

### DIFF
--- a/tests/runci/System.hx
+++ b/tests/runci/System.hx
@@ -134,11 +134,13 @@ class System {
 	}
 
 	static public function addToLIBPATH(path:String):Void {
-		infoMsg('Prepending $path to LD_LIBRARY_PATH.');
+		infoMsg('Prepending $path to loader path.');
 		switch (systemName) {
 			case "Windows": // pass
-			case "Mac", "Linux":
+			case "Linux":
 				Sys.putEnv("LD_LIBRARY_PATH", path + ":" + Sys.getEnv("LD_LIBRARY_PATH"));
+			case "Mac":
+				Sys.putEnv("DYLD_LIBRARY_PATH", path + ":" + Sys.getEnv("DYLD_LIBRARY_PATH"));
 		}
 	}
 

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -10,13 +10,15 @@ using StringTools;
 class Hl {
 	static final hlSrc = Path.join([getDownloadPath(), "hashlink"]);
 
-	static final hlBuild = Path.join([getInstallPath(), "hashlink_build"]);
+	static final hlBuild = Path.join([getDownloadPath(), "hashlink_build"]);
 
-	static final hlBuildBinDir = Path.join([getInstallPath(), "hashlink_build", "bin"]);
+	static final hlInstallDir = Path.join([getInstallPath(), "hashlink"]);
+	static final hlInstallBinDir = if (systemName == "Windows") hlInstallDir else Path.join([hlInstallDir, "bin"]);
+	static final hlInstallLibDir = if (systemName == "Windows") hlInstallDir else Path.join([hlInstallDir, "lib"]);
 
 	static final hlBinary =
 		if (isCi() || !commandSucceed("hl", ["--version"])){
-			Path.join([hlBuildBinDir, "hl"]) + ((systemName == "Windows") ? ".exe" : "");
+			Path.join([hlInstallBinDir, "hl"]) + ((systemName == "Windows") ? ".exe" : "");
 		} else {
 			commandResult(if(systemName == "Windows") "where" else "which", ["hl"]).stdout.trim();
 		};
@@ -56,16 +58,18 @@ class Hl {
 			"-DWITH_UI=OFF",
 			"-DWITH_UV=OFF",
 			"-DWITH_VIDEO=OFF",
+			"-DCMAKE_INSTALL_PREFIX=" + hlInstallDir,
 			"-B" + hlBuild,
 			"-H" + hlSrc
 		]));
 		runCommand("cmake", [
 			"--build", hlBuild
 		]);
+		runCommand("cmake", ["--build", hlBuild, "--target", "install"]);
 
+		addToPATH(hlInstallBinDir);
+		addToLIBPATH(hlInstallLibDir);
 		runCommand(hlBinary, ["--version"]);
-		addToPATH(hlBuildBinDir);
-		addToLIBPATH(hlBuildBinDir);
 
 		haxelibDev("hashlink", '$hlSrc/other/haxelib/');
 	}
@@ -79,12 +83,12 @@ class Hl {
 					"-o", '$dir/$filename.exe',
 					'$dir/$filename.c',
 					'-I$dir',
-					'-I$hlSrc/src',
-					'$hlBuildBinDir/fmt.hdll',
-					'$hlBuildBinDir/ssl.hdll',
-					'$hlBuildBinDir/sqlite.hdll',
+					'-I$hlInstallDir/include',
+					'$hlInstallLibDir/fmt.hdll',
+					'$hlInstallLibDir/ssl.hdll',
+					'$hlInstallLibDir/sqlite.hdll',
 					"-lm",
-					'-L$hlBuildBinDir', "-lhl"
+					'-L$hlInstallLibDir', "-lhl"
 				]);
 
 				run('$dir/$filename.exe', []);

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -77,24 +77,26 @@ class Hl {
 	static function buildAndRunHlc(dir:String, filename:String, ?run) {
 		if (run == null) run = runCommand;
 
-		switch (systemName) {
-			case "Linux" if (isCi()):
-				runCommand("gcc", [
-					"-o", '$dir/$filename.exe',
-					'$dir/$filename.c',
-					'-I$dir',
-					'-I$hlInstallDir/include',
-					'$hlInstallLibDir/fmt.hdll',
-					'$hlInstallLibDir/ssl.hdll',
-					'$hlInstallLibDir/sqlite.hdll',
-					"-lm",
-					'-L$hlInstallLibDir', "-lhl"
-				]);
+		if (!isCi())
+			return;
 
-				run('$dir/$filename.exe', []);
+		final compiler = if (systemName == "Mac") "clang" else "gcc";
+		final extraCompilerFlags = if (systemName == "Windows") ["-ldbghelp", "-municode"] else [];
 
-			case _: // TODO hl/c for mac/windows
-		}
+		runCommand(compiler, [
+			"-o", '$dir/$filename.exe',
+			'$dir/$filename.c',
+			'-I$dir',
+			'-I$hlInstallDir/include',
+			'-L$hlInstallLibDir',
+			'$hlInstallLibDir/fmt.hdll',
+			'$hlInstallLibDir/ssl.hdll',
+			'$hlInstallLibDir/sqlite.hdll',
+			"-lm",
+			"-lhl"
+		].concat(extraCompilerFlags));
+
+		run('$dir/$filename.exe', []);
 	}
 
 	static function buildAndRun(hxml:String, target:String, ?args:Array<String>) {


### PR DESCRIPTION
Enables hlc tests on windows with gcc and mac with clang.

It would still be a good idea to compile on windows with msvc, but the unit tests aren't passing yet, that is being handled in: #11733.