### PR TITLE
Rewrite deprecated defines

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -18,7 +18,8 @@
 	},
 	{
 		"name": "AnalyzerTimes",
-		"define": "analyzer-times",
+		"define": "times.analyzer",
+		"deprecatedDefine": "analyzer-times",
 		"doc": "Record detailed timers for the analyzer",
 		"params": ["level: 0 | 1 | 2"]
 	},
@@ -166,7 +167,8 @@
 	},
 	{
 		"name": "EvalTimes",
-		"define": "eval-times",
+		"define": "times.eval",
+		"deprecatedDefine": "eval-times",
 		"doc": "Record per-method execution times in macro/interp mode. Implies eval-stack.",
 		"platforms": ["eval"]
 	},
@@ -177,7 +179,8 @@
 	},
 	{
 		"name": "FilterTimes",
-		"define": "filter-times",
+		"define": "times.filter",
+		"deprecatedDefine": "filter-times",
 		"doc": "Record per-filter execution times upon --times."
 	},
 	{
@@ -273,7 +276,8 @@
 	},
 	{
 		"name": "HxbTimes",
-		"define": "hxb-times",
+		"define": "times.hxb",
+		"deprecatedDefine": "hxb-times",
 		"doc": "Display hxb timing when used with `--times`."
 	},
 	{
@@ -510,7 +514,8 @@
 	},
 	{
 		"name": "MacroTimes",
-		"define": "macro-times",
+		"define": "times.macro",
+		"deprecatedDefine": "macro-times",
 		"doc": "Display per-macro timing when used with `--times`."
 	},
 	{

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -273,11 +273,17 @@ end
 
 let check_defines com =
 	if is_next com then begin
-		PMap.iter (fun k _ ->
+		PMap.iter (fun k v ->
 			try
 				let reason = Hashtbl.find Define.deprecation_lut k in
 				let p = fake_pos ("-D " ^ k) in
-				com.warning WDeprecatedDefine [] reason p
+				begin match reason with
+				| DueTo reason ->
+					com.warning WDeprecatedDefine [] reason p
+				| InFavorOf d ->
+					Define.raw_define_value com.defines d v;
+					com.warning WDeprecatedDefine [] (Printf.sprintf "-D %s has been deprecated in favor of -D %s" k d) p
+				end;
 			with Not_found ->
 				()
 		) com.defines.values
@@ -422,7 +428,7 @@ let compile ctx actx callbacks =
 		) (List.rev actx.cmds)
 	end
 
-let make_ice_message com msg backtrace = 
+let make_ice_message com msg backtrace =
 		let ver = (s_version_full com.version) in
 		let os_type = if Sys.unix then "unix" else "windows" in
 		Printf.sprintf "%s\nHaxe: %s; OS type: %s;\n%s" msg ver os_type backtrace
@@ -455,7 +461,7 @@ with
 		error ctx ("Error: " ^ msg) null_pos
 	| Globals.Ice (msg,backtrace) when is_diagnostics com ->
 		let s = make_ice_message com msg backtrace in
-		handle_diagnostics ctx s null_pos DKCompilerMessage 
+		handle_diagnostics ctx s null_pos DKCompilerMessage
 	| Globals.Ice (msg,backtrace) when not Helper.is_debug_run ->
 		let s = make_ice_message com msg backtrace in
 		error ctx ("Error: " ^ s) null_pos

--- a/src/prebuild.ml
+++ b/src/prebuild.ml
@@ -105,18 +105,29 @@ let get_field name map fields =
 	| None -> raise (Prebuild_error ("field `" ^ name ^ "` has invalid data"))
 	| Some v -> v
 
+type parsed_define = {
+	d_name : string;
+	d_define : string;
+	d_doc : string;
+	d_params : string list;
+	d_platforms : string list;
+	d_links: string list;
+	d_deprecated : string option;
+}
 let parse_define json =
 	let fields = match json with
 		| JObject fl -> fl
 		| _ -> raise (Prebuild_error "not an object")
 	in
-	(* name *) get_field "name" as_string fields,
-	(* define *) get_field "define" as_string fields,
-	(* doc *) get_field "doc" as_string fields,
-	(* params *) get_optional_field "params" as_params [] fields,
-	(* platforms *) get_optional_field "platforms" as_platforms [] fields,
-	(* links *) get_optional_field "links" as_links [] fields,
-	(* deprecated *) get_optional_field2 "deprecated" as_string fields
+	{
+		d_name = get_field "name" as_string fields;
+		d_define = get_field "define" as_string fields;
+		d_doc = get_field "doc" as_string fields;
+		d_params = get_optional_field "params" as_params [] fields;
+		d_platforms = get_optional_field "platforms" as_platforms [] fields;
+		d_links = get_optional_field "links" as_links [] fields;
+		d_deprecated = get_optional_field2 "deprecated" as_string fields;
+	}
 
 let parse_meta json =
 	let fields = match json with
@@ -180,7 +191,7 @@ let gen_params = List.map (function param -> "HasParam \"" ^ param ^ "\"" )
 let gen_links = List.map (function link -> "Link \"" ^ link ^ "\"" )
 
 let gen_define_type defines =
-	String.concat "\n" (List.map (function (name, _, _, _, _, _, _) -> "\t| " ^ name) defines)
+	String.concat "\n" (List.map (function def -> "\t| " ^ def.d_name) defines)
 
 let gen_option f = function
 	| None -> "None"
@@ -189,12 +200,12 @@ let gen_option f = function
 let gen_define_info defines =
 	let deprecations = DynArray.create() in
 	let define_str = List.map (function
-		(name, define, doc, params, platforms, links, deprecated) ->
-			let platforms_str = gen_platforms platforms in
-			let params_str = gen_params params in
-			let links_str = gen_links links in
-			let define = String.concat "_" (ExtString.String.nsplit define "-") in
-			let deprecated = match deprecated with
+		def ->
+			let platforms_str = gen_platforms def.d_platforms in
+			let params_str = gen_params def.d_params in
+			let links_str = gen_links def.d_links in
+			let define = String.concat "_" (ExtString.String.nsplit def.d_define "-") in
+			let deprecated = match def.d_deprecated with
 				| None ->
 					[]
 				| Some x ->
@@ -202,7 +213,7 @@ let gen_define_info defines =
 					DynArray.add deprecations (Printf.sprintf "\t(%S,%S)" define x);
 					[Printf.sprintf "Deprecated(%s)" quoted]
 			in
-			"\t| " ^ name ^ " -> \"" ^ define ^ "\",(" ^ (Printf.sprintf "%S" doc) ^ ",[" ^ (String.concat "; " (platforms_str @ params_str @ links_str @ deprecated)) ^ "])"
+			"\t| " ^ def.d_name ^ " -> \"" ^ define ^ "\",(" ^ (Printf.sprintf "%S" def.d_doc) ^ ",[" ^ (String.concat "; " (platforms_str @ params_str @ links_str @ deprecated)) ^ "])"
 	) defines in
 	String.concat "\n" define_str,String.concat ";\n" (DynArray.to_list deprecations)
 

--- a/src/prebuild.ml
+++ b/src/prebuild.ml
@@ -113,6 +113,7 @@ type parsed_define = {
 	d_platforms : string list;
 	d_links: string list;
 	d_deprecated : string option;
+	d_deprecated_define : string option;
 }
 let parse_define json =
 	let fields = match json with
@@ -127,6 +128,7 @@ let parse_define json =
 		d_platforms = get_optional_field "platforms" as_platforms [] fields;
 		d_links = get_optional_field "links" as_links [] fields;
 		d_deprecated = get_optional_field2 "deprecated" as_string fields;
+		d_deprecated_define = get_optional_field2 "deprecatedDefine" as_string fields;
 	}
 
 let parse_meta json =
