### PR TITLE
Remove ppx_parser pin

### DIFF
--- a/haxe.opam
+++ b/haxe.opam
@@ -27,14 +27,11 @@ depends: [
   "extlib" {>= "1.7.8"}
   "sha"
   "camlp-streams"
-  "ppx_parser"
+  "ppx_parser" {>= "0.2.0"}
   "conf-libpcre2-8"
   "conf-zlib"
   "conf-neko"
   "luv" {>= "0.5.13"}
   "ipaddr"
   "terminal_size"
-]
-pin-depends: [
-  ["ppx_parser.dev" "git+https://github.com/NielsMommen/ppx_parser"]
 ]


### PR DESCRIPTION
ppx_parser has been released, we don't need the pin anymore

Closes #11875