### PR TITLE
Adds a new `--std-path` argument to set standard library path.

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -126,6 +126,9 @@ let parse_args com =
 		("Compilation",[],["-libcp"],Arg.String (fun path ->
 			com.class_paths#add (new ClassPath.directory_class_path (Path.add_trailing_slash path) Lib);
 		),"<path>","add a directory to find source files");
+		("Compilation",["--std-path"],["-std-path"],Arg.String (fun path ->
+			com.std_path <- path;
+		),"<path>","set the path of the standard library");
 		("Compilation",["--hxb-lib"],["-hxb-lib"],Arg.String (fun file ->
 			let lib = create_native_lib file false HxbLib in
 			actx.hxb_libs <- lib :: actx.hxb_libs

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -154,7 +154,7 @@ module Setup = struct
 					let hl_ver = try
 						Std.input_file (Common.find_file com "hl/hl_version")
 					with Not_found ->
-						failwith "The file hl_version could not be found. Please make sure HAXE_STD_PATH is set to the standard library corresponding to the used compiler version."
+						failwith "The file hl_version could not be found. Please make sure `HAXE_STD_PATH` environment variable or `--std-path` argument is set to the standard library corresponding to the used compiler version."
 					in
 					Define.define_value com.defines Define.HlVer hl_ver
 				end;
@@ -187,9 +187,9 @@ module Setup = struct
 
 	open ClassPath
 
-	let get_std_class_paths () =
+	let get_std_class_paths std_path =
 		try
-			let p = Sys.getenv "HAXE_STD_PATH" in
+			let p = if std_path = "" then Sys.getenv "HAXE_STD_PATH" else std_path in
 			let p = Path.remove_trailing_slash p in
 			let rec loop = function
 				| drive :: path :: l ->
@@ -224,7 +224,7 @@ module Setup = struct
 				let cp = new ClassPath.directory_class_path (Path.add_trailing_slash s) scope in
 				com.class_paths#add cp
 			with Sys_error _ -> ()
-		) (List.rev (get_std_class_paths ()));
+		) (List.rev (get_std_class_paths com.std_path));
 		com.class_paths#add com.empty_class_path
 
 	let setup_common_context ctx =

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -369,6 +369,7 @@ type context = {
 	mutable foptimize : bool;
 	mutable platform : platform;
 	mutable config : platform_config;
+	mutable std_path : string;
 	empty_class_path : ClassPath.class_path;
 	class_paths : ClassPaths.class_paths;
 	main : context_main;
@@ -793,6 +794,7 @@ let create compilation_step cs version args display_mode =
 		print = (fun s -> print_string s; flush stdout);
 		run_command = Sys.command;
 		run_command_args = (fun s args -> com.run_command (Printf.sprintf "%s %s" s (String.concat " " args)));
+		std_path = "";
 		empty_class_path = new ClassPath.directory_class_path "" User;
 		class_paths = new ClassPaths.class_paths;
 		main = {

--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -328,12 +328,12 @@ let raise_msg ?(depth = 0) msg p = raise_error_msg ~depth (Custom msg) p
 let raise_typing_error ?(depth = 0) msg p = raise_msg ~depth msg p
 let raise_typing_error_ext err = raise_error err
 
-let raise_std_not_found () =
+let raise_std_not_found std_path =
 	try
-		let std_path = Sys.getenv "HAXE_STD_PATH" in
-		raise_typing_error ("Standard library not found. Please check your `HAXE_STD_PATH` environment variable (current value: \"" ^ std_path ^ "\")") null_pos
+		let std_path = if std_path = "" then Sys.getenv "HAXE_STD_PATH" else std_path in
+		raise_typing_error ("Standard library not found. Please check your `HAXE_STD_PATH` environment variable or `--std-path` argument (current value: \"" ^ std_path ^ "\")") null_pos
 	with Not_found ->
-		raise_typing_error "Standard library not found. You may need to set your `HAXE_STD_PATH` environment variable" null_pos
+		raise_typing_error "Standard library not found. You may need to set your `HAXE_STD_PATH` environment variable or pass a `--std-path` argument" null_pos
 
 let error_require r p =
 	if r = "" then

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -722,7 +722,7 @@ let create_macro_context com =
 	(* This can run before `TyperEntry.create`, so in order to display nice error when std is not found, this needs to be checked here too *)
 	(match !eval_std with
 	| Some std -> com2.class_paths#add std
-	| None -> Error.raise_std_not_found ());
+	| None -> Error.raise_std_not_found com.std_path);
 	let defines = adapt_defines_to_macro_context com2.defines; in
 	com2.defines.values <- defines.values;
 	com2.defines.defines_signature <- None;

--- a/src/typing/typerEntry.ml
+++ b/src/typing/typerEntry.ml
@@ -63,7 +63,7 @@ let create com macros =
 		TypeloadModule.load_module ctx ([],"StdTypes") null_pos
 	with
 		Error { err_message = Module_not_found ([],"StdTypes") } ->
-			Error.raise_std_not_found ()
+			Error.raise_std_not_found com.std_path
 	);
 	(* We always want core types to be available so we add them as default imports (issue #1904 and #3131). *)
 	List.iter (fun mt ->


### PR DESCRIPTION
This PR adds an `--std-path` argument to set standard library path as an alternative to setting the `HAXE_STD_PATH` environment variable.

This is useful to be able to use Haxe from the ninja build system, as it does not support setting environment variables from its build scripts: https://github.com/ninja-build/ninja/issues/1002

I have also read that I might need to set `HAXELIB_PATH` and `HAXEPATH` to get haxelib working. I quickly checked the source code and the compiler does seem to invoke `haxelib` in some places, so would it be acceptable to add more flags for those paths? Or is there a better mechanism that could be used as an alternative?

Also this is my first using OCaml and hacking on the compiler to let me know of any issues with the code.

