### PR TITLE
Fix JsonPrinter Int64 Type

### DIFF
--- a/std/haxe/format/JsonPrinter.hx
+++ b/std/haxe/format/JsonPrinter.hx
@@ -83,7 +83,12 @@ class JsonPrinter {
 			v = replacer(k, v);
 		switch (Type.typeof(v)) {
 			case TUnknown:
-				add('"???"');
+				#if hl
+				if(haxe.Int64.isInt64(v))
+					add(haxe.Int64.toStr(v));
+				else
+				#end
+					add('"???"');
 			case TObject:
 				objString(v);
 			case TInt:
@@ -125,7 +130,9 @@ class JsonPrinter {
 				} else if (c == Date) {
 					var v:Date = v;
 					quote(v.toString());
-				} else
+				} else if(haxe.Int64.isInt64(v))
+					add(haxe.Int64.toStr(v));
+				  else
 					classString(v);
 			case TEnum(_):
 				var i = Type.enumIndex(v);

--- a/tests/unit/src/unit/TestJson.hx
+++ b/tests/unit/src/unit/TestJson.hx
@@ -91,7 +91,7 @@ class TestJson extends Test {
 		eq(haxe.format.JsonPrinter.print(Math.NaN), "null");
 		eq(haxe.format.JsonPrinter.print(function() {}), "\"<fun>\"");
 		eq(haxe.format.JsonPrinter.print({a: function() {}, b: 1}), "{\"b\":1}");
-		eq(haxe.format.JsonPrinter.print({a: function() {}, int64: haxe.Int64.parseString("123213213213213")}), "{\"int64\":123213213213213}");
+		eq(haxe.format.JsonPrinter.print({int64: haxe.Int64.parseString("123213213213213")}), "{\"int64\":123213213213213}");
 	}
 
 	function test3690() {

--- a/tests/unit/src/unit/TestJson.hx
+++ b/tests/unit/src/unit/TestJson.hx
@@ -91,6 +91,7 @@ class TestJson extends Test {
 		eq(haxe.format.JsonPrinter.print(Math.NaN), "null");
 		eq(haxe.format.JsonPrinter.print(function() {}), "\"<fun>\"");
 		eq(haxe.format.JsonPrinter.print({a: function() {}, b: 1}), "{\"b\":1}");
+		eq(haxe.format.JsonPrinter.print({a: function() {}, int64: haxe.Int64.parseString("123213213213213")}), "{\"int64\":123213213213213}");
 	}
 
 	function test3690() {


### PR DESCRIPTION
This commit enables Int64 to be used in json print.