### PR TITLE
Copy var flags when duplicating local variables

### DIFF
--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -328,6 +328,7 @@ let duplicate_tvars f_this e =
 		let v2 = alloc_var v.v_kind v.v_name v.v_type v.v_pos in
 		v2.v_meta <- v.v_meta;
 		v2.v_extra <- v.v_extra;
+		v2.v_flags <- v.v_flags;
 		Hashtbl.add vars v.v_id v2;
 		v2;
 	in

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -441,7 +441,7 @@ module ForRemap = struct
 		| TFor(v,e1,e2) ->
 			let e1 = loop e1 in
 			let e2 = loop e2 in
-			let iterator = ForLoop.IterationKind.of_texpr ctx e1 (ForLoop.is_cheap_enough_t ctx e2) e.epos in
+			let iterator = ForLoop.IterationKind.of_texpr ctx e1 (ForLoop.get_unroll_params_t ctx e2) e.epos in
 			let restore = save_locals ctx in
 			let e = ForLoop.IterationKind.to_texpr ctx v iterator e2 e.epos in
 			restore();

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -412,6 +412,8 @@ let is_cheap_enough ctx e2 i =
 	let rec loop e = match fst e with
 		| EContinue | EBreak ->
 			raise Exit
+		| EVars vl when (List.exists (fun ev -> ev.ev_static) vl) ->
+			raise Exit
 		| _ ->
 			incr num_expr;
 			Ast.map_expr loop e

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -56,6 +56,7 @@ let optimize_for_loop_iterator ctx v e1 e2 p =
 	]) ctx.t.tvoid p
 
 type unroll_parameters = {
+	expression_weight : int;
 	has_local_function : bool;
 }
 
@@ -173,7 +174,22 @@ module IterationKind = struct
 			)
 	 	| _ -> raise Not_found
 
-	let of_texpr ?(resume=false) ctx e unroll p =
+	let map_unroll_params ctx unroll_params i = match unroll_params with
+		| None ->
+			None
+		| Some unroll_params ->
+			let cost = i * unroll_params.expression_weight in
+			let max_cost = try
+				int_of_string (Common.defined_value ctx.com Define.LoopUnrollMaxCost)
+			with Not_found ->
+				250
+			in
+			if cost <= max_cost then
+				Some unroll_params
+			else
+				None
+
+	let of_texpr ?(resume=false) ctx e unroll_params p =
 		let dynamic_iterator e =
 			display_error ctx.com "You can't iterate on a Dynamic value, please specify Iterator or Iterable" e.epos;
 			IteratorDynamic,e,t_dynamic
@@ -214,10 +230,9 @@ module IterationKind = struct
 			let it = match efrom.eexpr,eto.eexpr with
 				| TConst (TInt a),TConst (TInt b) ->
 					let diff = Int32.to_int (Int32.sub a b) in
-					let unroll = unroll (abs diff) in
-					begin match unroll with
-					| Some unroll ->
-						IteratorIntUnroll(Int32.to_int a,abs(diff),diff <= 0,unroll)
+					begin match map_unroll_params ctx unroll_params (abs diff) with
+					| Some unroll_params ->
+						IteratorIntUnroll(Int32.to_int a,abs(diff),diff <= 0,unroll_params)
 					| None ->
 						IteratorIntConst(efrom,eto,diff <= 0)
 					end
@@ -230,7 +245,7 @@ module IterationKind = struct
 			in
 			it,e,ctx.t.tint
 		| TArrayDecl el,TInst({ cl_path = [],"Array" },[pt]) ->
-			let it = match unroll (List.length el) with
+			let it = match map_unroll_params ctx unroll_params (List.length el) with
 				| Some _ -> IteratorArrayDecl el
 				| None -> IteratorArray
 			in
@@ -338,18 +353,10 @@ module IterationKind = struct
 					let rec loop e = match e.eexpr with
 					| TLocal v' when v == v' ->
 						{ei with epos = e.epos}
-					| TVar(v,eo) when has_var_flag v VStatic || not unroll_params.has_local_function ->
-						let is_static = has_var_flag v VStatic in
+					| TVar(v,eo) when has_var_flag v VStatic ->
 						if acc = [] then
