### PR TITLE
Explicitly apply default type parameter

### DIFF
--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -709,6 +709,8 @@ and parse_complex_type_inner ctx allow_named s = match%parser s with
 		in
 		let p = punion p1 p2 in
 		CTPath (make_ptp (mk_type_path ~params:[TPType hint] (["haxe"],"Rest")) p),p
+	| [ (Kwd Default,p) ] ->
+		CTPath (make_ptp (mk_type_path (["$"],"_hx_default")) p),p
 	| [ dollar_ident as n ] ->
 		(match%parser s with
 		| [ (DblDot,_); [%let t = parse_complex_type ctx] ] when allow_named->

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -300,8 +300,8 @@ let rec load_params ctx info params p =
 	let is_java_rest = ctx.com.platform = Jvm && info.build_extern in
 	let is_rest = is_rest || is_java_rest in
 	let load_param t def =
-		match (t, def) with
-		| TPExpr e, _ ->
+		match t with
+		| TPExpr e ->
 			let name = (match fst e with
 				| EConst (String(s,_)) -> "S" ^ s
 				| EConst (Int (_,_) as c) -> "I" ^ s_constant c
@@ -314,11 +314,12 @@ let rec load_params ctx info params p =
 			let c = mk_class ctx.m.curmod ([],name) p (pos e) in
 			c.cl_kind <- KExpr e;
 			TInst (c,[]),pos e
-		| TPType (CTPath({ path = { tpackage = ["$"]; tname = "_hx_default" }}),p), None ->
-			raise_typing_error "Cannot apply default type parameter on non-default type parameter" p
-		| TPType (CTPath({ path = { tpackage = ["$"]; tname = "_hx_default" }}),p), Some def ->
-			def,p
-		| TPType t, _ ->
+		| TPType (CTPath({ path = { tpackage = ["$"]; tname = "_hx_default" }}),p) ->
+			(match def with
+				| Some def -> def,p
+				| None -> raise_typing_error "Cannot apply default type parameter on non-default type parameter" p
+			)
+		| TPType t ->
 			load_complex_type ctx true LoadNormal t,pos t
 	in
 	let checks = DynArray.create () in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -299,7 +299,7 @@ let rec load_params ctx info params p =
 	let is_rest = info.build_kind = BuildGenericBuild && (match info.build_params with [{ttp_name="Rest"}] -> true | _ -> false) in
 	let is_java_rest = ctx.com.platform = Jvm && info.build_extern in
 	let is_rest = is_rest || is_java_rest in
-	let load_param t def =
+	let load_param t ttp =
 		match t with
 		| TPExpr e ->
 			let name = (match fst e with
@@ -315,9 +315,14 @@ let rec load_params ctx info params p =
 			c.cl_kind <- KExpr e;
 			TInst (c,[]),pos e
 		| TPType (CTPath({ path = { tpackage = ["$"]; tname = "_hx_default" }}),p) ->
-			(match def with
-				| Some def -> def,p
-				| None -> raise_typing_error "Cannot apply default type parameter on non-default type parameter" p
+			(match ttp with
+				| Some { ttp_default = Some def } -> def,p
+				| Some ttp ->
+					raise_typing_error (Printf.sprintf "Invalid default, type parameter %s has no default value" ttp.ttp_name) p
+				| None when is_rest ->
+					raise_typing_error "Cannot use default with rest type parameters" p
+				| None ->
+					raise_typing_error ("Too many type parameters for " ^ s_type_path info.build_path) p
 			)
 		| TPType t ->
 			load_complex_type ctx true LoadNormal t,pos t
@@ -326,7 +331,7 @@ let rec load_params ctx info params p =
 	let rec loop tl1 tl2 is_rest = match tl1,tl2 with
 		| t :: tl1,ttp:: tl2 ->
 			let name = ttp.ttp_name in
-			let t,pt = load_param t ttp.ttp_default in
+			let t,pt = load_param t (Some ttp) in
 			let check_const c =
 				let is_expression = (match t with TInst ({ cl_kind = KExpr _ },_) -> true | _ -> false) in
 				let expects_expression = name = "Const" || Meta.has Meta.Const c.cl_meta in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -299,9 +299,9 @@ let rec load_params ctx info params p =
 	let is_rest = info.build_kind = BuildGenericBuild && (match info.build_params with [{ttp_name="Rest"}] -> true | _ -> false) in
 	let is_java_rest = ctx.com.platform = Jvm && info.build_extern in
 	let is_rest = is_rest || is_java_rest in
-	let load_param t =
-		match t with
-		| TPExpr e ->
+	let load_param t def =
+		match (t, def) with
+		| TPExpr e, _ ->
 			let name = (match fst e with
 				| EConst (String(s,_)) -> "S" ^ s
 				| EConst (Int (_,_) as c) -> "I" ^ s_constant c
@@ -314,14 +314,18 @@ let rec load_params ctx info params p =
 			let c = mk_class ctx.m.curmod ([],name) p (pos e) in
 			c.cl_kind <- KExpr e;
 			TInst (c,[]),pos e
-		| TPType t ->
+		| TPType (CTPath({ path = { tpackage = ["$"]; tname = "_hx_default" }}),p), None ->
+			raise_typing_error "Cannot apply default type parameter on non-default type parameter" p
+		| TPType (CTPath({ path = { tpackage = ["$"]; tname = "_hx_default" }}),p), Some def ->
+			def,p
+		| TPType t, _ ->
 			load_complex_type ctx true LoadNormal t,pos t
 	in
 	let checks = DynArray.create () in
 	let rec loop tl1 tl2 is_rest = match tl1,tl2 with
 		| t :: tl1,ttp:: tl2 ->
 			let name = ttp.ttp_name in
-			let t,pt = load_param t in
+			let t,pt = load_param t ttp.ttp_default in
 			let check_const c =
 				let is_expression = (match t with TInst ({ cl_kind = KExpr _ },_) -> true | _ -> false) in
 				let expects_expression = name = "Const" || Meta.has Meta.Const c.cl_meta in
@@ -360,7 +364,7 @@ let rec load_params ctx info params p =
 					t :: loop [] tl is_rest
 			end
 		| t :: tl,[] ->
-			let t,pt = load_param t in
+			let t,pt = load_param t None in
 			if is_rest then
 				t :: loop tl [] true
 			else if ignore_error ctx.com then
@@ -439,6 +443,7 @@ and load_complex_type' ctx allow_display mode (t,p) =
 	match t with
 	| CTParent t -> load_complex_type ctx allow_display mode t
 	| CTPath { path = {tpackage = ["$"]; tname = "_hx_mono" }} -> spawn_monomorph ctx p
+	| CTPath { path = {tpackage = ["$"]; tname = "_hx_default" }} -> raise_typing_error "Invalid type : default" p
 	| CTPath ptp -> load_instance ~allow_display ctx ptp ParamNormal mode
 	| CTOptional _ -> raise_typing_error "Optional type not allowed here" p
 	| CTNamed _ -> raise_typing_error "Named type not allowed here" p

--- a/tests/misc/projects/Issue11164/Macro.hx
+++ b/tests/misc/projects/Issue11164/Macro.hx
@@ -1,0 +1,5 @@
+class Macro {
+	public static function build() {
+		return macro :Any;
+	}
+}

--- a/tests/misc/projects/Issue11164/Main.hx
+++ b/tests/misc/projects/Issue11164/Main.hx
@@ -1,0 +1,29 @@
+typedef A<K = String, V> = haxe.ds.BalancedTree<K,V>;
+
+class B<T1 = Int, T2 = String, T3> {}
+
+class DefaultGeneric<T = String> {
+	public function new() {}
+}
+
+class Main {
+	static function main() {
+		var a:A<default,Int> = null;
+		$type(a);
+
+		var b:B<Bool,default,Int> = null;
+		$type(b);
+
+		var c = new DefaultGeneric();
+		$type(c);
+
+		var d = new DefaultGeneric<default>();
+		$type(d);
+
+		var e:DefaultGeneric = new DefaultGeneric();
+		$type(e);
+
+		var f:DefaultGeneric<default> = new DefaultGeneric();
+		$type(f);
+	}
+}

--- a/tests/misc/projects/Issue11164/Main2.hx
+++ b/tests/misc/projects/Issue11164/Main2.hx
@@ -1,0 +1,5 @@
+class Main2 {
+	static function main() {
+		var b:Array<default> = [];
+	}
+}

--- a/tests/misc/projects/Issue11164/Main3.hx
+++ b/tests/misc/projects/Issue11164/Main3.hx
@@ -1,0 +1,3 @@
+typedef B = default;
+
+function main() {}

--- a/tests/misc/projects/Issue11164/Main4.hx
+++ b/tests/misc/projects/Issue11164/Main4.hx
@@ -1,0 +1,3 @@
+typedef default = String;
+
+function main() {}

--- a/tests/misc/projects/Issue11164/Main5.hx
+++ b/tests/misc/projects/Issue11164/Main5.hx
@@ -1,0 +1,3 @@
+function main() {
+	var a:default;
+}

--- a/tests/misc/projects/Issue11164/Main6.hx
+++ b/tests/misc/projects/Issue11164/Main6.hx
@@ -1,0 +1,2 @@
+typedef Foo = Array<String, default>
+function main() {}

--- a/tests/misc/projects/Issue11164/Main7.hx
+++ b/tests/misc/projects/Issue11164/Main7.hx
@@ -1,0 +1,5 @@
+@:genericBuild(Macro.build())
+private class Foo<Rest> {}
+private typedef Bar = Foo<Int, default>
+
+function main() {}

--- a/tests/misc/projects/Issue11164/compile.hxml
+++ b/tests/misc/projects/Issue11164/compile.hxml
@@ -1,0 +1,3 @@
+-main Main
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile.hxml.stderr
@@ -1,0 +1,36 @@
+[WARNING] Main.hx:12: characters 9-10
+
+ 12 |   $type(a);
+    |         ^
+    | A<String, Int>
+
+[WARNING] Main.hx:15: characters 9-10
+
+ 15 |   $type(b);
+    |         ^
+    | B<Bool, String, Int>
+
+[WARNING] Main.hx:18: characters 9-10
+
+ 18 |   $type(c);
+    |         ^
+    | DefaultGeneric<Unknown<0>>
+
+[WARNING] Main.hx:21: characters 9-10
+
+ 21 |   $type(d);
+    |         ^
+    | DefaultGeneric<String>
+
+[WARNING] Main.hx:24: characters 9-10
+
+ 24 |   $type(e);
+    |         ^
+    | DefaultGeneric<String>
+
+[WARNING] Main.hx:27: characters 9-10
+
+ 27 |   $type(f);
+    |         ^
+    | DefaultGeneric<String>
+

--- a/tests/misc/projects/Issue11164/compile2-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile2-fail.hxml
@@ -1,0 +1,3 @@
+-main Main2
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile2-fail.hxml.stderr
@@ -1,0 +1,6 @@
+[ERROR] Main2.hx:3: characters 15-22
+
+ 3 |   var b:Array<default> = [];
+   |               ^^^^^^^
+   | Cannot apply default type parameter on non-default type parameter
+

--- a/tests/misc/projects/Issue11164/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile2-fail.hxml.stderr
@@ -2,5 +2,5 @@
 
  3 |   var b:Array<default> = [];
    |               ^^^^^^^
-   | Cannot apply default type parameter on non-default type parameter
+   | Invalid default, type parameter T has no default value
 

--- a/tests/misc/projects/Issue11164/compile3-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile3-fail.hxml
@@ -1,0 +1,3 @@
+-main Main3
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile3-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile3-fail.hxml.stderr
@@ -1,0 +1,6 @@
+[ERROR] Main3.hx:1: characters 13-20
+
+ 1 | typedef B = default;
+   |             ^^^^^^^
+   | Invalid type : default
+

--- a/tests/misc/projects/Issue11164/compile4-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile4-fail.hxml
@@ -1,0 +1,3 @@
+-main Main4
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile4-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile4-fail.hxml.stderr
@@ -1,0 +1,6 @@
+[ERROR] Main4.hx:1: characters 9-16
+
+ 1 | typedef default = String;
+   |         ^^^^^^^
+   | Unexpected keyword "default"
+

--- a/tests/misc/projects/Issue11164/compile5-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile5-fail.hxml
@@ -1,0 +1,3 @@
+-main Main5
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile5-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile5-fail.hxml.stderr
@@ -1,0 +1,6 @@
+[ERROR] Main5.hx:2: characters 8-15
+
+ 2 |  var a:default;
+   |        ^^^^^^^
+   | Invalid type : default
+

--- a/tests/misc/projects/Issue11164/compile6-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile6-fail.hxml
@@ -1,0 +1,3 @@
+-main Main6
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile6-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile6-fail.hxml.stderr
@@ -1,0 +1,6 @@
+[ERROR] Main6.hx:1: characters 29-36
+
+ 1 | typedef Foo = Array<String, default>
+   |                             ^^^^^^^
+   | Too many type parameters for Array
+

--- a/tests/misc/projects/Issue11164/compile7-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile7-fail.hxml
@@ -1,0 +1,3 @@
+-main Main7
+-D message.reporting=pretty
+-D message.no-color

--- a/tests/misc/projects/Issue11164/compile7-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11164/compile7-fail.hxml.stderr
@@ -1,0 +1,6 @@
+[ERROR] Main7.hx:3: characters 32-39
+
+ 3 | private typedef Bar = Foo<Int, default>
+   |                                ^^^^^^^
+   | Cannot use default with rest type parameters
+


### PR DESCRIPTION
Reimplemented #11165 with `default` instead of `_`
Closes #11164