### PR TITLE
handle HttpNodeJs request error

### DIFF
--- a/std/haxe/http/HttpNodeJs.hx
+++ b/std/haxe/http/HttpNodeJs.hx
@@ -124,6 +124,10 @@ class HttpNodeJs extends haxe.http.HttpBase {
 				req.write(Buffer.from(postBytes.getData()));
 			}
 
+			req.on('error', function(e) {
+				onError("Http Request Error: " + e);
+			});
+
 		req.end();
 	}
 }


### PR DESCRIPTION
Without this change, the error thrown by the request must be handled with a generic 

```
js.Node.process.on('uncaughtException', (e) -> trace(e));
```

I think is more convenient to handle the error with request.onError