### PR TITLE
Remove @:overload from Reflect.makeVarArgs

### DIFF
--- a/std/Reflect.hx
+++ b/std/Reflect.hx
@@ -197,6 +197,5 @@ extern class Reflect {
 		Transform a function taking an array of arguments into a function that can
 		be called with any number of arguments.
 	**/
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic;
+	static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic;
 }

--- a/std/cpp/_std/Reflect.hx
+++ b/std/cpp/_std/Reflect.hx
@@ -25,21 +25,18 @@ import cpp.ObjectType;
 @:coreApi
 @:analyzer(ignore)
 class Reflect {
-	public static function hasField(o:Dynamic, field:String):Bool
-		untyped {
-			return o != null && o.__HasField(field);
-		}
+	public static function hasField(o:Dynamic, field:String):Bool untyped {
+		return o != null && o.__HasField(field);
+	}
 
-	public static function field(o:Dynamic, field:String):Dynamic
-		untyped {
-			return (o == null) ? null : o.__Field(field, untyped __cpp__("::hx::paccNever"));
-		}
+	public static function field(o:Dynamic, field:String):Dynamic untyped {
+		return (o == null) ? null : o.__Field(field, untyped __cpp__("::hx::paccNever"));
+	}
 
-	public static function setField(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			if (o != null)
-				o.__SetField(field, value, untyped __cpp__("::hx::paccNever"));
-		}
+	public static function setField(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		if (o != null)
+			o.__SetField(field, value, untyped __cpp__("::hx::paccNever"));
+	}
 
 	public static function getProperty(o:Dynamic, field:String):Dynamic {
 		return (o == null) ? null : o.__Field(field, untyped __cpp__("::hx::paccAlways"));
@@ -50,32 +47,29 @@ class Reflect {
 			o.__SetField(field, value, untyped __cpp__("::hx::paccAlways"));
 	}
 
-	public static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic
-		untyped {
-			if (func != null && func.__GetType() == ObjectType.vtString) {
-				if (o == null)
-					throw cpp.ErrorConstants.invalidObject;
-				func = o.__Field(func, untyped __cpp__("::hx::paccDynamic"));
-			}
-			if (func == null)
-				throw cpp.ErrorConstants.nullFunctionPointer;
-			untyped func.__SetThis(o);
-			return untyped func.__Run(args);
-		}
-
-	public static function fields(o:Dynamic):Array<String>
-		untyped {
+	public static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic untyped {
+		if (func != null && func.__GetType() == ObjectType.vtString) {
 			if (o == null)
-				return new Array();
-			var a:Array<String> = [];
-			o.__GetFields(a);
-			return a;
+				throw cpp.ErrorConstants.invalidObject;
+			func = o.__Field(func, untyped __cpp__("::hx::paccDynamic"));
 		}
+		if (func == null)
+			throw cpp.ErrorConstants.nullFunctionPointer;
+		untyped func.__SetThis(o);
+		return untyped func.__Run(args);
+	}
 
-	public static function isFunction(f:Dynamic):Bool
-		untyped {
-			return f != null && f.__GetType() == ObjectType.vtFunction;
-		}
+	public static function fields(o:Dynamic):Array<String> untyped {
+		if (o == null)
+			return new Array();
+		var a:Array<String> = [];
+		o.__GetFields(a);
+		return a;
+	}
+
+	public static function isFunction(f:Dynamic):Bool untyped {
+		return f != null && f.__GetType() == ObjectType.vtFunction;
+	}
 
 	public static function compare<T>(a:T, b:T):Int {
 		return (a == b) ? 0 : (((a : Dynamic) > (b : Dynamic)) ? 1 : -1);
@@ -89,25 +83,22 @@ class Reflect {
 		return untyped __global__.__hxcpp_same_closure(f1, f2);
 	}
 
-	public static function isObject(v:Dynamic):Bool
-		untyped {
-			if (v == null)
-				return false;
-			var t:Int = v.__GetType();
-			return t == ObjectType.vtObject || t == ObjectType.vtClass || t == ObjectType.vtString || t == ObjectType.vtArray;
-		}
+	public static function isObject(v:Dynamic):Bool untyped {
+		if (v == null)
+			return false;
+		var t:Int = v.__GetType();
+		return t == ObjectType.vtObject || t == ObjectType.vtClass || t == ObjectType.vtString || t == ObjectType.vtArray;
+	}
 
-	public static function isEnumValue(v:Dynamic):Bool
-		untyped {
-			return v != null && v.__GetType() == ObjectType.vtEnum;
-		}
+	public static function isEnumValue(v:Dynamic):Bool untyped {
+		return v != null && v.__GetType() == ObjectType.vtEnum;
+	}
 
-	public static function deleteField(o:Dynamic, field:String):Bool
-		untyped {
-			if (o == null)
-				return false;
-			return untyped __global__.__hxcpp_anon_remove(o, field);
-		}
+	public static function deleteField(o:Dynamic, field:String):Bool untyped {
+		if (o == null)
+			return false;
+		return untyped __global__.__hxcpp_anon_remove(o, field);
+	}
 
 	public static function copy<T>(o:Null<T>):Null<T> {
 		if (o == null)
@@ -122,8 +113,7 @@ class Reflect {
 		return o2;
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return untyped __global__.__hxcpp_create_var_args(f);
 	}
 }

--- a/std/flash/_std/Reflect.hx
+++ b/std/flash/_std/Reflect.hx
@@ -20,65 +20,57 @@
  * DEALINGS IN THE SOFTWARE.
  */
 @:coreApi class Reflect {
-	public static function hasField(o:Dynamic, field:String):Bool
-		untyped {
-			return o.hasOwnProperty(field);
-		}
+	public static function hasField(o:Dynamic, field:String):Bool untyped {
+		return o.hasOwnProperty(field);
+	}
 
-	public static function field(o:Dynamic, field:String):Dynamic
-		untyped {
-			return o != null && __in__(field, o) ? o[field] : null;
-		}
+	public static function field(o:Dynamic, field:String):Dynamic untyped {
+		return o != null && __in__(field, o) ? o[field] : null;
+	}
 
-	public inline static function setField(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
+	public inline static function setField(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		o[field] = value;
+	}
+
+	public static function getProperty(o:Dynamic, field:String):Dynamic untyped {
+		if (o == null)
+			return null;
+		var getter = 'get_$field';
+		if (__in__(getter, o)) {
+			return o[getter]();
+		}
+		return __in__(field, o) ? o[field] : null;
+	}
+
+	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		var setter = 'set_$field';
+		if (__in__(setter, o)) {
+			o[setter](value);
+		} else {
 			o[field] = value;
 		}
+	}
 
-	public static function getProperty(o:Dynamic, field:String):Dynamic
-		untyped {
-			if (o == null)
-				return null;
-			var getter = 'get_$field';
-			if (__in__(getter, o)) {
-				return o[getter]();
-			}
-			return __in__(field, o) ? o[field] : null;
-		}
+	public inline static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic untyped {
+		return func.apply(o, args);
+	}
 
-	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			var setter = 'set_$field';
-			if (__in__(setter, o)) {
-				o[setter](value);
-			} else {
-				o[field] = value;
-			}
+	public static function fields(o:Dynamic):Array<String> untyped {
+		if (o == null)
+			return new Array();
+		var i = 0;
+		var a = [];
+		while (untyped __has_next__(o, i)) {
+			var prop = untyped __forin__(o, i);
+			if (o.hasOwnProperty(prop))
+				a.push(prop);
 		}
+		return a;
+	}
 
-	public inline static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic
-		untyped {
-			return func.apply(o, args);
-		}
-
-	public static function fields(o:Dynamic):Array<String>
-		untyped {
-			if (o == null)
-				return new Array();
-			var i = 0;
-			var a = [];
-			while (untyped __has_next__(o, i)) {
-				var prop = untyped __forin__(o, i);
-				if (o.hasOwnProperty(prop))
-					a.push(prop);
-			}
-			return a;
-		}
-
-	public static function isFunction(f:Dynamic):Bool
-		untyped {
-			return __typeof__(f) == "function";
-		}
+	public static function isFunction(f:Dynamic):Bool untyped {
+		return __typeof__(f) == "function";
+	}
 
 	public static function compare<T>(a:T, b:T):Int {
 		var a:Dynamic = a;
@@ -90,28 +82,26 @@
 		return f1 == f2; // VM-level closures
 	}
 
-	public static function isObject(v:Dynamic):Bool
-		untyped {
-			if (v == null)
-				return false;
-			var t = __typeof__(v);
-			if (t == "object") {
-				return !isEnumValue(v);
-			}
-			return (t == "string");
+	public static function isObject(v:Dynamic):Bool untyped {
+		if (v == null)
+			return false;
+		var t = __typeof__(v);
+		if (t == "object") {
+			return !isEnumValue(v);
 		}
+		return (t == "string");
+	}
 
 	public static function isEnumValue(v:Dynamic):Bool {
 		return try v.__enum__ == true catch (e:Dynamic) false;
 	}
 
-	public static function deleteField(o:Dynamic, field:String):Bool
-		untyped {
-			if (o.hasOwnProperty(field) != true)
-				return false;
-			__delete__(o, field);
-			return true;
-		}
+	public static function deleteField(o:Dynamic, field:String):Bool untyped {
+		if (o.hasOwnProperty(field) != true)
+			return false;
+		__delete__(o, field);
+		return true;
+	}
 
 	public static function copy<T>(o:Null<T>):Null<T> {
 		if (o == null)
@@ -122,8 +112,7 @@
 		return o2;
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return function(__arguments__) {
 			return f(__arguments__);
 		};

--- a/std/hl/_std/Reflect.hx
+++ b/std/hl/_std/Reflect.hx
@@ -130,8 +130,7 @@ class Reflect {
 		return null;
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	extern public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic;
+	extern public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic;
 
 	@:ifFeature("Reflect.makeVarArgs") static function _makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
 		return hl.Api.makeVarArgs(function(args:hl.NativeArray<Dynamic>) {

--- a/std/js/_std/Reflect.hx
+++ b/std/js/_std/Reflect.hx
@@ -37,21 +37,19 @@
 		o[cast field] = value;
 	}
 
-	public static function getProperty(o:Dynamic, field:String):Dynamic
-		untyped {
-			var tmp;
-			return if (o == null) __define_feature__("Reflect.getProperty",
-				null) else if (o.__properties__ && (tmp = o.__properties__["get_" + field])) o[tmp]() else o[field];
-		}
+	public static function getProperty(o:Dynamic, field:String):Dynamic untyped {
+		var tmp;
+		return if (o == null) __define_feature__("Reflect.getProperty",
+			null) else if (o.__properties__ && (tmp = o.__properties__["get_" + field])) o[tmp]() else o[field];
+	}
 
-	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			var tmp;
-			if (o.__properties__ && (tmp = o.__properties__["set_" + field]))
-				o[tmp](value)
-			else
-				o[field] = __define_feature__("Reflect.setProperty", value);
-		}
+	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		var tmp;
+		if (o.__properties__ && (tmp = o.__properties__["set_" + field]))
+			o[tmp](value)
+		else
+			o[field] = __define_feature__("Reflect.setProperty", value);
+	}
 
 	public inline static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic {
 		return (cast func : js.lib.Function).apply(o, args);
@@ -59,14 +57,13 @@
 
 	public static function fields(o:Dynamic):Array<String> {
 		var a = [];
-		if (o != null)
-			untyped {
-				var hasOwnProperty = js.lib.Object.prototype.hasOwnProperty;
-				js.Syntax.code("for( var f in o ) {");
-				if (f != "__id__" && f != "hx__closures__" && hasOwnProperty.call(o, f))
-					a.push(f);
-				js.Syntax.code("}");
-			}
+		if (o != null) untyped {
+			var hasOwnProperty = js.lib.Object.prototype.hasOwnProperty;
+			js.Syntax.code("for( var f in o ) {");
+			if (f != "__id__" && f != "hx__closures__" && hasOwnProperty.call(o, f))
+				a.push(f);
+			js.Syntax.code("}");
+		}
 		return a;
 	}
 
@@ -112,8 +109,7 @@
 		return o2;
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return function() {
 			var a = untyped Array.prototype.slice.call(js.Syntax.code("arguments"));
 			return f(a);

--- a/std/jvm/_std/Reflect.hx
+++ b/std/jvm/_std/Reflect.hx
@@ -20,13 +20,13 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-import jvm.Jvm;
-import java.lang.Number;
-import java.lang.Long.LongClass;
 import java.lang.Double.DoubleClass;
 import java.lang.Float.FloatClass;
+import java.lang.Long.LongClass;
+import java.lang.Number;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import jvm.Jvm;
 
 using jvm.NativeTools.NativeClassTools;
 
@@ -206,8 +206,7 @@ class Reflect {
 		return cast o._hx_clone();
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return new jvm.Closure.VarArgs((cast f : jvm.Function));
 	}
 }

--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -20,9 +20,9 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+import lua.Boot;
 import lua.Lua;
 import lua.TableTools;
-import lua.Boot;
 
 @:coreApi class Reflect {
 	public inline static function hasField(o:Dynamic, field:String):Bool {
@@ -30,26 +30,23 @@ import lua.Boot;
 			false;
 		} else if (Lua.type(o) == "string" && (untyped String.prototype[field] != null || field == "length")) {
 			true;
-		} else
-			untyped o.__fields__ != null ? o.__fields__[field] != null : o[field] != null;
+		} else untyped o.__fields__ != null ? o.__fields__[field] != null : o[field] != null;
 	}
 
-	public static function field(o:Dynamic, field:String):Dynamic
-		untyped {
-			if (Lua.type(o) == "string") {
-				if (field == "length") {
-					return cast(o : String).length;
-				} else
-					return untyped String.prototype[field];
-			} else {
-				return try o[field] catch (e:Dynamic) null;
-			}
+	public static function field(o:Dynamic, field:String):Dynamic untyped {
+		if (Lua.type(o) == "string") {
+			if (field == "length") {
+				return cast(o : String).length;
+			} else
+				return untyped String.prototype[field];
+		} else {
+			return try o[field] catch (e:Dynamic) null;
 		}
+	}
 
-	public inline static function setField(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			o[field] = value;
-		}
+	public inline static function setField(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		o[field] = value;
+	}
 
 	public static function getProperty(o:Dynamic, field:String):Dynamic {
 		return if (o == null) {
@@ -61,15 +58,14 @@ import lua.Boot;
 		}
 	}
 
-	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			if (o.__properties__ != null && o.__properties__["set_" + field]) {
-				var tmp:String = o.__properties__["set_" + field];
-				callMethod(o, Reflect.field(o, tmp), [value]);
-			} else {
-				o[field] = __define_feature__("Reflect.setProperty", value);
-			}
+	public static function setProperty(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		if (o.__properties__ != null && o.__properties__["set_" + field]) {
+			var tmp:String = o.__properties__["set_" + field];
+			callMethod(o, Reflect.field(o, tmp), [value]);
+		} else {
+			o[field] = __define_feature__("Reflect.setProperty", value);
 		}
+	}
 
 	public static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic {
 		if (args == null || args.length == 0) {
@@ -114,27 +110,25 @@ import lua.Boot;
 		return f1 == f2;
 	}
 
-	public static function isObject(v:Dynamic):Bool
-		untyped {
-			if (v == null)
-				return false;
-			var t = lua.Lua.type(v);
-			return (t == "string" || (t == "table" && v.__enum__ == null))
-				|| (t == "function" && (lua.Boot.isClass(v) || lua.Boot.isEnum(v)) != null);
-		}
+	public static function isObject(v:Dynamic):Bool untyped {
+		if (v == null)
+			return false;
+		var t = lua.Lua.type(v);
+		return (t == "string" || (t == "table" && v.__enum__ == null))
+			|| (t == "function" && (lua.Boot.isClass(v) || lua.Boot.isEnum(v)) != null);
+	}
 
 	public static function isEnumValue(v:Dynamic):Bool {
 		return v != null && Std.isOfType(v, lua.Table) && v.__enum__ != null;
 	}
 
-	public static function deleteField(o:Dynamic, field:String):Bool
-		untyped {
-			if (!hasField(o, field))
-				return false;
-			o[field] = null;
-			o.__fields__[field] = null;
-			return true;
-		}
+	public static function deleteField(o:Dynamic, field:String):Bool untyped {
+		if (!hasField(o, field))
+			return false;
+		o[field] = null;
+		o.__fields__[field] = null;
+		return true;
+	}
 
 	public static function copy<T>(o:Null<T>):Null<T> {
 		if (o == null)
@@ -145,8 +139,7 @@ import lua.Boot;
 		return o2;
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		/*
 			- Convert var arg to table
 			- Set indexing from zero

--- a/std/neko/_std/Reflect.hx
+++ b/std/neko/_std/Reflect.hx
@@ -20,81 +20,73 @@
  * DEALINGS IN THE SOFTWARE.
  */
 @:coreApi class Reflect {
-	public static function hasField(o:Dynamic, field:String):Bool
-		untyped {
-			return $typeof(o) == $tobject && $objfield(o, $fasthash(field.__s));
-		}
+	public static function hasField(o:Dynamic, field:String):Bool untyped {
+		return $typeof(o) == $tobject && $objfield(o, $fasthash(field.__s));
+	}
 
-	public inline static function field(o:Dynamic, field:String):Dynamic
-		untyped {
-			return if ($typeof(o) != $tobject) null else $objget(o, $fasthash(field.__s));
-		}
+	public inline static function field(o:Dynamic, field:String):Dynamic untyped {
+		return if ($typeof(o) != $tobject) null else $objget(o, $fasthash(field.__s));
+	}
 
-	public inline static function setField(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			if ($typeof(o) == $tobject)
+	public inline static function setField(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		if ($typeof(o) == $tobject)
+			$objset(o, $hash(field.__s), value);
+	}
+
+	public static inline function getProperty(o:Dynamic, field:String):Dynamic untyped {
+		var tmp;
+		return if ($typeof(o) != $tobject) null else if (o.__properties__ != null
+			&& (tmp = $objget(o.__properties__, $fasthash("get_".__s + field.__s))) != null) $call($objget(o, $fasthash(tmp)), o, $array()) else $objget(o,
+			$fasthash(field.__s));
+	}
+
+	public static inline function setProperty(o:Dynamic, field:String, value:Dynamic):Void untyped {
+		if ($typeof(o) == $tobject) {
+			var tmp;
+			if (o.__properties__ != null && (tmp = $objget(o.__properties__, $fasthash("set_".__s + field.__s))) != null)
+				$call($objget(o, $fasthash(tmp)), o, $array(value))
+			else
 				$objset(o, $hash(field.__s), value);
 		}
+	}
 
-	public static inline function getProperty(o:Dynamic, field:String):Dynamic
-		untyped {
-			var tmp;
-			return if ($typeof(o) != $tobject) null else if (o.__properties__ != null
-				&& (tmp = $objget(o.__properties__, $fasthash("get_".__s + field.__s))) != null) $call($objget(o, $fasthash(tmp)), o, $array()) else $objget(o,
-				$fasthash(field.__s));
+	public static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic untyped {
+		var a = args.__neko();
+		// pad missing args with null's
+		var n = $nargs(func);
+		if (n > $asize(a)) {
+			var a2 = $amake(n);
+			$ablit(a2, 0, a, 0, $asize(a));
+			a = a2;
 		}
+		return $call(func, o, a);
+	}
 
-	public static inline function setProperty(o:Dynamic, field:String, value:Dynamic):Void
-		untyped {
-			if ($typeof(o) == $tobject) {
-				var tmp;
-				if (o.__properties__ != null && (tmp = $objget(o.__properties__, $fasthash("set_".__s + field.__s))) != null)
-					$call($objget(o, $fasthash(tmp)), o, $array(value))
-				else
-					$objset(o, $hash(field.__s), value);
+	public static function fields(o:Dynamic):Array<String> untyped {
+		if ($typeof(o) != $tobject)
+			return new Array<String>();
+		else {
+			var a:neko.NativeArray<Int> = $objfields(o);
+			var i = 0;
+			var hasid = false;
+			var l = $asize(a);
+			while (i < l) {
+				var fid = a[i];
+				if (fid == -190054693)
+					hasid = true; // $hash("__id__")
+				a[i] = new String($field(fid));
+				i++;
 			}
+			var a:Array<String> = Array.new1(a, l);
+			if (hasid)
+				a.remove("__id__");
+			return a;
 		}
+	}
 
-	public static function callMethod(o:Dynamic, func:haxe.Constraints.Function, args:Array<Dynamic>):Dynamic
-		untyped {
-			var a = args.__neko();
-			// pad missing args with null's
-			var n = $nargs(func);
-			if (n > $asize(a)) {
-				var a2 = $amake(n);
-				$ablit(a2, 0, a, 0, $asize(a));
-				a = a2;
-			}
-			return $call(func, o, a);
-		}
-
-	public static function fields(o:Dynamic):Array<String>
-		untyped {
-			if ($typeof(o) != $tobject)
-				return new Array<String>();
-			else {
-				var a:neko.NativeArray<Int> = $objfields(o);
-				var i = 0;
-				var hasid = false;
-				var l = $asize(a);
-				while (i < l) {
-					var fid = a[i];
-					if (fid == -190054693)
-						hasid = true; // $hash("__id__")
-					a[i] = new String($field(fid));
-					i++;
-				}
-				var a:Array<String> = Array.new1(a, l);
-				if (hasid)
-					a.remove("__id__");
-				return a;
-			}
-		}
-
-	public static function isFunction(f:Dynamic):Bool
-		untyped {
-			return $typeof(f) == $tfunction;
-		}
+	public static function isFunction(f:Dynamic):Bool untyped {
+		return $typeof(f) == $tfunction;
+	}
 
 	public inline static function compare<T>(a:T, b:T):Int {
 		return untyped $compare(a, b);
@@ -104,20 +96,17 @@
 		return same_closure(f1, f2);
 	}
 
-	public static function isObject(v:Dynamic):Bool
-		untyped {
-			return $typeof(v) == $tobject && v.__enum__ == null;
-		}
+	public static function isObject(v:Dynamic):Bool untyped {
+		return $typeof(v) == $tobject && v.__enum__ == null;
+	}
 
-	public static function isEnumValue(v:Dynamic):Bool
-		untyped {
-			return $typeof(v) == $tobject && v.__enum__ != null;
-		}
+	public static function isEnumValue(v:Dynamic):Bool untyped {
+		return $typeof(v) == $tobject && v.__enum__ != null;
+	}
 
-	public inline static function deleteField(o:Dynamic, field:String):Bool
-		untyped {
-			return $objremove(o, $fasthash(field.__s));
-		}
+	public inline static function deleteField(o:Dynamic, field:String):Bool untyped {
+		return $objremove(o, $fasthash(field.__s));
+	}
 
 	public static function copy<T>(o:Null<T>):Null<T> {
 		if (o == null)
@@ -125,8 +114,7 @@
 		return untyped $new(o);
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return untyped $varargs(function(a) {
 			return f(Array.new1(a, $asize(a)));
 		});

--- a/std/php/_std/Reflect.hx
+++ b/std/php/_std/Reflect.hx
@@ -20,12 +20,12 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+import haxe.Constraints;
 import php.Boot;
-import php.Syntax;
 import php.Closure;
 import php.Const;
 import php.NativeAssocArray;
-import haxe.Constraints;
+import php.Syntax;
 
 using php.Global;
 
@@ -171,8 +171,7 @@ using php.Global;
 		}
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return function() {
 			return Global.call_user_func(f, @:privateAccess Array.wrap(Global.func_get_args()));
 		}

--- a/std/python/_std/Reflect.hx
+++ b/std/python/_std/Reflect.hx
@@ -20,16 +20,16 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-import python.internal.AnonObject;
-import python.internal.StringImpl;
-import python.internal.ArrayImpl;
-import python.internal.UBuiltins;
-import python.internal.MethodClosure;
-import python.lib.Inspect;
+import python.Boot.handleKeywords;
+import python.Boot;
 import python.Syntax;
 import python.VarArgs;
-import python.Boot;
-import python.Boot.handleKeywords;
+import python.internal.AnonObject;
+import python.internal.ArrayImpl;
+import python.internal.MethodClosure;
+import python.internal.StringImpl;
+import python.internal.UBuiltins;
+import python.lib.Inspect;
 
 @:access(python.Boot)
 @:coreApi
@@ -136,8 +136,7 @@ class Reflect {
 		return o2;
 	}
 
-	@:overload(function(f:Array<Dynamic>->Void):Dynamic {})
-	public static function makeVarArgs(f:Array<Dynamic>->Dynamic):Dynamic {
+	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
 		return function(v:VarArgs<Dynamic>) {
 			return f(v);
 		}


### PR DESCRIPTION
While working on #11843 I came across this function which has an `@:overload` in order to support both `Array<Dynamic>->Void` and `Array<Dynamic>->Dynamic` functions. This only works incidentally on some targets because the old `@:overload(function)` syntax doesn't perform the same checks that proper `overload function`s do. For example, to the JVM target both signatures are the same, so the compiler doesn't know which overload to resolve to.

Since this is only done so that we can support both `Dynamic` and `Void` callback returns, I think using a type parameter instead achieves the same goal without the overload hassle.

I had the formatter on so the diff is a bit bigger.