### PR TITLE
Add MDynamic to late-bind monomorphs to Dynamic 

### DIFF
--- a/src/core/error.ml
+++ b/src/core/error.ml
@@ -188,7 +188,7 @@ module BetterErrors = struct
 				let name = Printf.sprintf "Unknown<%d>" (try List.assq t (!ctx) with Not_found -> let n = List.length !ctx in ctx := (t,n) :: !ctx; n) in
 				List.fold_left (fun s modi -> match modi with
 					| MNullable _ -> Printf.sprintf "Null<%s>" s
-					| MOpenStructure -> s
+					| MOpenStructure | MDynamic -> s
 				) name r.tm_modifiers
 			| Some t ->
 				s_type ctx t)

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -101,6 +101,7 @@ and tmono_constraint_kind =
 and tmono_modifier =
 	| MNullable of (t -> t)
 	| MOpenStructure
+	| MDynamic (* There was a unificaiton against Dynamic, which didn't bind the mono *)
 
 and tlazy =
 	| LAvailable of t


### PR DESCRIPTION
The typer generally avoids binding monomorphs to Dynamic, which has been causing several issues. With this change, unification adds a `MDynamic` flag to the monomorph and then infers `Dynamic` if there has been no other unification by the time the monomorph is closed.

This means that it's still a monomorph during typing, as we can see here:

```haxe
function getArrayDynamic():Array<Dynamic> {
	return ["foo"];
}

function main() {
	var a = getArrayDynamic();
	var b = a[0];
	$type(b); // Unknown<0>
	trace(b);
}
```

However, the dump now shows `[Var b<0>(VUsedByTyper VAnalyzed):Dynamic]`, which confirms that the monomorph has been bound. This should always be preferable to having dangling open monomorphs, especially when they could appear in a function signature and could be inferred from the outside.

This shouldn't break anything but there's always a chance some code somehow relied on this behavior. It would be good to do a brief check @yuxiaomao.