### PR TITLE
Fix incorrect explanation.

### DIFF
--- a/std/String.hx
+++ b/std/String.hx
@@ -96,8 +96,8 @@ extern class String {
 		String.
 
 		If `startIndex` is given, the search is performed within the substring
-		of `this` String from 0 to `startIndex + str.length`. Otherwise the search
-		is performed within `this` String. In either case, the returned position
+		of `this` String from 0 to `startIndex + 1`. Otherwise the search is
+		performed within `this` String. In either case, the returned position
 		is relative to the beginning of `this` String.
 
 		If `startIndex` is negative, the result is unspecifed.


### PR DESCRIPTION
From my tests, `lastIndexOf()` can find the character at `startIndex` and no greater, meaning it searches the equivalent of `substring(0, startIndex + 1)`.

I also kind of like the explanation used for `Array.lastIndexOf()`: "If `fromIndex` is specified, it will be used as the starting index to search from." That seems more intuitive, if less precise. For now, I went for minimal changes.