### PR TITLE
Eliminate final case of camlp5 left-factorization

### DIFF
--- a/src/syntax/grammar.mly
+++ b/src/syntax/grammar.mly
@@ -969,12 +969,15 @@ and parse_class_field tdecl s =
 		| [< '(Kwd Final,p1) >] ->
 			check_redundant_var p1 s;
 			begin match s with parser
-			| [< opt,name = questionable_dollar_ident; '(POpen,_); i1 = property_ident; '(Comma,_); i2 = property_ident; '(PClose,_); t = popt parse_type_hint; e,p2 = parse_var_field_assignment >] ->
-				let meta = check_optional opt name in
-				name,punion p1 p2,FProp(i1,i2,t,e),(al @ [AFinal,p1]),meta
-			| [< opt,name = questionable_dollar_ident; t = popt parse_type_hint; e,p2 = parse_var_field_assignment >] ->
-				let meta = check_optional opt name in
-				name,punion p1 p2,FVar(t,e),(al @ [AFinal,p1]),meta
+			| [< opt,name = questionable_dollar_ident; s >] ->
+				begin match s with parser
+				| [< '(POpen,_); i1 = property_ident; '(Comma,_); i2 = property_ident; '(PClose,_); t = popt parse_type_hint; e,p2 = parse_var_field_assignment >] ->
+					let meta = check_optional opt name in
+					name,punion p1 p2,FProp(i1,i2,t,e),(al @ [AFinal,p1]),meta
+				| [< t = popt parse_type_hint; e,p2 = parse_var_field_assignment >] ->
+					let meta = check_optional opt name in
+					name,punion p1 p2,FVar(t,e),(al @ [AFinal,p1]),meta
+				end
 			| [< al2 = plist parse_cf_rights; f = parse_function_field doc meta (al @ ((AFinal,p1) :: al2)) >] ->
 				f
 			| [< >] ->


### PR DESCRIPTION
left-factorization is a feature of camlp5 that refactors consecutive parser rules that share a prefix:
https://camlp5.readthedocs.io/en/latest/parsers.html#left-factorization

If we stop relying on this feature we can potentially move the parser to [ppx_parser](https://github.com/NielsMommen/ppx_parser), which is a camlp4 alternative so it doesn't support this camlp5 feature.

With these previous commits already in `development`, this should remove the last of the occurrences:
1f8fcddff5744fd636af654c0f9b2ffc6461e04b
f3971a4b6926ae346e892a98ec4e21d807b8b84d
0620b1b1c7de765277ce736d992400a09429566c