### PR TITLE
Support `?.bind`, error on `?.new` and `?.match`

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -629,7 +629,8 @@ and type_access ctx e p mode with_type =
 	match e with
 	| EConst (Ident s) ->
 		type_ident ctx s p mode with_type
-	| EField (e1,"new",efk_todo) ->
+	| EField (e1,"new",efk) ->
+		if efk = EFSafe then raise_typing_error "?.new is not supported" p;
 		let e1 = type_expr ctx e1 WithType.value in
 		begin match e1.eexpr with
 			| TTypeExpr (TClassDecl c) ->
@@ -1752,7 +1753,8 @@ and type_call_builtin ctx e el mode with_type p =
 		in
 		warning ctx WInfo s e1.epos;
 		e1
-	| (EField(e,"match",efk_todo),p), [epat] ->
+	| (EField(e,"match",efk),p), [epat] ->
+		if efk = EFSafe then raise_typing_error "?.match is not supported" p;
 		let et = type_expr ctx e WithType.value in
 		let rec has_enum_match t = match follow t with
 			| TEnum _ -> true

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -370,3 +370,13 @@ let safe_nav_branch ctx sn f_then =
 	(match sn.sn_temp_var with
 	| None -> eif
 	| Some evar -> { eif with eexpr = TBlock [evar; eif] })
+
+let get_safe_nav_base ctx eobj =
+	match (Texpr.skip eobj).eexpr with
+	| TLocal _ | TTypeExpr _ | TConst _ ->
+		eobj, None
+	| _ ->
+		let v = alloc_var VGenerated "tmp" eobj.etype eobj.epos in
+		let temp_var = mk (TVar(v, Some eobj)) ctx.t.tvoid v.v_pos in
+		let eobj = mk (TLocal v) v.v_type v.v_pos in
+		eobj, Some temp_var

--- a/tests/misc/projects/Issue11571/MainMatch.hx
+++ b/tests/misc/projects/Issue11571/MainMatch.hx
@@ -1,0 +1,3 @@
+function main() {
+	(macro 1).expr?.match(1);
+}

--- a/tests/misc/projects/Issue11571/MainNew.hx
+++ b/tests/misc/projects/Issue11571/MainNew.hx
@@ -1,0 +1,3 @@
+function main() {
+	String?.new;
+}

--- a/tests/misc/projects/Issue11571/compile-match-fail.hxml
+++ b/tests/misc/projects/Issue11571/compile-match-fail.hxml
@@ -1,0 +1,2 @@
+--main MainMatch
+--interp

--- a/tests/misc/projects/Issue11571/compile-match-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11571/compile-match-fail.hxml.stderr
@@ -1,0 +1,1 @@
+MainMatch.hx:2: characters 2-23 : ?.match is not supported

--- a/tests/misc/projects/Issue11571/compile-new-fail.hxml
+++ b/tests/misc/projects/Issue11571/compile-new-fail.hxml
@@ -1,0 +1,2 @@
+--main MainNew
+--interp

--- a/tests/misc/projects/Issue11571/compile-new-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11571/compile-new-fail.hxml.stderr
@@ -1,0 +1,1 @@
+MainNew.hx:2: characters 2-13 : ?.new is not supported

--- a/tests/unit/src/unit/issues/Issue11571.hx
+++ b/tests/unit/src/unit/issues/Issue11571.hx
@@ -1,0 +1,15 @@
+package unit.issues;
+
+class Issue11571 extends unit.Test {
+	public function test() {
+		var fOk = () -> "ok";
+		var f:Null<() -> String> = fOk;
+		var boundOk = f?.bind();
+		f = null;
+		eq("ok", boundOk());
+
+		var boundNull = f?.bind();
+		f = fOk;
+		eq(null, boundNull());
+	}
+}


### PR DESCRIPTION
Currently the compiler just silently ignores the safe navigation operator in these cases. Supporting `?.bind` seems sensible, while `?.new` seems pointless. And I didn't want to think about `?.match` so I disallowed that one as well.

Closes #11571