### PR TITLE
[cpp] Allow setting callback for cppia script load

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -134,7 +134,7 @@ module Setup = struct
 				add_std "php";
 				"php"
 			| Cpp ->
-				Common.define_value com Define.HxcppApiLevel "430";
+				Common.define_value com Define.HxcppApiLevel "500";
 				add_std "cpp";
 				if Common.defined com Define.Cppia then
 					actx.classes <- (Path.parse_path "cpp.cppia.HostClasses" ) :: actx.classes;

--- a/std/cpp/vm/Debugger.hx
+++ b/std/cpp/vm/Debugger.hx
@@ -321,6 +321,17 @@ class Debugger {
 			THREAD_NOT_STOPPED);
 	}
 
+	#if scriptable
+	/**
+		Sets the callback to run whenever a new CPPIA script is loaded.
+
+		This can be helpful for adding breakpoints to a script.
+	**/
+	public static function setOnScriptLoadedFunction(callback:Void->Void):Void {
+		untyped __global__.__hxcpp_dbg_setOnScriptLoadedFunction(callback);
+	}
+	#end
+
 	// The hxcpp runtime calls back through these functions to create Haxe
 	// objects as needed, which allows the C++ implementation code to create
 	// Haxe objects without having to actually know the structure of those


### PR DESCRIPTION
Debugger clients may want to do some work if a script is loaded, e.g. adding breakpoints.


See: https://github.com/HaxeFoundation/hxcpp/pull/1203