### PR TITLE
[cpp] Fix mismatching type and getter return on pointer

### DIFF
--- a/std/cpp/ConstPointer.hx
+++ b/std/cpp/ConstPointer.hx
@@ -28,7 +28,7 @@ extern class ConstPointer<T> {
 	// Use value or ref to get dereferenced value
 	var ptr:Star<T>;
 
-	var value(get, never):T;
+	var value(get, never):Reference<T>;
 
 	// Typecast to non-const
 	var raw(get, never):RawPointer<T>;


### PR DESCRIPTION
@kevinresol noticed in #11981 that extra casts were being added around the `cpp.Pointers` `value` field, but nightlies are also effected by this.

```haxe
extern class Foo {
    function i() : Int;
}

function main() {
    final p : cpp.Pointer<Foo> = null;
    final i = p.value.i();

    trace(i);
}
```

In the above sample the line with assigns `i` generates the following c++ in 4.3.x releases.

```cpp
int i = p->get_value()->i();
```

But in nightlies it generates the following, with an incorrect cast.

```cpp
int i = ( ( ::Foo)(p->get_value()) )->i();
```

The actual cause of this ended up being quite silly, The type on the field `value` was `T` but the return type on its getter was `Reference<T>`. Since `Reference` is one of those magic typedefs haxe is fine with this, but some changes in the recent refactors  must now be tripped up by this and gencpps auto casting kicks in and adds that cast to deal with a `Reference<T>` to `T` conversion.

I'll try and get a test together for this and add it to the hxcpp repo.