### PR TITLE
Make some filters thread-safe

### DIFF
--- a/src/context/abstractCast.ml
+++ b/src/context/abstractCast.ml
@@ -5,9 +5,7 @@ open Type
 open Typecore
 open Error
 
-let cast_stack = new_rec_stack()
-
-let rec make_static_call ctx c cf a pl args t p =
+let rec make_static_call ctx stack c cf a pl args t p =
 	if cf.cf_kind = Method MethMacro then begin
 		match args with
 			| [e] ->
@@ -18,21 +16,21 @@ let rec make_static_call ctx c cf a pl args t p =
 					| _ ->  type_expr ctx (EConst (Ident "null"),p) WithType.value
 				in
 				ctx.e.with_type_stack <- List.tl ctx.e.with_type_stack;
-				let e = try cast_or_unify_raise ctx t e p with Error { err_message = Unify _ } -> raise Not_found in
+				let e = try cast_or_unify_raise ctx stack t e p with Error { err_message = Unify _ } -> raise Not_found in
 				f();
 				e
 			| _ -> die "" __LOC__
 	end else
 		CallUnification.make_static_call_better ctx c cf pl args t p
 
-and do_check_cast ctx uctx tleft eright p =
+and do_check_cast ctx uctx stack tleft eright p =
 	let recurse cf f =
 		(*
 			Without this special check for macro @:from methods we will always get "Recursive implicit cast" error
 			unlike non-macro @:from methods, which generate unification errors if no other @:from methods are involved.
 		*)
 		if cf.cf_kind = Method MethMacro then begin
-			match cast_stack.rec_stack with
+			match stack.rec_stack with
 			| previous_from :: _ when previous_from == cf ->
 				(try
 					Type.unify_custom uctx eright.etype tleft;
@@ -40,15 +38,15 @@ and do_check_cast ctx uctx tleft eright p =
 					raise_error_msg (Unify l) eright.epos)
 			| _ -> ()
 		end;
-		if cf == ctx.f.curfield || rec_stack_memq cf cast_stack then raise_typing_error "Recursive implicit cast" p;
-		rec_stack_loop cast_stack cf f ()
+		if cf == ctx.f.curfield || rec_stack_memq cf stack then raise_typing_error "Recursive implicit cast" p;
+		rec_stack_loop stack cf f ()
 	in
 	let make (a,tl,(tcf,cf)) =
 		if (Meta.has Meta.MultiType cf.cf_meta) then
 			mk_cast eright tleft p
 		else match a.a_impl with
 			| Some c -> recurse cf (fun () ->
-				let ret = make_static_call ctx c cf a tl [eright] tleft p in
+				let ret = make_static_call ctx stack c cf a tl [eright] tleft p in
 				{ ret with eexpr = TMeta( (Meta.ImplicitCast,[],ret.epos), ret) }
 			)
 			| None -> die "" __LOC__
@@ -108,18 +106,21 @@ and do_check_cast ctx uctx tleft eright p =
 		loop [] tleft eright.etype
 	end
 
-and cast_or_unify_raise ctx ?(uctx=None) tleft eright p =
+and cast_or_unify_raise ctx ?(uctx=None) stack tleft eright p =
 	let uctx = match uctx with
 		| None -> default_unification_context ()
 		| Some uctx -> uctx
 	in
 	try
-		do_check_cast ctx uctx tleft eright p
+		do_check_cast ctx uctx stack tleft eright p
 	with Not_found ->
 		unify_raise_custom uctx eright.etype tleft p;
 		eright
 
-and cast_or_unify ctx tleft eright p =
+let cast_or_unify_raise ctx ?(uctx=None) tleft eright p =
+	cast_or_unify_raise ctx ~uctx (new_rec_stack()) tleft eright p
+
+let cast_or_unify ctx tleft eright p =
 	try
 		cast_or_unify_raise ctx tleft eright p
 	with Error ({ err_message = Unify _ } as err) ->
@@ -259,7 +260,7 @@ let handle_abstract_casts ctx e =
 			end else begin
 				(* a TNew of an abstract implementation is only generated if it is a multi type abstract *)
 				let cf,m,pl = find_multitype_specialization' ctx.com a pl e.epos in
