### PR TITLE
Don't avoid exception wrapping on HL/neko/eval

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -650,6 +650,9 @@ let get_config com =
 			pf_supports_unicode = false;
 			pf_scoping = { default_config.pf_scoping with
 				vs_flags = [ReserveAllTopLevelSymbols];
+			};
+			pf_exceptions = { default_config.pf_exceptions with
+				ec_avoid_wrapping = false
 			}
 		}
 	| Flash ->
@@ -770,6 +773,9 @@ let get_config com =
 				vs_scope = BlockScope;
 				vs_flags = [NoShadowing]
 			};
+			pf_exceptions = { default_config.pf_exceptions with
+				ec_avoid_wrapping = false
+			}
 		}
 	| Eval ->
 		{
@@ -779,6 +785,9 @@ let get_config com =
 			pf_uses_utf16 = false;
 			pf_supports_threads = true;
 			pf_capture_policy = CPWrapRef;
+			pf_exceptions = { default_config.pf_exceptions with
+				ec_avoid_wrapping = false
+			}
 		}
 
 let memory_marker = [|Unix.time()|]

--- a/tests/misc/projects/Issue4982/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue4982/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:3: characters 15-30 : Cannot use Void as value
+Main.hx:3: characters 15-30 : Void should be Any

--- a/tests/unit/src/unit/issues/Issue12047.hx
+++ b/tests/unit/src/unit/issues/Issue12047.hx
@@ -1,0 +1,23 @@
+package unit.issues;
+
+import utest.Assert;
+
+class Issue12047 extends Test {
+	static function test() {
+		try {
+			throwCatchWrap();
+		} catch (err:Issue12047) {
+			trace(err);
+		} catch (e) {
+			Assert.pass();
+		}
+	}
+
+	static function throwCatchWrap() {
+		try {
+			throw "fatal";
+		} catch (e) {
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
Closes #12047

I don't know if this is an optimal solution, but the dump now looks like this:

```haxe
	static function main() {
		try {
			Main.throwCatchWrap();
		} catch (`:Dynamic) {
			haxe.NativeStackTrace.saveStack(`);
			var ` = haxe.Exception.caught(`);
			var ` = `.unwrap();
			if ((Std.isOfType(`, Main))) {
				var err = cast `;
				haxe.Log.trace(err, {fileName : "source/Main.hx", lineNumber : 6, className : "Main", methodName : "main"});
			} else {
				var e = `;
				haxe.Log.trace(e, {fileName : "source/Main.hx", lineNumber : 8, className : "Main", methodName : "main"});
			};
		};
	}
```

Which is exactly what I expect.