### PR TITLE
[LUA] Fix do while loops on lua

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -585,9 +585,9 @@ and gen_loop ctx cond do_while e =
         println ctx "local _hx_do_first_%i = true;" ctx.break_depth;
     let b = open_block ctx in
     print ctx "while ";
-    gen_cond ctx cond;
     if do_while then
-        print ctx " or _hx_do_first_%i" ctx.break_depth;
+        print ctx "_hx_do_first_%i or " ctx.break_depth;
+    gen_cond ctx cond;
     print ctx " do ";
     if do_while then begin
         newline ctx;

--- a/tests/unit/src/unit/issues/Issue11807.hx
+++ b/tests/unit/src/unit/issues/Issue11807.hx
@@ -8,6 +8,6 @@ class Issue11807 extends Test {
 			test = {type: 5};
 		} while (test.type != 5);
 
-		utest.Assert.pass();
+		eq(5, test.type);
 	}
 }

--- a/tests/unit/src/unit/issues/Issue11807.hx
+++ b/tests/unit/src/unit/issues/Issue11807.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+class Issue11807 extends Test {
+	function test() {
+		var test = null;
+
+		do {
+			test = {type: 5};
+		} while (test.type != 5);
+
+		utest.Assert.pass();
+	}
+}


### PR DESCRIPTION
This fixes an issue where

```hx
var test = null;

do {
    test = {type: 5};
}
while (test.type != 5);
```

would crash