### PR TITLE
[hl] Respect hl-legacy32 for I64 arrays

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -78,7 +78,7 @@ type array_impl = {
 	ai32 : tclass;
 	af32 : tclass;
 	af64 : tclass;
-	ai64 : tclass;
+	ai64 : tclass option;
 }
 
 type constval =
@@ -290,7 +290,10 @@ let array_class ctx t =
 	| HF64 ->
 		ctx.array_impl.af64
 	| HI64 ->
-		ctx.array_impl.ai64
+		begin match ctx.array_impl.ai64 with
+		| None -> die "" __LOC__
+		| Some c -> c
+		end
 	| HDyn ->
 		ctx.array_impl.adyn
 	| _ ->
@@ -4196,7 +4199,7 @@ let create_context com =
 			ai32 = get_class "ArrayBytes_Int";
 			af32 = get_class "ArrayBytes_hl_F32";
 			af64 = get_class "ArrayBytes_Float";
-			ai64 = get_class (if Gctx.raw_defined com "hl_legacy32" then "ArrayBytes_Int" else "ArrayBytes_hl_I64");
+			ai64 = if Gctx.raw_defined com "hl_legacy32" then None else Some (get_class "ArrayBytes_hl_I64");
 		};
 		base_class = get_class "Class";
 		base_enum = get_class "Enum";

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -4196,7 +4196,7 @@ let create_context com =
 			ai32 = get_class "ArrayBytes_Int";
 			af32 = get_class "ArrayBytes_hl_F32";
 			af64 = get_class "ArrayBytes_Float";
-			ai64 = get_class "ArrayBytes_hl_I64";
+			ai64 = get_class (if Gctx.raw_defined com "hl_legacy32" then "ArrayBytes_Int" else "ArrayBytes_hl_I64");
 		};
 		base_class = get_class "Class";
 		base_enum = get_class "Enum";

--- a/std/hl/types/ArrayBase.hx
+++ b/std/hl/types/ArrayBase.hx
@@ -149,6 +149,7 @@ class ArrayBase extends ArrayAccess {
 		return a;
 	}
 
+	#if !hl_legacy32
 	public static function allocI64(bytes:BytesAccess<I64>, length:Int) @:privateAccess {
 		var a:ArrayBytes.ArrayI64 = untyped $new(ArrayBytes.ArrayI64);
 		a.length = length;
@@ -156,4 +157,5 @@ class ArrayBase extends ArrayAccess {
 		a.size = length;
 		return a;
 	}
+	#end
 }

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -362,4 +362,6 @@ typedef ArrayI32 = ArrayBytes<Int>;
 typedef ArrayUI16 = ArrayBytes<UI16>;
 typedef ArrayF32 = ArrayBytes<F32>;
 typedef ArrayF64 = ArrayBytes<Float>;
+#if !hl_legacy32
 typedef ArrayI64 = ArrayBytes<I64>;
+#end


### PR DESCRIPTION
Since #11734, the `hl-legacy32` define is not respected by `ArrayBytes<I64>`.

This avoids the issue, however, I'm not sure if other parts of genhl.ml should be changed too?

(Alternatively, maybe `hl-legacy32` support should be removed along with 32 bit support in hashlink)