### PR TITLE
[JS] Fix for Issue11475

### DIFF
--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -439,7 +439,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	**/
 	@:op(A >>> B) public static inline function ushr(a:Int64, b:Int):Int64 {
 		b &= 63;
-		return if (b == 0) a.copy() else if (b < 32) make(a.high >>> b, (a.high << (32 - b)) | (a.low >>> b)); else make(0, a.high >>> (b - 32));
+		return if (b == 0) a.copy() else if (b < 32) make(a.high >>> b, (a.high << (32 - b)) | (a.low >>> b)); else make(0, a.high >>> (b - 32) #if js | 0 #end);
 	}
 
 	public var high(get, never):Int32;

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -439,7 +439,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	**/
 	@:op(A >>> B) public static inline function ushr(a:Int64, b:Int):Int64 {
 		b &= 63;
-		return if (b == 0) a.copy() else if (b < 32) make(a.high >>> b, (a.high << (32 - b)) | (a.low >>> b)); else make(0, a.high >>> (b - 32) #if js | 0 #end);
+		return if (b == 0) a.copy() else if (b < 32) make(a.high >>> b, (a.high << (32 - b)) | (a.low >>> b)); else make(0, clamp(a.high >>> (b - 32)));
 	}
 
 	public var high(get, never):Int32;
@@ -457,6 +457,29 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 
 	private inline function set_low(x)
 		return this.low = x;
+		
+    #if php
+	static var extraBits:Int = php.Const.PHP_INT_SIZE * 8 - 32;
+	#end
+
+	#if !lua
+	inline
+	#end
+	static function clamp(x:Int):Int {
+		// force to-int conversion on platforms that require it
+		#if js
+		return x | 0;
+		#elseif php
+		// we might be on 64-bit php, so sign extend from 32-bit
+		return (x << extraBits) >> extraBits;
+		#elseif python
+		return (python.Syntax.code("{0} % {1}", (x + python.Syntax.opPow(2, 31)), python.Syntax.opPow(2, 32)) : Int) - python.Syntax.opPow(2, 31);
+		#elseif lua
+		return lua.Boot.clampInt32(x);
+		#else
+		return (x);
+		#end
+	}
 }
 
 /**

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -458,7 +458,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	private inline function set_low(x)
 		return this.low = x;
 		
-    #if php
+	#if php
 	static var extraBits:Int = php.Const.PHP_INT_SIZE * 8 - 32;
 	#end
 
@@ -477,7 +477,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		#elseif lua
 		return lua.Boot.clampInt32(x);
 		#else
-		return (x);
+		return x;
 		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue11475.hx
+++ b/tests/unit/src/unit/issues/Issue11475.hx
@@ -1,0 +1,11 @@
+package unit.issues;
+
+import haxe.Int64;
+
+class Issue11475 extends Test {
+	function test() {
+		var i:Int64 = Int64.make(0xF0E3FF1B, 0x00000000);
+		var mcr:Int64 = Int64.ushr(i, 32);
+		eq(-253493477, mcr.low);
+	}
+}


### PR DESCRIPTION
The following code ( for JS target) will return the value ("low: 4041473819") as max Int for JS is 9007199254740991 .
After the fix the value should be "low: -253493477"
The max value for Int32 should be 2,147,483,647

```haxe
var i:Int64 = Int64.make(0xF0E3FF1B, 0x00000000);
var mcr:Int64 = Int64.ushr(i, 32);
trace("mcr: "+mcr);
trace("high: "+mcr.high);
trace("low: "+mcr.low);
```