### PR TITLE
[hl] Fix debug assigns not sorted when not optimize

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -3427,7 +3427,7 @@ and make_fun ?gen_content ctx name fidx f cthis cparent =
 		regs = DynArray.to_array ctx.m.mregs.arr;
 		code = DynArray.to_array ctx.m.mops;
 		debug = make_debug ctx ctx.m.mdebug;
-		assigns = Array.of_list (List.rev ctx.m.massign);
+		assigns = Array.of_list (List.sort (fun (_,p1) (_,p2) -> p1 - p2) (List.rev ctx.m.massign));
 	} in
 	ctx.m <- old;
 	Hashtbl.add ctx.defined_funs fidx ();


### PR DESCRIPTION
When the optimization is effective, `fun.assigns` are sorted correctly in ascending order. When no optimization or optimization is not needed in a inner function, arg (-1) seems to be placed before captured var (-2), which cause debugger not treating them correctly.

https://github.com/HaxeFoundation/haxe/blob/79e018d30a574f9a1893075a7054e820ced02903/src/generators/hlopt.ml#L618-L619

Tests in
- https://github.com/vshaxe/hashlink-debugger/pull/137