### PR TITLE
[ci] Fix macos-14 pkgconf issue.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -501,6 +501,7 @@ jobs:
         run: |
           set -ex
           brew update
+          brew uninstall --force pkg-config
           brew bundle --file=tests/Brewfile --no-upgrade
           cpanm IPC::System::Simple
           cpanm String::ShellQuote

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -7,6 +7,7 @@
   run: |
     set -ex
     brew update
+    brew uninstall --force pkg-config
     brew bundle --file=tests/Brewfile --no-upgrade
     cpanm IPC::System::Simple
     cpanm String::ShellQuote


### PR DESCRIPTION
pkg-config is pre-installed on certain runners, which results in conflicts with the pkgconf package that replaces it: https://github.com/actions/runner-images/issues/10984