### PR TITLE
[hl] Use HDyn instead of erroring on recursive types

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -390,7 +390,7 @@ let rec to_type ?tref ctx t =
 	| TType (td,tl) ->
 		let t =
 			get_rec_cache ctx t
-				(fun() -> abort "Unsupported recursive type" td.t_pos)
+				(fun() -> HDyn)
 				(fun tref -> to_type ~tref ctx (apply_typedef td tl))
 		in
 		(match td.t_path with

--- a/tests/unit/src/unit/issues/Issue3024.hx
+++ b/tests/unit/src/unit/issues/Issue3024.hx
@@ -1,13 +1,5 @@
 package unit.issues;
 
-#if hl
-
-// no support for recursive types atm
-class Issue3024 extends Test {
-}
-
-#else
-
 import haxe.ds.StringMap;
 import haxe.ds.Vector;
 
@@ -16,7 +8,6 @@ private typedef MyMap = StringMap<MyFunction>;
 private typedef MyFunction = MyVector->MyMap->Dynamic;
 
 class Issue3024 extends Test {
-
 	private var myVector:MyVector;
 
 	private var myMap:MyMap;
@@ -31,5 +22,3 @@ class Issue3024 extends Test {
 		this.myMap = myMap;
 	}
 }
-
-#end


### PR DESCRIPTION
This is what I've been doing on the JVM target and I think it makes sense because the types end up being erased at run-time anyway.

Please check and merge if you agree!

Closes #11839