### PR TITLE
Unconditionally use sys/wait.h on Unix-like sytems.

### DIFF
--- a/libs/extc/process_stubs.c
+++ b/libs/extc/process_stubs.c
@@ -37,13 +37,7 @@
 #	include <unistd.h>
 #	include <errno.h>
 #	include <string.h>
-#	ifndef __APPLE__
-#		if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)
-#			include <sys/wait.h>
-#		else
-#			include <wait.h>
-#		endif
-#	endif
+#	include <sys/wait.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
sys/wait.h is a Posix header present since the original standard. [^1]
It was added to glibc in 1991 [^2] and is present in musl [^3] and bionic (android) libc [^4].

All modern BSD systems (and macOS) derive from BSD 4.3 Reno, which has sys/wait.h in compliance with Posix.

wait.h is a legacy header from older Unixes and does not exist on BSD systems.
It is only present in glibc [^5], musl [^6] and Bionic [^7] for compatibility reasons, and simply redirects to sys/wait.h.
Musl's version generates a warning that including wait.h is incorrect.

Falling back to wait.h is therefore unnecessary and only causes portability issues.

[^1]: POSIX.1-1988 (FIPS 151-1): https://nvlpubs.nist.gov/nistpubs/Legacy/FIPS/fipspub151-1.pdf 
[^2]: see the copyright notice for that file: https://sourceware.org/git?p=glibc.git;a=blob_plain;f=posix/sys/wait.h;hb=HEAD
[^3]: https://git.musl-libc.org/cgit/musl/tree/include/sys/wait.h
[^4]: https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/sys/wait.h
[^5]: https://sourceware.org/git/?p=glibc.git;a=commit;f=posix/wait.h;h=8a52392237c44cbbd1ffc62b164230e1159dfb76
  this commit is from 1996, 5 years after sys/wait.h was added
[^6]: https://git.musl-libc.org/cgit/musl/commit/include/wait.h?id=c2d3fd3aad854af2875cff412cf52cead0a83a51
[^7]: https://android.googlesource.com/platform/bionic/+/2cc41d3e0054e414caa2022f4b625de2983006a2
  later a note was added that says new code should use sys/wait.h