### PR TITLE
Use SPDX license identifier in opam file.

### DIFF
--- a/haxe.opam
+++ b/haxe.opam
@@ -11,7 +11,7 @@ maintainer: ["Haxe Foundation <contact@haxe.org>" "Andy Li <andy@onthewings.net>
 authors: "Haxe Foundation <contact@haxe.org>"
 homepage: "https://haxe.org/"
 bug-reports: "https://github.com/HaxeFoundation/haxe/issues"
-license: ["GPL2+" "MIT"]
+license: ["GPL-2.0-or-later" "MIT"]
 dev-repo: "git+https://github.com/HaxeFoundation/haxe.git"
 build: [
   [make]


### PR DESCRIPTION
This stops Opam from complaining about failed checks.