### PR TITLE
[python] Mark threads as daemon threads.

### DIFF
--- a/std/python/_std/sys/thread/Thread.hx
+++ b/std/python/_std/sys/thread/Thread.hx
@@ -124,7 +124,7 @@ private class HxThread {
 			}
 			dropThread(nt);
 		}
-		nt = new NativeThread({target:wrappedCallB});
+		nt = new NativeThread({target:wrappedCallB, daemon: true});
 		t = new HxThread(nt);
 		if(withEventLoop)
 			t.events = new EventLoop();


### PR DESCRIPTION
Otherwise background threads keep the program alive, which is not consistent with other targets.