### PR TITLE
[tests] add test for Hashlink Issue 735

### DIFF
--- a/tests/unit/src/unit/issues/Issue12028.hx
+++ b/tests/unit/src/unit/issues/Issue12028.hx
@@ -1,0 +1,36 @@
+package unit.issues;
+
+private typedef StateHandler<T> = {
+    public function onUpdate():T;
+}
+
+class Issue12028 extends Test {
+	function testMakeVarArgsInDynamic() {
+		var func = function(args:Array<Dynamic>):String {
+			return args.length >= 1 ? args[0] : "";
+		};
+
+		var f2 = Reflect.makeVarArgs(func);
+		eq("a", f2("a")); // Important for repro
+		eq("b", foo(f2));
+		eq("d", Reflect.callMethod(null, f2, ["d"]));
+	}
+
+	function foo(func:Dynamic) {
+		return func("b", "c");
+	}
+
+	function testVoid2Dyn() {
+		var handlers:StateHandler<Void> = {
+			onUpdate: function():Bool {
+				return true;
+			}
+		}
+		foo2(handlers);
+		noAssert();
+	}
+
+	function foo2<T>(handlers:StateHandler<T>):Null<T> {
+		return handlers.onUpdate();
+	}
+}

--- a/tests/unit/src/unit/issues/Issue12028.hx
+++ b/tests/unit/src/unit/issues/Issue12028.hx
@@ -5,6 +5,7 @@ private typedef StateHandler<T> = {
 }
 
 class Issue12028 extends Test {
+	#if !lua
 	function testMakeVarArgsInDynamic() {
 		var func = function(args:Array<Dynamic>):String {
 			return args.length >= 1 ? args[0] : "";
@@ -33,4 +34,5 @@ class Issue12028 extends Test {
 	function foo2<T>(handlers:StateHandler<T>):Null<T> {
 		return handlers.onUpdate();
 	}
+	#end
 }


### PR DESCRIPTION
Related issue
- https://github.com/HaxeFoundation/hashlink/issues/735

Original error before fix: access violation / segfault on `foo` / `foo2`