### PR TITLE
[eval] Fix ssl cert verification failures on clean windows environments

### DIFF
--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -302,12 +302,57 @@ static struct custom_operations ssl_config_ops = {
 	.deserialize = custom_deserialize_default,
 };
 
+#ifdef _WIN32
+static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+	if(depth == 0) {
+		HCERTSTORE store = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG, NULL);
+		if(store == NULL) {
+			// handle error
+		}
+		PCCERT_CONTEXT primary_context = {0};
+		if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &primary_context)) {
+			return MBEDTLS_ERR_X509_FATAL_ERROR;
+		}
+		while(crt->next) {
+			crt = crt->next;
+			PCCERT_CONTEXT ctx = {0};
+			if (!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &ctx))
+			{
+				return MBEDTLS_ERR_X509_FATAL_ERROR;
+			}
+			CertFreeCertificateContext(ctx);
+		}
+		PCCERT_CHAIN_CONTEXT chain_context = {0};
+		PCERT_CHAIN_PARA parameters = {0};
+		if(!CertGetCertificateChain(NULL, primary_context, NULL, store, parameters, 0, NULL, &chain_context)) {
+			return MBEDTLS_ERR_X509_FATAL_ERROR;
+		}
+		PCERT_CHAIN_POLICY_PARA policy_parameters = {0};
+		CERT_CHAIN_POLICY_STATUS policy_status = {0};
+		if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, policy_parameters, &policy_status)) {
+			return MBEDTLS_ERR_X509_FATAL_ERROR;
+		}
+		if(policy_status.dwError != 0) {
+			// TODO: properly map errors
+			*flags |= MBEDTLS_X509_BADCERT_OTHER;
+		}
+		CertFreeCertificateChain(chain_context);
+		CertFreeCertificateContext(primary_context);
+		CertCloseStore(store, 0);
+	}
+	return 0;
+}
+#endif
+
 CAMLprim value ml_mbedtls_ssl_config_init(void) {
 	CAMLparam0();
 	CAMLlocal1(obj);
 	obj = caml_alloc_custom(&ssl_config_ops, sizeof(mbedtls_ssl_config*), 0, 1);
 	mbedtls_ssl_config* ssl_config = malloc(sizeof(mbedtls_ssl_config));
 	mbedtls_ssl_config_init(ssl_config);
+	#ifdef _WIN32
+	mbedtls_ssl_conf_verify(ssl_config, verify_callback, NULL);
+	#endif
 	Config_val(obj) = ssl_config;
 	CAMLreturn(obj);
 }

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -307,7 +307,7 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 	if(depth == 0) {
 		HCERTSTORE store = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG, NULL);
 		if(store == NULL) {
-			// handle error
+			return MBEDTLS_ERR_X509_FATAL_ERROR;
 		}
 		PCCERT_CONTEXT primary_context = {0};
 		if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &primary_context)) {

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -323,13 +323,13 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 			CertFreeCertificateContext(ctx);
 		}
 		PCCERT_CHAIN_CONTEXT chain_context = {0};
-		PCERT_CHAIN_PARA parameters = {0};
-		if(!CertGetCertificateChain(NULL, primary_context, NULL, store, parameters, 0, NULL, &chain_context)) {
+		CERT_CHAIN_PARA parameters = {0};
+		if(!CertGetCertificateChain(NULL, primary_context, NULL, store, &parameters, 0, NULL, &chain_context)) {
 			return MBEDTLS_ERR_X509_FATAL_ERROR;
 		}
-		PCERT_CHAIN_POLICY_PARA policy_parameters = {0};
+		CERT_CHAIN_POLICY_PARA policy_parameters = {0};
 		CERT_CHAIN_POLICY_STATUS policy_status = {0};
-		if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, policy_parameters, &policy_status)) {
+		if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, &policy_parameters, &policy_status)) {
 			return MBEDTLS_ERR_X509_FATAL_ERROR;
 		}
 		if(policy_status.dwError != 0) {

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -304,7 +304,7 @@ static struct custom_operations ssl_config_ops = {
 
 #ifdef _WIN32
 static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
-	if (*flags & MBEDTLS_X509_BADCERT_CN_MISMATCH) {
+	if (*flags == 0 || *flags & MBEDTLS_X509_BADCERT_CN_MISMATCH) {
 		return 0;
 	}
 

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -304,6 +304,10 @@ static struct custom_operations ssl_config_ops = {
 
 #ifdef _WIN32
 static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
+	if (*flags & MBEDTLS_X509_BADCERT_CN_MISMATCH) {
+		return 0;
+	}
+
 	HCERTSTORE store = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG, NULL);
 	if(store == NULL) {
 		return MBEDTLS_ERR_X509_FATAL_ERROR;

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -332,7 +332,9 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 		if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, &policy_parameters, &policy_status)) {
 			return MBEDTLS_ERR_X509_FATAL_ERROR;
 		}
-		if(policy_status.dwError != 0) {
+		if(policy_status.dwError == 0) {
+			*flags = 0;
+		} else {
 			// TODO: properly map errors
 			*flags |= MBEDTLS_X509_BADCERT_OTHER;
 		}

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -304,44 +304,33 @@ static struct custom_operations ssl_config_ops = {
 
 #ifdef _WIN32
 static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32_t *flags) {
-	if(depth == 0) {
-		HCERTSTORE store = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG, NULL);
-		if(store == NULL) {
-			return MBEDTLS_ERR_X509_FATAL_ERROR;
-		}
-		PCCERT_CONTEXT primary_context = {0};
-		if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &primary_context)) {
-			return MBEDTLS_ERR_X509_FATAL_ERROR;
-		}
-		while(crt->next) {
-			crt = crt->next;
-			PCCERT_CONTEXT ctx = {0};
-			if (!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &ctx))
-			{
-				return MBEDTLS_ERR_X509_FATAL_ERROR;
-			}
-			CertFreeCertificateContext(ctx);
-		}
-		PCCERT_CHAIN_CONTEXT chain_context = {0};
-		CERT_CHAIN_PARA parameters = {0};
-		if(!CertGetCertificateChain(NULL, primary_context, NULL, store, &parameters, 0, NULL, &chain_context)) {
-			return MBEDTLS_ERR_X509_FATAL_ERROR;
-		}
-		CERT_CHAIN_POLICY_PARA policy_parameters = {0};
-		CERT_CHAIN_POLICY_STATUS policy_status = {0};
-		if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, &policy_parameters, &policy_status)) {
-			return MBEDTLS_ERR_X509_FATAL_ERROR;
-		}
-		if(policy_status.dwError == 0) {
-			*flags = 0;
-		} else {
-			// TODO: properly map errors
-			*flags |= MBEDTLS_X509_BADCERT_OTHER;
-		}
-		CertFreeCertificateChain(chain_context);
-		CertFreeCertificateContext(primary_context);
-		CertCloseStore(store, 0);
+	HCERTSTORE store = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_DEFER_CLOSE_UNTIL_LAST_FREE_FLAG, NULL);
+	if(store == NULL) {
+		return MBEDTLS_ERR_X509_FATAL_ERROR;
 	}
