### PR TITLE
Analyzer const propagation typing fixes

### DIFF
--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -360,7 +360,7 @@ module ConstPropagation = DataFlow(struct
 		| Top
 		| Bottom
 		| Null of Type.t
-		| Const of tconstant
+		| Const of tconstant * Type.t
 		| EnumValue of int * t list
 		| ModuleType of module_type * Type.t
 
@@ -377,7 +377,7 @@ module ConstPropagation = DataFlow(struct
 
 	let equals lat1 lat2 = match lat1,lat2 with
 		| Top,Top | Bottom,Bottom -> true
-		| Const ct1,Const ct2 -> ct1 = ct2
+		| Const(ct1,t1),Const(ct2,t2) -> ct1 = ct2 && t1 == t2
 		| Null t1,Null t2 -> t1 == t2
 		| EnumValue(i1,[]),EnumValue(i2,[]) -> i1 = i2
 		| ModuleType(mt1,_),ModuleType (mt2,_) -> mt1 == mt2
@@ -386,12 +386,12 @@ module ConstPropagation = DataFlow(struct
 	let transfer ctx bb e =
 		let rec eval bb e =
 			let wrap = function
-				| Const ct -> mk (TConst ct) t_dynamic null_pos
+				| Const(ct,t) -> mk (TConst ct) t null_pos
 				| Null t -> mk (TConst TNull) t e.epos
 				| _ -> raise Exit
 			in
 			let unwrap e = match e.eexpr with
-				| TConst ct -> Const ct
+				| TConst ct -> Const(ct,e.etype)
 				| _ -> raise Exit
 			in
 			match e.eexpr with
@@ -400,7 +400,7 @@ module ConstPropagation = DataFlow(struct
 			| TConst TNull ->
 				Null e.etype
 			| TConst ct ->
-				Const ct
+				Const(ct,e.etype)
 			| TTypeExpr mt ->
 				ModuleType(mt,e.etype)
 			| TLocal v ->
@@ -442,12 +442,12 @@ module ConstPropagation = DataFlow(struct
 				end;
 			| TEnumIndex e1 ->
 				begin match eval bb e1 with
-					| EnumValue(i,_) -> Const (TInt (Int32.of_int i))
+					| EnumValue(i,_) -> Const (TInt (Int32.of_int i),ctx.com.basic.tint)
 					| _ -> raise Exit
 				end;
 			| TCall ({ eexpr = TField (_,FStatic({cl_path=[],"Type"} as c,({cf_name="enumIndex"} as cf)))},[e1]) when ctx.com.platform = Eval ->
 				begin match follow e1.etype,eval bb e1 with
-					| TEnum _,EnumValue(i,_) -> Const (TInt (Int32.of_int i))
+					| TEnum _,EnumValue(i,_) -> Const (TInt (Int32.of_int i),ctx.com.basic.tint)
 					| _,e1 ->
 						begin match Inline.api_inline2 ctx.com c cf.cf_name [wrap e1] e.epos with
 							| None -> raise Exit
@@ -472,7 +472,7 @@ module ConstPropagation = DataFlow(struct
 					| _ -> raise Exit
 				in
 				begin match follow e1.etype,eval bb e1 with
-					| TEnum _,EnumValue(i,_) -> Const (TInt (Int32.of_int i))
+					| TEnum _,EnumValue(i,_) -> Const (TInt (Int32.of_int i),ctx.com.basic.tint)
 					| _ -> raise Exit
 				end
 		in
@@ -488,7 +488,7 @@ module ConstPropagation = DataFlow(struct
 		let inline e i = match get_cell i with
 			| Top | Bottom | EnumValue _ | Null _ ->
 				raise Not_found
-			| Const ct ->
+			| Const(ct,tTODO) ->
 				let e' = Texpr.type_constant ctx.com.basic (tconst_to_const ct) e.epos in
 				if not (type_change_ok ctx.com e'.etype e.etype) then raise Not_found;
 				e'

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -185,6 +185,7 @@ end
 
 module type DataFlowApi = sig
 	type t
+	val to_string : t -> string
 	val flag : BasicBlock.cfg_edge_Flag
 	val transfer : analyzer_context -> BasicBlock.t -> texpr -> t (* The transfer function *)
 	val equals : t -> t -> bool                                   (* The equality function *)
@@ -364,6 +365,16 @@ module ConstPropagation = DataFlow(struct
 		| EnumValue of int * t list
 		| ModuleType of module_type * Type.t
 
+	let rec to_string =
+		let st = s_type (print_context()) in
+		function
+		| Top -> "Top"
+		| Bottom -> "Bottom"
+		| Null t -> Printf.sprintf "Null(%s)" (st t)
+		| Const(ct,t) -> Printf.sprintf "Const(%s,%s)" (s_const ct) (st t)
+		| EnumValue(i,tl) -> Printf.sprintf "EnumValue(%i, %s)" i (String.concat ", " (List.map to_string tl))
+		| ModuleType(mt,t) -> Printf.sprintf "ModuleType(%s,%s)" (s_module_type_kind mt) (st t)
+
 	let conditional = true
 	let flag = FlagExecutable
 
@@ -377,7 +388,7 @@ module ConstPropagation = DataFlow(struct
 
 	let equals lat1 lat2 = match lat1,lat2 with
 		| Top,Top | Bottom,Bottom -> true
-		| Const(ct1,t1),Const(ct2,t2) -> ct1 = ct2 && t1 == t2
+		| Const(ct1,t1),Const(ct2,t2) -> ct1 = ct2 && type_iseq t1 t2
 		| Null t1,Null t2 -> t1 == t2
 		| EnumValue(i1,[]),EnumValue(i2,[]) -> i1 = i2
 		| ModuleType(mt1,_),ModuleType (mt2,_) -> mt1 == mt2
@@ -488,8 +499,9 @@ module ConstPropagation = DataFlow(struct
 		let inline e i = match get_cell i with
 			| Top | Bottom | EnumValue _ | Null _ ->
 				raise Not_found
-			| Const(ct,tTODO) ->
+			| Const(ct,t) ->
 				let e' = Texpr.type_constant ctx.com.basic (tconst_to_const ct) e.epos in
+				let e' = {e' with etype = t} in
 				if not (type_change_ok ctx.com e'.etype e.etype) then raise Not_found;
 				e'
 			| ModuleType(mt,t) ->

--- a/src/optimization/optimizerTexpr.ml
+++ b/src/optimization/optimizerTexpr.ml
@@ -130,9 +130,9 @@ let optimize_binop e op e1 e2 =
 		| OpAnd -> opt Int32.logand
 		| OpOr -> opt Int32.logor
 		| OpXor -> opt Int32.logxor
-		| OpShl -> opt (fun a b -> Int32.shift_left a (Int32.to_int (Int32.logand b i32_31)))
-		| OpShr -> opt (fun a b -> Int32.shift_right a (Int32.to_int (Int32.logand b i32_31)))
-		| OpUShr -> opt (fun a b -> Int32.shift_right_logical a (Int32.to_int (Int32.logand b i32_31)))
+		| OpShl when is_numeric e.etype -> opt (fun a b -> Int32.shift_left a (Int32.to_int (Int32.logand b i32_31)))
+		| OpShr when is_numeric e.etype -> opt (fun a b -> Int32.shift_right a (Int32.to_int (Int32.logand b i32_31)))
+		| OpUShr when is_numeric e.etype -> opt (fun a b -> Int32.shift_right_logical a (Int32.to_int (Int32.logand b i32_31)))
 		| OpEq -> ebool (=)
 		| OpNotEq -> ebool (<>)
 		| OpGt -> ebool (>)

--- a/tests/optimization/src/issues/Issue6229.hx
+++ b/tests/optimization/src/issues/Issue6229.hx
@@ -18,7 +18,7 @@ class Issue6229 {
 		}
 	}
 
-	@:js('var a = 1 + 1;')
+	@:js('var v_x = 1;var v_y = 1;var a = 2;')
 	@:analyzer(no_local_dce)
     static function test() {
         var v = mkVec(1);

--- a/tests/unit/src/unit/issues/Issue12031.hx
+++ b/tests/unit/src/unit/issues/Issue12031.hx
@@ -1,0 +1,30 @@
+package unit.issues;
+
+import utest.Assert;
+
+class Issue12031 extends Test {
+	#if hl
+	inline function inlinef(v:hl.I64) {
+		var str = "";
+		str += (v >> 32);
+		return str;
+	}
+
+	function noInlinef(v:hl.I64) {
+		var str = "";
+		str += (v >> 32);
+		return str;
+	}
+
+	function test() {
+		var base:hl.I64 = 22; // 0b10110
+		eq(22, base.toInt());
+		eq("0", inlinef(base));
+		eq("0", noInlinef(base));
+		var manual1 = "" + (base >> 33);
+		eq("0", manual1);
+		var manual2 = "" + (base >> 34);
+		eq("0", manual2);
+	}
+	#end
+}


### PR DESCRIPTION
This keeps track of the actual type of constants instead of using Dynamic internally. Also has a better fix for #12031.

The general problem with Int64 is that we don't have Int64 constants in the compiler itself. Given something like `var a:Int64 = 22`, what ends up being promoted is the Int `22` because that's the only thing we can represent. I thought about working with some casting mechanism here, but that seems out-of-scope for something that's promoting _constants_.

I'll think about this some more, but for now this should be a good change.