### PR TITLE
Include module path in virtual file names

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -232,9 +232,9 @@ class file_keys = object(self)
 
 	val virtual_counter = ref 0
 
-	method generate_virtual step =
+	method generate_virtual mpath step =
 		incr virtual_counter;
-		Printf.sprintf "file_%i_%i" step !virtual_counter
+		Printf.sprintf "%s/file_%i_%i" (s_type_path mpath) step !virtual_counter
 
 end
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -234,7 +234,8 @@ class file_keys = object(self)
 
 	method generate_virtual mpath step =
 		incr virtual_counter;
-		Printf.sprintf "%s/%s_%i_%i" (ExtLib.String.join "/" (fst mpath)) (snd mpath) step !virtual_counter
+		let base = match fst mpath with | [] -> "." | pack -> ExtLib.String.join "/" pack in
+		Printf.sprintf "%s/%s_%i_%i" base (snd mpath) step !virtual_counter
 
 end
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -234,7 +234,7 @@ class file_keys = object(self)
 
 	method generate_virtual mpath step =
 		incr virtual_counter;
-		Printf.sprintf "%s/file_%i_%i" (s_type_path mpath) step !virtual_counter
+		Printf.sprintf "%s/%s_%i_%i" (ExtLib.String.join "/" (fst mpath)) (snd mpath) step !virtual_counter
 
 end
 

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -455,7 +455,7 @@ let make_macro_api ctx mctx p =
 			let mctx = (match ctx.g.macros with None -> die "" __LOC__ | Some (_,mctx) -> mctx) in
 			let ttype = Typeload.load_instance mctx (make_ptp cttype p) ParamNormal LoadNormal in
 			let f () = Interp.decode_type_def v in
-			let m, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
+			let mpath, tdef, pos = safe_decode ctx.com v "TypeDefinition" ttype p f in
 			let has_native_meta = match tdef with
 				| EClass d -> Meta.has Meta.Native d.d_meta
 				| EEnum d -> Meta.has Meta.Native d.d_meta
@@ -465,7 +465,7 @@ let make_macro_api ctx mctx p =
 			in
 			let add is_macro ctx =
 				let mdep = Option.map_default (fun s -> TypeloadModule.load_module ~origin:MDepFromMacro ctx (parse_path s) pos) ctx.m.curmod mdep in
-				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) m (ctx.com.file_keys#generate_virtual m ctx.com.compilation_step) [tdef,pos] pos in
+				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) mpath (ctx.com.file_keys#generate_virtual mpath ctx.com.compilation_step) [tdef,pos] pos in
 				mnew.m_extra.m_kind <- if is_macro then MMacro else MFake;
 				add_dependency mnew mdep MDepFromMacro;
 				add_dependency mdep mnew MDepFromMacroDefine;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -465,7 +465,7 @@ let make_macro_api ctx mctx p =
 			in
 			let add is_macro ctx =
 				let mdep = Option.map_default (fun s -> TypeloadModule.load_module ~origin:MDepFromMacro ctx (parse_path s) pos) ctx.m.curmod mdep in
-				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) m (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) [tdef,pos] pos in
+				let mnew = TypeloadModule.type_module ctx.com ctx.g ~dont_check_path:(has_native_meta) m (ctx.com.file_keys#generate_virtual m ctx.com.compilation_step) [tdef,pos] pos in
 				mnew.m_extra.m_kind <- if is_macro then MMacro else MFake;
 				add_dependency mnew mdep MDepFromMacro;
 				add_dependency mdep mnew MDepFromMacroDefine;
@@ -502,7 +502,7 @@ let make_macro_api ctx mctx p =
 				end else
 					ignore(TypeloadModule.type_types_into_module ctx.com ctx.g m types pos)
 			with Not_found ->
-				let mnew = TypeloadModule.type_module ctx.com ctx.g mpath (ctx.com.file_keys#generate_virtual ctx.com.compilation_step) types pos in
+				let mnew = TypeloadModule.type_module ctx.com ctx.g mpath (ctx.com.file_keys#generate_virtual mpath ctx.com.compilation_step) types pos in
 				mnew.m_extra.m_kind <- MFake;
 				add_dependency mnew ctx.m.curmod MDepFromMacro;
 				add_dependency ctx.m.curmod mnew MDepFromMacroDefine;

--- a/tests/misc/projects/Issue11852/Main.hx
+++ b/tests/misc/projects/Issue11852/Main.hx
@@ -1,0 +1,51 @@
+import sys.io.File;
+
+class Main {
+	#if macro
+	public static function init() {
+		var pos = haxe.macro.Context.currentPos();
+
+		haxe.macro.Context.onAfterInitMacros(() -> {
+			haxe.macro.Context.defineType({
+				pack: [],
+				name: "TopLevelType",
+				pos: pos,
+				kind: TDStructure,
+				fields: []
+			});
+
+			haxe.macro.Context.defineType({
+				pack: ["foo", "bar"],
+				name: "DefinedType",
+				pos: pos,
+				kind: TDStructure,
+				fields: []
+			});
+		});
+	}
+	#else
+	public static function main() {
+		// Add generated modules as dependencies for Main
+		var _:TopLevelType = {};
+		var _:foo.bar.DefinedType = {};
+
+		var lines = File.getContent("dump/eval/dependencies.dump").split("\n");
+		lines = lines.map(l -> StringTools.replace(l, "\\", "/"));
+		inline function check(module:String) {
+			var line = Lambda.filter(lines, l -> StringTools.endsWith(l, module)).shift();
+
+			if (line == null)
+				throw 'Cannot find $module in dependency dump';
+
+			if (!StringTools.endsWith(line, 'tests/misc/projects/Issue11852/$module')) {
+				trace(module, line);
+				throw 'Incorrect path generated for $module';
+			}
+		}
+
+		// Check generated path for macro generated modules
+		check("TopLevelType_1_1");
+		check("foo/bar/DefinedType_1_2");
+	}
+	#end
+}

--- a/tests/misc/projects/Issue11852/compile.hxml
+++ b/tests/misc/projects/Issue11852/compile.hxml
@@ -1,0 +1,4 @@
+--macro Main.init()
+-main Main
+-D dump-dependencies
+--interp


### PR DESCRIPTION
When using `-D dump-dependencies`, macro modules show up with their file names, but for macro generated modules that's unusable (they're all named `/server/file_x_y` which doesn't help much).

tbh I'm not sure this is the kind of fix we need here, but I also didn't want to break things relying on current `-D dump-dependencies` output.