### PR TITLE
Remove unused null check in Bytes.getString

### DIFF
--- a/std/haxe/io/Bytes.hx
+++ b/std/haxe/io/Bytes.hx
@@ -404,8 +404,6 @@ class Bytes {
 		interpreted with the given `encoding` (UTF-8 by default).
 	**/
 	public function getString(pos:Int, len:Int, ?encoding:Encoding):String {
-		if (encoding == null)
-			encoding == UTF8;
 		#if !neko
 		if (pos < 0 || len < 0 || pos + len > length)
 			throw Error.OutsideBounds;


### PR DESCRIPTION
#12024, but touches less lines.