### PR TITLE
[CI] brew: --preinstall has been renamed to --auto-update

### DIFF
--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -39,7 +39,7 @@ class Hl {
 			case "Linux":
 				Linux.requireAptPackages(["libpng-dev", "libjpeg-turbo8-dev", "libturbojpeg", "zlib1g-dev", "libvorbis-dev", "libsqlite3-dev"]);
 			case "Mac":
-				runNetworkCommand("brew", ["update", '--preinstall']);
+				runNetworkCommand("brew", ["update", '--auto-update']);
 				runNetworkCommand("brew", ["bundle", '--file=${hlSrc}/Brewfile']);
 			case "Windows":
 				//pass


### PR DESCRIPTION
See https://github.com/Homebrew/brew/commit/fb4c9353bbd5b022137f6e0a48c71b85503d80ca