### PR TITLE
[std/hl] move some hl.Format into lib format/heaps

### DIFF
--- a/std/hl/Format.hx
+++ b/std/hl/Format.hx
@@ -22,6 +22,7 @@
 
 package hl;
 
+@:deprecated("hl.Format.PixelFormat is deprecated, use format.hl.Native.PixelFormat instead")
 enum abstract PixelFormat(Int) {
 	var RGB = 0;
 	var BGR = 1;
@@ -44,6 +45,7 @@ class Format {
 	/**
 		Decode JPG data into the target buffer.
 	**/
+	@:deprecated("hl.Format.decodeJPG is deprecated, use format.hl.Native.decodeJPG instead")
 	@:hlNative("fmt", "jpg_decode")
 	public static function decodeJPG(src:hl.Bytes, srcLen:Int, dst:hl.Bytes, width:Int, height:Int, stride:Int, format:PixelFormat, flags:Int):Bool {
 		return false;
@@ -52,6 +54,7 @@ class Format {
 	/**
 		Decode PNG data into the target buffer.
 	**/
+	@:deprecated("hl.Format.decodePNG is deprecated, use format.hl.Native.decodePNG instead")
 	@:hlNative("fmt", "png_decode")
 	public static function decodePNG(src:hl.Bytes, srcLen:Int, dst:hl.Bytes, width:Int, height:Int, stride:Int, format:PixelFormat, flags:Int):Bool {
 		return false;
@@ -61,6 +64,7 @@ class Format {
 		Decode any image data into ARGB pixels
 	**/
 	#if (hl_ver >= version("1.10.0"))
+	@:deprecated("hl.Format.decodeDXT is deprecated, use format.hl.Native.decodeDXT instead")
 	@:hlNative("fmt", "dxt_decode")
 	public static function decodeDXT(src:hl.Bytes, dst:hl.Bytes, width:Int, height:Int, dxtFormat:Int):Bool {
 		return false;
@@ -71,6 +75,7 @@ class Format {
 		Upscale/downscale an image.
 		Currently supported flag bits: 1 = bilinear filtering
 	**/
+	@:deprecated("hl.Format.scaleImage is deprecated, use format.hl.Native.scaleImage instead")
 	@:hlNative("fmt", "img_scale")
 	public static function scaleImage(out:hl.Bytes, outPos:Int, outStride:Int, outWidth:Int, outHeight:Int, _in:hl.Bytes, inPos:Int, inStride:Int,
 		inWidth:Int, inHeight:Int, flags:Int) {}
@@ -84,6 +89,7 @@ class Format {
 	public static function digest(out:hl.Bytes, src:hl.Bytes, srcLen:Int, algorithm:Int) {}
 }
 
+@:deprecated("hl.Format.Mikktspace is deprecated, use hxd.MeshTools.Mikktspace instead")
 class Mikktspace {
 	public var buffer:hl.BytesAccess<Single>;
 	public var stride:Int;
@@ -96,8 +102,10 @@ class Mikktspace {
 	public var indexes:hl.BytesAccess<Int>;
 	public var indices:Int;
 
+	@:deprecated("hl.Format.Mikktspace is deprecated, use hxd.MeshTools.Mikktspace instead")
 	public function new() {}
 
+	@:deprecated("hl.Format.Mikktspace is deprecated, use hxd.MeshTools.Mikktspace instead")
 	public function compute(threshold = 180.) {
 		if (!_compute(this, threshold))
 			throw "assert";

--- a/std/hl/Format.hx
+++ b/std/hl/Format.hx
@@ -22,63 +22,10 @@
 
 package hl;
 
-@:deprecated("hl.Format.PixelFormat is deprecated, use format.hl.Native.PixelFormat instead")
-enum abstract PixelFormat(Int) {
-	var RGB = 0;
-	var BGR = 1;
-	var RGBX = 2;
-	var BGRX = 3;
-	var XBGR = 4;
-	var XRGB = 5;
-	var GRAY = 6;
-	var RGBA = 7;
-	var BGRA = 8;
-	var ABGR = 9;
-	var ARGB = 10;
-	var CMYK = 11;
-}
-
 /**
-	These are the bindings for the HL `fmt.hdll` library, which contains various low level formats handling.
+	These are some bindings for the HL `fmt.hdll` library, which contains various low level formats handling.
 **/
 class Format {
-	/**
-		Decode JPG data into the target buffer.
-	**/
-	@:deprecated("hl.Format.decodeJPG is deprecated, use format.hl.Native.decodeJPG instead")
-	@:hlNative("fmt", "jpg_decode")
-	public static function decodeJPG(src:hl.Bytes, srcLen:Int, dst:hl.Bytes, width:Int, height:Int, stride:Int, format:PixelFormat, flags:Int):Bool {
-		return false;
-	}
-
-	/**
-		Decode PNG data into the target buffer.
-	**/
-	@:deprecated("hl.Format.decodePNG is deprecated, use format.hl.Native.decodePNG instead")
-	@:hlNative("fmt", "png_decode")
-	public static function decodePNG(src:hl.Bytes, srcLen:Int, dst:hl.Bytes, width:Int, height:Int, stride:Int, format:PixelFormat, flags:Int):Bool {
-		return false;
-	}
-
-	/**
-		Decode any image data into ARGB pixels
-	**/
-	#if (hl_ver >= version("1.10.0"))
-	@:deprecated("hl.Format.decodeDXT is deprecated, use format.hl.Native.decodeDXT instead")
-	@:hlNative("fmt", "dxt_decode")
-	public static function decodeDXT(src:hl.Bytes, dst:hl.Bytes, width:Int, height:Int, dxtFormat:Int):Bool {
-		return false;
-	}
-	#end
-
-	/**
-		Upscale/downscale an image.
-		Currently supported flag bits: 1 = bilinear filtering
-	**/
-	@:deprecated("hl.Format.scaleImage is deprecated, use format.hl.Native.scaleImage instead")
-	@:hlNative("fmt", "img_scale")
-	public static function scaleImage(out:hl.Bytes, outPos:Int, outStride:Int, outWidth:Int, outHeight:Int, _in:hl.Bytes, inPos:Int, inStride:Int,
-		inWidth:Int, inHeight:Int, flags:Int) {}
 
 	/**
 		Performs a cryptographic digest of some bytes.
@@ -87,31 +34,4 @@ class Format {
 	**/
 	@:hlNative("fmt", "digest")
 	public static function digest(out:hl.Bytes, src:hl.Bytes, srcLen:Int, algorithm:Int) {}
-}
-
-@:deprecated("hl.Format.Mikktspace is deprecated, use hxd.MeshTools.Mikktspace instead")
-class Mikktspace {
-	public var buffer:hl.BytesAccess<Single>;
-	public var stride:Int;
-	public var xPos:Int;
-	public var normalPos:Int;
-	public var uvPos:Int;
-	public var tangents:hl.BytesAccess<Single>;
-	public var tangentStride:Int;
-	public var tangentPos:Int;
-	public var indexes:hl.BytesAccess<Int>;
-	public var indices:Int;
-
-	@:deprecated("hl.Format.Mikktspace is deprecated, use hxd.MeshTools.Mikktspace instead")
-	public function new() {}
-
-	@:deprecated("hl.Format.Mikktspace is deprecated, use hxd.MeshTools.Mikktspace instead")
-	public function compute(threshold = 180.) {
-		if (!_compute(this, threshold))
-			throw "assert";
-	}
-
-	@:hlNative("fmt", "compute_mikkt_tangents") static function _compute(m:Dynamic, threshold:Float):Bool {
-		return false;
-	}
 }


### PR DESCRIPTION
This PR address the problem that some `hl.Format` function should not exist in std.
The idea is to split `hl.Format` functions into 3 types:
- `digest`: needed by some std crypto function (`hl/_std/haxe/crypto`), we can keep it
  - It can also be moved into `hl.Api` if we'd like to remove this file
- png, jpg, dxt, scale: basic image function, will be moved to `format.hl.Native`
  - https://github.com/HaxeFoundation/format/pull/112
- Mikktspace, and other heaps-specific functionalities such as MeshOptimizer: will be moved/added to `hxd.MeshTools` (in heaps)
  - https://github.com/HeapsIO/heaps/pull/1250

I don't know if it's ok to remove totally these functions so I just declared them deprecated.

