### PR TITLE
[filters] raise error upon failure instead of using die

### DIFF
--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -57,7 +57,11 @@ let run_expression_filters ?(ignore_processed_status=false) ctx detail_times fil
 	let com = ctx.com in
 	let run (ctx : typer) identifier e =
 		List.fold_left (fun e (filter_name,f) ->
-			FilterContext.with_timer detail_times filter_name identifier (fun () -> f ctx e)
+			(try
+				FilterContext.with_timer detail_times filter_name identifier (fun () -> f ctx e)
+			with Failure msg ->
+				com.error msg e.epos;
+				e)
 		) e filters
 	in
 	match t with

--- a/src/filters/renameVars.ml
+++ b/src/filters/renameVars.ml
@@ -384,24 +384,20 @@ let rec rename_vars rc scope =
 	Rename local variables in `e` expression if needed.
 *)
 let run cl_path ri e =
-	(try
-		let rc = {
-			rc_scope = ri.ri_scope;
-			rc_hoisting = ri.ri_hoisting;
-			rc_no_shadowing = ri.ri_no_shadowing;
-			rc_no_catch_var_shadowing = ri.ri_no_catch_var_shadowing;
-			rc_switch_cases_no_blocks = ri.ri_switch_cases_no_blocks;
-			rc_reserved = ri.ri_reserved;
-			rc_var_origins = Hashtbl.create 0;
-		} in
-		if ri.ri_reserve_current_top_level_symbol then begin
-			match cl_path with
-			| s :: _,_ | [],s -> reserve_ctx rc s
-		end;
-		let scope = create_scope None in
-		collect_vars rc scope e;
-		rename_vars rc scope;
-	with Failure msg ->
-		die ~p:e.epos msg __LOC__
-	);
+	let rc = {
+		rc_scope = ri.ri_scope;
+		rc_hoisting = ri.ri_hoisting;
+		rc_no_shadowing = ri.ri_no_shadowing;
+		rc_no_catch_var_shadowing = ri.ri_no_catch_var_shadowing;
+		rc_switch_cases_no_blocks = ri.ri_switch_cases_no_blocks;
+		rc_reserved = ri.ri_reserved;
+		rc_var_origins = Hashtbl.create 0;
+	} in
+	if ri.ri_reserve_current_top_level_symbol then begin
+		match cl_path with
+		| s :: _,_ | [],s -> reserve_ctx rc s
+	end;
+	let scope = create_scope None in
+	collect_vars rc scope e;
+	rename_vars rc scope;
 	e

--- a/tests/server/src/TestCase.hx
+++ b/tests/server/src/TestCase.hx
@@ -125,7 +125,7 @@ class TestCase implements ITest implements ITestCase {
 		errorMessages = [];
 		server.rawRequest(args, null, function(result) {
 			handleResult(result);
-			var json = try Json.parse(result.stderr) catch(e) {result: null, error: e.message};
+			var json = try Json.parse(result.stderr) catch(e) {result: null, error: e.message + " (Response: " + result.stderr + ")"};
 
 			if (json.result != null) {
 				callback(json.result?.result);

--- a/tests/server/src/cases/issues/Issue11711.hx
+++ b/tests/server/src/cases/issues/Issue11711.hx
@@ -1,0 +1,26 @@
+package cases.issues;
+
+import haxe.display.Diagnostic;
+
+class Issue11711 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11711/Main.hx"));
+		var args = ["-main", "Main", "--js", "no.js", "--no-output"];
+		runHaxe(args);
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			Assert.equals(1, res.length);
+			var diag = res[0];
+			Assert.equals(1, diag.diagnostics.length);
+			var diag = diag.diagnostics[0];
+			Assert.equals(Warning, diag.severity);
+			Assert.equals("WInfo", diag.code);
+			Assert.equals("Int", diag.args);
+		});
+
+		vfs.putContent("Main.hx", getTemplate("issues/Issue11711/Main1.hx"));
+		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
+		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
+			trace(res);
+		});
+	}
+}

--- a/tests/server/src/cases/issues/Issue11711.hx
+++ b/tests/server/src/cases/issues/Issue11711.hx
@@ -6,7 +6,6 @@ class Issue11711 extends TestCase {
 	function test(_) {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue11711/Main.hx"));
 		var args = ["-main", "Main", "--js", "no.js", "--no-output"];
-		runHaxe(args);
 		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
 			Assert.equals(1, res.length);
 			var diag = res[0];
@@ -20,7 +19,18 @@ class Issue11711 extends TestCase {
 		vfs.putContent("Main.hx", getTemplate("issues/Issue11711/Main1.hx"));
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("Main.hx")});
 		runHaxeJsonCb(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")}, res -> {
-			trace(res);
+			Assert.equals(1, res.length);
+			var found = false;
+			var diag = res[0];
+			for (d in diag.diagnostics) {
+				if (d.severity != Warning) continue;
+				if (d.code != "WInfo") continue;
+				if (d.args != "Int") continue;
+				found = true;
+				break;
+			}
+
+			Assert.isTrue(found);
 		});
 	}
 }

--- a/tests/server/test/templates/issues/Issue11711/Main.hx
+++ b/tests/server/test/templates/issues/Issue11711/Main.hx
@@ -1,0 +1,9 @@
+class Main {
+	static function main() {
+		var jit = {align: {ptr: 42}};
+		// var bar =
+		var excPos = jit.align.ptr * 5 + 8;
+		trace(excPos);
+		$type(excPos);
+	}
+}

--- a/tests/server/test/templates/issues/Issue11711/Main1.hx
+++ b/tests/server/test/templates/issues/Issue11711/Main1.hx
@@ -1,0 +1,9 @@
+class Main {
+	static function main() {
+		var jit = {align: {ptr: 42}};
+		var bar =
+		var excPos = jit.align.ptr * 5 + 8;
+		trace(excPos);
+		$type(excPos);
+	}
+}


### PR DESCRIPTION
Closes #11711 

~~Adding a failing test for a repro of the issue; still need a fix.~~
Didn't repro on eval and jvm, as `RenameVars` filter doesn't run for those.