-							local_vars := {e with eexpr = TVar(v,if is_static then eo else None)} :: !local_vars;
-						begin match eo with
-						| Some e when not is_static ->
-							let e = loop e in
-							let ev = mk (TLocal v) v.v_type e.epos in
-							Texpr.Builder.binop OpAssign ev e v.v_type e.epos
-						| _ ->
-							mk (TConst TNull) t_dynamic null_pos
-						end
+							local_vars := {e with eexpr = TVar(v,eo)} :: !local_vars;
+						mk (TConst TNull) t_dynamic null_pos
 					| _ ->
 						map_expr loop e
 				in
@@ -438,7 +445,7 @@ module IterationKind = struct
 			mk (TFor(v,e1,e2)) t_void p
 end
 
-let is_cheap_enough ctx e2 i =
+let get_unroll_params ctx e2 =
 	let num_expr = ref 0 in
 	let has_local_function = ref false in
 	let rec loop e = match fst e with
@@ -454,20 +461,14 @@ let is_cheap_enough ctx e2 i =
 	try
 		if ctx.com.display.dms_kind <> DMNone then raise Exit;
 		ignore(loop e2);
-		let cost = i * !num_expr in
-		let max_cost = try
-			int_of_string (Common.defined_value ctx.com Define.LoopUnrollMaxCost)
-		with Not_found ->
-			250
-		in
-		if cost <= max_cost then
-			Some {has_local_function = !has_local_function}
-		else
-			None
+		Some {
+			expression_weight = !num_expr;
+			has_local_function = !has_local_function;
+		}
 	with Exit ->
 		None
 
-let is_cheap_enough_t ctx e2 i =
+let get_unroll_params_t ctx e2 =
 	let num_expr = ref 0 in
 	let has_local_function = ref false in
 	let rec loop e = match e.eexpr with
@@ -483,16 +484,10 @@ let is_cheap_enough_t ctx e2 i =
 	try
 		if ctx.com.display.dms_kind <> DMNone then raise Exit;
 		ignore(loop e2);
-		let cost = i * !num_expr in
-		let max_cost = try
-			int_of_string (Common.defined_value ctx.com Define.LoopUnrollMaxCost)
-		with Not_found ->
-			250
-		in
-		if cost <= max_cost then
-			Some {has_local_function = !has_local_function}
-		else
-			None
+		Some {
+			expression_weight = !num_expr;
+			has_local_function = !has_local_function;
+		}
 	with Exit ->
 		None
 
@@ -513,7 +508,7 @@ let type_for_loop ctx handle_display ik e1 e2 p =
 	in
 	match ik with
 	| IKNormal(i,pi,dko) ->
-		let iterator = IterationKind.of_texpr ctx e1 (is_cheap_enough ctx e2) p in
+		let iterator = IterationKind.of_texpr ctx e1 (get_unroll_params ctx e2) p in
 		let i = add_local_with_origin ctx TVOForVariable i iterator.it_type pi in
 		let e2 = type_expr ctx e2 NoValue in
 		check_display (i,pi,dko);

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -319,15 +319,28 @@ module IterationKind = struct
 		| IteratorIntUnroll(offset,length,ascending) ->
 			check_loop_var_modification [v] e2;
 			if not ascending then raise_typing_error "Cannot iterate backwards" p;
-			let el = ExtList.List.init length (fun i ->
-				let ei = make_int ctx.t (if ascending then i + offset else offset - i) p in
-				let rec loop e = match e.eexpr with
-					| TLocal v' when v == v' -> {ei with epos = e.epos}
-					| _ -> map_expr loop e
+			let rec unroll acc i =
+				if i = length then
+					List.rev acc
+				else begin
+					let ei = make_int ctx.t (if ascending then i + offset else offset - i) p in
+					let static_locals = ref [] in
+					let rec loop e = match e.eexpr with
+					| TLocal v' when v == v' ->
+						{ei with epos = e.epos}
+					| TVar(v,eo) when has_var_flag v VStatic ->
+						if acc = [] then
+							static_locals := e :: !static_locals;
+						mk (TConst TNull) t_dynamic null_pos
+					| _ ->
+						map_expr loop e
 				in
 				let e2 = loop e2 in
-				Texpr.duplicate_tvars e_identity e2
-			) in
+				let acc = acc @ !static_locals in
+				let e2 = Texpr.duplicate_tvars e_identity e2 in
+				unroll (e2 :: acc) (i + 1)
+			end in
+			let el = unroll [] 0 in
 			mk (TBlock el) t_void p
 		| IteratorIntConst(a,b,ascending) ->
 			check_loop_var_modification [v] e2;
