### PR TITLE
Add CfNoLookup

### DIFF
--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -505,10 +505,11 @@ type flag_tclass_field =
 	| CfPostProcessed (* Marker to indicate the field has been post-processed *)
 	| CfUsed (* Marker for DCE *)
 	| CfMaybeUsed (* Marker for DCE *)
+	| CfNoLookup (* Field cannot be accessed by-name. *)
 
 (* Order has to match declaration for printing*)
 let flag_tclass_field_names = [
-	"CfPublic";"CfStatic";"CfExtern";"CfFinal";"CfModifiesThis";"CfOverride";"CfAbstract";"CfOverload";"CfImpl";"CfEnum";"CfGeneric";"CfDefault";"CfPostProcessed";"CfUsed";"CfMaybeUsed"
+	"CfPublic";"CfStatic";"CfExtern";"CfFinal";"CfModifiesThis";"CfOverride";"CfAbstract";"CfOverload";"CfImpl";"CfEnum";"CfGeneric";"CfDefault";"CfPostProcessed";"CfUsed";"CfMaybeUsed";"CfNoLookup"
 ]
 
 type flag_tenum =

--- a/src/filters/localStatic.ml
+++ b/src/filters/localStatic.ml
@@ -18,7 +18,8 @@ let promote_local_static lsctx run v eo =
 		] v.v_pos);
 	with Not_found ->
 		let cf = mk_field name ~static:true v.v_type v.v_pos v.v_pos in
-		cf.cf_meta <- v.v_meta;
+		cf.cf_meta <- (Meta.NoCompletion,[],Globals.null_pos) :: v.v_meta;
+		add_class_field_flag cf CfNoLookup;
 		begin match eo with
 		| None ->
 			()

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -310,6 +310,9 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 			acc
 		) c.cl_implements
 	in
+	let no_no_lookup cf =
+		if has_class_field_flag cf CfNoLookup then display_error ctx.com "This field cannot be accessed explicitly" pfield
+	in
 	let rec type_field_by_type e t =
 		let field_access = field_access e in
 		match t with
@@ -334,6 +337,7 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 					begin try
 						let cf = PMap.find i c.cl_statics in
 						if has_class_field_flag cf CfImpl && not (has_class_field_flag cf CfEnum) then display_error ctx.com "Cannot access non-static abstract field statically" pfield;
+						no_no_lookup cf;
 						field_access cf (FHStatic c)
 					with Not_found ->
 						begin match c.cl_kind with
@@ -401,6 +405,7 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 				let c = find_some a.a_impl in
 				let f = PMap.find i c.cl_statics in
 				if not (has_class_field_flag f CfImpl) then raise Not_found;
+				no_no_lookup f;
 				field_access f (FHAbstract (a,tl,c))
 			with Not_found ->
 				type_field_by_forward_member type_field_by_type e a tl

--- a/tests/server/src/cases/display/issues/Issue11817.hx
+++ b/tests/server/src/cases/display/issues/Issue11817.hx
@@ -1,0 +1,23 @@
+package cases.display.issues;
+
+class Issue11817 extends DisplayTestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11817/MainBefore.hx"));
+		vfs.putContent("Utils.hx", getTemplate("issues/Issue11817/Utils.hx"));
+		runHaxe(["--main", "Main"]);
+		var mainHx = Marker.extractMarkers(getTemplate("issues/Issue11817/MainAfter.hx"));
+		vfs.putContent("Main.hx", mainHx.source);
+		runHaxeJson([], DisplayMethods.Completion, {
+			file: file,
+			offset: mainHx.markers[1],
+			wasAutoTriggered: true
+		});
+		var result = parseCompletion().result;
+		Assert.equals(1, result.items.length);
+		Assert.equals('foo', result.items[0].args.field.name);
+
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11817/MainError.hx"));
+		runHaxe(["--main", "Main"]);
+		assertErrorMessage("This field cannot be accessed explicitly");
+	}
+}

--- a/tests/server/src/cases/display/issues/Issue11817.hx
+++ b/tests/server/src/cases/display/issues/Issue11817.hx
@@ -7,6 +7,7 @@ class Issue11817 extends DisplayTestCase {
 		runHaxe(["--main", "Main"]);
 		var mainHx = Marker.extractMarkers(getTemplate("issues/Issue11817/MainAfter.hx"));
 		vfs.putContent("Main.hx", mainHx.source);
+		runHaxeJson([], ServerMethods.Invalidate, {file: file});
 		runHaxeJson([], DisplayMethods.Completion, {
 			file: file,
 			offset: mainHx.markers[1],

--- a/tests/server/test/templates/issues/Issue11817/MainAfter.hx
+++ b/tests/server/test/templates/issues/Issue11817/MainAfter.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		Utils.foo;
+		Utils.{-1-}
+	}
+}

--- a/tests/server/test/templates/issues/Issue11817/MainBefore.hx
+++ b/tests/server/test/templates/issues/Issue11817/MainBefore.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main() {
+		Utils.foo;
+	}
+}

--- a/tests/server/test/templates/issues/Issue11817/MainError.hx
+++ b/tests/server/test/templates/issues/Issue11817/MainError.hx
@@ -1,0 +1,6 @@
+class Main {
+	static function main() {
+		Utils.foo;
+		Utils.foo_leak;
+	}
+}

--- a/tests/server/test/templates/issues/Issue11817/Utils.hx
+++ b/tests/server/test/templates/issues/Issue11817/Utils.hx
@@ -1,0 +1,6 @@
+class Utils {
+	public static function foo():Int {
+		static var leak = 0;
+		return leak;
+	}
+}


### PR DESCRIPTION
This adds a class field flag to mark fields as unlookupable for cases such as #11817. I've only implemented it for statics for now, but there might be other situations where we generate fields that we don't want to explicitly access.

The test I added fails on the unixes for some reason. @kLabz Any chance you could take a look at that?