### PR TITLE
[dune] Add rule to copy haxe.exe into source dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ NEKO_VERSION_TAG=v$(shell echo "$(NEKO_VERSION)" | sed "s/\./-/g")
 all: haxe tools
 
 haxe:
-	dune build --profile release src/haxe.exe
-	cp -f _build/default/src/haxe.exe ./"$(HAXE_OUTPUT)"
+	dune build --profile release
 
 plugin: haxe
 	$(DUNE_COMMAND) build --profile release plugins/$(PLUGIN)/$(PLUGIN).cmxs
@@ -234,7 +233,7 @@ package_installer_mac: $(INSTALLER_TMP_DIR)/neko-osx.tar.gz package_unix
 clean: clean_haxe clean_tools clean_package
 
 clean_haxe:
-	rm -f -r _build $(HAXE_OUTPUT) $(PREBUILD_OUTPUT)
+	dune clean
 
 clean_tools:
 	rm -f $(HAXE_OUTPUT) $(PREBUILD_OUTPUT) $(HAXELIB_OUTPUT)

--- a/dune
+++ b/dune
@@ -1,2 +1,9 @@
 (dirs src libs)
 (data_only_dirs src-json)
+
+(rule
+ (action
+  (copy src/haxe.exe haxe%{ext_exe}))
+ (mode
+  (promote (until-clean)))
+ (alias default))


### PR DESCRIPTION
Using a separate rule allows for the correct executable extension to be used.