@@ -204,18 +206,25 @@ let gen_define_info defines =
 			let platforms_str = gen_platforms def.d_platforms in
 			let params_str = gen_params def.d_params in
 			let links_str = gen_links def.d_links in
-			let define = String.concat "_" (ExtString.String.nsplit def.d_define "-") in
+			let convert_define s = String.concat "_" (ExtString.String.nsplit s "-") in
+			let define = convert_define def.d_define in
 			let deprecated = match def.d_deprecated with
 				| None ->
+					begin match def.d_deprecated_define with
+					| None ->
+						()
+					| Some s ->
+						DynArray.add deprecations (Printf.sprintf "\t(%S,InFavorOf(%S));" (convert_define s) define)
+					end;
 					[]
 				| Some x ->
 					let quoted = Printf.sprintf "%S" x in
-					DynArray.add deprecations (Printf.sprintf "\t(%S,%S)" define x);
+					DynArray.add deprecations (Printf.sprintf "\t(%S,DueTo(%S));" define x);
 					[Printf.sprintf "Deprecated(%s)" quoted]
 			in
 			"\t| " ^ def.d_name ^ " -> \"" ^ define ^ "\",(" ^ (Printf.sprintf "%S" def.d_doc) ^ ",[" ^ (String.concat "; " (platforms_str @ params_str @ links_str @ deprecated)) ^ "])"
 	) defines in
-	String.concat "\n" define_str,String.concat ";\n" (DynArray.to_list deprecations)
+	String.concat "\n" define_str,String.concat "\n" (DynArray.to_list deprecations)
 
 let gen_meta_type metas =
 	String.concat "\n" (List.map (function
@@ -289,6 +298,11 @@ type define_parameter =
 	| Platforms of platform list
 	| Link of string
 	| Deprecated of string
+
+type define_deprecation =
+	| DueTo of string
+	| InFavorOf of string
+
 "
 
 let meta_header = autogen_header ^ "


### PR DESCRIPTION
Allows specifying deprecated defines with a modern alternative. I'm using it to change `-D filter-times` and friends to `-D times.filter`.