### PR TITLE
Fix compilation error in `dce.ml`.

### DIFF
--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -87,7 +87,7 @@ let overrides_extern_field cf c =
 	loop c cf
 
 let is_std_file dce file =
-	List.exists (ExtString.String.starts_with file) dce.std_dirs
+	List.exists (fun dir -> ExtString.String.starts_with file dir) dce.std_dirs
 
 let keep_metas = [Meta.Keep;Meta.Expose]
 


### PR DESCRIPTION
Its my first time hacking on Haxe and I came across the following error. The fix works, but I am not really sure what I am doing with OCaml yet, so is this a proper fix to the error?

This fixes the following compilation error:

```ocaml
File "src/optimization/dce.ml", line 90, characters 13-48:
90 |    List.exists (ExtString.String.starts_with file) dce.std_dirs
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type prefix:string -> bool
       but an expression was expected of type 'a -> bool
make: *** [Makefile:81: haxe] Error 1
```

By replacing:

```ocaml
let is_std_file dce file =
	List.exists (ExtString.String.starts_with file) dce.std_dirs
```

with:

```ocaml
let is_std_file dce file =
	List.exists (fun dir -> ExtString.String.starts_with file dir)
dce.std_dirs
```