+	PCCERT_CONTEXT primary_context = {0};
+	if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &primary_context)) {
+		return MBEDTLS_ERR_X509_FATAL_ERROR;
+	}
+	PCCERT_CHAIN_CONTEXT chain_context = {0};
+	CERT_CHAIN_PARA parameters = {0};
+	if(!CertGetCertificateChain(NULL, primary_context, NULL, store, &parameters, 0, NULL, &chain_context)) {
+		return MBEDTLS_ERR_X509_FATAL_ERROR;
+	}
+	CERT_CHAIN_POLICY_PARA policy_parameters = {0};
+	CERT_CHAIN_POLICY_STATUS policy_status = {0};
+	if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, &policy_parameters, &policy_status)) {
+		return MBEDTLS_ERR_X509_FATAL_ERROR;
+	}
+	if(policy_status.dwError == 0) {
+		*flags = 0;
+	} else {
+		// TODO: properly map errors
+		*flags |= MBEDTLS_X509_BADCERT_OTHER;
+	}
+	CertFreeCertificateChain(chain_context);
+	CertFreeCertificateContext(primary_context);
+	CertCloseStore(store, 0);
 	return 0;
 }
 #endif

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -309,7 +309,7 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 		return MBEDTLS_ERR_X509_FATAL_ERROR;
 	}
 	PCCERT_CONTEXT primary_context = {0};
-	if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &primary_context)) {
+	if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_REPLACE_EXISTING, &primary_context)) {
 		CertCloseStore(store, 0);
 		return MBEDTLS_ERR_X509_FATAL_ERROR;
 	}

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -310,16 +310,22 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 	}
 	PCCERT_CONTEXT primary_context = {0};
 	if(!CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, crt->raw.p, crt->raw.len, CERT_STORE_ADD_ALWAYS, &primary_context)) {
+		CertCloseStore(store, 0);
 		return MBEDTLS_ERR_X509_FATAL_ERROR;
 	}
 	PCCERT_CHAIN_CONTEXT chain_context = {0};
 	CERT_CHAIN_PARA parameters = {0};
 	if(!CertGetCertificateChain(NULL, primary_context, NULL, store, &parameters, 0, NULL, &chain_context)) {
+		CertFreeCertificateContext(primary_context);
+		CertCloseStore(store, 0);
 		return MBEDTLS_ERR_X509_FATAL_ERROR;
 	}
 	CERT_CHAIN_POLICY_PARA policy_parameters = {0};
 	CERT_CHAIN_POLICY_STATUS policy_status = {0};
 	if(!CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain_context, &policy_parameters, &policy_status)) {
+		CertFreeCertificateChain(chain_context);
+		CertFreeCertificateContext(primary_context);
+		CertCloseStore(store, 0);
 		return MBEDTLS_ERR_X509_FATAL_ERROR;
 	}
 	if(policy_status.dwError == 0) {

--- a/libs/mbedtls/mbedtls_stubs.c
+++ b/libs/mbedtls/mbedtls_stubs.c
@@ -335,7 +335,8 @@ static int verify_callback(void* param, mbedtls_x509_crt *crt, int depth, uint32
 	if(policy_status.dwError == 0) {
 		*flags = 0;
 	} else {
-		// TODO: properly map errors
+		// if we ever want to read the verification result,
+		// we need to properly map dwError to flags
 		*flags |= MBEDTLS_X509_BADCERT_OTHER;
 	}
 	CertFreeCertificateChain(chain_context);


### PR DESCRIPTION
This uses an mbedtls callback to call some windows api functions if verification fails, which avoids certain failures in clean windows environments.

For example, this allows running haxelib via eval in a clean windows environment without the certificate verification failing.

Thanks to @Apprentice-Alchemist and @Aidan63 for their help in solving/debugging the problem!