### PR TITLE
Fix: stop running hl when compiling to hlc on arm64

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -963,7 +963,15 @@ let init_platform com =
 	| Jvm ->
 		raw_define com "java"
 	| Hl ->
-		if Path.file_extension com.file = "c" then define com Define.Hlc;
+		if Path.file_extension com.file = "c" then begin 
+			define com Define.Hlc;
+			(* Hashlink isn't built for arm64, no point in running it. *)
+			let ic, pid = Process_helper.open_process_args_in_pid "uname" [| "uname"; "-m" |] in
+			let arch = input_line ic in
+			if arch <> "arm64" || arch <> "aarch64" then
+				define com Define.NoCompilation;
+			Stdlib.ignore (Process_helper.close_process_in_pid (ic, pid));
+		end;
 	| _ ->
 		()
 	end;


### PR DESCRIPTION
I was fiddling with Haxe/HashLink in my M1 Macbook, and when compiling HashLink from source this message was displayed:

`Makefile:174: HashLink vm is not supported on arm64, skipping`

I already knew that HashLink didn't have arm64 JIT and only supported `hlc` compilation, but when compiling on arm64 with this command:

`haxe --main Main --hl out/main.c`

An error message is displayed although valid C code is generated without any problems:
```sh
Error: Library hashlink is not installed
 ERROR  (unknown position)

   | Error: Build failed
```

It seems counterintuitive to run the `hl` binary when the architecture doesn't support it. I know if I supply `-D no-compilation=true` this won't be shown, as the Haxe compiler doesn't try to run `haxelib run hashlink` (this happens on file `src/generators/genhl.ml` around line 4305), but again, it seems counterintuitive.

This fix simply checks if we are on arm64 and sets the define flag NoCompilation accordingly. If this fix is not desirable, please let me know so that I can proceed and maybe document the use of the `no-compilation` flag on the HashLink section of the Haxe manual. Thank you for the amazing language!