-				let e = make_static_call ctx c cf a pl ((mk (TConst TNull) (TAbstract(a,pl)) e.epos) :: el) m e.epos in
+				let e = make_static_call ctx (new_rec_stack()) c cf a pl ((mk (TConst TNull) (TAbstract(a,pl)) e.epos) :: el) m e.epos in
 				{e with etype = m}
 			end
 		| TCall({eexpr = TField(_,FStatic({cl_path=[],"Std"},{cf_name = "string"}))},[e1]) when (match follow e1.etype with TAbstract({a_impl = Some _},_) -> true | _ -> false) ->
@@ -267,7 +268,7 @@ let handle_abstract_casts ctx e =
 				| TAbstract({a_impl = Some c} as a,tl) ->
 					begin try
 						let cf = PMap.find "toString" c.cl_statics in
-						let call() = make_static_call ctx c cf a tl [e1] ctx.t.tstring e.epos in
+						let call() = make_static_call ctx (new_rec_stack()) c cf a tl [e1] ctx.t.tstring e.epos in
 						if not ctx.allow_transform then
 							{ e1 with etype = ctx.t.tstring; epos = e.epos }
 						else if not (is_nullable e1.etype) then
@@ -350,7 +351,7 @@ let handle_abstract_casts ctx e =
 							match follow m with
 							| TAbstract({a_impl = Some c} as a,pl) ->
 								let cf = PMap.find fname c.cl_statics in
-								make_static_call ctx c cf a pl (e2 :: el) e.etype e.epos
+								make_static_call ctx (new_rec_stack()) c cf a pl (e2 :: el) e.etype e.epos
 							| _ -> raise Not_found
 						end
 					| _ ->

--- a/src/context/abstractCast.ml
+++ b/src/context/abstractCast.ml
@@ -5,7 +5,10 @@ open Type
 open Typecore
 open Error
 
-let rec make_static_call ctx stack c cf a pl args t p =
+let cast_stack = new_rec_stack()
+
+
+let rec make_static_call ctx c cf a pl args t p =
 	if cf.cf_kind = Method MethMacro then begin
 		match args with
 			| [e] ->
@@ -16,21 +19,21 @@ let rec make_static_call ctx stack c cf a pl args t p =
 					| _ ->  type_expr ctx (EConst (Ident "null"),p) WithType.value
 				in
 				ctx.e.with_type_stack <- List.tl ctx.e.with_type_stack;
-				let e = try cast_or_unify_raise ctx stack t e p with Error { err_message = Unify _ } -> raise Not_found in
+				let e = try cast_or_unify_raise ctx t e p with Error { err_message = Unify _ } -> raise Not_found in
 				f();
 				e
 			| _ -> die "" __LOC__
 	end else
 		CallUnification.make_static_call_better ctx c cf pl args t p
 
-and do_check_cast ctx uctx stack tleft eright p =
+and do_check_cast ctx uctx tleft eright p =
 	let recurse cf f =
 		(*
 			Without this special check for macro @:from methods we will always get "Recursive implicit cast" error
 			unlike non-macro @:from methods, which generate unification errors if no other @:from methods are involved.
 		*)
 		if cf.cf_kind = Method MethMacro then begin
-			match stack.rec_stack with
+			match cast_stack.rec_stack with
 			| previous_from :: _ when previous_from == cf ->
 				(try
 					Type.unify_custom uctx eright.etype tleft;
@@ -38,15 +41,15 @@ and do_check_cast ctx uctx stack tleft eright p =
 					raise_error_msg (Unify l) eright.epos)
 			| _ -> ()
 		end;
-		if cf == ctx.f.curfield || rec_stack_memq cf stack then raise_typing_error "Recursive implicit cast" p;
-		rec_stack_loop stack cf f ()
+		if cf == ctx.f.curfield || rec_stack_memq cf cast_stack then raise_typing_error "Recursive implicit cast" p;
+		rec_stack_loop cast_stack cf f ()
 	in
 	let make (a,tl,(tcf,cf)) =
 		if (Meta.has Meta.MultiType cf.cf_meta) then
 			mk_cast eright tleft p
 		else match a.a_impl with
 			| Some c -> recurse cf (fun () ->
-				let ret = make_static_call ctx stack c cf a tl [eright] tleft p in
+				let ret = make_static_call ctx c cf a tl [eright] tleft p in
 				{ ret with eexpr = TMeta( (Meta.ImplicitCast,[],ret.epos), ret) }
 			)
 			| None -> die "" __LOC__
