### PR TITLE
[cppia] Generate full debug source paths

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -44,6 +44,11 @@
 		"doc": "Generate cpp instruction assembly."
 	},
 	{
+		"name": "CppiaAbsoluteSourcePaths",
+		"define": "cppia.absolute-source-paths",
+		"doc": "Embed absolute paths to source files for debugging."
+	},
+	{
 		"name": "NoCppiaAst",
 		"define": "nocppiaast",
 		"doc": "Use legacy cppia generation."

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -44,11 +44,6 @@
 		"doc": "Generate cpp instruction assembly."
 	},
 	{
-		"name": "CppiaAbsoluteSourcePaths",
-		"define": "cppia.absolute-source-paths",
-		"doc": "Embed absolute paths to source files for debugging."
-	},
-	{
 		"name": "NoCppiaAst",
 		"define": "nocppiaast",
 		"doc": "Use legacy cppia generation."

--- a/src/generators/cpp/gen/cppCppia.ml
+++ b/src/generators/cpp/gen/cppCppia.ml
@@ -521,7 +521,6 @@ class script_writer ctx filename asciiOut =
     val fileTable = Hashtbl.create 0
     val identBuffer = Buffer.create 0
     val cppiaAst = not (Gctx.defined ctx.ctx_common Define.NoCppiaAst)
-    val absoluteSourcePaths = Gctx.defined ctx.ctx_common Define.CppiaAbsoluteSourcePaths
 
     method stringId name =
       try Hashtbl.find identTable name
@@ -786,12 +785,8 @@ class script_writer ctx filename asciiOut =
 
     method wpos p =
       if debug then
-        let filepath = if absoluteSourcePaths then
-          Path.get_full_path p.pfile
-        else p.pfile
-        in
         this#write
-          (this#fileText filepath ^ "\t"
+          (this#fileText (Path.get_full_path p.pfile) ^ "\t"
           ^ string_of_int (Lexer.get_error_line p)
           ^ indent)
 

--- a/src/generators/cpp/gen/cppCppia.ml
+++ b/src/generators/cpp/gen/cppCppia.ml
@@ -521,6 +521,7 @@ class script_writer ctx filename asciiOut =
     val fileTable = Hashtbl.create 0
     val identBuffer = Buffer.create 0
     val cppiaAst = not (Gctx.defined ctx.ctx_common Define.NoCppiaAst)
+    val absoluteSourcePaths = Gctx.defined ctx.ctx_common Define.CppiaAbsoluteSourcePaths
 
     method stringId name =
       try Hashtbl.find identTable name
@@ -785,8 +786,12 @@ class script_writer ctx filename asciiOut =
 
     method wpos p =
       if debug then
+        let filepath = if absoluteSourcePaths then
+          Path.get_full_path p.pfile
+        else p.pfile
+        in
         this#write
-          (this#fileText p.pfile ^ "\t"
+          (this#fileText filepath ^ "\t"
           ^ string_of_int (Lexer.get_error_line p)
           ^ indent)
 


### PR DESCRIPTION
See #12052

Perhaps this should be on by default, given that the debugger doesn't work without this, but I'm not sure if doing that might break anything else.