### PR TITLE
[hlc] Fix SMOD/SDIV overflow exception when INT_MIN / -1

### DIFF
--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -823,7 +823,7 @@ let generate_function ctx f =
 		| OSDiv (r,a,b) ->
 			(match rtype r with
 			| HUI8 | HUI16 | HI32 ->
-				sexpr "%s = %s == 0 ? 0 : %s / %s" (reg r) (reg b) (reg a) (reg b)
+				sexpr "%s = (%s == 0 || %s == -1) ? %s * %s : %s / %s" (reg r) (reg b) (reg b) (reg a) (reg b) (reg a) (reg b)
 			| _ ->
 				sexpr "%s = %s / %s" (reg r) (reg a) (reg b))
 		| OUDiv (r,a,b) ->
@@ -831,7 +831,7 @@ let generate_function ctx f =
 		| OSMod (r,a,b) ->
 			(match rtype r with
 			| HUI8 | HUI16 | HI32 | HI64 ->
-				sexpr "%s = %s == 0 ? 0 : %s %% %s" (reg r) (reg b) (reg a) (reg b)
+				sexpr "%s = (%s == 0 || %s == -1) ? 0 : %s %% %s" (reg r) (reg b) (reg b) (reg a) (reg b)
 			| HF32 ->
 				sexpr "%s = fmodf(%s,%s)" (reg r) (reg a) (reg b)
 			| HF64 ->

--- a/tests/unit/src/unitstd/haxe/Int32.unit.hx
+++ b/tests/unit/src/unitstd/haxe/Int32.unit.hx
@@ -49,3 +49,14 @@ c == 0xfffffffe;
 -min == min;              // two's complement overflow,
 -2147483643 == 5 + -min;  // order of ops and negate
 2147483643 == -(5 + min); // static analyzer issue
+
+0 == min % 0;
+0 == Std.int(min / 0);
+0 == min % -1;
+0 == min % 1;
+min == Std.int(min / -1);
+min == min * -1;
+0 == max % -1;
+0 == max % 1;
+-max == Std.int(max / -1);
+-max == max * -1;

--- a/tests/unit/src/unitstd/haxe/Int32.unit.hx
+++ b/tests/unit/src/unitstd/haxe/Int32.unit.hx
@@ -51,16 +51,16 @@ c == 0xfffffffe;
 2147483643 == -(5 + min); // static analyzer issue
 
 #if hl
-0 == min % 0;
+0 == min % 0;              // % 0 div by zero exception
 0 == Std.int(min / 0);
-#end
-0 == min % -1;
-0 == min % 1;
-#if !python
+0 == min % -1;             // min % -1 integer overflow exception
 min == Std.int(min / -1);
-#end
 min == min * -1;
+0 == min % 1;
+0 == max % 0;
+0 == Std.int(max / 0);
 0 == max % -1;
-0 == max % 1;
 -max == Std.int(max / -1);
 -max == max * -1;
+0 == max % 1;
+#end

--- a/tests/unit/src/unitstd/haxe/Int32.unit.hx
+++ b/tests/unit/src/unitstd/haxe/Int32.unit.hx
@@ -50,11 +50,15 @@ c == 0xfffffffe;
 -2147483643 == 5 + -min;  // order of ops and negate
 2147483643 == -(5 + min); // static analyzer issue
 
+#if hl
 0 == min % 0;
 0 == Std.int(min / 0);
+#end
 0 == min % -1;
 0 == min % 1;
+#if !python
 min == Std.int(min / -1);
+#end
 min == min * -1;
 0 == max % -1;
 0 == max % 1;


### PR DESCRIPTION
Related Issue: https://github.com/HaxeFoundation/hashlink/issues/730

Related PR for HL/JIT (need merge there first for CI): https://github.com/HaxeFoundation/hashlink/pull/740

I added some overflow exception tests that can also cause problem on others targets (e.g. Neko fail in silence on try haxe), I can add a `if hl` if necessary