@@ -106,21 +109,18 @@ and do_check_cast ctx uctx stack tleft eright p =
 		loop [] tleft eright.etype
 	end
 
-and cast_or_unify_raise ctx ?(uctx=None) stack tleft eright p =
+and cast_or_unify_raise ctx ?(uctx=None) tleft eright p =
 	let uctx = match uctx with
 		| None -> default_unification_context ()
 		| Some uctx -> uctx
 	in
 	try
-		do_check_cast ctx uctx stack tleft eright p
+		do_check_cast ctx uctx tleft eright p
 	with Not_found ->
 		unify_raise_custom uctx eright.etype tleft p;
 		eright
 
-let cast_or_unify_raise ctx ?(uctx=None) tleft eright p =
-	cast_or_unify_raise ctx ~uctx (new_rec_stack()) tleft eright p
-
-let cast_or_unify ctx tleft eright p =
+and cast_or_unify ctx tleft eright p =
 	try
 		cast_or_unify_raise ctx tleft eright p
 	with Error ({ err_message = Unify _ } as err) ->
@@ -260,7 +260,7 @@ let handle_abstract_casts ctx e =
 			end else begin
 				(* a TNew of an abstract implementation is only generated if it is a multi type abstract *)
 				let cf,m,pl = find_multitype_specialization' ctx.com a pl e.epos in
-				let e = make_static_call ctx (new_rec_stack()) c cf a pl ((mk (TConst TNull) (TAbstract(a,pl)) e.epos) :: el) m e.epos in
+				let e = make_static_call ctx c cf a pl ((mk (TConst TNull) (TAbstract(a,pl)) e.epos) :: el) m e.epos in
 				{e with etype = m}
 			end
 		| TCall({eexpr = TField(_,FStatic({cl_path=[],"Std"},{cf_name = "string"}))},[e1]) when (match follow e1.etype with TAbstract({a_impl = Some _},_) -> true | _ -> false) ->
@@ -268,7 +268,7 @@ let handle_abstract_casts ctx e =
 				| TAbstract({a_impl = Some c} as a,tl) ->
 					begin try
 						let cf = PMap.find "toString" c.cl_statics in
-						let call() = make_static_call ctx (new_rec_stack()) c cf a tl [e1] ctx.t.tstring e.epos in
+						let call() = make_static_call ctx c cf a tl [e1] ctx.t.tstring e.epos in
 						if not ctx.allow_transform then
 							{ e1 with etype = ctx.t.tstring; epos = e.epos }
 						else if not (is_nullable e1.etype) then
@@ -351,7 +351,7 @@ let handle_abstract_casts ctx e =
 							match follow m with
 							| TAbstract({a_impl = Some c} as a,pl) ->
 								let cf = PMap.find fname c.cl_statics in
-								make_static_call ctx (new_rec_stack()) c cf a pl (e2 :: el) e.etype e.epos
+								make_static_call ctx c cf a pl (e2 :: el) e.etype e.epos
 							| _ -> raise Not_found
 						end
 					| _ ->

--- a/src/context/parallel.ml
+++ b/src/context/parallel.ml
@@ -13,5 +13,5 @@ let run_parallel_on_seq pool seq f =
 	run_parallel_on_array pool (Array.of_seq seq) f
 
 let run_in_new_pool f =
-	let pool = Domainslib.Task.setup_pool ~num_domains:(Domain.recommended_domain_count()) () in
+	let pool = Domainslib.Task.setup_pool ~num_domains:(Domain.recommended_domain_count() - 1) () in
 	Std.finally (fun () -> Domainslib.Task.teardown_pool pool) f pool

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -728,7 +728,9 @@ let run tctx ectx main before_destruction =
 		| _ -> (fun tctx e -> RenameVars.run tctx.c.curclass.cl_path locals e));
 		"mark_switch_break_loops",(fun _ -> mark_switch_break_loops);
 	] in
