### PR TITLE
Update windows build documentation

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -46,12 +46,9 @@ ifeq ($(STATICLINK),0)
 	LIB_PARAMS = -cclib -lpcre2-8 -cclib -lz -cclib -lcrypt32 -cclib -lmbedtls -cclib -lmbedcrypto -cclib -lmbedx509
 endif
 
-PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std \
-	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep zlib1.dll | sed -e 's/^\s*//')" \
-	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libpcre2-8-0.dll | sed -e 's/^\s*//')" \
-	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedcrypto.dll | sed -e 's/^\s*//')" \
-	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedtls.dll | sed -e 's/^\s*//')" \
-	"$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep libmbedx509.dll | sed -e 's/^\s*//')"
+MINGW_DLLS=$$(cygcheck $(CURDIR)/$(HAXE_OUTPUT) | grep "\\\\sys-root\\\\mingw\\\\bin" | sed -e 's/^\s*//g')
+
+PACKAGE_FILES=$(HAXE_OUTPUT) $(HAXELIB_OUTPUT) std $(MINGW_DLLS)
 
 # haxelib should depends on haxe, but we don't want to do that...
 haxelib_win:
@@ -59,6 +56,9 @@ haxelib_win:
 	HAXE_STD_PATH=$$(cygpath -m $(CURDIR)/std) $(CURDIR)/$(HAXE_OUTPUT) client.hxml && \
 	nekotools boot run.n
 	mv extra/haxelib_src/run$(EXTENSION) $(HAXELIB_OUTPUT)
+
+copy_mingw_dlls:
+	cp $(MINGW_DLLS) .
 
 echo_package_files:
 	echo $(PACKAGE_FILES)
