### PR TITLE
[tests] allow running display tests with another haxe version

### DIFF
--- a/tests/display/src/BaseDisplayTestContext.hx
+++ b/tests/display/src/BaseDisplayTestContext.hx
@@ -6,7 +6,16 @@ using StringTools;
 import Types;
 
 class BaseDisplayTestContext {
-	static var haxeServer = haxeserver.HaxeServerSync.launch("haxe", []);
+	static var haxeServer = {
+		var hx = "haxe";
+		var testHaxe = haxe.macro.Compiler.getDefine("test_haxe");
+		if (testHaxe != null) {
+			Sys.putEnv("HAXE_STD_PATH", '${Path.directory(testHaxe)}/std');
+			hx = testHaxe;
+		}
+
+		haxeserver.HaxeServerSync.launch(hx, []);
+	}
 
 	var dir:String = ".";
 	var vfs:Vfs;


### PR DESCRIPTION
Since display tests usually only compile with latest (or recent) nightlies, this is needed to run tests with a previous Haxe version.

I don't think the `HAXE_STD_PATH` part is needed on windows, but it shouldn't hurt?