-	List.iter (run_expression_filters tctx detail_times filters) new_types;
+	Parallel.run_in_new_pool (fun pool ->
+		Parallel.run_parallel_on_array pool (Array.of_list new_types) (run_expression_filters tctx detail_times filters)
+	);
 	with_timer detail_times "callbacks" None (fun () ->
 		com.callbacks#run com.error_ext com.callbacks#get_before_save;
 	);

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -75,7 +75,7 @@ let run_expression_filters ?(ignore_processed_status=false) ctx detail_times fil
 				(match cf.cf_expr with
 				| Some e when not (is_removable_field com cf) ->
 					let identifier = Printf.sprintf "%s.%s" (s_type_path c.cl_path) cf.cf_name in
-					cf.cf_expr <- Some (rec_stack_loop (new_rec_stack()) cf (run ctx (Some identifier)) e);
+					cf.cf_expr <- Some (run ctx (Some identifier) e);
 				| _ -> ());
 			end;
 			List.iter process_field cf.cf_overloads

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -75,7 +75,7 @@ let run_expression_filters ?(ignore_processed_status=false) ctx detail_times fil
 				(match cf.cf_expr with
 				| Some e when not (is_removable_field com cf) ->
 					let identifier = Printf.sprintf "%s.%s" (s_type_path c.cl_path) cf.cf_name in
-					cf.cf_expr <- Some (rec_stack_loop AbstractCast.cast_stack cf (run ctx (Some identifier)) e);
+					cf.cf_expr <- Some (rec_stack_loop (new_rec_stack()) cf (run ctx (Some identifier)) e);
 				| _ -> ());
 			end;
 			List.iter process_field cf.cf_overloads

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -333,10 +333,8 @@ let reduce_control_flow com e = match e.eexpr with
 	| _ ->
 		e
 
-let inline_stack = new_rec_stack()
-
-let rec reduce_loop ctx e =
-	let e = Type.map_expr (reduce_loop ctx) e in
+let rec reduce_loop ctx stack e =
+	let e = Type.map_expr (reduce_loop ctx stack) e in
 	sanitize_expr ctx.com (match e.eexpr with
 	| TCall(e1,el) ->
 		begin match Texpr.skip e1 with
@@ -346,18 +344,18 @@ let rec reduce_loop ctx e =
 				let rt = (match follow ef.etype with TFun (_,rt) -> rt | _ -> die "" __LOC__) in
 				begin try
 					let e = type_inline ctx cf func ethis el rt None e.epos ~self_calling_closure:true false in
-					reduce_loop ctx e
+					reduce_loop ctx stack e
 				with Error { err_message = Custom _ } ->
 					reduce_expr ctx e
 				end;
-			| {eexpr = TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf)))} when needs_inline ctx (Some cl) cf && not (rec_stack_memq cf inline_stack) ->
+			| {eexpr = TField(ef,(FStatic(cl,cf) | FInstance(cl,_,cf)))} when needs_inline ctx (Some cl) cf && not (rec_stack_memq cf stack) ->
 				begin match cf.cf_expr with
 				| Some {eexpr = TFunction tf} ->
 					let config = inline_config (Some cl) cf el e.etype in
 					let rt = (match Abstract.follow_with_abstracts e1.etype with TFun (_,rt) -> rt | _ -> die "" __LOC__) in
 					begin try
 						let e = type_inline ctx cf tf ef el rt config e.epos false in
-						rec_stack_default inline_stack cf (fun cf' -> cf' == cf) (fun () -> reduce_loop ctx e) e
+						rec_stack_default stack cf (fun cf' -> cf' == cf) (fun () -> reduce_loop ctx stack e) e
 					with Error { err_message = Custom _ } ->
 						reduce_expr ctx e
 					end
@@ -367,7 +365,7 @@ let rec reduce_loop ctx e =
 			| { eexpr = TField ({ eexpr = TTypeExpr (TClassDecl c) },field) } ->
 				(match api_inline ctx c (field_name field) el e.epos with
 				| None -> reduce_expr ctx e
-				| Some e -> reduce_loop ctx e)
+				| Some e -> reduce_loop ctx stack e)
 			| _ ->
 				reduce_expr ctx e
 		end