@@ -411,8 +424,6 @@ let is_cheap_enough ctx e2 i =
 	let num_expr = ref 0 in
 	let rec loop e = match fst e with
 		| EContinue | EBreak ->
-			raise Exit
-		| EVars vl when (List.exists (fun ev -> ev.ev_static) vl) ->
 			raise Exit
 		| _ ->
 			incr num_expr;

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -55,10 +55,14 @@ let optimize_for_loop_iterator ctx v e1 e2 p =
 		mk (TWhile (ehasnext,eblock,NormalWhile)) ctx.t.tvoid p
 	]) ctx.t.tvoid p
 
+type unroll_parameters = {
+	has_local_function : bool;
+}
+
 module IterationKind = struct
 	type t_kind =
 		| IteratorIntConst of texpr * texpr * bool (* ascending? *)
-		| IteratorIntUnroll of int * int * bool
+		| IteratorIntUnroll of int * int * bool * unroll_parameters
 		| IteratorInt of texpr * texpr
 		| IteratorArrayDecl of texpr list
 		| IteratorArray
@@ -211,8 +215,12 @@ module IterationKind = struct
 				| TConst (TInt a),TConst (TInt b) ->
 					let diff = Int32.to_int (Int32.sub a b) in
 					let unroll = unroll (abs diff) in
-					if unroll then IteratorIntUnroll(Int32.to_int a,abs(diff),diff <= 0)
-					else IteratorIntConst(efrom,eto,diff <= 0)
+					begin match unroll with
+					| Some unroll ->
+						IteratorIntUnroll(Int32.to_int a,abs(diff),diff <= 0,unroll)
+					| None ->
+						IteratorIntConst(efrom,eto,diff <= 0)
+					end
 				| _ ->
 					let eto = match follow eto.etype with
 						| TAbstract ({ a_path = ([],"Int") }, []) -> eto
@@ -222,8 +230,10 @@ module IterationKind = struct
 			in
 			it,e,ctx.t.tint
 		| TArrayDecl el,TInst({ cl_path = [],"Array" },[pt]) ->
-			let it = if unroll (List.length el) then IteratorArrayDecl el
-			else IteratorArray in
+			let it = match unroll (List.length el) with
+				| Some _ -> IteratorArrayDecl el
+				| None -> IteratorArray
+			in
 			(it,e,pt)
 		| _,TInst({ cl_path = [],"Array" },[pt])
 		| _,TInst({ cl_path = ["flash"],"Vector" },[pt]) ->
@@ -316,7 +326,7 @@ module IterationKind = struct
 		match iterator.it_kind with
 		| _ when not ctx.allow_transform ->
 			mk (TFor(v,e1,e2)) t_void p
-		| IteratorIntUnroll(offset,length,ascending) ->
+		| IteratorIntUnroll(offset,length,ascending,unroll_params) ->
 			check_loop_var_modification [v] e2;
 			if not ascending then raise_typing_error "Cannot iterate backwards" p;
 			let rec unroll acc i =
@@ -328,7 +338,7 @@ module IterationKind = struct
 					let rec loop e = match e.eexpr with
 					| TLocal v' when v == v' ->
 						{ei with epos = e.epos}
-					| TVar(v,eo) ->
+					| TVar(v,eo) when has_var_flag v VStatic || not unroll_params.has_local_function ->
 						let is_static = has_var_flag v VStatic in
 						if acc = [] then
 							local_vars := {e with eexpr = TVar(v,if is_static then eo else None)} :: !local_vars;
@@ -430,9 +440,13 @@ end
 
 let is_cheap_enough ctx e2 i =
 	let num_expr = ref 0 in
+	let has_local_function = ref false in
 	let rec loop e = match fst e with
 		| EContinue | EBreak ->
 			raise Exit
