### PR TITLE
Add eval $(opam env) for osx vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,9 @@
 			"label": "make: haxe",
 			"type": "shell",
 			"command": "make ADD_REVISION=1 -s -j haxe",
+			"osx": {
+				"command": "eval $(opam env) && make ADD_REVISION=1 -s -j haxe",
+			},
 			"windows": {
 				"command": "make ADD_REVISION=1 -f Makefile.win -s -j haxe"
 			},


### PR DESCRIPTION
VSCode has stopped pulling up env context for tasks in the last few versions and now the haxe ocaml build only works through the terminal for me. I think this addition shouldn't spoil anything.