### PR TITLE
[jvm] Improve NativeOutput performance

### DIFF
--- a/std/jvm/io/NativeOutput.hx
+++ b/std/jvm/io/NativeOutput.hx
@@ -46,6 +46,20 @@ import java.io.IOException;
 		}
 	}
 
+	override public function writeBytes(s:Bytes, pos:Int, len:Int) {
+		if (pos < 0 || len < 0 || pos + len > s.length)
+			throw haxe.io.Error.OutsideBounds;
+		try {
+			stream.write(s.getData(), pos, len);
+		} catch (e:EOFException) {
+
+			throw new Eof();
+		} catch (e:IOException) {
+			throw haxe.io.Error.Custom(e);
+		}
+		return len;
+	}
+
 	override public function close():Void {
 		try {
 			stream.close();


### PR DESCRIPTION
This commit improves NativeOutput performance

POC
```haxe
var bytes:Bytes = Bytes.alloc(1024 * 1024 * 100);
socket.output.writeInput(new BytesInput(bytes));
```

 ## Benchmark Results

### Before
JVM: 800-1100 kb per second
C++: 200-300 mb per second

### After
JVM: 200-300 mb per second
C++: 200-300 mb per second