@@ -375,37 +373,38 @@ let rec reduce_loop ctx e =
 		reduce_expr ctx (reduce_control_flow ctx.com e))
 
 let reduce_expression ctx e =
-	if ctx.com.foptimize then
+	if ctx.com.foptimize then begin
 		(* We go through rec_stack_default here so that the current field is on inline_stack. This prevents self-recursive
 		   inlining (#7569). *)
-		rec_stack_default inline_stack ctx.f.curfield (fun cf' -> cf' == ctx.f.curfield) (fun () -> reduce_loop ctx e) e
-	else
+		let stack = new_rec_stack() in
+		rec_stack_default stack ctx.f.curfield (fun cf' -> cf' == ctx.f.curfield) (fun () -> reduce_loop ctx stack e) e
+	end else
 		e
 
-let rec make_constant_expression ctx ?(concat_strings=false) e =
-	let e = reduce_loop ctx e in
+let rec make_constant_expression ctx stack ?(concat_strings=false) e =
+	let e = reduce_loop ctx stack e in
 	match e.eexpr with
 	| TConst _ -> Some e
 	| TField({eexpr = TTypeExpr _},FEnum _) -> Some e
-	| TBinop ((OpAdd|OpSub|OpMult|OpDiv|OpMod|OpShl|OpShr|OpUShr|OpOr|OpAnd|OpXor) as op,e1,e2) -> (match make_constant_expression ctx e1,make_constant_expression ctx e2 with
+	| TBinop ((OpAdd|OpSub|OpMult|OpDiv|OpMod|OpShl|OpShr|OpUShr|OpOr|OpAnd|OpXor) as op,e1,e2) -> (match make_constant_expression ctx stack e1,make_constant_expression ctx stack e2 with
 		| Some ({eexpr = TConst (TString s1)}), Some ({eexpr = TConst (TString s2)}) when concat_strings ->
 			Some (mk (TConst (TString (s1 ^ s2))) ctx.com.basic.tstring (punion e1.epos e2.epos))
 		| Some e1, Some e2 -> Some (mk (TBinop(op, e1, e2)) e.etype e.epos)
 		| _ -> None)
-	| TUnop((Neg | NegBits) as op,Prefix,e1) -> (match make_constant_expression ctx e1 with
+	| TUnop((Neg | NegBits) as op,Prefix,e1) -> (match make_constant_expression ctx stack e1 with
 		| Some e1 -> Some (mk (TUnop(op,Prefix,e1)) e.etype e.epos)
 		| None -> None)
 	| TCast (e1, None) ->
-		(match make_constant_expression ctx e1 with
+		(match make_constant_expression ctx stack e1 with
 		| None -> None
 		| Some e1 -> Some {e with eexpr = TCast(e1,None)})
 	| TParenthesis e1 ->
-		begin match make_constant_expression ctx ~concat_strings e1 with
+		begin match make_constant_expression ctx stack ~concat_strings e1 with
 			| None -> None
 			| Some e1 -> Some {e with eexpr = TParenthesis e1}
 		end
 	| TMeta(m,e1) ->
-		begin match make_constant_expression ctx ~concat_strings e1 with
+		begin match make_constant_expression ctx stack ~concat_strings e1 with
 			| None -> None
 			| Some e1 -> Some {e with eexpr = TMeta(m,e1)}
 		end
@@ -422,3 +421,6 @@ let rec make_constant_expression ctx ?(concat_strings=false) e =
 			| Some e -> make_constant_expression ctx e)
 		with Not_found -> None) *)
 	| _ -> None
+
+let make_constant_expression ctx ?(concat_strings=false) e =
+	make_constant_expression ctx (new_rec_stack()) ~concat_strings e


### PR DESCRIPTION
I found some more evil global state stacks. Other than that this seems to just work. Our unit tests don't have particularly high numbers for these filters in the first place (it goes from 55ms to 33ms), but I know some codebases struggle with RenameVars in particular.