### PR TITLE
[hlc] split hl_init_roots to prevent out of heap in msvc

### DIFF
--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1574,8 +1574,8 @@ let write_c com file (code:code) gnames =
 	line "}";
 	line "void hl_init_roots() {";
 	block ctx;
-	expr "void hl_init_roots_constants()";
-	expr "void hl_init_roots_globals()";
+	expr "hl_init_roots_constants()";
+	expr "hl_init_roots_globals()";
 	unblock ctx;
 	line "}";
 

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1556,16 +1556,26 @@ let write_c com file (code:code) gnames =
 		sexpr "static struct _%s %s = {%s}" (ctype t) name (String.concat "," fields);
 	) code.constants;
 	line "";
-	line "void hl_init_roots() {";
+	line "void hl_init_roots_constants() {";
 	block ctx;
 	let is_const = Hashtbl.create 0 in
 	Array.iter (fun (g,fields) ->
 		sexpr "%s = &const_%s" gnames.(g) gnames.(g);
 		Hashtbl.add is_const g true;
 	) code.constants;
+	unblock ctx;
+	line "}";
+	line "void hl_init_roots_globals() {";
+	block ctx;
 	Array.iteri (fun i t ->
 		if is_ptr t && not (Hashtbl.mem is_const i) then sexpr "hl_add_root((void**)&%s)" gnames.(i);
 	) code.globals;
+	unblock ctx;
+	line "}";
+	line "void hl_init_roots() {";
+	block ctx;
+	expr "void hl_init_roots_constants()";
+	expr "void hl_init_roots_globals()";
 	unblock ctx;
 	line "}";
 


### PR DESCRIPTION
When building two of Shiro's projects in HL/C using Visual Studio, the linkage time is extremely long and fail at the end with the following error.

```
xxx\hlc\src\hl\globals.c(46185): fatal error C1002: compiler is out of heap space in pass 2
  LINK : the 32-bit linker ran out of heap space and is going to restart linking with a 64-bit linker
```

The related value in `globals.c` is `hl_init_roots`, split it into two functions works well for these projects (30 secs for compilation, instead of 25 mins and fail).

I still don't understand why, we have larger project with larger `hl_init_roots` which works correctly.