### PR TITLE
[hxb] only load up to EOF if at least one field is accessed

### DIFF
--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -154,6 +154,7 @@ class hxb_reader
 	val mutable api = Obj.magic ""
 	val mutable full_restore = true
 	val mutable current_module = null_module
+	val mutable delayed_field_loading : (unit->unit) list = []
 
 	val mutable ch = BytesWithPosition.create (Bytes.create 0)
 	val mutable has_string_pool = (string_pool <> None)
@@ -176,6 +177,9 @@ class hxb_reader
 
 	val mutable field_type_parameter_offset = 0
 	val empty_anon = mk_anon (ref Closed)
+
+	method set_delayed_field_loading f =
+		delayed_field_loading <- f :: delayed_field_loading
 
 	method resolve_type pack mname tname =
 		try
@@ -1933,7 +1937,22 @@ class hxb_reader
 				c.cl_flags <- read_uleb128 ch;
 
 				let read_field () =
-					self#read_class_field_forward;
+					let cf = self#read_class_field_forward in
+					if not full_restore then begin
+						let r = ref (lazy_processing t_dynamic) in
+						r := lazy_wait (fun() ->
+							let rec loop = function
+								| [] -> []
+								| f :: l ->
+									f();
+									loop l
+							in
+							delayed_field_loading <- loop delayed_field_loading;
+							cf.cf_type
+						);
+						cf.cf_type <- TLazy r;
+					end;
+					cf
 				in
 
 				c.cl_constructor <- self#read_option read_field;
@@ -1943,7 +1962,7 @@ class hxb_reader
 						if i = 0 then
 							acc_l,acc_pm
 						else begin
-							let cf = self#read_class_field_forward in
+							let cf = read_field () in
 							loop (cf :: acc_l) (PMap.add cf.cf_name cf acc_pm) (i - 1)
 						end
 					in

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -453,7 +453,7 @@ class hxb_reader_api_server
 			(* We try to avoid reading expressions as much as possible, so we only do this for
 				 our current display file if we're in display mode. *)
 			if full_restore then ignore(f_next chunks EOM)
-			else delay PConnectField (fun () -> ignore(f_next chunks EOF));
+			else reader#set_delayed_field_loading (fun () -> ignore(f_next chunks EOF));
 			m
 		| BadModule reason ->
 			die (Printf.sprintf "Unexpected BadModule %s (%s)" (s_type_path path) (Printer.s_module_skip_reason reason)) __LOC__
@@ -605,7 +605,7 @@ and type_module sctx com delay mpath p =
 					(* We try to avoid reading expressions as much as possible, so we only do this for
 					   our current display file if we're in display mode. *)
 					if full_restore then ignore(f_next chunks EOM)
-					else delay PConnectField (fun () -> ignore(f_next chunks EOF));
+					else reader#set_delayed_field_loading (fun () -> ignore(f_next chunks EOF));
 					add_modules true m;
 				| Some reason ->
 					skip mpath reason


### PR DESCRIPTION
Trying again with the following from #11866:

* Similar to #11873, uses `TLazy` on `cf_type`. Initially, modules that are non essential are only partially loaded. `cf_type` is being followed when a field is used, which will trigger the loading of the rest of the module.

Will need to list all the things that were wrong with that in #11866, and check if latest fixes there are enough to make this work (issue could have just been #11928).

Edit: currently getting `Invalid call to static function iterator through abstract instance` errors with this PR