### PR TITLE
[hl] Fix debug pos in assign when reg reuse arg

### DIFF
--- a/src/generators/hlopt.ml
+++ b/src/generators/hlopt.ml
@@ -578,7 +578,7 @@ let remap_fun ctx f dump get_str old_code =
 				if p < 0 || (match op p with ONop _ -> false | _ -> true) then [(i,p)] else
 				let reg, last_w = try Hashtbl.find ctx.r_reg_moved p with Not_found -> (-1,-1) in
 				if reg < 0 then [] (* ? *) else
-				if reg < nargs then [(i,-reg-1)] else
+				if reg < nargs then [(i,-reg-2)] else
 				let b = resolve_block p in
 				if last_w >= b.bstart && last_w < b.bend && last_w < p then loop last_w else
 				let wp = try PMap.find reg b.bwrite with Not_found -> -1 in


### PR DESCRIPTION
The structure `f.assigns` (from `ctx.m.massign`) is composed of a name and a position, and the position being
- `>0` if the assigns occurs in the function body
- `-1` when it's an argument
- `-2` when it's captured variables, located at r0 (position value is `-(r+2)` added by `add_capture`). Note: I never see "this" at r0 and captured variables at r1, so captured variables are always at r0 in my experience.

But when a variable is optimized by hlopt and uses the same register as an argument, currently reusing `r1` will cause assign position becomes `-2` (`-reg-1`), which could not be differenced with captured variable at r0 when interpreting the position `-2`.
This commit fix this position by using `-r-2`, so a variable using r1 will have position `-3`, can be distinguish from captured variables located at r0.

Example:
```haxe
class Test {
	public function new() {
		foo(10, 11);
		var functionvar = 15;
		function bar(x, y) {
			var pt = new Point(x, y);
			// negative assigns before fix: pt.y: -3, pt.x: -2, functionvar: -2, x: -1, y: -1
			// negative assigns after fix : pt.y: -4, pt.x: -3, functionvar: -2, x: -1, y: -1
			trace(functionvar, pt.x, pt.y); // nargs=3, captured functionvar at r0, x=pt.x=r1, y=pt.y=r2
		}
		bar(12, 13);
		function bar2(x, y) {
			var pt = new Point(x, y);
			// negative assigns before fix: pt.y: -2, pt.x: -1, x: -1, y: -1
			// negative assigns after fix : pt.y: -3, pt.x: -2, x: -1, y: -1
			trace(pt.x, pt.y); // nargs=2, x=pt.x=r0, y=pt.y=r1
		}
		bar2(14, 15);
	}
	function foo(x : Int, y : Int) {
		var pt = new Point(x, y);
		// negative assigns before fix: pt.y: -3, pt.x: -2, x: -1, y: -1
		// negative assigns after fix : pt.y: -4, pt.x: -3, x: -1, y: -1
		trace(pt.x, pt.y);  // nargs=3, this at r0, x=pt.x=r1, y=pt.y=r2
	}

	static function main() {
		new Test();
	}
}

class Point {
	public var x : Int;
	public var y : Int;
	public inline function new(x = 0, y = 0) {
		this.x = x;
		this.y = y;
	}
}
```
