### PR TITLE
[hxb] Catch unification errors when trying to close a monomorph

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -132,5 +132,10 @@
 		"name": "WUnboundTypeParameter",
 		"doc": "Hxb (either --hxb output or haxe compiler cache) failed to link a type parameter to an actual type",
 		"parent": "WHxb"
+	},
+	{
+		"name": "WUnclosedMonomorph",
+		"doc": "Hxb writer failed to close a monomorph (that monomorph should have been closed in the first place, please open an issue)",
+		"parent": "WHxb"
 	}
 ]

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -135,7 +135,7 @@
 	},
 	{
 		"name": "WUnclosedMonomorph",
-		"doc": "Hxb writer failed to close a monomorph (that monomorph should have been closed in the first place, please open an issue)",
+		"doc": "Hxb writer failed to close a monomorph (that monomorph should have been closed in the first place)",
 		"parent": "WHxb"
 	}
 ]

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -1197,7 +1197,11 @@ module HxbWriter = struct
 			| TInst ({cl_path = ([],"String")},[]) ->
 				Chunk.write_u8 writer.chunk 104;
 			| TMono r ->
-				Monomorph.close r;
+				(try Monomorph.close r with TUnification.Unify_error e ->
+					let p = file_pos (Path.UniqueKey.lazy_path writer.current_module.m_extra.m_file) in
+					let msg = Printf.sprintf "Error while handling unclosed monomorph: %s" (Error.error_msg (Unify e)) in
+					writer.warn WUnclosedMonomorph msg p
+				);
 				begin match r.tm_type with
 				| None ->
 					Chunk.write_u8 writer.chunk 0;

--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -440,6 +440,7 @@ type hxb_writer = {
 	mutable wrote_local_type_param : bool;
 	mutable needs_local_context : bool;
 	unbound_ttp : (typed_type_param,unit) IdentityPool.t;
+	unclosed_mono : (tmono,unit) IdentityPool.t;
 	t_instance_chunk : Chunk.t;
 }
 
@@ -1198,9 +1199,17 @@ module HxbWriter = struct
 				Chunk.write_u8 writer.chunk 104;
 			| TMono r ->
 				(try Monomorph.close r with TUnification.Unify_error e ->
-					let p = file_pos (Path.UniqueKey.lazy_path writer.current_module.m_extra.m_file) in
-					let msg = Printf.sprintf "Error while handling unclosed monomorph: %s" (Error.error_msg (Unify e)) in
-					writer.warn WUnclosedMonomorph msg p
+					try ignore(IdentityPool.get writer.unclosed_mono r) with Not_found -> begin
+						ignore(IdentityPool.add writer.unclosed_mono r ());
+
+						let p = file_pos (Path.UniqueKey.lazy_path writer.current_module.m_extra.m_file) in
+						let msg = Printf.sprintf
+							"Error while handling unclosed monomorph:\n%s\n\n%s"
+								(Error.error_msg (Unify e))
+								"Unclosed monomorph should not reach hxb writer, please submit an issue at https://github.com/HaxeFoundation/haxe/issues/new"
+						in
+						writer.warn WUnclosedMonomorph msg p
+					end;
 				);
 				begin match r.tm_type with
 				| None ->
@@ -2342,6 +2351,7 @@ let create config string_pool warn anon_id =
 		wrote_local_type_param = false;
 		needs_local_context = false;
 		unbound_ttp = IdentityPool.create ();
+		unclosed_mono = IdentityPool.create ();
 		t_instance_chunk = Chunk.create EOM cp 32;
 	}
 


### PR DESCRIPTION
See #11881 (this is not a fix, just a way to avoid a crash)

![image](https://github.com/user-attachments/assets/304b0adb-7bfd-4c06-9938-66b3d24512c4)
