### PR TITLE
[dune] Add universe dep to version.ml rule.

### DIFF
--- a/src/compiler/dune
+++ b/src/compiler/dune
@@ -1,5 +1,5 @@
 (rule
-	(deps (env_var ADD_REVISION))
+	(deps (env_var ADD_REVISION) (universe))
 	(targets version.ml)
 	(action (with-stdout-to version.ml (run ../prebuild.exe version)))
 )


### PR DESCRIPTION
Without the dep on `universe`, dune will fail to update version.ml when switching commits