+		| EFunction _ ->
+			has_local_function := true;
+			Ast.map_expr loop e
 		| _ ->
 			incr num_expr;
 			Ast.map_expr loop e
@@ -446,15 +460,22 @@ let is_cheap_enough ctx e2 i =
 		with Not_found ->
 			250
 		in
-		cost <= max_cost
+		if cost <= max_cost then
+			Some {has_local_function = !has_local_function}
+		else
+			None
 	with Exit ->
-		false
+		None
 
 let is_cheap_enough_t ctx e2 i =
 	let num_expr = ref 0 in
+	let has_local_function = ref false in
 	let rec loop e = match e.eexpr with
 		| TContinue | TBreak ->
 			raise Exit
+		| TFunction _ ->
+			has_local_function := true;
+			Type.map_expr loop e
 		| _ ->
 			incr num_expr;
 			Type.map_expr loop e
@@ -468,9 +489,12 @@ let is_cheap_enough_t ctx e2 i =
 		with Not_found ->
 			250
 		in
-		cost <= max_cost
+		if cost <= max_cost then
+			Some {has_local_function = !has_local_function}
+		else
+			None
 	with Exit ->
-		false
+		None
 
 type iteration_ident = string * pos * display_kind option
 

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -57,7 +57,6 @@ let optimize_for_loop_iterator ctx v e1 e2 p =
 
 type unroll_parameters = {
 	expression_weight : int;
-	has_local_function : bool;
 }
 
 module IterationKind = struct
@@ -447,13 +446,9 @@ end
 
 let get_unroll_params ctx e2 =
 	let num_expr = ref 0 in
-	let has_local_function = ref false in
 	let rec loop e = match fst e with
 		| EContinue | EBreak ->
 			raise Exit
-		| EFunction _ ->
-			has_local_function := true;
-			Ast.map_expr loop e
 		| _ ->
 			incr num_expr;
 			Ast.map_expr loop e
@@ -463,20 +458,15 @@ let get_unroll_params ctx e2 =
 		ignore(loop e2);
 		Some {
 			expression_weight = !num_expr;
-			has_local_function = !has_local_function;
 		}
 	with Exit ->
 		None
 
 let get_unroll_params_t ctx e2 =
 	let num_expr = ref 0 in
-	let has_local_function = ref false in
 	let rec loop e = match e.eexpr with
 		| TContinue | TBreak ->
 			raise Exit
-		| TFunction _ ->
-			has_local_function := true;
-			Type.map_expr loop e
 		| _ ->
 			incr num_expr;
 			Type.map_expr loop e
@@ -486,7 +476,6 @@ let get_unroll_params_t ctx e2 =
 		ignore(loop e2);
 		Some {
 			expression_weight = !num_expr;
-			has_local_function = !has_local_function;
 		}
 	with Exit ->
 		None

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -324,19 +324,27 @@ module IterationKind = struct
 					List.rev acc
 				else begin
 					let ei = make_int ctx.t (if ascending then i + offset else offset - i) p in
-					let static_locals = ref [] in
+					let local_vars = ref [] in
 					let rec loop e = match e.eexpr with
 					| TLocal v' when v == v' ->
 						{ei with epos = e.epos}
-					| TVar(v,eo) when has_var_flag v VStatic ->
+					| TVar(v,eo) ->
+						let is_static = has_var_flag v VStatic in
 						if acc = [] then
-							static_locals := e :: !static_locals;
-						mk (TConst TNull) t_dynamic null_pos
+							local_vars := {e with eexpr = TVar(v,if is_static then eo else None)} :: !local_vars;
+						begin match eo with
+						| Some e when not is_static ->
+							let e = loop e in
+							let ev = mk (TLocal v) v.v_type e.epos in
+							Texpr.Builder.binop OpAssign ev e v.v_type e.epos
+						| _ ->
+							mk (TConst TNull) t_dynamic null_pos
+						end
 					| _ ->
 						map_expr loop e
 				in
 				let e2 = loop e2 in
