### PR TITLE
[jvm] fix indexOf

### DIFF
--- a/std/jvm/StringExt.hx
+++ b/std/jvm/StringExt.hx
@@ -48,6 +48,9 @@ class StringExt {
 	}
 
 	public static function indexOf(me:String, str:String, startIndex:Null<Int>) {
+		if(str == null) {
+			return -1;
+		}
 		if (str.length == 0) {
 			return java.lang.Math.max(0, java.lang.Math.min(startIndex == null ? 0 : startIndex, me.length));
 		}
@@ -55,6 +58,9 @@ class StringExt {
 	}
 
 	public static function lastIndexOf(me:String, str:String, ?startIndex:Int):Int {
+		if(str == null) {
+			return -1;
+		}
 		if (str.length == 0) {
 			return java.lang.Math.max(0, java.lang.Math.min(startIndex == null ? me.length : startIndex, me.length));
 		}


### PR DESCRIPTION
This commit resolves the error if the indexOf parameter is null.

Code
```haxe
var value:String = "data";
trace(value.indexOf(null));
```
Exception
```ex
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.coder()" because "str" is null
	at java.base/java.lang.String.indexOf(String.java:2593)
	at haxe.jvm.StringExt.indexOf(/usr/local/lib/haxe/std/jvm/StringExt.hx:51)
	at haxe.root.App.main(src/App.hx:36)
	at haxe.root.App.main(src/App.hx:1)
```