### PR TITLE
bugfix when string ends with escape sequence

### DIFF
--- a/std/haxe/xml/Parser.hx
+++ b/std/haxe/xml/Parser.hx
@@ -395,8 +395,10 @@ class Parser {
 			if (parent.nodeType == Element) {
 				throw new XmlParserException("Unclosed node <" + parent.nodeName + ">", str, p);
 			}
-			if (p != start || nsubs == 0) {
+			if( p != start )
 				buf.addSub(str, start, p - start);
+			var str = buf.toString();
+			if (str.length > 0 || nsubs == 0) {
 				addChild(Xml.createPCData(buf.toString()));
 			}
 			return p;

--- a/std/php/_std/haxe/xml/Parser.hx
+++ b/std/php/_std/haxe/xml/Parser.hx
@@ -363,8 +363,7 @@ class Parser {
 			}
 			if (p != start)
 				buf = buf.addSub(str, start, p - start);
-			var str = buf.toString();
-			if (str.length > 0 || nsubs == 0) {
+			if (str != "" || nsubs == 0) {
 				addChild(Xml.createPCData(buf));
 			}
 			return p;

--- a/std/php/_std/haxe/xml/Parser.hx
+++ b/std/php/_std/haxe/xml/Parser.hx
@@ -363,7 +363,7 @@ class Parser {
 			}
 			if (p != start)
 				buf = buf.addSub(str, start, p - start);
-			if (str != "" || nsubs == 0) {
+			if (buf != "" || nsubs == 0) {
 				addChild(Xml.createPCData(buf));
 			}
 			return p;

--- a/std/php/_std/haxe/xml/Parser.hx
+++ b/std/php/_std/haxe/xml/Parser.hx
@@ -175,9 +175,8 @@ class Parser {
 								p += 8;
 								state = S.DOCTYPE;
 								start = p + 1;
-							} else if (str.fastCodeAt(p + 1) != '-'.code || str.fastCodeAt(p + 2) != '-'.code)
-								throw new XmlParserException("Expected <!--", str, p);
-							else {
+							} else if (str.fastCodeAt(p + 1) != '-'.code || str.fastCodeAt(p + 2) != '-'.code) throw new XmlParserException("Expected <!--",
+								str, p); else {
 								p += 2;
 								state = S.COMMENT;
 								start = p + 1;
@@ -362,8 +361,10 @@ class Parser {
 			if (parent.nodeType == Element) {
 				throw new XmlParserException("Unclosed node <" + parent.nodeName + ">", str, p);
 			}
-			if (p != start || nsubs == 0) {
+			if (p != start)
 				buf = buf.addSub(str, start, p - start);
+			var str = buf.toString();
+			if (str.length > 0 || nsubs == 0) {
 				addChild(Xml.createPCData(buf));
 			}
 			return p;

--- a/tests/unit/src/unit/issues/Issue11883.hx
+++ b/tests/unit/src/unit/issues/Issue11883.hx
@@ -1,0 +1,9 @@
+package unit.issues;
+
+import unit.Test;
+
+class Issue11883 extends Test {
+	function test() {
+		eq(Xml.parse("<foo>xx</foo> bar&lt;").toString(), "<foo>xx</foo> bar&lt;");
+	}
+}


### PR DESCRIPTION
This fixes `Xml.parse("<foo>xx</foo> bar&lt;").toString() == "<foo>xx</foo> bar&lt;"`, without the fix the whole postfix data is ignored because we have processes `&lt;` so p == start but the buffer is not empty.