### PR TITLE
[ci] Revert setup-ocaml constraint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         run: neko -version 2>&1
 
       - name: Setup ocaml
-        uses: ocaml/setup-ocaml@v3.1.5
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4
           opam-local-packages: |

--- a/extra/github-actions/install-ocaml-windows.yml
+++ b/extra/github-actions/install-ocaml-windows.yml
@@ -1,5 +1,5 @@
 - name: Setup ocaml
-  uses: ocaml/setup-ocaml@v3.1.5
+  uses: ocaml/setup-ocaml@v3
   with:
     ocaml-compiler: 4
     opam-local-packages: |


### PR DESCRIPTION
Setup-ocaml was constrained to 3.1.5 in #11906 due to a bug that broke luv, but it should now be fixed: https://github.com/ocaml/setup-ocaml/pull/921