### PR TITLE
Sys: Clarify `cpuTime` documentation

### DIFF
--- a/std/Sys.hx
+++ b/std/Sys.hx
@@ -139,8 +139,10 @@ extern class Sys {
 	static function time():Float;
 
 	/**
-		Gives the most precise timestamp value available (in seconds),
-		but only accounts for the actual time spent running on the CPU for the current thread/process.
+    		Returns CPU time consumed by the current process or thread, measured in seconds.
+		This value only includes the actual time the CPU has actively spent executing 
+		instructions for the process/thread and excludes idle or sleep time. The precision 
+		and behavior may vary depending on the platform and underlying implementation.
 	**/
 	static function cpuTime():Float;
 


### PR DESCRIPTION
The existing documentation can be confusing. I think its easy to assume that this returns the time since the process was started, especially if you dont understand how the native api's calculate it. It easy to mistake that this simply might be the wall time since the cpu was running and end up with unreliable behavior when sleep is introduced to your thread.

The new documentation makes this pretty clear I think.