### PR TITLE
[std] Serializer: Implement `reset` method

### DIFF
--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -110,6 +110,17 @@ class Serializer {
 	}
 
 	/**
+		Resets the Serializer's internal state so that it
+		can be reused.
+	**/
+	public function reset() {
+		buf = new StringBuf();
+		cach.resize(0);
+		shash.clear();
+		scount = 0;
+	}
+
+	/**
 		Return the String representation of `this` Serializer.
 
 		The exact format specification can be found here:

--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -115,7 +115,7 @@ class Serializer {
 	**/
 	public function reset() {
 		buf = new StringBuf();
-		cach.resize(0);
+		cache.resize(0);
 		shash.clear();
 		scount = 0;
 	}

--- a/std/haxe/Serializer.hx
+++ b/std/haxe/Serializer.hx
@@ -44,28 +44,35 @@ import haxe.ds.List;
 **/
 class Serializer {
 	/**
-		If the values you are serializing can contain circular references or
-		objects repetitions, you should set `USE_CACHE` to true to prevent
-		infinite loops.
-
-		This may also reduce the size of serialization Strings at the expense of
-		performance.
-
-		This value can be changed for individual instances of `Serializer` by
-		setting their `useCache` field.
-	**/
+		Enables object caching during serialization to handle circular references and 
+		repeated objects.
+	
+		Set `USE_CACHE` to `true` if the values you are serializing may contain 
+		circular references or repeated objects. This prevents infinite loops and 
+		ensures that shared references are preserved in the serialized output.
+	
+		Enabling this option may also reduce the size of the resulting serialized 
+		string, but can have a minor performance impact.
+	
+		This is a global default. You can override it per instance using the 
+		`useCache` field on a `Serializer`.
+	 */
 	public static var USE_CACHE = false;
 
 	/**
-		Use constructor indexes for enums instead of names.
-
-		This may reduce the size of serialization Strings, but makes them less
-		suited for long-term storage: If constructors are removed or added from
-		the enum, the indices may no longer match.
-
-		This value can be changed for individual instances of `Serializer` by
-		setting their `useEnumIndex` field.
-	**/
+		Serializes enum values using constructor indices instead of names.
+	
+		When `USE_ENUM_INDEX` is set to `true`, enum constructors are serialized by 
+		their numeric index. This can reduce the size of the serialized data, 
+		especially for enums with long or frequently used constructor names.
+	
+		However, using indices makes serialized data more fragile for long-term 
+		storage. If enum definitions change (e.g., by adding or removing constructors), 
+		the indices may no longer match the intended constructors.
+	
+		This is a global default. You can override it per instance using the 
+		`useEnumIndex` field on a `Serializer`.
+	 */
 	public static var USE_ENUM_INDEX = false;
 
 	static var BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789%:";
@@ -77,17 +84,24 @@ class Serializer {
 	var scount:Int;
 
 	/**
-		The individual cache setting for `this` Serializer instance.
-
-		See `USE_CACHE` for a complete description.
-	**/
+	 	Determines whether this `Serializer` instance uses object caching.
+	
+	 	When enabled, repeated references to the same object are serialized using references 
+	 	instead of duplicating data, reducing output size and preserving object identity.
+	
+	 	See `USE_CACHE` for a complete description.
+ 	*/
 	public var useCache:Bool;
 
 	/**
-		The individual enum index setting for `this` Serializer instance.
+		Determines whether this `Serializer` instance serializes enum values using their index
+		instead of their constructor name.
+
+		Using indexes can reduce the size of the serialized data but may be less readable and 
+		more fragile if enum definitions change.
 
 		See `USE_ENUM_INDEX` for a complete description.
-	**/
+	 */
 	public var useEnumIndex:Bool;
 
 	/**
@@ -110,8 +124,10 @@ class Serializer {
 	}
 
 	/**
-		Resets the Serializer's internal state so that it
-		can be reused.
+		Resets the internal state of the Serializer, allowing it to be reused.
+		
+		This does not affect the `useCache` or `useEnumIndex` properties;
+		their values will remain unchanged after calling this method.
 	**/
 	public function reset() {
 		buf = new StringBuf();

--- a/tests/unit/src/unit/TestSerialize.hx
+++ b/tests/unit/src/unit/TestSerialize.hx
@@ -227,7 +227,7 @@ class TestSerialize extends Test {
 		}
 	}
 
-	public function doTestReset()
+	function doTestReset()
 	{
 		var serializer = new Serializer();
 		serializer.useCache = true;

--- a/tests/unit/src/unit/TestSerialize.hx
+++ b/tests/unit/src/unit/TestSerialize.hx
@@ -139,6 +139,7 @@ class TestSerialize extends Test {
 			b.set(i, i % 10);
 		doTestBytes(b);
 		doTestBytesCrossPlatform();
+		doTestReset();
 
 		// recursivity
 		c.ref = c;
@@ -224,5 +225,56 @@ class TestSerialize extends Test {
 			if (i != byte)
 				break;
 		}
+	}
+
+	public static function doTestReset()
+	{
+		var serializer = new Serializer();
+		serializer.useCache = true;
+
+		// first serialization
+		var obj1 = { a: 1, b: 2, c: "test" };
+		serializer.serialize(obj1);
+		var serialized1 = serializer.toString();
+		var deserialized1 = Unserializer.run(serialized1);
+
+		eq(deserialized1.a, obj1.a);
+		eq(deserialized1.b, obj1.b);
+		eq(deserialized1.c, obj1.c);
+
+		// reset the serializer
+		serializer.reset();
+
+		// checks if buffer is empty after reset
+		eq(serializer.toString(), "");
+
+		// we serialize a second, different object
+		var obj2 = { x: 42, y: "new", z: false };
+		serializer.serialize(obj2);
+		var serialized2 = serializer.toString();
+		var deserialized2 = Unserializer.run(serialized2);
+
+		eq(deserialized2.x, obj2.x);
+		eq(deserialized2.y, obj2.y);
+		eq(deserialized2.z, obj2.z);
+
+		// ensures serialization changed after reset
+		f(serialized1 == serialized2);
+
+		// resets again and serialize obj2 again to verify consistency
+		serializer.reset();
+		serializer.serialize(obj2);
+		var serialized2Again = serializer.toString();
+
+		// serialization should be identical if reset() truly resets state
+		eq(serialized2, serialized2Again);
+
+		// check against a fresh serializer instance
+		var freshSerializer = new Serializer();
+		freshSerializer.useCache = true;
+		freshSerializer.serialize(obj2);
+		var freshSerialized2 = freshSerializer.toString();
+
+		eq(serialized2, freshSerialized2);
 	}
 }

--- a/tests/unit/src/unit/TestSerialize.hx
+++ b/tests/unit/src/unit/TestSerialize.hx
@@ -227,7 +227,7 @@ class TestSerialize extends Test {
 		}
 	}
 
-	public static function doTestReset()
+	public function doTestReset()
 	{
 		var serializer = new Serializer();
 		serializer.useCache = true;


### PR DESCRIPTION
The `reset` method allows reusing a `Serializer` instance instead of creating new ones, reducing memory allocations and avoiding unnecessary garbage collection.