### PR TITLE
[CI] increase setup timeout (mac runners often take longer)

### DIFF
--- a/tests/server/src/cases/CsSafeTypeBuilding.hx
+++ b/tests/server/src/cases/CsSafeTypeBuilding.hx
@@ -13,6 +13,7 @@ using Lambda;
 class CsSafeTypeBuilding extends TestCase {
 	var originalContent:String;
 
+	@:timeout(3000)
 	override public function setup(async:utest.Async) {
 		testDir = "test/cases/" + @:privateAccess TestCase.i++;
 		vfs = new Vfs(testDir);


### PR DESCRIPTION
Example failure: https://github.com/HaxeFoundation/haxe/actions/runs/12910549251/job/36005326301?pr=11936#step:10:1753