### PR TITLE
[hlc] Fix warning truncation double to float

### DIFF
--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -811,7 +811,11 @@ let generate_function ctx f =
 				sexpr "%s = %ld" (reg r) code.ints.(idx)
 		| OFloat (r,idx) ->
 			let fstr = sprintf "%.19g" code.floats.(idx) in
-			sexpr "%s = %s" (reg r) (if String.contains fstr '.' || String.contains fstr 'e' then fstr else fstr ^ ".")
+			let fstr = (if String.contains fstr '.' || String.contains fstr 'e' then fstr else fstr ^ ".") in
+			(match rtype r with
+			| HF32 -> sexpr "%s = %sf" (reg r) fstr
+			| _ -> sexpr "%s = %s" (reg r) fstr
+			);
 		| OBool (r,b) ->
 			sexpr "%s = %s" (reg r) (if b then "true" else "false")
 		| OBytes (r,idx) ->


### PR DESCRIPTION
Since I enabled F32 literal optimization in
- https://github.com/HaxeFoundation/haxe/pull/12041

hl/c will generate for `var a : Single = 13.3;`
```c
float r1 = 13.300000000000001;
```
and have warning in Visual Studio `warning C4305: '=': truncation from 'double' to 'float'`.

This PR makes it generate with a `f` at the end.

(Note: Use `%.15g` looks better than `%.19g` too, to generate only `float r1 = 13.3f;`. But I'm not sure that it's always better, so I prefer keep it for now.)