@@ -117,3 +117,5 @@ package_installer_win: $(INSTALLER_TMP_DIR)/neko-win.zip package_win
 	cd $(INSTALLER_TMP_DIR) && makensis installer.nsi
 	7z a -r -tzip $(OUTFILE) $(INSTALLER_TMP_DIR)/*.exe
 	dir $(PACKAGE_OUT_DIR)
+
+.PHONY: copy_mingw_dlls

--- a/extra/BUILDING.md
+++ b/extra/BUILDING.md
@@ -53,6 +53,12 @@ To install the native libraries, use the appropriate system package manager.
       * Download the [Neko binaries](https://nekovm.org/download/), and add the extracted directory to the beginning of PATH.
       * Install the [Chocolatey Neko package](https://chocolatey.org/packages/neko).
 
+On Windows, add the following PATH entry prior to installing libraries:
+
+```pwsh
+$env:PATH="$(opam exec -- cygpath -w /usr/x86_64-w64-mingw32/bin);$env:PATH"
+```
+
 To install the OCaml libraries, use OPAM as follows:
 
 ```sh

--- a/extra/BUILDING.md
+++ b/extra/BUILDING.md
@@ -26,12 +26,13 @@ Also note that since OPAM 2 on Linux will try to use bubblewrap, which uses Linu
 
 You need to install some native libraries as well as some OCaml libraries.
 
- * Native libraries
-    * PCRE
-    * zlib
-    * Neko (for building haxelib)
- * OCaml libraries
-    * listed in the `opam` file at the repository root
+* Native libraries
+  * PCRE
+  * zlib
+  * mbedtls
+  * Neko (for building haxelib)
+* OCaml libraries
+  * listed in the `opam` file at the repository root
 
 To install the native libraries, use the appropriate system package manager.
 
@@ -41,6 +42,13 @@ To install the native libraries, use the appropriate system package manager.
     * `sudo apt install libpcre2-dev zlib1g-dev libmbedtls-dev`.
  * Windows (Cygwin)
     * Run `opam init` to ensure cygwin is configured with the base packages required. Additional cygwin packages will be installed during the `opam install` further below.
+
+    * Manually install [mingw64-mbedtls](https://github.com/Simn/mingw64-mbedtls) into the cygwin root. First download the correct package from [the releases tab](https://github.com/Simn/mingw64-mbedtls/releases/latest), and then run:
+
+      ```pwsh
+      & $(opam exec -- cygpath -w "/bin/tar") -C / -xvf path/to/package.tar.xz
+      ```
+
     * Install Neko by either
       * Download the [Neko binaries](https://nekovm.org/download/), and add the extracted directory to the beginning of PATH.
       * Install the [Chocolatey Neko package](https://chocolatey.org/packages/neko).

--- a/extra/BUILDING.md
+++ b/extra/BUILDING.md
@@ -40,7 +40,7 @@ To install the native libraries, use the appropriate system package manager.
  * Debian / Ubuntu
     * `sudo apt install libpcre2-dev zlib1g-dev libmbedtls-dev`.
  * Windows (Cygwin)
-    * Run the Cygwin [setup-x86_64.exe](https://cygwin.com/install.html) against the Cygwin installation directory. Install `make`, `git`, `zlib-devel`, `libpcre2-devel`, `mingw64-x86_64-gcc-core`, `mingw64-x86_64-zlib`, and `mingw64-x86_64-pcre2`. You may need to select "Not Installed" in the dropdown list to see the packages. Copy `zlib1.dll` and `libpcre2-8-0.dll` from `path/to/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin` to the checked out Haxe source directory.
+    * Run the Cygwin [setup-x86_64.exe](https://cygwin.com/install.html) against the Cygwin installation directory. Install `make`, `git`, `zlib-devel`, `libpcre2-devel`, `mingw64-x86_64-gcc-core`, `mingw64-x86_64-zlib`, and `mingw64-x86_64-pcre2`. You may need to select "Not Installed" in the dropdown list to see the packages.
     * Install Neko by either
       * Download the [Neko binaries](https://nekovm.org/download/), and add the extracted directory to the beginning of PATH.
       * Install the [Chocolatey Neko package](https://chocolatey.org/packages/neko).
@@ -76,4 +76,10 @@ To install the freshly built Haxe,
     ```sh
     sudo make install
     ```
- * On Windows, add the checked out Haxe source directory to the beginning of PATH.
+ * On Windows, first copy the required dlls next to the haxe executable:
+
+   ```pwsh
+   make -f Makefile.win copy_mingw_dlls
+   ```
+
+   Then add the checked out Haxe source directory to the beginning of PATH.

--- a/extra/BUILDING.md
+++ b/extra/BUILDING.md
@@ -71,6 +71,12 @@ opam install haxe --deps-only
 
 ## Compile
 
+On Windows, cygwin's make must be available in PATH. To do this, run:
+
+```pwsh
+$env:PATH="$(opam exec -- cygpath -w /bin);$env:PATH"
+```
+
 In the checked out Haxe source directory,
 ```sh
 # On Unix

--- a/extra/BUILDING.md
+++ b/extra/BUILDING.md
@@ -16,9 +16,9 @@ The Haxe compiler is written in OCaml, so you have to set up an OCaml developmen
 
 The Haxe compiler requires OCaml version 4.02 or higher. Since some of the OCaml libraries Haxe depends on were uploaded in the OPAM 2 format, you should use OPAM 2.x instead of OPAM 1.x.
 
-To install OPAM on Unix (e.g. Mac, Linux) systems, follow the [instruction given by OPAM](https://opam.ocaml.org/doc/Install.html). On Windows, we recommend using the [Cygwin/MinGW-based OPAM environment provided by fdopen](https://fdopen.github.io/opam-repository-mingw/installation/), choose the 64-bit versions of everything, also make sure to [use the OPAM 2 version](https://github.com/fdopen/opam-repository-mingw/issues/48).
+To install OPAM, follow the [instruction given by OPAM](https://opam.ocaml.org/doc/Install.html).
 
-In case you messed up the OPAM installation, you can uninstall OPAM and remove `~/.opam`, which contains the OCaml switches (OCaml compilers and libraries), and start over.
+In case you messed up the OPAM installation, you can uninstall OPAM and remove `~/.opam` (or `%LOCALAPPDATA%\opam` on Windows), which contains the OCaml switches (OCaml compilers and libraries), and start over.
 
 Also note that since OPAM 2 on Linux will try to use bubblewrap, which uses Linux user namespaces, which might not be available on environments like Docker or Windows Subsystem for Linux (WSL). In case of encountering related errors, use `--disable-sandboxing` during `opam init`.
 
@@ -40,7 +40,7 @@ To install the native libraries, use the appropriate system package manager.
  * Debian / Ubuntu
     * `sudo apt install libpcre2-dev zlib1g-dev libmbedtls-dev`.
  * Windows (Cygwin)
-    * Run the Cygwin [setup-x86_64.exe](https://cygwin.com/install.html) against the Cygwin installation directory. Install `make`, `git`, `zlib-devel`, `libpcre2-devel`, `mingw64-x86_64-gcc-core`, `mingw64-x86_64-zlib`, and `mingw64-x86_64-pcre2`. You may need to select "Not Installed" in the dropdown list to see the packages.
+    * Run `opam init` to ensure cygwin is configured with the base packages required. Additional cygwin packages will be installed during the `opam install` further below.
     * Install Neko by either
       * Download the [Neko binaries](https://nekovm.org/download/), and add the extracted directory to the beginning of PATH.
       * Install the [Chocolatey Neko package](https://chocolatey.org/packages/neko).


### PR DESCRIPTION
Opam runs natively on Windows now and manages cygwin automatically, so there is no need to install cygwin manually anymore. These instructions explain how to set up opam like this.

A workaround is currently needed for luv, see: https://github.com/aantron/luv/issues/162