### PR TITLE
[tests] add test for #8712

### DIFF
--- a/std/haxe/display/Display.hx
+++ b/std/haxe/display/Display.hx
@@ -129,7 +129,7 @@ typedef DisplayLocal<T> = {
 	var id:Int;
 	var name:String;
 	var type:JsonType<T>;
-	var origin:LocalOrigin;
+	var ?origin:LocalOrigin;
 	var capture:Bool;
 	var ?extra:{
 		var params:Array<JsonTypeParameter>;

--- a/tests/display/src/cases/Issue8712.hx
+++ b/tests/display/src/cases/Issue8712.hx
@@ -1,0 +1,41 @@
+package cases;
+
+import haxe.display.Display;
+import haxe.display.FsPath;
+
+class Issue8712 extends DisplayTestCase {
+	#if (display.protocol == "jsonrpc")
+	/**
+		abstract Foo(Int) {
+			function foo() {
+				ab{-2-}stract;
+				ab{-3-}stract.bar();
+			}
+
+			function bar() return th{-1-}is;
+		}
+	**/
+	function test() @:privateAccess {
+		function hover(marker:Int, ?p:haxe.PosInfos) {
+			var item = ctx.callDisplay(DisplayMethods.Hover, {
+				file: new FsPath(ctx.source.path),
+				offset: pos(marker),
+			}).result.item;
+
+			switch (item.kind) {
+				case Local if (marker == 1):
+					eq("this", item.args.name);
+					eq(null, item.args.origin); // = NOT VUser
+
+				case Literal if (marker >= 2):
+					eq("abstract", item.args.name);
+
+				case kind:
+					utest.Assert.fail("Unexpected item kind: " + kind, p);
+			}
+		}
+
+		for (i in 1...4) hover(i);
+	}
+	#end
+}


### PR DESCRIPTION
`tvar_kind` is not exposed by our display API, but I think all we care about here is that it's not `VUser`?

Note: `origin` field is set there: https://github.com/HaxeFoundation/haxe/blob/development/src/core/json/genjson.ml#L316-L320 (only for `v_kind = VUser _`)

Closes #8712