### PR TITLE
Fix typos throughout the source code

### DIFF
--- a/std/Std.hx
+++ b/std/Std.hx
@@ -97,7 +97,7 @@ extern class Std {
 
 		Leading whitespaces are ignored.
 
-		`x` may optionally start with a + or - to denote a postive or negative value respectively.
+		`x` may optionally start with a + or - to denote a positive or negative value respectively.
 
 		If the optional sign is followed 0x or 0X, hexadecimal notation is recognized where the following
 		digits may contain 0-9 and A-F. Both the prefix and digits are case insensitive.

--- a/std/String.hx
+++ b/std/String.hx
@@ -102,7 +102,7 @@ extern class String {
 		is performed within `this` String. In either case, the returned position
 		is relative to the beginning of `this` String.
 
-		If `startIndex` is negative, the result is unspecifed.
+		If `startIndex` is negative, the result is unspecified.
 
 		If `str` cannot be found, -1 is returned.
 	**/

--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -82,7 +82,7 @@ extern class Sys {
 	static function sleep(seconds:Float):Void;
 
 	/**
-		Changes the current time locale, which will affect `DateTools.format` date formating.
+		Changes the current time locale, which will affect `DateTools.format` date formatting.
 		Returns `true` if the locale was successfully changed.
 	**/
 	static function setTimeLocale(loc:String):Bool;

--- a/std/Xml.hx
+++ b/std/Xml.hx
@@ -361,7 +361,7 @@ class Xml {
 
 	/**
 		Removes a child from the Document or Element.
-		Returns true if the child was successfuly removed.
+		Returns true if the child was successfully removed.
 	**/
 	public function removeChild(x:Xml):Bool {
 		ensureElementType();

--- a/std/cpp/cppia/HostClasses.hx
+++ b/std/cpp/cppia/HostClasses.hx
@@ -176,7 +176,7 @@ class HostClasses {
 		externs.set("haxe._Int64.___Int64", true);
 		externs.set("haxe._Int32.Int32_Impl_", true);
 		externs.set("haxe._Int32.___Int32", true);
-		// Hidded in implementation classes
+		// Hidden in implementation classes
 		// externs.set("sys.db.RecordType",true);
 		externs.set("sys.net._Socket.SocketInput", true);
 		externs.set("sys.net._Socket.SocketOutput", true);

--- a/std/cpp/net/ThreadServer.hx
+++ b/std/cpp/net/ThreadServer.hx
@@ -347,7 +347,7 @@ class ThreadServer<Client, Message> {
 	}
 
 	/**
-		Called when a message has been recieved. Message handling code should go here.
+		Called when a message has been received. Message handling code should go here.
 	**/
 	public dynamic function clientMessage(c:Client, msg:Message) {}
 

--- a/std/cpp/vm/Debugger.hx
+++ b/std/cpp/vm/Debugger.hx
@@ -121,7 +121,7 @@ class Debugger {
 		Sets the handler callback to be made when asynchronous events occur,
 		specifically, when threads are created, terminated, started, or
 		stopped. The calling thread becomes the "debugger" thread, which means
-		that it will be discluded from any breakpoints and will not be reported
+		that it will be excluded from any breakpoints and will not be reported
 		on by any thread reporting requests.
 
 		Be aware that this callback is made asynchronously and possibly by

--- a/std/eval/luv/File.hx
+++ b/std/eval/luv/File.hx
@@ -296,17 +296,17 @@ enum abstract FileSymlinkFlag(Int) {
 	static public function realPath(loop:Loop, path:NativeString, ?request:FileRequest, callback:(result:Result<NativeString>)->Void):Void;
 
 	/**
-		Changes owneship of the file at the given path.
+		Changes ownership of the file at the given path.
 	**/
 	static public function chown(loop:Loop, path:NativeString, uid:Int, gid:Int, ?request:FileRequest, callback:(result:Result<Result.NoData>)->Void):Void;
 
 	/**
-		Changes owneship of the file at the given path. without dereferencing symlinks.
+		Changes ownership of the file at the given path. without dereferencing symlinks.
 	**/
 	static public function lchown(loop:Loop, path:NativeString, uid:Int, gid:Int, ?request:FileRequest, callback:(result:Result<Result.NoData>)->Void):Void;
 
 	/**
-		Changes owneship of the file.
+		Changes ownership of the file.
 	**/
 	public function fchown(loop:Loop, uid:Int, gid:Int, ?request:FileRequest, callback:(result:Result<Result.NoData>)->Void):Void;
 

--- a/std/eval/luv/Pipe.hx
+++ b/std/eval/luv/Pipe.hx
@@ -63,7 +63,7 @@ enum ReceiveHandle {
 		calls its callback, there may be file descriptors in the pipe, in addition
 		to the ordinary data provided to the callback.
 
-		To check, call this function `eval.luv.Pipe.recieveHandle` in a loop until
+		To check, call this function `eval.luv.Pipe.receiveHandle` in a loop until
 		it returns `NONE`. Each time it returns `TCP(associate)` or `PIPE(associate)`,
 		create an appropriate handle using either `eval.luv.TCP.init` or `eval.uv.Pipe.init`,
 		and call `associate` to receive the file descriptor and associate it with handle.

--- a/std/eval/vm/Gc.hx
+++ b/std/eval/vm/Gc.hx
@@ -123,7 +123,7 @@ typedef Control = {
 	var major_heap_increment:Int;
 
 	/**
-		The major GC speed is computed from this parameter. This is the memory that will be "wasted" because the GC does not immediatly collect unreachable blocks. It is expressed as a percentage of the memory used for live data. The GC will work more (use more CPU time and collect blocks more eagerly) if space_overhead is smaller. Default: 80.
+		The major GC speed is computed from this parameter. This is the memory that will be "wasted" because the GC does not immediately collect unreachable blocks. It is expressed as a percentage of the memory used for live data. The GC will work more (use more CPU time and collect blocks more eagerly) if space_overhead is smaller. Default: 80.
 	**/
 	var space_overhead:Int;
 

--- a/std/flash/AnyType.hx
+++ b/std/flash/AnyType.hx
@@ -2,7 +2,7 @@ package flash;
 
 /**
 	This type represents the Flash `*` type, which is
-	actually the absense of type. It can be used as a
+	actually the absence of type. It can be used as a
 	type parameter for `flash.Vector` to represent the
 	native `Vector.<*>` type.
 **/

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -165,7 +165,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	}
 
 	/**
-		Performs signed integer divison of `dividend` by `divisor`.
+		Performs signed integer division of `dividend` by `divisor`.
 		Returns `{ quotient : Int64, modulus : Int64 }`.
 	**/
 	public static function divMod(dividend:Int64, divisor:Int64):{quotient:Int64, modulus:Int64} {

--- a/std/haxe/Int64Helper.hx
+++ b/std/haxe/Int64Helper.hx
@@ -83,8 +83,8 @@ class Int64Helper {
 
 		var noFractions = f - (f % 1);
 
-		// 2^53-1 and -2^53+1: these are parseable without loss of precision.
-		// In theory 2^53 and -2^53 are parseable too, but then there's no way to
+		// 2^53-1 and -2^53+1: these are parsable without loss of precision.
+		// In theory 2^53 and -2^53 are parsable too, but then there's no way to
 		// distinguish 2^53 from 2^53+1
 		// (i.e. trace(9007199254740992. + 1. > 9007199254740992.); // false!)
 		if (noFractions > 9007199254740991) {

--- a/std/haxe/atomic/AtomicInt.hx
+++ b/std/haxe/atomic/AtomicInt.hx
@@ -19,7 +19,7 @@ abstract AtomicInt {
 	public function add(b:Int):Int;
 
 	/**
-		Atomically substracts `b` from `a`.
+		Atomically subtracts `b` from `a`.
 		Returns the original value of `a`.
 	**/
 	public function sub(b:Int):Int;

--- a/std/haxe/display/Display.hx
+++ b/std/haxe/display/Display.hx
@@ -164,7 +164,7 @@ enum abstract ClassFieldOriginKind<T>(Int) {
 
 	/**
 		The field is declared on a parent type, such as:
-		- a super class field that is not overriden
+		- a super class field that is not overridden
 		- a forwarded abstract field
 	**/
 	var Parent:ClassFieldOriginKind<JsonModuleType<T>>;
@@ -508,7 +508,7 @@ enum abstract FindReferencesKind(String) to String {
 	var Direct = "direct";
 
 	/**
-		Find references to the base field and all the overidding fields in the inheritance chain.
+		Find references to the base field and all the overriding fields in the inheritance chain.
 	**/
 	var WithBaseAndDescendants = "withBaseAndDescendants";
 

--- a/std/haxe/hxb/WriterConfig.hx
+++ b/std/haxe/hxb/WriterConfig.hx
@@ -7,7 +7,7 @@ typedef WriterTargetConfig = {
 	var ?generate:Null<Bool>;
 
 	/**
-		Dot paths of modules or packages to be exluded from the archive.
+		Dot paths of modules or packages to be excluded from the archive.
 	**/
 	var ?exclude:Null<Array<String>>;
 

--- a/std/haxe/io/Error.hx
+++ b/std/haxe/io/Error.hx
@@ -29,7 +29,7 @@ package haxe.io;
 @:keep
 #end
 enum Error {
-	/** The IO is set into nonblocking mode and some data cannot be read or written **/
+	/** The IO is set into non-blocking mode and some data cannot be read or written **/
 	Blocked;
 
 	/** An integer value is outside its allowed range **/

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -397,7 +397,7 @@ class Compiler {
 	}
 
 	/**
-		Register a custom medatada for documentation and completion purposes
+		Register a custom metadata for documentation and completion purposes
 	**/
 	public static function registerCustomMetadata(meta:MetadataDescription, ?source:String):Void {
 		#if (neko || eval)

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -466,7 +466,7 @@ class Context {
 		is done running initialization macros, when typing begins.
 
 		`onAfterInitMacros` should be used to delay typer-dependant code from
-		your initalization macros, to properly separate configuration phase and
+		your initialization macros, to properly separate configuration phase and
 		actual typing.
 	**/
 	public static function onAfterInitMacros(callback:Void->Void):Void {

--- a/std/haxe/macro/Expr.hx
+++ b/std/haxe/macro/Expr.hx
@@ -342,7 +342,7 @@ typedef Var = {
 	var ?isStatic:Bool;
 
 	/**
-		Metadata associatied with the variable, if available.
+		Metadata associated with the variable, if available.
 	**/
 	var ?meta:Metadata;
 }

--- a/std/haxe/macro/JSGenApi.hx
+++ b/std/haxe/macro/JSGenApi.hx
@@ -61,6 +61,6 @@ typedef JSGenApi = {
 	/** create the metadata expression for the given type **/
 	function buildMetaData(t:BaseType):Null<TypedExpr>;
 
-	/** select the current classe **/
+	/** select the current class **/
 	function setCurrentClass(c:ClassType):Void;
 }

--- a/std/js/Syntax.hx
+++ b/std/js/Syntax.hx
@@ -71,12 +71,12 @@ extern class Syntax {
 	@:pure static function typeof(o:Dynamic):String;
 
 	/**
-		Genearte `a === b` expression.
+		Generate `a === b` expression.
 	**/
 	@:pure static function strictEq(a:Dynamic, b:Dynamic):Bool;
 
 	/**
-		Genearte `a !== b` expression.
+		Generate `a !== b` expression.
 	**/
 	@:pure static function strictNeq(a:Dynamic, b:Dynamic):Bool;
 

--- a/std/js/lib/intl/PluralRules.hx
+++ b/std/js/lib/intl/PluralRules.hx
@@ -39,7 +39,7 @@ extern class PluralRules {
 	@:pure function resolvedOptions():PluralRulesResolvedOptions;
 
 	/**
-		Returns a String indicating which plurar rule to use for locale-aware formatting.
+		Returns a String indicating which plural rule to use for locale-aware formatting.
 	**/
 	@:pure function select(number:Int):String;
 
@@ -105,12 +105,12 @@ typedef PluralRulesResolvedOptions = {
 
 enum abstract PluralRulesType(String) {
 	/**
-		For cardinal numbers (refering to the quantity of things).
+		For cardinal numbers (referring to the quantity of things).
 	 */
 	var Cardinal = "cardinal";
 
 	/**
-		For ordinal number (refering to the ordering or ranking of things, e.g. "1st", "2nd", "3rd" in English).
+		For ordinal number (referring to the ordering or ranking of things, e.g. "1st", "2nd", "3rd" in English).
 	 */
 	var Ordinal = "ordinal";
 }

--- a/std/neko/vm/Module.hx
+++ b/std/neko/vm/Module.hx
@@ -103,7 +103,7 @@ class Module {
 	}
 
 	/**
-		Each Module has an export table which can be useful to transfert
+		Each Module has an export table which can be useful to transfer
 		values between modules.
 	**/
 	public function getExports():Map<String, Dynamic> {
@@ -157,7 +157,7 @@ class Module {
 	}
 
 	/**
-		Reads a module from a name and using the specified seach path and loader.
+		Reads a module from a name and using the specified search path and loader.
 		The module is initialized but has not yet been executed.
 	**/
 	public static function readPath(name:String, path:Array<String>, loader:Loader) {

--- a/std/php/ErrorException.hx
+++ b/std/php/ErrorException.hx
@@ -27,7 +27,7 @@ package php;
 **/
 @:native('ErrorException')
 extern class ErrorException implements Throwable {
-	function new(?message:String, ?code:Int, ?severety:Int, ?filename:String, ?lineno:Int, ?previous:Throwable):Void;
+	function new(?message:String, ?code:Int, ?severity:Int, ?filename:String, ?lineno:Int, ?previous:Throwable):Void;
 
 	final function getSeverity():Int;
 	final function getPrevious():Throwable; // Returns previous Throwable

--- a/std/php/Syntax.hx
+++ b/std/php/Syntax.hx
@@ -293,7 +293,7 @@ extern class Syntax {
 
 	/**
 		```haxe
-		Syntax.assocDecl({field1:'first', field2:2}});
+		Syntax.assocDecl({field1:'first', field2:2});
 		```
 		Generates native associative array declaration:
 		```haxe

--- a/std/python/lib/Os.hx
+++ b/std/python/lib/Os.hx
@@ -92,7 +92,7 @@ extern class Os {
 	static var sep(default, null):String;
 	static var pathsep(default, null):String;
 
-	static function makedirs(path:String, mode:Int = 511 /* Oktal 777 */, exist_ok:Bool = false):Void;
+	static function makedirs(path:String, mode:Int = 511 /* Octal 777 */, exist_ok:Bool = false):Void;
 
-	static function mkdir(path:String, mode:Int = 511 /* Oktal 777 */):Void;
+	static function mkdir(path:String, mode:Int = 511 /* Octal 777 */):Void;
 }

--- a/std/python/lib/net/Address.hx
+++ b/std/python/lib/net/Address.hx
@@ -22,5 +22,5 @@
 
 package python.lib.net;
 
-@:deprecated("Use python.lib.socket.Adress instead")
+@:deprecated("Use python.lib.socket.Address instead")
 typedef Address = python.lib.socket.Address;

--- a/std/sys/ssl/Socket.hx
+++ b/std/sys/ssl/Socket.hx
@@ -58,7 +58,7 @@ extern class Socket extends sys.net.Socket {
 	function setCertificate(cert:Certificate, key:Key):Void;
 
 	/**
-		Configure additionals certificates and private keys for Server Name Indication extension.
+		Configure additional certificates and private keys for Server Name Indication extension.
 		The callback may be called during handshake to determine the certificate to use.
 	**/
 	function addSNICertificate(cbServernameMatch:String->Bool, cert:Certificate, key:Key):Void;

--- a/std/sys/thread/ElasticThreadPool.hx
+++ b/std/sys/thread/ElasticThreadPool.hx
@@ -103,7 +103,7 @@ class ElasticThreadPool implements IThreadPool {
 
 	/**
 		Initiates a shutdown.
-		All previousely submitted tasks will be executed, but no new tasks will
+		All previously submitted tasks will be executed, but no new tasks will
 		be accepted.
 
 		Multiple calls to this method have no effect.

--- a/std/sys/thread/FixedThreadPool.hx
+++ b/std/sys/thread/FixedThreadPool.hx
@@ -72,7 +72,7 @@ class FixedThreadPool implements IThreadPool {
 
 	/**
 		Initiates a shutdown.
-		All previousely submitted tasks will be executed, but no new tasks will
+		All previously submitted tasks will be executed, but no new tasks will
 		be accepted.
 
 		Multiple calls to this method have no effect.

--- a/std/sys/thread/IThreadPool.hx
+++ b/std/sys/thread/IThreadPool.hx
@@ -42,7 +42,7 @@ interface IThreadPool {
 
 	/**
 		Initiates a shutdown.
-		All previousely submitted tasks will be executed, but no new tasks will
+		All previously submitted tasks will be executed, but no new tasks will
 		be accepted.
 
 		Multiple calls to this method have no effect.

--- a/std/sys/thread/Semaphore.hx
+++ b/std/sys/thread/Semaphore.hx
@@ -20,7 +20,7 @@ package sys.thread;
 		Try to lock the semaphore.
 		If the value of the semaphore is zero, `false` is returned, else the value is increased.
 
-		If `timeout` is specified, this function will block until the thread is able to acquire the semaphore, or the timout expires.
+		If `timeout` is specified, this function will block until the thread is able to acquire the semaphore, or the timeout expires.
 		`timeout` is in seconds.
 	**/
 	public function tryAcquire(?timeout:Float):Bool;


### PR DESCRIPTION
There were some inconsistencies with British and American english, but I'm not gonna fix that, since its technically correct, and I don't know what language the documentation is supposed to be.