-				let acc = acc @ !static_locals in
+				let acc = acc @ !local_vars in
 				let e2 = Texpr.duplicate_tvars e_identity e2 in
 				unroll (e2 :: acc) (i + 1)
 			end in

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -518,7 +518,7 @@ and display_expr ctx e_ast e dk mode with_type p =
 		let fields = DisplayFields.collect ctx e_ast e dk with_type p in
 		let item = completion_item_of_expr ctx e in
 		let iterator = try
-			let it = (ForLoop.IterationKind.of_texpr ~resume:true ctx e (fun _ -> None) e.epos) in
+			let it = (ForLoop.IterationKind.of_texpr ~resume:true ctx e None e.epos) in
 			match follow it.it_type with
 				| TDynamic _ ->  None
 				| t -> Some t

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -518,7 +518,7 @@ and display_expr ctx e_ast e dk mode with_type p =
 		let fields = DisplayFields.collect ctx e_ast e dk with_type p in
 		let item = completion_item_of_expr ctx e in
 		let iterator = try
-			let it = (ForLoop.IterationKind.of_texpr ~resume:true ctx e (fun _ -> false) e.epos) in
+			let it = (ForLoop.IterationKind.of_texpr ~resume:true ctx e (fun _ -> None) e.epos) in
 			match follow it.it_type with
 				| TDynamic _ ->  None
 				| t -> Some t

--- a/tests/optimization/src/issues/Issue11800.hx
+++ b/tests/optimization/src/issues/Issue11800.hx
@@ -1,0 +1,25 @@
+package issues;
+
+class Issue11800 {
+	@:js('
+		++issues_Issue11800.test_a;
+		++issues_Issue11800.test_b;
+		++issues_Issue11800.test_a;
+		++issues_Issue11800.test_b;
+	')
+	static function test() {
+		static var a = 0;
+
+		for (i in 0...3) {
+			switch i {
+				case n if (n < 2):
+					use(++a);
+					static var b = 0;
+					use(++b);
+				case _:
+			}
+		}
+	}
+
+	static function use(v:Int) {}
+}

--- a/tests/optimization/src/issues/Issue11800.hx
+++ b/tests/optimization/src/issues/Issue11800.hx
@@ -21,21 +21,5 @@ class Issue11800 {
 		}
 	}
 
-	@:js('
-		var b = issues_Issue11800.get0();
-		b = issues_Issue11800.get0();
-		b = issues_Issue11800.get0();
-	')
-	static function testLocal() {
-		for (i in 0...3) {
-			var b = get0();
-			use(b);
-		}
-	}
-
-	static function get0() {
-		return 0;
-	}
-
 	static function use(v:Int) {}
 }

--- a/tests/optimization/src/issues/Issue11800.hx
+++ b/tests/optimization/src/issues/Issue11800.hx
@@ -21,5 +21,21 @@ class Issue11800 {
 		}
 	}
 
+	@:js('
+		var b = issues_Issue11800.get0();
+		b = issues_Issue11800.get0();
+		b = issues_Issue11800.get0();
+	')
+	static function testLocal() {
+		for (i in 0...3) {
+			var b = get0();
+			use(b);
+		}
+	}
+
+	static function get0() {
+		return 0;
+	}
+
 	static function use(v:Int) {}
 }

--- a/tests/unit/src/unit/issues/Issue11800.hx
+++ b/tests/unit/src/unit/issues/Issue11800.hx
@@ -1,0 +1,21 @@
+package unit.issues;
+
+class Issue11800 extends unit.Test {
+	public function test() {
+		static var a = 0; // Works.
+		var buf = new StringBuf();
+		function append(v:Int) {
+			buf.add(Std.string(v));
+		}
+		for (i in 0...3) {
+			switch i {
+				case n if (n < 2):
+					append(++a);
+					static var b = 0; // Not static.
+					append(++b); // Always `1`.
+				case _:
+			}
+		}
+		eq("1122", buf.toString());
+	}
+}


### PR DESCRIPTION
This is a pretty bad oversight which might cause all sorts of issues, so we might want to pull it onto the 4.3 branch as well.

As fallout, we now hoist static locals inside unrollable loops in order to avoid duplicate declarations. Looking at this makes we wonder if we shouldn't always hoist local declarations in these cases to avoid declaring multiple variables unnecessarily.

Closes #11800