### PR TITLE
Add context to parser

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -607,7 +607,8 @@
 	{
 		"name": "OldErrorFormat",
 		"define": "old-error-format",
-		"doc": "Use Haxe 3.x zero-based column error messages instead of new one-based format."
+		"doc": "Use Haxe 3.x zero-based column error messages instead of new one-based format.",
+		"deprecated": "OldErrorFormat has been removed in Haxe 5"
 	},
 	{
 		"name": "PhpPrefix",

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -438,7 +438,7 @@ with
 	| Parser.Error (m,p) ->
 		error ctx (Parser.error_msg m) p
 	| Typecore.Forbid_package ((pack,m,p),pl,pf)  ->
-		if !Parser.display_mode <> DMNone && ctx.has_next then begin
+		if ctx.com.display.dms_kind <> DMNone && ctx.has_next then begin
 			ctx.has_error <- false;
 			ctx.messages <- [];
 		end else begin
@@ -539,7 +539,7 @@ let create_context comm cs timer_ctx compilation_step params = {
 		revision = version_revision;
 		pre = version_pre;
 		extra = Version.version_extra;
-	} params (DisplayTypes.DisplayMode.create !Parser.display_mode);
+	} params (DisplayTypes.DisplayMode.create DMNone);
 	messages = [];
 	has_next = false;
 	has_error = false;

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -29,7 +29,6 @@ let handle_display_argument_old com file_pos actx =
 		let file_unique = com.file_keys#get file in
 		let pos, smode = try ExtString.String.split pos "@" with _ -> pos,"" in
 		let create mode =
-			Parser.display_mode := mode;
 			DisplayTypes.DisplayMode.create mode
 		in
 		let dm = match smode with

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -103,17 +103,6 @@ let process_display_configuration ctx =
 			| WMDisable ->
 				()
 		);
-	end;
-	Lexer.old_format := Common.defined com Define.OldErrorFormat;
-	if !Lexer.old_format && !Parser.in_display then begin
-		let p = DisplayPosition.display_position#get in
-		(* convert byte position to utf8 position *)
-		try
-			let content = Std.input_file ~bin:true (Path.get_real_path p.pfile) in
-			let pos = Extlib_leftovers.UTF8.length (String.sub content 0 p.pmin) in
-			DisplayPosition.display_position#set { p with pmin = pos; pmax = pos }
-		with _ ->
-			() (* ignore *)
 	end
 
 let process_display_file com actx =

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -264,7 +264,7 @@ let maybe_load_display_file_before_typing tctx display_file_dot_path = match dis
 let handle_display_after_typing ctx tctx display_file_dot_path =
 	let com = ctx.com in
 	if ctx.com.display.dms_kind = DMNone && ctx.has_error then raise Abort;
-	begin match ctx.com.display.dms_kind,Atomic.get ctx.com.delayed_syntax_completion with
+	begin match ctx.com.display.dms_kind,Atomic.get ctx.com.parser_state.delayed_syntax_completion with
 		| DMDefault,Some(kind,subj) -> DisplayOutput.handle_syntax_completion com kind subj
 		| _ -> ()
 	end;

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -264,7 +264,7 @@ let maybe_load_display_file_before_typing tctx display_file_dot_path = match dis
 let handle_display_after_typing ctx tctx display_file_dot_path =
 	let com = ctx.com in
 	if ctx.com.display.dms_kind = DMNone && ctx.has_error then raise Abort;
-	begin match ctx.com.display.dms_kind,!Parser.delayed_syntax_completion with
+	begin match ctx.com.display.dms_kind,Atomic.get ctx.com.delayed_syntax_completion with
 		| DMDefault,Some(kind,subj) -> DisplayOutput.handle_syntax_completion com kind subj
 		| _ -> ()
 	end;

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -57,12 +57,12 @@ let parse_file cs com (rfile : ClassPaths.resolved_file) p =
 			try
 				let cfile = cc#find_file fkey in
 				if cfile.c_time <> ftime then raise Not_found;
-				Parser.ParseSuccess((cfile.c_package,cfile.c_decls),false,cfile.c_pdi)
+				Parser.ParseSuccess((cfile.c_package,cfile.c_decls),cfile.c_pdi)
 			with Not_found ->
 				let parse_result = TypeloadParse.parse_file com rfile p in
 				let info,is_unusual = match parse_result with
 					| ParseError(_,_,_) -> "not cached, has parse error",true
-					| ParseSuccess(data,is_display_file,pdi) ->
+					| ParseSuccess(data,pdi) ->
 						if is_display_file then begin
 							if pdi.pd_errors <> [] then
 								"not cached, is display file with parse errors",true

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -75,7 +75,7 @@ let parse_file cs com (rfile : ClassPaths.resolved_file) p =
 							(* We assume that when not in display mode it's okay to cache stuff that has #if display
 							checks. The reasoning is that non-display mode has more information than display mode. *)
 							if com.display.dms_full_typing then raise Not_found;
-							let ident = Hashtbl.find Parser.special_identifier_files fkey in
+							let ident = ThreadSafeHashtbl.find com.special_identifier_files fkey in
 							Printf.sprintf "not cached, using \"%s\" define" ident,true
 						with Not_found ->
 							cc#cache_file fkey (ClassPaths.create_resolved_file ffile rfile.class_path) ftime data pdi;

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -75,7 +75,7 @@ let parse_file cs com (rfile : ClassPaths.resolved_file) p =
 							(* We assume that when not in display mode it's okay to cache stuff that has #if display
 							checks. The reasoning is that non-display mode has more information than display mode. *)
 							if com.display.dms_full_typing then raise Not_found;
-							let ident = ThreadSafeHashtbl.find com.special_identifier_files fkey in
+							let ident = ThreadSafeHashtbl.find com.parser_state.special_identifier_files fkey in
 							Printf.sprintf "not cached, using \"%s\" define" ident,true
 						with Not_found ->
 							cc#cache_file fkey (ClassPaths.create_resolved_file ffile rfile.class_path) ftime data pdi;

--- a/src/compiler/server.ml
+++ b/src/compiler/server.ml
@@ -295,7 +295,7 @@ let check_module sctx com m_path m_extra p =
 				end
 		in
 		let has_policy policy = List.mem policy m_extra.m_check_policy || match policy with
-			| NoFileSystemCheck when !ServerConfig.do_not_check_modules && !Parser.display_mode <> DMNone -> true
+			| NoFileSystemCheck when !ServerConfig.do_not_check_modules && com.display.dms_kind <> DMNone -> true
 			| _ -> false
 		in
 		let check_file () =

--- a/src/compiler/serverCompilationContext.ml
+++ b/src/compiler/serverCompilationContext.ml
@@ -44,7 +44,6 @@ let reset sctx =
 	Hashtbl.clear sctx.changed_directories;
 	sctx.was_compilation <- false;
 	Parser.reset_state();
-	Lexer.cur := Lexer.make_file "";
 	Hashtbl.clear DeprecationCheck.warned_positions;
 	stats.s_files_parsed := 0;
 	stats.s_classes_built := 0;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -254,6 +254,7 @@ type context = {
 	mutable was_auto_triggered : bool;
 	mutable had_parser_resume : bool;
 	delayed_syntax_completion : Parser.syntax_completion_on option Atomic.t;
+	special_identifier_files : (Path.UniqueKey.t,string) ThreadSafeHashtbl.t;
 	(* communication *)
 	mutable print : string -> unit;
 	mutable error : Gctx.error_function;
@@ -777,6 +778,7 @@ let create timer_ctx compilation_step cs version args display_mode =
 		was_auto_triggered = false;
 		had_parser_resume = false;
 		delayed_syntax_completion = Atomic.make None;
+		special_identifier_files = ThreadSafeHashtbl.create 0;
 	} in
 	com
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -227,6 +227,13 @@ class virtual abstract_hxb_lib = object(self)
 	method virtual get_string_pool : string -> string array option
 end
 
+type parser_state = {
+	mutable was_auto_triggered : bool;
+	mutable had_parser_resume : bool;
+	delayed_syntax_completion : Parser.syntax_completion_on option Atomic.t;
+	special_identifier_files : (Path.UniqueKey.t,string) ThreadSafeHashtbl.t;
+}
+
 type context = {
 	compilation_step : int;
 	mutable stage : compiler_stage;
@@ -250,11 +257,7 @@ type context = {
 	main : Gctx.context_main;
 	mutable package_rules : (string,package_rule) PMap.t;
 	mutable report_mode : report_mode;
-	(* parser stuff to clean up later *)
-	mutable was_auto_triggered : bool;
-	mutable had_parser_resume : bool;
-	delayed_syntax_completion : Parser.syntax_completion_on option Atomic.t;
-	special_identifier_files : (Path.UniqueKey.t,string) ThreadSafeHashtbl.t;
+	parser_state : parser_state;
 	(* communication *)
 	mutable print : string -> unit;
 	mutable error : Gctx.error_function;
@@ -775,10 +778,12 @@ let create timer_ctx compilation_step cs version args display_mode =
 		hxb_reader_api = None;
 		hxb_reader_stats = HxbReader.create_hxb_reader_stats ();
 		hxb_writer_config = None;
-		was_auto_triggered = false;
-		had_parser_resume = false;
-		delayed_syntax_completion = Atomic.make None;
-		special_identifier_files = ThreadSafeHashtbl.create 0;
+		parser_state = {
+			was_auto_triggered = false;
+			had_parser_resume = false;
+			delayed_syntax_completion = Atomic.make None;
+			special_identifier_files = ThreadSafeHashtbl.create 0;
+		}
 	} in
 	com
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -251,6 +251,7 @@ type context = {
 	mutable package_rules : (string,package_rule) PMap.t;
 	mutable report_mode : report_mode;
 	mutable was_auto_triggered : bool;
+	mutable had_parser_resume : bool;
 	(* communication *)
 	mutable print : string -> unit;
 	mutable error : Gctx.error_function;
@@ -772,6 +773,7 @@ let create timer_ctx compilation_step cs version args display_mode =
 		hxb_reader_stats = HxbReader.create_hxb_reader_stats ();
 		hxb_writer_config = None;
 		was_auto_triggered = false;
+		had_parser_resume = false;
 	} in
 	com
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -250,8 +250,10 @@ type context = {
 	main : Gctx.context_main;
 	mutable package_rules : (string,package_rule) PMap.t;
 	mutable report_mode : report_mode;
+	(* parser stuff to clean up later *)
 	mutable was_auto_triggered : bool;
 	mutable had_parser_resume : bool;
+	delayed_syntax_completion : Parser.syntax_completion_on option Atomic.t;
 	(* communication *)
 	mutable print : string -> unit;
 	mutable error : Gctx.error_function;
@@ -774,6 +776,7 @@ let create timer_ctx compilation_step cs version args display_mode =
 		hxb_writer_config = None;
 		was_auto_triggered = false;
 		had_parser_resume = false;
+		delayed_syntax_completion = Atomic.make None;
 	} in
 	com
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -250,6 +250,7 @@ type context = {
 	main : Gctx.context_main;
 	mutable package_rules : (string,package_rule) PMap.t;
 	mutable report_mode : report_mode;
+	mutable was_auto_triggered : bool;
 	(* communication *)
 	mutable print : string -> unit;
 	mutable error : Gctx.error_function;
@@ -770,6 +771,7 @@ let create timer_ctx compilation_step cs version args display_mode =
 		hxb_reader_api = None;
 		hxb_reader_stats = HxbReader.create_hxb_reader_stats ();
 		hxb_writer_config = None;
+		was_auto_triggered = false;
 	} in
 	com
 

--- a/src/context/display/display.ml
+++ b/src/context/display/display.ml
@@ -31,8 +31,8 @@ module ReferencePosition = struct
 end
 
 let preprocess_expr com e = match com.display.dms_kind with
-	| DMDefinition | DMTypeDefinition | DMUsage _ | DMImplementation | DMHover | DMDefault -> ExprPreprocessing.find_before_pos com.was_auto_triggered com.display.dms_kind e
-	| DMSignature -> ExprPreprocessing.find_display_call com.was_auto_triggered e
+	| DMDefinition | DMTypeDefinition | DMUsage _ | DMImplementation | DMHover | DMDefault -> ExprPreprocessing.find_before_pos com.parser_state.was_auto_triggered com.display.dms_kind e
+	| DMSignature -> ExprPreprocessing.find_display_call com.parser_state.was_auto_triggered e
 	| _ -> e
 
 let sort_fields l with_type tk =

--- a/src/context/display/display.ml
+++ b/src/context/display/display.ml
@@ -31,8 +31,8 @@ module ReferencePosition = struct
 end
 
 let preprocess_expr com e = match com.display.dms_kind with
-	| DMDefinition | DMTypeDefinition | DMUsage _ | DMImplementation | DMHover | DMDefault -> ExprPreprocessing.find_before_pos com.display.dms_kind e
-	| DMSignature -> ExprPreprocessing.find_display_call e
+	| DMDefinition | DMTypeDefinition | DMUsage _ | DMImplementation | DMHover | DMDefault -> ExprPreprocessing.find_before_pos com.was_auto_triggered com.display.dms_kind e
+	| DMSignature -> ExprPreprocessing.find_display_call com.was_auto_triggered e
 	| _ -> e
 
 let sort_fields l with_type tk =

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -64,7 +64,7 @@ class display_handler (jsonrpc : jsonrpc_handler) com (cs : CompilationCache.t) 
 		) None in
 
 		let pos = if requires_offset then jsonrpc#get_int_param "offset" else (-1) in
-		Parser.was_auto_triggered := was_auto_triggered;
+		com.was_auto_triggered <- was_auto_triggered;
 
 		if file <> file_input_marker then begin
 			let file_unique = com.file_keys#get file in

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -64,7 +64,7 @@ class display_handler (jsonrpc : jsonrpc_handler) com (cs : CompilationCache.t) 
 		) None in
 
 		let pos = if requires_offset then jsonrpc#get_int_param "offset" else (-1) in
-		com.was_auto_triggered <- was_auto_triggered;
+		com.parser_state.was_auto_triggered <- was_auto_triggered;
 
 		if file <> file_input_marker then begin
 			let file_unique = com.file_keys#get file in

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -51,7 +51,6 @@ class display_handler (jsonrpc : jsonrpc_handler) com (cs : CompilationCache.t) 
 
 	method enable_display ?(skip_define=false) mode =
 		com.display <- create mode;
-		Parser.display_mode := mode;
 		if not skip_define then Common.define_value com Define.Display "1"
 
 	method set_display_file was_auto_triggered requires_offset =

--- a/src/context/display/exprPreprocessing.ml
+++ b/src/context/display/exprPreprocessing.ml
@@ -3,7 +3,7 @@ open Ast
 open DisplayTypes.DisplayMode
 open DisplayPosition
 
-let find_before_pos dm e =
+let find_before_pos was_auto_triggered dm e =
 	let display_pos = ref (DisplayPosition.display_position#get) in
 	let was_annotated = ref false in
 	let is_annotated,is_completion = match dm with
@@ -160,7 +160,7 @@ let find_before_pos dm e =
 			raise Exit
 		| EMeta((Meta.Markup,_,_),(EConst(String _),p)) when is_annotated p ->
 			annotate_marked e
-		| EConst (String (_,q)) when ((q <> SSingleQuotes) || !Parser.was_auto_triggered) && is_annotated (pos e) && is_completion ->
+		| EConst (String (_,q)) when ((q <> SSingleQuotes) || was_auto_triggered) && is_annotated (pos e) && is_completion ->
 			(* TODO: check if this makes any sense *)
 			raise Exit
 		| EConst(Regexp _) when is_annotated (pos e) && is_completion ->
@@ -199,13 +199,13 @@ let find_before_pos dm e =
 	in
 	try map e with Exit -> e
 
-let find_display_call e =
+let find_display_call was_auto_triggered e =
 	let found = ref false in
 	let handle_el e el =
 		let call_arg_is_marked () =
 			el = [] || List.exists (fun (e,_) -> match e with EDisplay(_,DKMarked) -> true | _ -> false) el
 		in
-		if not !Parser.was_auto_triggered || call_arg_is_marked () then begin
+		if not was_auto_triggered || call_arg_is_marked () then begin
 		found := true;
 		Parser.mk_display_expr e DKCall
 		end else

--- a/src/context/formatString.ml
+++ b/src/context/formatString.ml
@@ -1,7 +1,7 @@
 open Globals
 open Ast
 
-let format_string defines s p process_expr =
+let format_string config s p process_expr =
 	let e = ref None in
 	let pmin = ref p.pmin in
 	let min = ref (p.pmin + 1) in
@@ -83,7 +83,7 @@ let format_string defines s p process_expr =
 					if Lexer.string_is_whitespace scode then Error.raise_typing_error "Expression cannot be empty" ep
 					else Error.raise_typing_error msg pos
 				in
-				match ParserEntry.parse_expr_string defines scode ep error true with
+				match ParserEntry.parse_expr_string config scode ep error true with
 					| ParseSuccess(data,_,_) -> data
 					| ParseError(_,(msg,p),_) -> error (Parser.error_msg msg) p
 			in

--- a/src/context/formatString.ml
+++ b/src/context/formatString.ml
@@ -84,7 +84,7 @@ let format_string config s p process_expr =
 					else Error.raise_typing_error msg pos
 				in
 				match ParserEntry.parse_expr_string config scode ep error true with
-					| ParseSuccess(data,_,_) -> data
+					| ParseSuccess(data,_) -> data
 					| ParseError(_,(msg,p),_) -> error (Parser.error_msg msg) p
 			in
 			add_expr e slen

--- a/src/core/ds/threadSafeHashtbl.ml
+++ b/src/core/ds/threadSafeHashtbl.ml
@@ -1,0 +1,18 @@
+type ('a,'b) t = {
+	h : ('a,'b) Hashtbl.t;
+	mutex : Mutex.t
+}
+
+let create size = {
+	h = Hashtbl.create size;
+	mutex = Mutex.create ();
+}
+
+let add h k v =
+	Mutex.protect h.mutex (fun () -> Hashtbl.add h.h k) v
+
+let replace h k v =
+	Mutex.protect h.mutex (fun () -> Hashtbl.replace h.h k) v
+
+let find h k =
+	Mutex.protect h.mutex (fun () -> Hashtbl.find h.h) k

--- a/src/core/warning.ml
+++ b/src/core/warning.ml
@@ -11,7 +11,7 @@ type warning_option = {
 	wo_mode : warning_mode;
 }
 
-let parse_options s ps lexbuf =
+let parse_options lctx s ps lexbuf =
 	let fail msg p =
 		raise_typing_error msg {p with pmin = ps.pmin + p.pmin; pmax = ps.pmin + p.pmax}
 	in
@@ -22,7 +22,7 @@ let parse_options s ps lexbuf =
 			fail (Printf.sprintf "Unknown warning: %s" s) p
 		end
 	in
-	let parse_warning () = match Lexer.token lexbuf with
+	let parse_warning () = match Lexer.token lctx lexbuf with
 		| Const (Ident s),p ->
 			parse_string s p
 		| (_,p) ->
@@ -31,7 +31,7 @@ let parse_options s ps lexbuf =
 	let add acc mode warning =
 		{ wo_warning = warning; wo_mode = mode } :: acc
 	in
-	let rec next acc = match Lexer.token lexbuf with
+	let rec next acc = match Lexer.token lctx lexbuf with
 		| Binop OpAdd,_ ->
 			next (add acc WMEnable (parse_warning()))
 		| Binop OpSub,_ ->
@@ -44,13 +44,9 @@ let parse_options s ps lexbuf =
 	next []
 
 let parse_options s ps =
-	let restore = Lexer.reinit ps.pfile in
-	Std.finally (fun () ->
-		restore()
-	) (fun () ->
-		let lexbuf = Sedlexing.Utf8.from_string s in
-		parse_options s ps lexbuf
-	) ()
+	let lctx = Lexer.create_temp_ctx ps.pfile in
+	let lexbuf = Sedlexing.Utf8.from_string s in
+	parse_options lctx s ps lexbuf
 
 let from_meta ml =
 	let parse_arg e = match fst e with

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -78,9 +78,9 @@ let find_breakpoint ctx sid =
 
 exception Parse_expr_error of string
 
-let parse_expr ctx s p =
+let parse_expr ctx config s p =
 	let error s = raise (Parse_expr_error s) in
-	match ParserEntry.parse_expr_string (ctx.curapi.get_com()).Common.defines s p error true with
+	match ParserEntry.parse_expr_string config s p error true with
 	| ParseSuccess(data,_,_) -> data
 	| ParseError(_,(msg,_),_) -> error (Parser.error_msg msg)
 

--- a/src/macro/eval/evalDebugMisc.ml
+++ b/src/macro/eval/evalDebugMisc.ml
@@ -81,7 +81,7 @@ exception Parse_expr_error of string
 let parse_expr ctx config s p =
 	let error s = raise (Parse_expr_error s) in
 	match ParserEntry.parse_expr_string config s p error true with
-	| ParseSuccess(data,_,_) -> data
+	| ParseSuccess(data,_) -> data
 	| ParseError(_,(msg,_),_) -> error (Parser.error_msg msg)
 
 (* Vars *)

--- a/src/macro/eval/evalDebugSocket.ml
+++ b/src/macro/eval/evalDebugSocket.ml
@@ -475,17 +475,16 @@ module ValueCompletion = struct
 	let get_completion ctx text column env =
 		let p = file_pos "" in
 		let save =
-			let old = !Parser.display_mode,DisplayPosition.display_position#get in
+			let old = DisplayPosition.display_position#get in
 			(fun () ->
-				Parser.display_mode := fst old;
-				DisplayPosition.display_position#set (snd old);
+				DisplayPosition.display_position#set old;
 			)
 		in
-		Parser.display_mode := DMDefault;
+		let config = Parser.create_config (ctx.curapi.get_com()).Common.defines true true DMDefault in
 		let offset = column + (String.length "class X{static function main() ") - 1 (* this is retarded *) in
 		DisplayPosition.display_position#set {p with pmin = offset; pmax = offset};
 		begin try
-			let e = parse_expr ctx text p in
+			let e = parse_expr ctx config text p in
 			let e = ExprPreprocessing.find_before_pos DMDefault e in
 			save();
 			let rec loop e = match fst e with
@@ -542,6 +541,9 @@ let expect_env hctx env = match env with
 	| None -> hctx.send_error "No frame found"
 
 let handler =
+	let parse_expr ctx p =
+		parse_expr ctx (ParserConfig.default_config (ctx.curapi.get_com()).Common.defines) p
+	in
 	let parse_breakpoint hctx jo =
 		let j = hctx.jsonrpc in
 		let obj = j#get_object "breakpoint" jo in

--- a/src/macro/eval/evalDebugSocket.ml
+++ b/src/macro/eval/evalDebugSocket.ml
@@ -480,12 +480,13 @@ module ValueCompletion = struct
 				DisplayPosition.display_position#set old;
 			)
 		in
-		let config = Parser.create_config (ctx.curapi.get_com()).Common.defines true true DMDefault in
+		let com = (ctx.curapi.get_com()) in
+		let config = Parser.create_config com.Common.defines true true DMDefault com.was_auto_triggered in
 		let offset = column + (String.length "class X{static function main() ") - 1 (* this is retarded *) in
 		DisplayPosition.display_position#set {p with pmin = offset; pmax = offset};
 		begin try
 			let e = parse_expr ctx config text p in
-			let e = ExprPreprocessing.find_before_pos DMDefault e in
+			let e = ExprPreprocessing.find_before_pos com.was_auto_triggered DMDefault e in
 			save();
 			let rec loop e = match fst e with
 			| EDisplay(e1,DKDot) ->

--- a/src/macro/eval/evalDebugSocket.ml
+++ b/src/macro/eval/evalDebugSocket.ml
@@ -481,7 +481,7 @@ module ValueCompletion = struct
 			)
 		in
 		let com = (ctx.curapi.get_com()) in
-		let config = Parser.create_config com.Common.defines true true DMDefault com.was_auto_triggered in
+		let config = Parser.create_config com.Common.defines true true DMDefault com.was_auto_triggered None in
 		let offset = column + (String.length "class X{static function main() ") - 1 (* this is retarded *) in
 		DisplayPosition.display_position#set {p with pmin = offset; pmax = offset};
 		begin try

--- a/src/macro/eval/evalDebugSocket.ml
+++ b/src/macro/eval/evalDebugSocket.ml
@@ -481,12 +481,12 @@ module ValueCompletion = struct
 			)
 		in
 		let com = (ctx.curapi.get_com()) in
-		let config = Parser.create_config com.Common.defines true true DMDefault com.was_auto_triggered None in
+		let config = Parser.create_config com.Common.defines true true DMDefault com.parser_state.was_auto_triggered None in
 		let offset = column + (String.length "class X{static function main() ") - 1 (* this is retarded *) in
 		DisplayPosition.display_position#set {p with pmin = offset; pmax = offset};
 		begin try
 			let e = parse_expr ctx config text p in
-			let e = ExprPreprocessing.find_before_pos com.was_auto_triggered DMDefault e in
+			let e = ExprPreprocessing.find_before_pos com.parser_state.was_auto_triggered DMDefault e in
 			save();
 			let rec loop e = match fst e with
 			| EDisplay(e1,DKDot) ->

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -35,7 +35,7 @@ type 'value compiler_api = {
 	on_type_not_found : (string -> 'value) -> unit;
 	parse_string : string -> Globals.pos -> bool -> Ast.expr;
 	register_file_contents : string -> string -> unit;
-	parse : 'a . ((Ast.token * Globals.pos) Stream.t -> 'a) -> string -> 'a;
+	parse : 'a . (Parser.parser_ctx -> (Ast.token * Globals.pos) Stream.t -> 'a) -> string -> 'a;
 	type_expr : Ast.expr -> Type.texpr;
 	resolve_type  : Ast.complex_type -> Globals.pos -> t;
 	resolve_complex_type : Ast.type_hint -> Ast.type_hint;
@@ -2398,9 +2398,9 @@ let macro_api ccom get_api =
 		);
 		"with_imports", vfun3(fun imports usings f ->
 			let imports = List.map decode_string (decode_array imports) in
-			let imports = List.map ((get_api()).parse (fun s -> Grammar.parse_import' s Globals.null_pos)) imports in
+			let imports = List.map ((get_api()).parse (fun pctx s -> Grammar.parse_import' pctx s Globals.null_pos)) imports in
 			let usings = List.map decode_string (decode_array usings) in
-			let usings = List.map ((get_api()).parse (fun s -> Grammar.parse_using' s Globals.null_pos)) usings in
+			let usings = List.map ((get_api()).parse (fun pctx s -> Grammar.parse_using' pctx s Globals.null_pos)) usings in
 			let f = prepare_callback f 0 in
 			(get_api()).with_imports imports usings (fun () -> f [])
 		);

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2234,7 +2234,7 @@ let macro_api ccom get_api =
 				encode_obj ["file",encode_string p.Globals.pfile;"pos",vint p.Globals.pmin]
 		);
 		"get_display_mode", vfun0 (fun() ->
-			encode_display_mode !Parser.display_mode
+			encode_display_mode (ccom()).display.dms_kind;
 		);
 		"get_configuration", vfun0 (fun() ->
 			let com = ccom() in

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -227,7 +227,7 @@ and parse_class_content ctx doc meta flags n p1 s =
 		d_doc = doc_from_string_opt doc;
 		d_meta = meta;
 		d_params = tl;
-		d_flags = ExtList.List.filter_map decl_flag_to_class_flag flags @ n @ hl;
+		d_flags = ExtList.List.filter_map (decl_flag_to_class_flag ctx) flags @ n @ hl;
 		d_data = fl;
 	}, punion p1 p2)
 
@@ -256,7 +256,7 @@ and parse_type_decl ctx mode s =
 				d_doc = doc_from_string_opt doc;
 				d_meta = meta;
 				d_params = pl;
-				d_flags = ExtList.List.filter_map decl_flag_to_module_field_flag c;
+				d_flags = ExtList.List.filter_map (decl_flag_to_module_field_flag ctx) c;
 				d_data = FFun f;
 			}, punion p1 p2)
 		| [ (Kwd Var,p1); dollar_ident as name ] ->
@@ -275,12 +275,12 @@ and parse_type_decl ctx mode s =
 				d_doc = doc_from_string_opt doc;
 				d_meta = meta;
 				d_params = [];
-				d_flags = ExtList.List.filter_map decl_flag_to_module_field_flag c;
+				d_flags = ExtList.List.filter_map (decl_flag_to_module_field_flag ctx) c;
 				d_data = t;
 			}, punion p1 p2)
 		| [ (Kwd Enum,p1) ] ->
 			begin match%parser s with
-			| [ (Kwd Abstract,p1); [%let a,p = parse_abstract ctx doc meta (AbEnum :: (convert_abstract_flags c)) p1] ] ->
+			| [ (Kwd Abstract,p1); [%let a,p = parse_abstract ctx doc meta (AbEnum :: (convert_abstract_flags ctx c)) p1] ] ->
 				(EAbstract a,p)
 			| [ [%let name = type_name ctx]; [%let tl = parse_constraint_params ctx]; (BrOpen,_); [%let l = plist (parse_enum ctx)]; (BrClose,p2) ] ->
 				(EEnum {
@@ -288,7 +288,7 @@ and parse_type_decl ctx mode s =
 					d_doc = doc_from_string_opt doc;
 					d_meta = meta;
 					d_params = tl;
-					d_flags = ExtList.List.filter_map decl_flag_to_enum_flag c;
+					d_flags = ExtList.List.filter_map (decl_flag_to_enum_flag ctx) c;
 					d_data = l
 				}, punion p1 p2)
 			end
@@ -303,12 +303,12 @@ and parse_type_decl ctx mode s =
 				d_doc = doc_from_string_opt doc;
 				d_meta = meta;
 				d_params = tl;
-				d_flags = ExtList.List.filter_map decl_flag_to_typedef_flag c;
+				d_flags = ExtList.List.filter_map (decl_flag_to_typedef_flag ctx) c;
 				d_data = t;
 			}, punion p1 (pos t))
 		| [ (Kwd Abstract,p1) ] ->
 			begin match%parser s with
-			| [ [%let a,p = parse_abstract ctx doc meta (convert_abstract_flags c) p1] ] ->
+			| [ [%let a,p = parse_abstract ctx doc meta (convert_abstract_flags ctx c) p1] ] ->
 				EAbstract a,p
 			| [ ] ->
 				let c2 = parse_common_flags s in
@@ -329,7 +329,7 @@ and parse_type_decl ctx mode s =
 						d_doc = doc_from_string_opt doc;
 						d_meta = meta;
 						d_params = [];
-						d_flags = (ExtList.List.filter_map decl_flag_to_module_field_flag (List.rev crest)) @ [AFinal,p1];
+						d_flags = (ExtList.List.filter_map (decl_flag_to_module_field_flag ctx) (List.rev crest)) @ [AFinal,p1];
 						d_data = FVar(t,e);
 					}, punion p1 p2)
 				| [ ] -> check_type_decl_flag_completion ctx mode c s)

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -1291,26 +1291,26 @@ and inline_function = function%parser
 
 and parse_macro_expr ctx p = function%parser
 	| [ (DblDot,_); [%let t = parse_complex_type ctx] ] ->
-		let _, to_type, _  = reify !in_macro in
+		let _, to_type, _  = reify ctx.in_macro in
 		let t = to_type t p in
 		let ct = make_ptp_ct_null (mk_type_path ~sub:"ComplexType" (["haxe";"macro"],"Expr")) in
 		(ECheckType (t,(ct,p)),p)
 	| [ (Kwd Var,p1); [%let vl = psep Comma (parse_var_decl ctx false)] ] ->
-		reify_expr (EVars vl,p1) !in_macro
+		reify_expr (EVars vl,p1) ctx.in_macro
 	| [ (Kwd Final,p1); [%s s] ] ->
 		check_redundant_var ctx p1 s;
 		begin match%parser s with
 		| [ [%let vl = psep Comma (parse_var_decl ctx true)] ] ->
-			reify_expr (EVars vl,p1) !in_macro
+			reify_expr (EVars vl,p1) ctx.in_macro
 		| [ ] ->
 			serror()
 		end
 	| [ [%let d = parse_class ctx None [] [] false] ] ->
-		let _,_,to_type = reify !in_macro in
+		let _,_,to_type = reify ctx.in_macro in
 		let ct = make_ptp_ct_null (mk_type_path ~sub:"TypeDefinition" (["haxe";"macro"],"Expr")) in
 		(ECheckType (to_type d,(ct,null_pos)),p)
 	| [ [%let e = secure_expr ctx] ] ->
-		reify_expr e !in_macro
+		reify_expr e ctx.in_macro
 
 and parse_function ctx p1 inl s =
 	let name = match%parser s with

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -56,12 +56,12 @@ let pignore f =
 	with Stream.Error _ | Stream.Failure ->
 		()
 
-let expect_unless_resume_p t s = match Stream.peek s with
+let expect_unless_resume_p ctx t s = match Stream.peek s with
 	| Some (t',p) when t' = t ->
 		Stream.junk s;
 		p
 	| _ ->
-		syntax_error (Expected [s_token t]) s (next_pos s)
+		syntax_error ctx (Expected [s_token t]) s (next_pos ctx s)
 
 let ident = function%parser
 	| [ (Const (Ident i),p) ] -> i,p
@@ -89,7 +89,7 @@ let property_ident = function%parser
 	| [ (Kwd Default,p) ] -> "default",p
 	| [ (Kwd Null,p) ] -> "null",p
 
-let questionable_dollar_ident s =
+let questionable_dollar_ident ctx s =
 	let po = match%parser s with
 		| [ (Question,p) ] -> Some p
 		| [ ] -> None
@@ -99,46 +99,46 @@ let questionable_dollar_ident s =
 		| None ->
 			false,(name,p)
 		| Some p' ->
-			if p.pmin <> p'.pmax then syntax_error (Custom (Printf.sprintf "Invalid usage of ?, use ?%s instead" name)) s ~pos:(Some p') ();
+			if p.pmin <> p'.pmax then syntax_error ctx (Custom (Printf.sprintf "Invalid usage of ?, use ?%s instead" name)) s ~pos:(Some p') ();
 			true,(name,p)
 
 let question_mark = function%parser
 	| [ (Question,p) ] -> p
 
-let semicolon s =
-	if fst (last_token s) = BrClose then
+let semicolon ctx s =
+	if fst (last_token ctx s) = BrClose then
 		match%parser s with
 		| [ (Semicolon,p) ] -> p
-		| [ ] -> snd (last_token s)
+		| [ ] -> snd (last_token ctx s)
 	else
 		match%parser s with
 		| [ (Semicolon,p) ] -> p
 		| [ ] ->
-			syntax_error Missing_semicolon s (next_pos s)
+			syntax_error ctx Missing_semicolon s (next_pos ctx s)
 
-let check_redundant_var p1 = function%parser
+let check_redundant_var ctx p1 = function%parser
 	| [ (Kwd Var),p2; [%s s] ] ->
-		syntax_error (Custom "`final var` is not supported, use `final` instead") ~pos:(Some (punion p1 p2)) s ();
+		syntax_error ctx (Custom "`final var` is not supported, use `final` instead") ~pos:(Some (punion p1 p2)) s ();
 	| [ ] ->
 		()
 
 let parsing_macro_cond = ref false
 
-let rec parse_file s =
+let rec parse_file (ctx : parser_ctx) s =
 	last_doc := None;
 	match%parser s with
 	| [ (Kwd Package,_); parse_package as pack ] ->
 		begin match%parser s with
 		| [ (Const(Ident _),p) ] when pack = [] -> error (Custom "Package name must start with a lowercase character") p
-		| [ semicolon as psem; [%let l = parse_type_decls TCAfterImport psem.pmax pack []] ] -> pack , l
+		| [ [%let psem = semicolon ctx]; [%let l = parse_type_decls ctx TCAfterImport psem.pmax pack []] ] -> pack , l
 		end
-	| [ [%let l = parse_type_decls TCBeforePackage (-1) [] []] ] -> [] , l
+	| [ [%let l = parse_type_decls ctx TCBeforePackage (-1) [] []] ] -> [] , l
 
-and parse_type_decls mode pmax pack acc s =
-	check_type_decl_completion mode pmax s;
+and parse_type_decls ctx mode pmax pack acc s =
+	check_type_decl_completion ctx mode pmax s;
 	let result = try
 		begin match%parser s with
-		| [ [%let cff = parse_type_decl mode] ] -> Success cff
+		| [ [%let cff = parse_type_decl ctx mode] ] -> Success cff
 		| [ (Eof,p) ] -> End p
 		| [ ] -> Error "Parse error."
 		end
@@ -163,19 +163,19 @@ and parse_type_decls mode pmax pack acc s =
 			| EImport _ | EUsing _ -> TCAfterImport
 			| _ -> TCAfterType
 		in
-		parse_type_decls mode p.pmax pack ((td,p) :: acc) s
+		parse_type_decls ctx mode p.pmax pack ((td,p) :: acc) s
 	| End _ ->
 		List.rev acc
 	| Error msg ->
-		handle_stream_error msg s;
-		ignore(resume false false s);
-		parse_type_decls mode (last_pos s).pmax pack acc s
+		handle_stream_error ctx msg s;
+		ignore(resume ctx false false s);
+		parse_type_decls ctx mode (last_pos ctx s).pmax pack acc s
 
-and parse_abstract doc meta flags p1 = function%parser
-	| [ type_name as name; parse_constraint_params as tl; parse_abstract_subtype as st; [%let sl = plist parse_abstract_relations]; [%s s] ] ->
+and parse_abstract ctx doc meta flags p1 = function%parser
+	| [ [%let name = type_name ctx]; [%let tl = parse_constraint_params ctx]; [%let st = parse_abstract_subtype ctx]; [%let sl = plist (parse_abstract_relations ctx)]; [%s s] ] ->
 		let fl,p2 = match%parser s with
-			| [ (BrOpen,_); [%let fl, p2 = parse_class_fields false p1] ] -> fl,p2
-			| [ ] -> syntax_error (Expected ["{";"to";"from"]) s ([],last_pos s)
+			| [ (BrOpen,_); [%let fl, p2 = parse_class_fields ctx false p1] ] -> fl,p2
+			| [ ] -> syntax_error ctx (Expected ["{";"to";"from"]) s ([],last_pos ctx s)
 		in
 		let flags = (match st with None -> flags | Some t -> AbOver t :: flags) in
 		({
@@ -187,23 +187,23 @@ and parse_abstract doc meta flags p1 = function%parser
 			d_data = fl;
 		},punion p1 p2)
 
-and parse_class_content doc meta flags n p1 s =
-	let name = type_name s in
-	let tl = parse_constraint_params s in
+and parse_class_content ctx doc meta flags n p1 s =
+	let name = type_name ctx s in
+	let tl = parse_constraint_params ctx s in
 	let rec loop had_display p0 acc =
 		let check_display p1 =
 			if not had_display && !in_display_file && !display_mode = DMDefault && display_position#enclosed_in p1 then
 				syntax_completion (if List.mem HInterface n then SCInterfaceRelation else SCClassRelation) None (display_position#with_pos p1)
 		in
 		match%parser s with
-		| [ (Kwd Extends,p1); [%let ptp,b = parse_type_path_or_resume p1] ] ->
+		| [ (Kwd Extends,p1); [%let ptp,b = parse_type_path_or_resume ctx p1] ] ->
 			check_display {p1 with pmin = p0.pmax; pmax = p1.pmin};
 			let p0 = ptp.pos_full in
 			(* If we don't have type parameters, we have to offset by one so to not complete `extends`
 				and `implements` after the identifier. *)
 			let p0 = {p0 with pmax = p0.pmax + (if ptp.path.tparams = [] then 1 else 0)} in
 			loop (had_display || b) p0 ((HExtends ptp) :: acc)
-		| [ (Kwd Implements,p1); [%let ptp,b = parse_type_path_or_resume p1] ] ->
+		| [ (Kwd Implements,p1); [%let ptp,b = parse_type_path_or_resume ctx p1] ] ->
 			check_display {p1 with pmin = p0.pmax; pmax = p1.pmin};
 			let p0 = ptp.pos_full in
 			let p0 = {p0 with pmax = p0.pmax + (if ptp.path.tparams = [] then 1 else 0)} in
@@ -216,12 +216,12 @@ and parse_class_content doc meta flags n p1 s =
 			| Some((Const(Ident name),p)) when display_position#enclosed_in p ->
 				syntax_completion (if List.mem HInterface n then SCInterfaceRelation else SCClassRelation) (Some name) p
 			| _ ->
-				check_display {p1 with pmin = p0.pmax; pmax = (next_pos s).pmax};
-				syntax_error (Expected ["extends";"implements";"{"]) s (List.rev acc)
+				check_display {p1 with pmin = p0.pmax; pmax = (next_pos ctx s).pmax};
+				syntax_error ctx (Expected ["extends";"implements";"{"]) s (List.rev acc)
 			end
 	in
-	let hl = loop false (last_pos s) [] in
-	let fl, p2 = parse_class_fields false p1 s in
+	let hl = loop false (last_pos ctx s) [] in
+	let fl, p2 = parse_class_fields ctx false p1 s in
 	(EClass {
 		d_name = name;
 		d_doc = doc_from_string_opt doc;
@@ -231,18 +231,18 @@ and parse_class_content doc meta flags n p1 s =
 		d_data = fl;
 	}, punion p1 p2)
 
-and parse_type_decl mode s =
+and parse_type_decl ctx mode s =
 	match%parser s with
-	| [ (Kwd Import,p1) ] -> parse_import s p1
-	| [ (Kwd Using,p1) ] -> parse_using s p1
-	| [ get_doc as doc; parse_meta as meta; parse_common_flags as c ] ->
+	| [ (Kwd Import,p1) ] -> parse_import ctx s p1
+	| [ (Kwd Using,p1) ] -> parse_using ctx s p1
+	| [ get_doc as doc; [%let meta = parse_meta ctx]; parse_common_flags as c ] ->
 		match%parser s with
-		| [ (Kwd Function,p1); dollar_ident as name; parse_constraint_params as pl; (POpen,_); [%let args = psep_trailing Comma parse_fun_param]; (PClose,_); [%let t = popt parse_type_hint] ] ->
+		| [ (Kwd Function,p1); dollar_ident as name; [%let pl = parse_constraint_params ctx]; (POpen,_); [%let args = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let t = popt (parse_type_hint ctx)] ] ->
 			let e, p2 = (match%parser s with
-				| [ expr as e ] ->
-					ignore(semicolon s);
+				| [ [%let e = expr ctx] ] ->
+					ignore(semicolon ctx s);
 					Some e, pos e
-				| [ semicolon as p ] -> None, p
+				| [ [%let p = semicolon ctx] ] -> None, p
 				| [ ] -> serror()
 			) in
 			let f = {
@@ -263,11 +263,11 @@ and parse_type_decl mode s =
 			let p2,t =
 				match%parser s with
 				| [ (POpen,_); property_ident as i1; (Comma,_); property_ident as i2; (PClose,_) ] ->
-					let t = popt parse_type_hint s in
-					let e,p2 = parse_var_field_assignment s in
+					let t = popt (parse_type_hint ctx) s in
+					let e,p2 = parse_var_field_assignment ctx s in
 					p2,FProp (i1,i2,t,e)
-				| [ [%let t = popt parse_type_hint] ] ->
-					let e,p2 = parse_var_field_assignment s in
+				| [ [%let t = popt (parse_type_hint ctx)] ] ->
+					let e,p2 = parse_var_field_assignment ctx s in
 					p2,FVar (t,e)
 			in
 			(EStatic {
@@ -280,9 +280,9 @@ and parse_type_decl mode s =
 			}, punion p1 p2)
 		| [ (Kwd Enum,p1) ] ->
 			begin match%parser s with
-			| [ (Kwd Abstract,p1); [%let a,p = parse_abstract doc meta (AbEnum :: (convert_abstract_flags c)) p1] ] ->
+			| [ (Kwd Abstract,p1); [%let a,p = parse_abstract ctx doc meta (AbEnum :: (convert_abstract_flags c)) p1] ] ->
 				(EAbstract a,p)
-			| [ type_name as name; parse_constraint_params as tl; (BrOpen,_); [%let l = plist parse_enum]; (BrClose,p2) ] ->
+			| [ [%let name = type_name ctx]; [%let tl = parse_constraint_params ctx]; (BrOpen,_); [%let l = plist (parse_enum ctx)]; (BrClose,p2) ] ->
 				(EEnum {
 					d_name = name;
 					d_doc = doc_from_string_opt doc;
@@ -293,8 +293,8 @@ and parse_type_decl mode s =
 				}, punion p1 p2)
 			end
 		| [ [%let n, p1 = parse_class_flags] ] ->
-			parse_class_content doc meta c n p1 s
-		| [ (Kwd Typedef,p1); type_name as name; parse_constraint_params as tl; (Binop OpAssign,p2); [%let t = parse_complex_type_at p2] ] ->
+			parse_class_content ctx doc meta c n p1 s
+		| [ (Kwd Typedef,p1); [%let name = type_name ctx]; [%let tl = parse_constraint_params ctx]; (Binop OpAssign,p2); [%let t = parse_complex_type_at ctx p2] ] ->
 			(match%parser s with
 			| [ (Semicolon,_) ] -> ()
 			| [ ] -> ());
@@ -308,13 +308,13 @@ and parse_type_decl mode s =
 			}, punion p1 (pos t))
 		| [ (Kwd Abstract,p1) ] ->
 			begin match%parser s with
-			| [ [%let a,p = parse_abstract doc meta (convert_abstract_flags c) p1] ] ->
+			| [ [%let a,p = parse_abstract ctx doc meta (convert_abstract_flags c) p1] ] ->
 				EAbstract a,p
 			| [ ] ->
 				let c2 = parse_common_flags s in
 				begin match%parser s with
 				| [ [%let flags,_p = parse_class_flags ] ] ->
-					parse_class_content doc meta (c @ c2) (HAbstract :: flags) p1 s
+					parse_class_content ctx doc meta (c @ c2) (HAbstract :: flags) p1 s
 				| [ ] ->
 					serror()
 				end
@@ -323,7 +323,7 @@ and parse_type_decl mode s =
 			match List.rev c with
 			| (DFinal,p1) :: crest ->
 				(match%parser s with
-				| [ dollar_ident as name; [%let t = popt parse_type_hint]; [%let e,p2 = parse_var_field_assignment] ] ->
+				| [ dollar_ident as name; [%let t = popt (parse_type_hint ctx)]; [%let e,p2 = parse_var_field_assignment ctx] ] ->
 					(EStatic {
 						d_name = name;
 						d_doc = doc_from_string_opt doc;
@@ -332,15 +332,15 @@ and parse_type_decl mode s =
 						d_flags = (ExtList.List.filter_map decl_flag_to_module_field_flag (List.rev crest)) @ [AFinal,p1];
 						d_data = FVar(t,e);
 					}, punion p1 p2)
-				| [ ] -> check_type_decl_flag_completion mode c s)
+				| [ ] -> check_type_decl_flag_completion ctx mode c s)
 			| _ ->
-				check_type_decl_flag_completion mode c s
+				check_type_decl_flag_completion ctx mode c s
 
 
-and parse_class doc meta cflags need_name s =
-	let opt_name = if need_name then type_name else (fun s -> match popt type_name s with None -> "",null_pos | Some n -> n) in
+and parse_class ctx doc meta cflags need_name s =
+	let opt_name = if need_name then type_name ctx else (fun s -> match popt (type_name ctx) s with None -> "",null_pos | Some n -> n) in
 	match%parser s with
-	| [ [%let n,p1 = parse_class_flags]; opt_name as name; parse_constraint_params as tl; [%let hl = plist parse_class_herit]; (BrOpen,_); [%let fl, p2 = parse_class_fields (not need_name) p1] ] ->
+	| [ [%let n,p1 = parse_class_flags]; [%let name = opt_name]; [%let tl = parse_constraint_params ctx]; [%let hl = plist (parse_class_herit ctx)]; (BrOpen,_); [%let fl, p2 = parse_class_fields ctx (not need_name) p1] ] ->
 		(EClass {
 			d_name = name;
 			d_doc = doc;
@@ -350,14 +350,14 @@ and parse_class doc meta cflags need_name s =
 			d_data = fl;
 		}, punion p1 p2)
 
-and parse_import' s p1 =
+and parse_import' ctx s p1 =
 	let rec loop pn acc =
 		match%parser s with
 		| [ (Dot,p) ] ->
 			let resume() =
 				type_path (List.map fst acc) true (punion pn p)
 			in
-			check_resume p resume (fun () -> ());
+			check_resume ctx p resume (fun () -> ());
 			begin match%parser s with
 			| [ (Const (Ident k),p) ] ->
 				loop pn ((k,p) :: acc)
@@ -370,8 +370,8 @@ and parse_import' s p1 =
 			| [ (Binop OpMult,_) ] ->
 				List.rev acc, IAll
 			| [ ] ->
-				ignore(popt semicolon s);
-				syntax_error (Expected ["identifier"]) s (List.rev acc,INormal)
+				ignore(popt (semicolon ctx) s);
+				syntax_error ctx (Expected ["identifier"]) s (List.rev acc,INormal)
 			end
 		| [ (Kwd In,_); (Const (Ident name),pname) ] ->
 			List.rev acc, IAsName(name,pname)
@@ -383,31 +383,31 @@ and parse_import' s p1 =
 	let path, mode = (match%parser s with
 		| [ (Const (Ident name),p) ] -> loop p [name,p]
 		| [ ] ->
-			if would_skip_display_position p1 true s then
+			if would_skip_display_position ctx p1 true s then
 				([],INormal)
 			else
-				syntax_error (Expected ["identifier"]) s ([],INormal)
+				syntax_error ctx (Expected ["identifier"]) s ([],INormal)
 	) in
 	(path,mode)
 
-and parse_import s p1 =
-	let (path,mode) = parse_import' s p1 in
+and parse_import ctx s p1 =
+	let (path,mode) = parse_import' ctx s p1 in
 	let p2 = match%parser s with
 	| [ (Semicolon,p2) ] ->
 		p2
 	| [ ] ->
-		if would_skip_display_position p1 true s then
+		if would_skip_display_position ctx p1 true s then
 			display_position#with_pos p1
 		else
-			syntax_error (Expected [".";";";"as"]) s (last_pos s)
+			syntax_error ctx (Expected [".";";";"as"]) s (last_pos ctx s)
 	in
 	(EImport (path,mode),punion p1 p2)
 
-and parse_using' s p1 =
+and parse_using' ctx s p1 =
 	let rec loop pn acc =
 		match%parser s with
 		| [ (Dot,p) ] ->
-			check_resume p (fun () -> type_path (List.map fst acc) false (punion pn p)) (fun () -> ());
+			check_resume ctx p (fun () -> type_path (List.map fst acc) false (punion pn p)) (fun () -> ());
 			begin match%parser s with
 			| [ (Const (Ident k),p) ] ->
 				loop pn ((k,p) :: acc)
@@ -418,7 +418,7 @@ and parse_using' s p1 =
 			| [ (Kwd Function,p) ] ->
 				loop pn (("function",p) :: acc)
 			| [ ] ->
-				syntax_error (Expected ["identifier"]) s (List.rev acc);
+				syntax_error ctx (Expected ["identifier"]) s (List.rev acc);
 			end
 		| [ ] ->
 			List.rev acc
@@ -426,25 +426,25 @@ and parse_using' s p1 =
 	match%parser s with
 		| [ (Const (Ident name),p) ] -> loop p [name,p]
 		| [ ] ->
-			if would_skip_display_position p1 true s then
+			if would_skip_display_position ctx p1 true s then
 				[]
 			else
-				syntax_error (Expected ["identifier"]) s []
+				syntax_error ctx (Expected ["identifier"]) s []
 
-and parse_using s p1 =
-	let path = parse_using' s p1 in
+and parse_using ctx s p1 =
+	let path = parse_using' ctx s p1 in
 	let p2 = match%parser s with
 	| [ (Semicolon,p2) ] ->
 		p2
 	| [ ] ->
-		if would_skip_display_position p1 true s then
+		if would_skip_display_position ctx p1 true s then
 			display_position#with_pos p1
 		else
-			syntax_error (Expected [".";";"]) s (last_pos s)
+			syntax_error ctx (Expected [".";";"]) s (last_pos ctx s)
 	in
 	(EUsing path,punion p1 p2)
 
-and parse_abstract_relations =
+and parse_abstract_relations ctx =
 	let check_display p1 (ct,p2) =
 		if !in_display_file && p1.pmax < (display_position#get).pmin && p2.pmin >= (display_position#get).pmax then
 			(* This means we skipped the display position between the to/from and the type-hint we parsed.
@@ -454,16 +454,16 @@ and parse_abstract_relations =
 			(ct,p2)
 	in
 	function%parser
-	| [ (Const (Ident "to"),p1); [%let t = parse_complex_type_at p1] ] -> (AbTo (check_display p1 t))
-	| [ (Const (Ident "from"),p1); [%let t = parse_complex_type_at p1] ] -> AbFrom (check_display p1 t)
+	| [ (Const (Ident "to"),p1); [%let t = parse_complex_type_at ctx p1] ] -> (AbTo (check_display p1 t))
+	| [ (Const (Ident "from"),p1); [%let t = parse_complex_type_at ctx p1] ] -> AbFrom (check_display p1 t)
 
-and parse_abstract_subtype = function%parser
-	| [ (POpen, _); parse_complex_type as t; (PClose,_) ] -> Some t
+and parse_abstract_subtype ctx = function%parser
+	| [ (POpen, _); [%let t = parse_complex_type ctx]; (PClose,_) ] -> Some t
 	| [ ] -> None
 
 and parse_package = psep Dot lower_ident_or_macro
 
-and resume tdecl fdecl s =
+and resume ctx tdecl fdecl s =
 	(* look for next variable/function or next type declaration *)
 	let rec junk k =
 		if k <= 0 then () else begin
@@ -525,10 +525,10 @@ and resume tdecl fdecl s =
 	in
 	loop 1
 
-and parse_class_field_resume acc tdecl s =
+and parse_class_field_resume ctx acc tdecl s =
 	let result = try
 		begin match%parser s with
-		| [ [%let cff = parse_class_field tdecl] ] -> Success cff
+		| [ [%let cff = parse_class_field ctx tdecl] ] -> Success cff
 		| [ (BrClose,p) ] -> End p
 		| [ ] -> Error "Parse error."
 		end
@@ -537,26 +537,26 @@ and parse_class_field_resume acc tdecl s =
 	in
 	match result with
 	| Success cff ->
-		parse_class_field_resume (cff :: acc) tdecl s
+		parse_class_field_resume ctx (cff :: acc) tdecl s
 	| End p ->
 		List.rev acc,p
 	| Error msg ->
-		handle_stream_error msg s;
-		if resume tdecl true s then
-			parse_class_field_resume acc tdecl s
+		handle_stream_error ctx msg s;
+		if resume ctx tdecl true s then
+			parse_class_field_resume ctx acc tdecl s
 		else
-			acc,last_pos s
+			acc,last_pos ctx s
 
-and parse_class_fields tdecl p1 s =
+and parse_class_fields ctx tdecl p1 s =
 	if not (!in_display_file) then begin
-		let acc = plist (parse_class_field tdecl) s in
+		let acc = plist (parse_class_field ctx tdecl) s in
 		let p2 = (match%parser s with
 			| [ (BrClose,p2) ] -> p2
-			| [ ] -> error (Expected ["}"]) (next_pos s)
+			| [ ] -> error (Expected ["}"]) (next_pos ctx s)
 		) in
 		acc,p2
 	end else
-		parse_class_field_resume [] tdecl s
+		parse_class_field_resume ctx [] tdecl s
 
 and parse_common_flags = function%parser
 	| [ (Kwd Private,p); parse_common_flags as l ] -> (DPrivate,p) :: l
@@ -570,8 +570,8 @@ and parse_common_flags = function%parser
 	| [ (Kwd Overload,p); parse_common_flags as l ] -> (DOverload,p) :: l
 	| [ ] -> []
 
-and parse_meta_argument_expr s =
-	let e = expr s in
+and parse_meta_argument_expr ctx s =
+	let e = expr ctx s in
 	begin match fst e with
 	| EDisplay(e1,DKDot) ->
 		begin try
@@ -583,42 +583,42 @@ and parse_meta_argument_expr s =
 		e
 	end
 
-and parse_meta_params pname s = match%parser s with
-	| [ (POpen,p); [%let params = psep_trailing Comma parse_meta_argument_expr]; ] when p.pmin = pname.pmax ->
-		ignore(expect_unless_resume_p PClose s);
+and parse_meta_params ctx pname s = match%parser s with
+	| [ (POpen,p); [%let params = psep_trailing Comma (parse_meta_argument_expr ctx)]; ] when p.pmin = pname.pmax ->
+		ignore(expect_unless_resume_p ctx PClose s);
 		params
 	| [ ] -> []
 
-and parse_meta_entry = function%parser
+and parse_meta_entry ctx = function%parser
 	[ (At,p1); [%s s] ] ->
-		let meta = check_resume p1 (fun () -> Some (Meta.HxCompletion,[],p1)) (fun () -> None) in
+		let meta = check_resume ctx p1 (fun () -> Some (Meta.HxCompletion,[],p1)) (fun () -> None) in
 		match%parser s with
-		| [ [%let name,p = parse_meta_name p1]; [%let params = parse_meta_params p] ] -> (name,params,punion p1 p)
+		| [ [%let name,p = parse_meta_name ctx p1]; [%let params = parse_meta_params ctx p] ] -> (name,params,punion p1 p)
 		| [ ] -> match meta with None -> serror() | Some meta -> meta
 
-and parse_meta = function%parser
-	| [ parse_meta_entry as entry; [%s s] ] ->
-		entry :: parse_meta s
+and parse_meta ctx = function%parser
+	| [ [%let entry = parse_meta_entry ctx]; [%s s] ] ->
+		entry :: parse_meta ctx s
 	| [ ] -> []
 
-and parse_meta_name_2 p1 acc s =
+and parse_meta_name_2 ctx p1 acc s =
 	let part,p = match%parser s with
 		| [ (Const (Ident i),p) ] when p.pmin = p1.pmax -> i,p
 		| [ (Kwd k,p) ] when p.pmin = p1.pmax -> s_keyword k,p
 	in
 	let acc = part :: acc in
 	match%parser s with
-	| [ (Dot,p1); [%let part,p2 = parse_meta_name_2 p1 acc] ] -> part,punion p p2
+	| [ (Dot,p1); [%let part,p2 = parse_meta_name_2 ctx p1 acc] ] -> part,punion p p2
 	| [ ] -> acc,punion p1 p
 
-and parse_meta_name p1 s = match%parser s with
+and parse_meta_name ctx p1 s = match%parser s with
 	| [ (DblDot,p) ]  when p.pmin = p1.pmax ->
-		let meta = check_resume p (fun () -> Some (Meta.HxCompletion,p)) (fun() -> None) in
+		let meta = check_resume ctx p (fun () -> Some (Meta.HxCompletion,p)) (fun() -> None) in
 		begin match%parser s with
-		| [ [%let name,p2 = parse_meta_name_2 p []] ] -> (Meta.parse (rev_concat "." name)),p2
+		| [ [%let name,p2 = parse_meta_name_2 ctx p []] ] -> (Meta.parse (rev_concat "." name)),p2
 		| [ ] -> match meta with None -> raise Stream.Failure | Some meta -> meta
 		end
-	| [ [%let name,p2 = parse_meta_name_2 p1 []] ] -> (Meta.Custom (rev_concat "." name)),p2
+	| [ [%let name,p2 = parse_meta_name_2 ctx p1 []] ] -> (Meta.Custom (rev_concat "." name)),p2
 
 and parse_enum_flags = function%parser
 	| [ (Kwd Enum,p) ] -> [] , p
@@ -627,18 +627,18 @@ and parse_class_flags = function%parser
 	| [ (Kwd Class,p) ] -> [] , p
 	| [ (Kwd Interface,p) ] -> [HInterface] , p
 
-and parse_complex_type_at p s = match%parser s with
-	| [ parse_complex_type as t ] -> t
+and parse_complex_type_at ctx p s = match%parser s with
+	| [ [%let t = parse_complex_type ctx] ] -> t
 	| [ ] ->
-		if would_skip_display_position p false s then
+		if would_skip_display_position ctx p false s then
 			(magic_type_th (display_position#with_pos p))
 		else
 			serror()
 
-and parse_type_hint = function%parser
+and parse_type_hint ctx = function%parser
 	| [ (DblDot,p1); [%s s] ] ->
-		let f () = parse_complex_type_at p1 s in
-		check_resume_range p1 s
+		let f () = parse_complex_type_at ctx p1 s in
+		check_resume_range ctx p1 s
 			(fun p2 ->
 				pignore(f);
 				magic_type_th (display_position#with_pos p1)
@@ -649,36 +649,36 @@ and parse_type_opt = function%parser
 	| [ parse_type_hint as t ] -> Some t
 	| [ ] -> None
 
-and parse_complex_type s = parse_complex_type_maybe_named false s
+and parse_complex_type ctx s = parse_complex_type_maybe_named ctx false s
 
-and parse_complex_type_maybe_named allow_named = function%parser
-	| [ (POpen,p1); [%let tl = psep_trailing Comma (parse_complex_type_maybe_named true)]; (PClose,p2); [%s s] ] ->
+and parse_complex_type_maybe_named ctx allow_named = function%parser
+	| [ (POpen,p1); [%let tl = psep_trailing Comma (parse_complex_type_maybe_named ctx true)]; (PClose,p2); [%s s] ] ->
 		begin match tl with
 		| [] | [(CTNamed _,_)] ->
 			(* it was () or (a:T) - clearly a new function type syntax, proceed with parsing return type *)
-			parse_function_type_next tl p1 s
+			parse_function_type_next ctx tl p1 s
 		| [t] ->
 			(* it was some single unnamed type in parenthesis - use old function type syntax  *)
 			let t = CTParent t,punion p1 p2 in
-			parse_complex_type_next t s
+			parse_complex_type_next ctx t s
 		| _ ->
 			(* it was multiple arguments - clearly a new function type syntax, proceed with parsing return type  *)
-			parse_function_type_next tl p1 s
+			parse_function_type_next ctx tl p1 s
 		end
 	| [ [%s s] ] ->
-		let t = parse_complex_type_inner allow_named s in
-		parse_complex_type_next t s
+		let t = parse_complex_type_inner ctx allow_named s in
+		parse_complex_type_next ctx t s
 
-and parse_structural_extension = function%parser
+and parse_structural_extension ctx = function%parser
 	| [ (Binop OpGt,p1); [%s s] ] ->
 		match%parser s with
-		| [ parse_type_path as t ] ->
+		| [ [%let t = parse_type_path ctx] ] ->
 			begin match%parser s with
 				| [ (Comma,_) ] -> t
-				| [ ] -> syntax_error (Expected [","]) s t
+				| [ ] -> syntax_error ctx (Expected [","]) s t
 			end;
 		| [ ] ->
-			if would_skip_display_position p1 false s then begin
+			if would_skip_display_position ctx p1 false s then begin
 				begin match%parser s with
 					| [ (Comma,_) ] -> ()
 					| [ ] -> ()
@@ -688,21 +688,21 @@ and parse_structural_extension = function%parser
 			end else
 				raise Stream.Failure
 
-and parse_complex_type_inner allow_named s = match%parser s with
-	| [ (POpen,p1); parse_complex_type as t; (PClose,p2) ] -> CTParent t,punion p1 p2
+and parse_complex_type_inner ctx allow_named s = match%parser s with
+	| [ (POpen,p1); [%let t = parse_complex_type ctx]; (PClose,p2) ] -> CTParent t,punion p1 p2
 	| [ (BrOpen,p1) ] ->
 		(match%parser s with
-		| [ [%let l,p2 = parse_type_anonymous] ] -> CTAnonymous l,punion p1 p2
-		| [ parse_structural_extension as t ] ->
-			let tl = t :: plist parse_structural_extension s in
+		| [ [%let l,p2 = parse_type_anonymous ctx] ] -> CTAnonymous l,punion p1 p2
+		| [ [%let t = parse_structural_extension ctx] ] ->
+			let tl = t :: plist (parse_structural_extension ctx) s in
 			(match%parser s with
-			| [ [%let l,p2 = parse_type_anonymous] ] -> CTExtend (tl,l),punion p1 p2
-			| [ [%let l,p2 = parse_class_fields true p1] ] -> CTExtend (tl,l),punion p1 p2)
-		| [ [%let l,p2 = parse_class_fields true p1] ] -> CTAnonymous l,punion p1 p2
+			| [ [%let l,p2 = parse_type_anonymous ctx] ] -> CTExtend (tl,l),punion p1 p2
+			| [ [%let l,p2 = parse_class_fields ctx true p1] ] -> CTExtend (tl,l),punion p1 p2)
+		| [ [%let l,p2 = parse_class_fields ctx true p1] ] -> CTAnonymous l,punion p1 p2
 		| [ ] -> serror())
-	| [ (Question,p1); [%let t,p2 = parse_complex_type_inner allow_named] ] ->
+	| [ (Question,p1); [%let t,p2 = parse_complex_type_inner ctx allow_named] ] ->
 		CTOptional (t,p2),punion p1 p2
-	| [ (Spread,p1); [%let t,p2 = parse_complex_type_inner allow_named] ] ->
+	| [ (Spread,p1); [%let t,p2 = parse_complex_type_inner ctx allow_named] ] ->
 		let hint =
 			match t with
 			| CTNamed (_,hint) -> hint
@@ -712,24 +712,24 @@ and parse_complex_type_inner allow_named s = match%parser s with
 		CTPath (make_ptp (mk_type_path ~params:[TPType hint] (["haxe"],"Rest")) p),p
 	| [ dollar_ident as n ] ->
 		(match%parser s with
-		| [ (DblDot,_); parse_complex_type as t ] when allow_named->
+		| [ (DblDot,_); [%let t = parse_complex_type ctx] ] when allow_named->
 			let p1 = snd n in
 			let p2 = snd t in
 			CTNamed (n,t),punion p1 p2
 		| [ [%s s] ] ->
 			let n,p = n in
-			let ptp = parse_type_path2 None [] n p s in
+			let ptp = parse_type_path2 ctx None [] n p s in
 			CTPath ptp,ptp.pos_full)
-	| [ parse_type_path as ptp ] ->
+	| [ [%let ptp = parse_type_path ctx] ] ->
 		CTPath ptp,ptp.pos_full
 
-and parse_type_path s = parse_type_path1 None [] s
+and parse_type_path ctx s = parse_type_path1 ctx None [] s
 
-and parse_type_path1 p0 pack = function%parser
+and parse_type_path1 ctx p0 pack = function%parser
 	| [ [%let name, p1 = dollar_ident_macro pack]; [%s s] ] ->
-		parse_type_path2 p0 pack name p1 s
+		parse_type_path2 ctx p0 pack name p1 s
 
-and parse_type_path2 p0 pack name p1 s : placed_type_path =
+and parse_type_path2 ctx p0 pack name p1 s : placed_type_path =
 	let check_display f =
 		let p = match p0 with
 			| None -> p1
@@ -743,9 +743,9 @@ and parse_type_path2 p0 pack name p1 s : placed_type_path =
 	if is_lower_ident name then
 		(match%parser s with
 		| [ (Dot,p) ] ->
-			check_resume p
+			check_resume ctx p
 				(fun () -> raise (TypePath (List.rev (name :: pack),None,false,punion (match p0 with None -> p1 | Some p0 -> p0) p)))
-				(fun () -> parse_type_path1 (match p0 with None -> Some p1 | Some _ -> p0) (name :: pack) s)
+				(fun () -> parse_type_path1 ctx (match p0 with None -> Some p1 | Some _ -> p0) (name :: pack) s)
 		| [ (Semicolon,_) ] ->
 			check_display (fun () -> error (Custom "Type name should start with an uppercase letter") p1)
 		| [ ] ->
@@ -753,7 +753,7 @@ and parse_type_path2 p0 pack name p1 s : placed_type_path =
 	else
 		let sub,p2 = (match%parser s with
 			| [ (Dot,p) ] ->
-				(check_resume p
+				(check_resume ctx p
 					(fun () -> raise (TypePath (List.rev pack,Some (name,false),false,punion (match p0 with None -> p1 | Some p0 -> p0) p)))
 					(fun () -> match%parser s with
 					| [ (Const (Ident name),p2) ] when not (is_lower_ident name) -> Some name,p2
@@ -763,11 +763,11 @@ and parse_type_path2 p0 pack name p1 s : placed_type_path =
 		let p1 = match p0 with None -> p1 | Some p -> p in
 		let p_path = punion p1 p2 in
 		let params,p2 = (match%parser s with
-			| [ (Binop OpLt,plt); [%let l = psep Comma (parse_type_path_or_const plt)] ] ->
+			| [ (Binop OpLt,plt); [%let l = psep Comma (parse_type_path_or_const ctx plt)] ] ->
 				begin match%parser s with
 				| [ (Binop OpGt,p2) ] -> l,p2
 				| [ ] ->
-					syntax_error (Expected [">"]) s (l,pos (last_token s))
+					syntax_error ctx (Expected [">"]) s (l,pos (last_token ctx s))
 				end
 			| [ ] -> [],p2
 		) in
@@ -775,34 +775,34 @@ and parse_type_path2 p0 pack name p1 s : placed_type_path =
 		and p_full = punion p1 p2 in
 		make_ptp tp ~p_path p_full
 
-and type_name = function%parser
+and type_name ctx = function%parser
 	| [ (Const (Ident name),p); [%s s] ] ->
 		if is_lower_ident name then
-			syntax_error (Custom "Type name should start with an uppercase letter") ~pos:(Some p) s (name,p)
+			syntax_error ctx (Custom "Type name should start with an uppercase letter") ~pos:(Some p) s (name,p)
 		else
 			name,p
 	| [ (Dollar name,p) ] -> "$" ^ name,p
 
-and parse_type_path_or_const plt = function%parser
+and parse_type_path_or_const ctx plt = function%parser
 	(* we can't allow (expr) here *)
-	| [ (BkOpen,p1); [%let e = parse_array_decl p1] ] -> TPExpr (e)
-	| [ parse_complex_type as t ] -> TPType t
+	| [ (BkOpen,p1); [%let e = parse_array_decl ctx p1] ] -> TPExpr (e)
+	| [ [%let t = parse_complex_type ctx] ] -> TPType t
 	| [ (Unop op,p1); (Const c,p2) ] -> TPExpr (make_unop op (EConst c,p2) p1)
 	| [ (Binop OpSub,p1); (Const c,p2) ] -> TPExpr (make_unop Neg (EConst c,p2) p1)
 	| [ (Const c,p) ] -> TPExpr (EConst c,p)
 	| [ (Kwd True,p) ] -> TPExpr (EConst (Ident "true"),p)
 	| [ (Kwd False,p) ] -> TPExpr (EConst (Ident "false"),p)
-	| [ expr as e ] -> TPExpr e
+	| [ [%let e = expr ctx] ] -> TPExpr e
 	| [ [%s s] ] ->
 		if !in_display_file then begin
-			if would_skip_display_position plt false s then begin
+			if would_skip_display_position ctx plt false s then begin
 				TPType (magic_type_th (display_position#with_pos plt))
 			end else
 				raise Stream.Failure
 		end else
 			serror()
 
-and parse_complex_type_next (t : type_hint) s =
+and parse_complex_type_next ctx (t : type_hint) s =
 	let make_fun t2 p2 = match t2 with
 		| CTFunction (args,r) ->
 			CTFunction (t :: args,r),punion (pos t) p2
@@ -818,44 +818,44 @@ and parse_complex_type_next (t : type_hint) s =
 	match%parser s with
 	| [ (Arrow,pa) ] ->
 		begin match%parser s with
-		| [ [%let t2,p2 = parse_complex_type] ] -> make_fun t2 p2
+		| [ [%let t2,p2 = parse_complex_type ctx] ] -> make_fun t2 p2
 		| [ ] ->
-			if would_skip_display_position pa false s then begin
+			if would_skip_display_position ctx pa false s then begin
 				let p = display_position#with_pos pa in
 				make_fun (magic_type_ct p) p
 			end else serror()
 		end
 	| [ (Binop OpAnd,pa) ] ->
 		begin match%parser s with
-		| [ [%let t2,p2 = parse_complex_type] ] -> make_intersection t2 p2
+		| [ [%let t2,p2 = parse_complex_type ctx] ] -> make_intersection t2 p2
 		| [ ] ->
-			if would_skip_display_position pa false s then begin
+			if would_skip_display_position ctx pa false s then begin
 				let p = display_position#with_pos pa in
 				make_intersection (magic_type_ct p) p
 			end else serror()
 		end
 	| [ ] -> t
 
-and parse_function_type_next tl p1 = function%parser
+and parse_function_type_next ctx tl p1 = function%parser
 	| [ (Arrow,pa); [%s s] ] ->
 		begin match%parser s with
-		| [ [%let tret = parse_complex_type_inner false] ] -> CTFunction (tl,tret), punion p1 (snd tret)
-		| [ ] -> if would_skip_display_position pa false s then begin
+		| [ [%let tret = parse_complex_type_inner ctx false] ] -> CTFunction (tl,tret), punion p1 (snd tret)
+		| [ ] -> if would_skip_display_position ctx pa false s then begin
 				let ct = magic_type_th (display_position#with_pos pa) in
 				CTFunction (tl,ct), punion p1 pa
 			end else serror()
 		end
 	| [ ] -> serror ()
 
-and parse_type_anonymous s =
+and parse_type_anonymous ctx s =
 	let p0 = popt question_mark s in
 	match%parser s with
-	| [ [%let name, p1 = dollar_ident]; parse_type_hint as t ] ->
+	| [ [%let name, p1 = dollar_ident]; [%let t = parse_type_hint ctx] ] ->
 		let opt,p1 = match p0 with
 			| Some p -> true,punion p p1
 			| None -> false,p1
 		in
-		let p2 = pos (last_token s) in
+		let p2 = pos (last_token ctx s) in
 		let next acc =
 			{
 				cff_name = name,p1;
@@ -871,26 +871,26 @@ and parse_type_anonymous s =
 		| [ (Comma,p2) ] ->
 			(match%parser s with
 			| [ (BrClose,p2) ] -> next [],p2
-			| [ [%let l,p2 = parse_type_anonymous] ] -> next l,punion p1 p2
+			| [ [%let l,p2 = parse_type_anonymous ctx] ] -> next l,punion p1 p2
 			| [ ] -> serror());
 		| [ ] ->
-			syntax_error (Expected [",";"}"]) s (next [],p2)
+			syntax_error ctx (Expected [",";"}"]) s (next [],p2)
 		end
 	| [ ] ->
 		if p0 = None then raise Stream.Failure else serror()
 
-and parse_enum s =
+and parse_enum ctx s =
 	let doc = get_doc s in
-	let meta = parse_meta s in
+	let meta = parse_meta ctx s in
 	match%parser s with
-	| [ [%let name, p1 = ident]; parse_constraint_params as params ] ->
+	| [ [%let name, p1 = ident]; [%let params = parse_constraint_params ctx] ] ->
 		let args = (match%parser s with
-		| [ (POpen,_); [%let l = psep_trailing Comma parse_enum_param]; (PClose,_) ] -> l
+		| [ (POpen,_); [%let l = psep_trailing Comma (parse_enum_param ctx)]; (PClose,_) ] -> l
 		| [ ] -> []
 		) in
-		let t = popt parse_type_hint s in
+		let t = popt (parse_type_hint ctx) s in
 		let p2 = (match%parser s with
-			| [ semicolon as p ] -> p
+			| [ [%let p = semicolon ctx] ] -> p
 			| [ ] -> serror()
 		) in
 		{
@@ -903,17 +903,17 @@ and parse_enum s =
 			ec_pos = punion p1 p2;
 		}
 
-and parse_enum_param = function%parser
-	| [ (Question,_); [%let name,_p = ident]; parse_type_hint as t ] -> (name,true,t)
-	| [ [%let name,_p = ident]; parse_type_hint as t ] -> (name,false,t)
+and parse_enum_param ctx = function%parser
+	| [ (Question,_); [%let name,_p = ident]; [%let t = parse_type_hint ctx] ] -> (name,true,t)
+	| [ [%let name,_p = ident]; [%let t = parse_type_hint ctx] ] -> (name,false,t)
 
-and parse_function_field doc meta al = function%parser
-	| [ (Kwd Function,p1); parse_fun_name as name; parse_constraint_params as pl; (POpen,_); [%let args = psep_trailing Comma parse_fun_param]; (PClose,_); [%let t = popt parse_type_hint]; [%s s] ] ->
+and parse_function_field ctx doc meta al = function%parser
+	| [ (Kwd Function,p1); parse_fun_name as name; [%let pl = parse_constraint_params ctx]; (POpen,_); [%let args = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let t = popt (parse_type_hint ctx)]; [%s s] ] ->
 		let e, p2 = (match%parser s with
-			| [ expr as e ] ->
-				ignore(semicolon s);
+			| [ [%let e = expr ctx] ] ->
+				ignore(semicolon ctx s);
 				Some e, pos e
-			| [ semicolon as p ] -> None, p
+			| [ [%let p = semicolon ctx] ] -> None, p
 			| [ ] -> serror()
 		) in
 		let f = {
@@ -924,71 +924,71 @@ and parse_function_field doc meta al = function%parser
 		} in
 		name,punion p1 p2,FFun f,al,meta
 
-and parse_var_field_assignment = function%parser
+and parse_var_field_assignment ctx = function%parser
 	| [ (Binop OpAssign,_); [%s s] ] ->
 		begin match%parser s with
 		| [ (Binop OpLt,p1) ] ->
-			let e = handle_xml_literal p1 in
+			let e = handle_xml_literal ctx p1 in
 			(* accept but don't expect semicolon *)
 			let p2 = match%parser s with
 				| [ (Semicolon,p) ] -> p
 				| [ ] -> pos e
 			in
 			Some e,p2
-		| [ expr as e; semicolon as p2 ] -> Some e , p2
+		| [ [%let e = expr ctx]; [%let p2 = semicolon ctx] ] -> Some e , p2
 		| [ ] -> serror()
 		end
-	| [ semicolon as p2 ] -> None , p2
+	| [ [%let p2 = semicolon ctx] ] -> None , p2
 	| [ ] -> serror()
 
-and parse_class_field tdecl s =
+and parse_class_field ctx tdecl s =
 	let doc = get_doc s in
-	let meta = parse_meta s in
+	let meta = parse_meta ctx s in
 	match%parser s with
 	| [ [%let al = plist parse_cf_rights] ] ->
 		let check_optional opt name =
 			if opt then begin
-				if not tdecl then syntax_error (Custom "?var syntax is only allowed in structures") ~pos:(Some (pos name)) s ();
+				if not tdecl then syntax_error ctx (Custom "?var syntax is only allowed in structures") ~pos:(Some (pos name)) s ();
 				(Meta.Optional,[],null_pos) :: meta
 			end else
 				meta
 		in
 		let name,pos,k,al,meta = (match%parser s with
-		| [ (Kwd Var,p1); [%let opt,name = questionable_dollar_ident] ] ->
+		| [ (Kwd Var,p1); [%let opt,name = questionable_dollar_ident ctx] ] ->
 			let meta = check_optional opt name in
 			begin match%parser s with
 			| [ (POpen,_); property_ident as i1; (Comma,_); property_ident as i2; (PClose,_) ] ->
-				let t = popt parse_type_hint s in
-				let e,p2 = parse_var_field_assignment s in
+				let t = popt (parse_type_hint ctx) s in
+				let e,p2 = parse_var_field_assignment ctx s in
 				name,punion p1 p2,FProp (i1,i2,t,e),al,meta
-			| [ [%let t = popt parse_type_hint] ] ->
-				let e,p2 = parse_var_field_assignment s in
+			| [ [%let t = popt (parse_type_hint ctx)] ] ->
+				let e,p2 = parse_var_field_assignment ctx s in
 				name,punion p1 p2,FVar (t,e),al,meta
 			end
 		| [ (Kwd Final,p1) ] ->
-			check_redundant_var p1 s;
+			check_redundant_var ctx p1 s;
 			begin match%parser s with
-			| [ [%let opt,name = questionable_dollar_ident]] ->
+			| [ [%let opt,name = questionable_dollar_ident ctx]] ->
 				begin match%parser s with
-				| [(POpen,_); property_ident as i1; (Comma,_); property_ident as i2; (PClose,_); [%let t = popt parse_type_hint]; [%let e, p2 = parse_var_field_assignment] ] ->
+				| [(POpen,_); property_ident as i1; (Comma,_); property_ident as i2; (PClose,_); [%let t = popt (parse_type_hint ctx)]; [%let e, p2 = parse_var_field_assignment ctx] ] ->
 					let meta = check_optional opt name in
 					name,punion p1 p2,FProp(i1,i2,t,e),(al @ [AFinal,p1]),meta
-				| [ [%let t = popt parse_type_hint]; [%let e,p2 = parse_var_field_assignment]] ->
+				| [ [%let t = popt (parse_type_hint ctx)]; [%let e,p2 = parse_var_field_assignment ctx]] ->
 					let meta = check_optional opt name in
 					name,punion p1 p2,FVar(t,e),(al @ [AFinal,p1]),meta
 				end
-			| [ [%let al2 = plist parse_cf_rights]; [%let f = parse_function_field doc meta (al @ ((AFinal,p1) :: al2))] ] ->
+			| [ [%let al2 = plist parse_cf_rights]; [%let f = parse_function_field ctx doc meta (al @ ((AFinal,p1) :: al2))] ] ->
 				f
 			| [ ] ->
 				serror()
 			end
-		| [ [%let f = parse_function_field doc meta al] ] ->
+		| [ [%let f = parse_function_field ctx doc meta al] ] ->
 			f
 		| [ ] ->
 			begin match List.rev al with
 				| [] -> raise Stream.Failure
 				| (AOverride,po) :: _ ->
-					begin match check_completion po true s with
+					begin match check_completion ctx po true s with
 					| None ->
 						serror()
 					| Some(so,p) ->
@@ -1036,52 +1036,52 @@ and parse_fun_name = function%parser
 	| [ [%let i = dollar_ident] ] -> i
 	| [ (Kwd New,p) ] -> "new",p
 
-and parse_fun_param s =
-	let meta = parse_meta s in
+and parse_fun_param ctx s =
+	let meta = parse_meta ctx s in
 	match%parser s with
-	| [ (Question,_); [%let name, pn = dollar_ident]; [%let t = popt parse_type_hint]; parse_fun_param_value as c ] -> ((name,pn),true,meta,t,c)
-	| [ [%let name, pn = dollar_ident]; [%let t = popt parse_type_hint]; parse_fun_param_value as c ] -> ((name,pn),false,meta,t,c)
-	| [ (Spread,_); [%let name, pn = dollar_ident]; [%let t = popt parse_type_hint]; parse_fun_param_value as c ] ->
+	| [ (Question,_); [%let name, pn = dollar_ident]; [%let t = popt (parse_type_hint ctx)]; [%let c = parse_fun_param_value ctx] ] -> ((name,pn),true,meta,t,c)
+	| [ [%let name, pn = dollar_ident]; [%let t = popt (parse_type_hint ctx)]; [%let c = parse_fun_param_value ctx] ] -> ((name,pn),false,meta,t,c)
+	| [ (Spread,_); [%let name, pn = dollar_ident]; [%let t = popt (parse_type_hint ctx)]; [%let c = parse_fun_param_value ctx] ] ->
 		let t = match t with Some t -> t | None -> (ct_mono,null_pos) in
 		let t = CTPath (make_ptp (mk_type_path ~params:[TPType t] (["haxe"],"Rest")) (snd t)),(snd t) in
 		((name,pn),false,meta,Some t,c)
 
-and parse_fun_param_value = function%parser
-	| [ (Binop OpAssign,_); expr as e ] -> Some e
+and parse_fun_param_value ctx = function%parser
+	| [ (Binop OpAssign,_); [%let e = expr ctx] ] -> Some e
 	| [ ] -> None
 
-and parse_fun_param_type = function%parser
-	| [ (Question,_); ident as name; parse_type_hint as t ] -> (name,true,t)
-	| [ ident as name; parse_type_hint as t ] -> (name,false,t)
+and parse_fun_param_type ctx = function%parser
+	| [ (Question,_); ident as name; [%let t = parse_type_hint ctx] ] -> (name,true,t)
+	| [ ident as name; [%let t = parse_type_hint ctx] ] -> (name,false,t)
 
-and parse_constraint_params = function%parser
+and parse_constraint_params ctx = function%parser
 	| [ (Binop OpLt,p); [%s s] ] ->
 		begin match%parser s with
-		| [ [%let l = psep_nonempty Comma parse_constraint_param]; (Binop OpGt,_) ] -> l
+		| [ [%let l = psep_nonempty Comma (parse_constraint_param ctx)]; (Binop OpGt,_) ] -> l
 		| [ ] ->
 			let pos = match%parser s with
 			| [ (Binop OpGt,p) ] -> Some p (* junk > so we don't get weird follow-up errors *)
 			| [ ] -> None
 			in
-			syntax_error (Expected ["type parameter"]) ~pos s [];
+			syntax_error ctx (Expected ["type parameter"]) ~pos s [];
 		end
 	| [ ] -> []
 
-and parse_constraint_param s =
-	let meta = parse_meta s in
+and parse_constraint_param ctx s =
+	let meta = parse_meta ctx s in
 	match%parser s with
-	| [ type_name as name ] ->
+	| [ [%let name = type_name ctx] ] ->
 		let cto = (match%parser s with
 			| [ (DblDot,_) ] ->
 				(match%parser s with
-				| [ parse_complex_type as t ] -> Some t
+				| [ [%let t = parse_complex_type ctx] ] -> Some t
 				| [ ] -> serror())
 			| [ ] -> None
 		) in
 		let default = (match%parser s with
 			| [ (Binop OpAssign,_) ] ->
 				(match%parser s with
-				| [ parse_complex_type as t ] -> Some t
+				| [ [%let t = parse_complex_type ctx] ] -> Some t
 				| [ ] -> serror())
 			| [ ] -> None
 		) in
@@ -1094,115 +1094,115 @@ and parse_constraint_param s =
 		}
 	| [ ] ->
 		(* If we have a metadata but no name afterwards, we have to fail hard. *)
-		if meta <> [] then syntax_error (Expected ["type name"]) s ();
+		if meta <> [] then syntax_error ctx (Expected ["type name"]) s ();
 		raise Stream.Failure;
 
-and parse_type_path_or_resume p1 s =
+and parse_type_path_or_resume ctx p1 s =
 	let check_resume exc =
-		if would_skip_display_position p1 true s then begin
+		if would_skip_display_position ctx p1 true s then begin
 			let p = display_position#with_pos p1 in
 			make_ptp magic_type_path p,true
 		end else
 			raise exc
 	in
 	try
-		let t = parse_type_path s in
+		let t = parse_type_path ctx s in
 		t,false
 	with Stream.Failure | Stream.Error _ as exc -> check_resume exc
 
-and parse_class_herit = function%parser
-	| [ (Kwd Extends,p1); [%let t,_p = parse_type_path_or_resume p1] ] -> HExtends t
-	| [ (Kwd Implements,p1); [%let t,_p = parse_type_path_or_resume p1] ] -> HImplements t
+and parse_class_herit ctx = function%parser
+	| [ (Kwd Extends,p1); [%let t,_p = parse_type_path_or_resume ctx p1] ] -> HExtends t
+	| [ (Kwd Implements,p1); [%let t,_p = parse_type_path_or_resume ctx p1] ] -> HImplements t
 
-and block1 s = match%parser s with
-	| [ [%let name, p = dollar_ident] ] -> block2 (name,p,NoQuotes) (Ident name) p s
-	| [ (Const (String(name,qs)),p) ] -> block2 (name,p,DoubleQuotes) (String(name,qs)) p s (* STRINGTODO: qs... hmm *)
-	| [ [%let b = block []] ] -> EBlock b
+and block1 ctx s = match%parser s with
+	| [ [%let name, p = dollar_ident] ] -> block2 ctx (name,p,NoQuotes) (Ident name) p s
+	| [ (Const (String(name,qs)),p) ] -> block2 ctx (name,p,DoubleQuotes) (String(name,qs)) p s (* STRINGTODO: qs... hmm *)
+	| [ [%let b = block ctx []] ] -> EBlock b
 
-and block2 name ident p s =
+and block2 ctx name ident p s =
 	match%parser s with
 	| [ (DblDot,_) ] ->
-		let e = secure_expr s in
-		fst (parse_obj_decl name e p s)
+		let e = secure_expr ctx s in
+		fst (parse_obj_decl ctx name e p s)
 	| [ ] ->
 		let f s =
-			let e = expr_next (EConst ident,p) s in
-			let _ = semicolon s in
+			let e = expr_next ctx (EConst ident,p) s in
+			let _ = semicolon ctx s in
 			e
 		in
-		let el,_ = block_with_pos' [] f p s in
+		let el,_ = block_with_pos' ctx [] f p s in
 		EBlock el
 
-and block acc s =
-	fst (block_with_pos acc null_pos s)
+and block ctx acc s =
+	fst (block_with_pos ctx acc null_pos s)
 
-and block_with_pos' acc f p s =
+and block_with_pos' ctx acc f p s =
 	try
 		(* because of inner recursion, we can't put Display handling in errors below *)
 		let e = f s in
-		block_with_pos (e :: acc) (pos e) s
+		block_with_pos ctx (e :: acc) (pos e) s
 	with
 		| Stream.Failure ->
 			List.rev acc,p
 		| Stream.Error msg when !in_display_file ->
-			handle_stream_error msg s;
-			(block_with_pos acc (next_pos s) s)
+			handle_stream_error ctx msg s;
+			(block_with_pos ctx acc (next_pos ctx s) s)
 
-and block_with_pos acc p s =
-	block_with_pos' acc parse_block_elt p s
+and block_with_pos ctx acc p s =
+	block_with_pos' ctx acc (parse_block_elt ctx) p s
 
-and parse_block_var = function%parser
-	| [ (Kwd Var,p1); [%let vl = parse_var_decls false p1]; semicolon as p2 ] ->
+and parse_block_var ctx = function%parser
+	| [ (Kwd Var,p1); [%let vl = parse_var_decls ctx false p1]; [%let p2 = semicolon ctx] ] ->
 		(vl,punion p1 p2)
 	| [ (Kwd Final,p1); [%s s] ] ->
-		check_redundant_var p1 s;
+		check_redundant_var ctx p1 s;
 		match%parser s with
-		| [ [%let vl = parse_var_decls true p1]; semicolon as p2 ] ->
+		| [ [%let vl = parse_var_decls ctx true p1]; [%let p2 = semicolon ctx] ] ->
 			(vl,punion p1 p2)
 		| [ ] ->
 			serror();
 
-and parse_block_elt s = match%parser s with
-	| [ [%let vl,p = parse_block_var] ] ->
+and parse_block_elt ctx s = match%parser s with
+	| [ [%let vl,p = parse_block_var ctx] ] ->
 		(EVars vl,p)
 	| [ (Kwd Inline,p1) ] ->
 		begin match%parser s with
-		| [ (Kwd Function,_); [%let e = parse_function p1 true]; semicolon as _s ] -> e
-		| [ secure_expr as e; semicolon as _s ] -> make_meta Meta.Inline [] e p1
+		| [ (Kwd Function,_); [%let e = parse_function ctx p1 true]; [%let _s = semicolon ctx] ] -> e
+		| [ [%let e = secure_expr ctx]; [%let _s = semicolon ctx] ] -> make_meta Meta.Inline [] e p1
 		| [ ] -> serror()
 		end
 	| [ (Kwd Static,p) ] ->
 		begin match%parser s with
-		| [ [%let vl,p = parse_block_var] ] ->
+		| [ [%let vl,p = parse_block_var ctx] ] ->
 			let vl = List.map (fun ev -> {ev with ev_static = true}) vl in
 			(EVars vl,p)
-		| [] -> syntax_error (Expected ["var";"final"]) s (mk_null_expr p)
+		| [] -> syntax_error ctx (Expected ["var";"final"]) s (mk_null_expr p)
 		end
 	| [ (Binop OpLt,p1) ] ->
-		let e = handle_xml_literal p1 in
+		let e = handle_xml_literal ctx p1 in
 		(* accept but don't expect semicolon *)
 		begin match%parser s with
 			| [ (Semicolon,_) ] -> ()
 			| [ ] -> ()
 		end;
 		e
-	| [ expr as e; semicolon as _s ] -> e
+	| [ [%let e = expr ctx]; [%let _s = semicolon ctx] ] -> e
 
-and parse_obj_decl name e p0 s =
+and parse_obj_decl ctx name e p0 s =
 	let make_obj_decl el p1 =
 		EObjectDecl (List.rev el),punion p0 p1
 	in
 	let rec loop p_end acc = match%parser s with
 		| [ (Comma,p1) ] ->
 			let next_expr key =
-				let e = secure_expr s in
+				let e = secure_expr ctx s in
 				loop (pos e) ((key,e) :: acc)
 			in
 			let next key = match%parser s with
 				| [ (DblDot,_) ] ->
 					next_expr key
 				| [ ] ->
-					syntax_error (Expected [":"]) s (next_expr key)
+					syntax_error ctx (Expected [":"]) s (next_expr key)
 			in
 			begin match%parser s with
 				| [ [%let name, p = ident] ] -> next (name,p,NoQuotes)
@@ -1215,42 +1215,42 @@ and parse_obj_decl name e p0 s =
 	let e = make_obj_decl el p_end in
 	e
 
-and parse_array_decl p1 s =
+and parse_array_decl ctx p1 s =
 	let resume_or_fail p1 =
-		syntax_error (Expected ["expr";"]"]) s (
-			let p = punion_next p1 s in
+		syntax_error ctx (Expected ["expr";"]"]) s (
+			let p = punion_next ctx p1 s in
 			[mk_null_expr p],p
 		)
 	in
 	let el,p2 = match%parser s with
 		| [ (BkClose,p2) ] -> [],p2
-		| [ secure_expr as e0 ] ->
+		| [ [%let e0 = secure_expr ctx] ] ->
 			let rec loop acc = match%parser s with
 				| [ (Comma,pk) ] ->
 					begin match%parser s with
 						| [ (BkClose,p2) ] -> acc,p2
-						| [ secure_expr as e ] -> loop (e :: acc)
+						| [ [%let e = secure_expr ctx] ] -> loop (e :: acc)
 						| [ ] ->
-							syntax_error (Expected ["expr";"]"]) s (acc,pk)
+							syntax_error ctx (Expected ["expr";"]"]) s (acc,pk)
 					end
 				| [ (BkClose,p2) ] -> acc,p2
 				| [ ] ->
-					syntax_error (Expected [",";"]"]) s (acc,next_pos s)
+					syntax_error ctx (Expected [",";"]"]) s (acc,next_pos ctx s)
 			in
 			loop [e0]
 		| [ ] -> resume_or_fail p1
 	in
 	EArrayDecl (List.rev el),punion p1 p2
 
-and parse_var_decl_head final s =
-	let meta = parse_meta s in
+and parse_var_decl_head ctx final s =
+	let meta = parse_meta ctx s in
 	match%parser s with
 	| [ [%let name, p = dollar_ident] ] ->
 		begin match%parser s with
-		| [ [%let t = popt parse_type_hint] ] ->
+		| [ [%let t = popt (parse_type_hint ctx)] ] ->
 			(meta,name,final,t,p)
-		| [ (POpen,p1); property_ident as _p1; (Comma,_); property_ident as _p2; (PClose,p2); [%let t = popt parse_type_hint] ] ->
-			syntax_error (Custom "Cannot define property accessors for local vars") ~pos:(Some (punion p1 p2)) s (meta,name,final,t,p)
+		| [ (POpen,p1); property_ident as _p1; (Comma,_); property_ident as _p2; (PClose,p2); [%let t = popt (parse_type_hint ctx)] ] ->
+			syntax_error ctx (Custom "Cannot define property accessors for local vars") ~pos:(Some (punion p1 p2)) s (meta,name,final,t,p)
 		end
 	| [ ] ->
 		(* This nonsense is here for the var @ case in issue #9639 *)
@@ -1261,66 +1261,66 @@ and parse_var_decl_head final s =
 		in
 		loop meta
 
-and parse_var_assignment = function%parser
+and parse_var_assignment ctx = function%parser
 	| [ (Binop OpAssign,p1); [%s s] ] ->
-		Some (secure_expr s)
+		Some (secure_expr ctx s)
 	| [ ] -> None
 
-and parse_var_assignment_resume final vl name pn t meta s =
-	let eo = parse_var_assignment s in
+and parse_var_assignment_resume ctx final vl name pn t meta s =
+	let eo = parse_var_assignment ctx s in
 	mk_evar ~final ?t ?eo ~meta (name,pn)
 
-and parse_var_decls_next final vl = function%parser
-	| [ (Comma,p1); [%let meta,name,final,t,pn = parse_var_decl_head final]; [%s s] ] ->
-		let v_decl = parse_var_assignment_resume final vl name pn t meta s in
-		parse_var_decls_next final (v_decl :: vl) s
+and parse_var_decls_next ctx final vl = function%parser
+	| [ (Comma,p1); [%let meta,name,final,t,pn = parse_var_decl_head ctx final]; [%s s] ] ->
+		let v_decl = parse_var_assignment_resume ctx final vl name pn t meta s in
+		parse_var_decls_next ctx final (v_decl :: vl) s
 	| [ ] ->
 		vl
 
-and parse_var_decls final p1 = function%parser
-	| [ [%let meta,name,final,t,pn = parse_var_decl_head final]; [%s s] ] ->
-		let v_decl = parse_var_assignment_resume final [] name pn t meta s in
-		List.rev (parse_var_decls_next final [v_decl] s)
+and parse_var_decls ctx final p1 = function%parser
+	| [ [%let meta,name,final,t,pn = parse_var_decl_head ctx final]; [%s s] ] ->
+		let v_decl = parse_var_assignment_resume ctx final [] name pn t meta s in
+		List.rev (parse_var_decls_next ctx final [v_decl] s)
 	| [ ] -> error (Custom "Missing variable identifier") p1
 
-and parse_var_decl final = function%parser
-	| [ [%let meta,name,final,t,pn = parse_var_decl_head final]; [%let v_decl = parse_var_assignment_resume final [] name pn t meta] ] -> v_decl
+and parse_var_decl ctx final = function%parser
+	| [ [%let meta,name,final,t,pn = parse_var_decl_head ctx final]; [%let v_decl = parse_var_assignment_resume ctx final [] name pn t meta] ] -> v_decl
 
 and inline_function = function%parser
 	| [ (Kwd Inline,_); (Kwd Function,p1) ] -> true, p1
 	| [ (Kwd Function,p1) ] -> false, p1
 
-and parse_macro_expr p = function%parser
-	| [ (DblDot,_); parse_complex_type as t ] ->
+and parse_macro_expr ctx p = function%parser
+	| [ (DblDot,_); [%let t = parse_complex_type ctx] ] ->
 		let _, to_type, _  = reify !in_macro in
 		let t = to_type t p in
 		let ct = make_ptp_ct_null (mk_type_path ~sub:"ComplexType" (["haxe";"macro"],"Expr")) in
 		(ECheckType (t,(ct,p)),p)
-	| [ (Kwd Var,p1); [%let vl = psep Comma (parse_var_decl false)] ] ->
+	| [ (Kwd Var,p1); [%let vl = psep Comma (parse_var_decl ctx false)] ] ->
 		reify_expr (EVars vl,p1) !in_macro
 	| [ (Kwd Final,p1); [%s s] ] ->
-		check_redundant_var p1 s;
+		check_redundant_var ctx p1 s;
 		begin match%parser s with
-		| [ [%let vl = psep Comma (parse_var_decl true)] ] ->
+		| [ [%let vl = psep Comma (parse_var_decl ctx true)] ] ->
 			reify_expr (EVars vl,p1) !in_macro
 		| [ ] ->
 			serror()
 		end
-	| [ [%let d = parse_class None [] [] false] ] ->
+	| [ [%let d = parse_class ctx None [] [] false] ] ->
 		let _,_,to_type = reify !in_macro in
 		let ct = make_ptp_ct_null (mk_type_path ~sub:"TypeDefinition" (["haxe";"macro"],"Expr")) in
 		(ECheckType (to_type d,(ct,null_pos)),p)
-	| [ secure_expr as e ] ->
+	| [ [%let e = secure_expr ctx] ] ->
 		reify_expr e !in_macro
 
-and parse_function p1 inl s =
+and parse_function ctx p1 inl s =
 	let name = match%parser s with
 		| [ dollar_ident as name ] -> Some name
 		| [ ] -> None
 	in
-	let pl = parse_constraint_params s in
+	let pl = parse_constraint_params ctx s in
 	match%parser s with
-	| [ (POpen,_); [%let al = psep_trailing Comma parse_fun_param]; (PClose,_); [%let t = popt parse_type_hint] ] ->
+	| [ (POpen,_); [%let al = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let t = popt (parse_type_hint ctx)] ] ->
 		let make e =
 			let f = {
 				f_params = pl;
@@ -1330,11 +1330,11 @@ and parse_function p1 inl s =
 			} in
 			EFunction ((match name with None -> FKAnonymous | Some (name,pn) -> FKNamed ((name,pn),inl)),f), punion p1 (pos e)
 		in
-		make (secure_expr s)
+		make (secure_expr ctx s)
 	| [ ] ->
 		(* Generate pseudo function to avoid toplevel-completion (issue #10691). We check against p1 here in order to cover cases
 		   like `function a|b` *)
-		if would_skip_display_position p1 false s then begin
+		if would_skip_display_position ctx p1 false s then begin
 			let null_func =
 				let f = {
 					f_params = [];
@@ -1342,7 +1342,7 @@ and parse_function p1 inl s =
 					f_args = [];
 					f_expr = None
 				} in
-				let p = punion p1 (next_pos s) in
+				let p = punion p1 (next_pos ctx s) in
 				let name = ("_hx_magic",p) in
 				EFunction(FKNamed(name,inl),f),p
 			in
@@ -1350,18 +1350,18 @@ and parse_function p1 inl s =
 		end else
 			serror()
 
-and arrow_expr = function%parser
-	| [ (Arrow,_); expr as e ] -> e
+and arrow_expr ctx = function%parser
+	| [ (Arrow,_); [%let e = expr ctx] ] -> e
 	| [ ] -> serror()
 
-and arrow_function p1 al er s =
+and arrow_function ctx p1 al er s =
 	let make e =
 		let p = pos e in
 		let return = (EMeta((Meta.ImplicitReturn, [], null_pos), (EReturn(Some e), p)), p) in
 		EFunction(FKArrow, { f_params = []; f_type = None; f_args = al; f_expr = Some return;  }), punion p1 p
 	in
 	List.iter (fun (_,_,ml,_,_) ->	match ml with
-		| (_,_,p) :: _ -> syntax_error (Custom "Metadata on arrow function arguments is not allowed") ~pos:(Some p) s ()
+		| (_,_,p) :: _ -> syntax_error ctx (Custom "Metadata on arrow function arguments is not allowed") ~pos:(Some p) s ()
 		| [] -> ()
 	) al;
 	make er
@@ -1371,10 +1371,10 @@ and arrow_ident_checktype e = (match e with
 	| ECheckType((EConst(Ident n),p),(t,pt)),_ -> (n,p),(Some (t,pt))
 	| _ -> serror())
 
-and arrow_first_param e s =
+and arrow_first_param ctx e s =
 	(match fst e with
 	| EConst(Ident ("true" | "false" | "null" | "this" | "super")) ->
-		syntax_error (Custom "Invalid argument name") ~pos:(Some (pos e)) s (("",null_pos),false,[],None,None)
+		syntax_error ctx (Custom "Invalid argument name") ~pos:(Some (pos e)) s (("",null_pos),false,[],None,None)
 	| EConst(Ident n) ->
 		(n,snd e),false,[],None,None
 	| EBinop(OpAssign,e1,e2)
@@ -1385,135 +1385,135 @@ and arrow_first_param e s =
 	| _ ->
 		serror())
 
-and expr s = match%parser s with
-	| [ [%let name,params,p = parse_meta_entry] ] ->
+and expr (ctx : parser_ctx) s = match%parser s with
+	| [ [%let name,params,p = parse_meta_entry ctx] ] ->
 		begin try
-			make_meta name params (secure_expr s) p
+			make_meta name params (secure_expr ctx s) p
 		with
 		| Stream.Failure | Stream.Error _ when !in_display_file ->
 			let e = EConst (Ident "null"),null_pos in
 			make_meta name params e p
 		end
 	| [ (Binop OpLt,p1) ] ->
-		handle_xml_literal p1
+		handle_xml_literal ctx p1
 	| [ (BrOpen,p1) ] ->
 		(match%parser s with
-		| [ block1 as b ] ->
+		| [ [%let b = block1 ctx] ] ->
 			let p2 = match%parser s with
 				| [ (BrClose,p2) ] -> p2
 				| [ ] ->
 					(* Ignore missing } if we are resuming and "guess" the last position. *)
-					syntax_error (Expected ["}"]) s (pos (next_token s))
+					syntax_error ctx (Expected ["}"]) s (pos (next_token ctx s))
 			in
 			let e = (b,punion p1 p2) in
 			(match b with
-			| EObjectDecl _ -> expr_next e s
+			| EObjectDecl _ -> expr_next ctx e s
 			| _ -> e)
 		| [ ] ->
-			check_resume p1 (fun() -> (EDisplay ((EObjectDecl [],p1),DKStructure),p1)) serror;
+			check_resume ctx p1 (fun() -> (EDisplay ((EObjectDecl [],p1),DKStructure),p1)) serror;
 		)
 	| [ (Kwd k,p) ] when !parsing_macro_cond ->
-		expr_next (EConst (Ident (s_keyword k)), p) s
+		expr_next ctx (EConst (Ident (s_keyword k)), p) s
 	| [ (Kwd Macro,p) ] ->
 		begin match%parser s with
-		| [ (Dot,pd); [%let e = parse_field (EConst (Ident "macro"),p) EFNormal pd] ] -> e
-		| [ [%let e = parse_macro_expr p] ] -> e
+		| [ (Dot,pd); [%let e = parse_field ctx (EConst (Ident "macro"),p) EFNormal pd] ] -> e
+		| [ [%let e = parse_macro_expr ctx p] ] -> e
 		| [ ] -> serror()
 		end
-	| [ (Kwd Var,p1); [%let v = parse_var_decl false] ] -> (EVars [v],p1)
+	| [ (Kwd Var,p1); [%let v = parse_var_decl ctx false] ] -> (EVars [v],p1)
 	| [ (Kwd Final,p1) ] ->
-		check_redundant_var p1 s;
+		check_redundant_var ctx p1 s;
 		begin match%parser s with
-			| [ [%let v = parse_var_decl true] ] ->
+			| [ [%let v = parse_var_decl ctx true] ] ->
 				(EVars [v],p1)
 			| [ ] ->
 				serror()
 		end
-	| [ (Const c,p) ] -> expr_next (EConst c,p) s
-	| [ (Kwd This,p) ] -> expr_next (EConst (Ident "this"),p) s
-	| [ (Kwd Abstract,p) ] -> expr_next (EConst (Ident "abstract"),p) s
-	| [ (Kwd True,p) ] -> expr_next (EConst (Ident "true"),p) s
-	| [ (Kwd False,p) ] -> expr_next (EConst (Ident "false"),p) s
-	| [ (Kwd Null,p) ] -> expr_next (EConst (Ident "null"),p) s
+	| [ (Const c,p) ] -> expr_next ctx (EConst c,p) s
+	| [ (Kwd This,p) ] -> expr_next ctx (EConst (Ident "this"),p) s
+	| [ (Kwd Abstract,p) ] -> expr_next ctx (EConst (Ident "abstract"),p) s
+	| [ (Kwd True,p) ] -> expr_next ctx (EConst (Ident "true"),p) s
+	| [ (Kwd False,p) ] -> expr_next ctx (EConst (Ident "false"),p) s
+	| [ (Kwd Null,p) ] -> expr_next ctx (EConst (Ident "null"),p) s
 	| [ (Kwd Cast,p1) ] ->
 		(match%parser s with
-		| [ (POpen,pp); expr as e ] ->
+		| [ (POpen,pp); [%let e = expr ctx] ] ->
 			(match%parser s with
-			| [ (Comma,pc); parse_complex_type as t; (PClose,p2) ] -> expr_next (ECast (e,Some t),punion p1 p2) s
-			| [ [%let t,pt = parse_type_hint]; (PClose,p2) ] ->
+			| [ (Comma,pc); [%let t = parse_complex_type ctx]; (PClose,p2) ] -> expr_next ctx (ECast (e,Some t),punion p1 p2) s
+			| [ [%let t,pt = parse_type_hint ctx]; (PClose,p2) ] ->
 				let ep = EParenthesis (ECheckType(e,(t,pt)),punion p1 p2), punion p1 p2 in
-				expr_next (ECast (ep,None),punion p1 (pos ep)) s
+				expr_next ctx (ECast (ep,None),punion p1 (pos ep)) s
 			| [ (PClose,p2) ] ->
-				let ep = expr_next (EParenthesis(e),punion pp p2) s in
-				expr_next (ECast (ep,None),punion p1 (pos ep)) s
+				let ep = expr_next ctx (EParenthesis(e),punion pp p2) s in
+				expr_next ctx (ECast (ep,None),punion p1 (pos ep)) s
 			| [ ] -> serror())
-		| [ secure_expr as e ] -> expr_next (ECast (e,None),punion p1 (pos e)) s)
-	| [ (Kwd Throw,p); expr as e ] -> (EThrow e,p)
-	| [ (Kwd New,p1); [%let t,_p = parse_type_path_or_resume p1] ] ->
+		| [ [%let e = secure_expr ctx] ] -> expr_next ctx (ECast (e,None),punion p1 (pos e)) s)
+	| [ (Kwd Throw,p); [%let e = expr ctx] ] -> (EThrow e,p)
+	| [ (Kwd New,p1); [%let t,_p = parse_type_path_or_resume ctx p1] ] ->
 		begin match%parser s with
-		| [ (POpen,po); [%let e = parse_call_params (fun el p2 -> (ENew(t,el)),punion p1 p2) po] ] -> expr_next e s
+		| [ (POpen,po); [%let e = parse_call_params ctx (fun el p2 -> (ENew(t,el)),punion p1 p2) po] ] -> expr_next ctx e s
 		| [ ] ->
-			syntax_error (Expected ["("]) s (ENew(t,[]),punion p1 t.pos_full)
+			syntax_error ctx (Expected ["("]) s (ENew(t,[]),punion p1 t.pos_full)
 		end
 	| [ (POpen,p1) ] -> (match%parser s with
-		| [ (PClose,p2); arrow_expr as er; ] ->
-			arrow_function p1 [] er s
-		| [ (Question,p2); [%let al = psep_trailing Comma parse_fun_param]; (PClose,_); arrow_expr as er; ] ->
+		| [ (PClose,p2); [%let er = arrow_expr ctx] ] ->
+			arrow_function ctx p1 [] er s
+		| [ (Question,p2); [%let al = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let er = arrow_expr ctx]; ] ->
 			let al = (match al with | (np,_,_,topt,e) :: al -> (np,true,[],topt,e) :: al | _ -> die "" __LOC__ ) in
-			arrow_function p1 al er s
-		| [  expr as e ] -> (match%parser s with
-			| [ (PClose,p2) ] -> expr_next (EParenthesis e, punion p1 p2) s
-			| [ (Comma,pc); [%let al = psep_trailing Comma parse_fun_param]; (PClose,_); arrow_expr as er; ] ->
-				arrow_function p1 ((arrow_first_param e s) :: al) er s
-			| [ [%let t,pt = parse_type_hint] ] -> (match%parser s with
-				| [ (PClose,p2) ] -> expr_next (EParenthesis (ECheckType(e,(t,pt)),punion p1 p2), punion p1 p2) s
-				| [ (Comma,pc); [%let al = psep_trailing Comma parse_fun_param]; (PClose,_); arrow_expr as er; ] ->
+			arrow_function ctx p1 al er s
+		| [ [%let e = expr ctx] ] -> (match%parser s with
+			| [ (PClose,p2) ] -> expr_next ctx (EParenthesis e, punion p1 p2) s
+			| [ (Comma,pc); [%let al = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let er = arrow_expr ctx]; ] ->
+				arrow_function ctx p1 ((arrow_first_param ctx e s) :: al) er s
+			| [ [%let t,pt = parse_type_hint ctx] ] -> (match%parser s with
+				| [ (PClose,p2) ] -> expr_next ctx (EParenthesis (ECheckType(e,(t,pt)),punion p1 p2), punion p1 p2) s
+				| [ (Comma,pc); [%let al = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let er = arrow_expr ctx]; ] ->
 					let (np,_) = arrow_ident_checktype e in
-					arrow_function p1 ((np,false,[],(Some(t,pt)),None) :: al) er s
-				| [ ((Binop OpAssign),p2); expr as ea1 ] ->
+					arrow_function ctx p1 ((np,false,[],(Some(t,pt)),None) :: al) er s
+				| [ ((Binop OpAssign),p2); [%let ea1 = expr ctx] ] ->
 					let with_args al er = (match fst e with
 						| EConst(Ident n) ->
-							arrow_function p1 (((n,snd e),true,[],(Some(t,pt)),(Some ea1)) :: al) er s
+							arrow_function ctx p1 (((n,snd e),true,[],(Some(t,pt)),(Some ea1)) :: al) er s
 						| _ -> serror())
 					in
 					(match%parser s with
-					| [ (PClose,p2); arrow_expr as er; ] ->
+					| [ (PClose,p2); [%let er = arrow_expr ctx]; ] ->
 						with_args [] er
-					| [ (Comma,pc); [%let al = psep_trailing Comma parse_fun_param]; (PClose,_); arrow_expr as er; ] ->
+					| [ (Comma,pc); [%let al = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let er = arrow_expr ctx]; ] ->
 						with_args al er
 					| [ ] -> serror())
 				| [ ] -> serror())
 			| [ ] ->
-				syntax_error (Expected [")";",";":"]) s (expr_next (EParenthesis e, punion p1 (pos e)) s))
+				syntax_error ctx (Expected [")";",";":"]) s (expr_next ctx (EParenthesis e, punion p1 (pos e)) s))
 		)
-	| [ (BkOpen,p1); [%let e = parse_array_decl p1] ] -> expr_next e s
-	| [ (Kwd Function,p1); [%let e = parse_function p1 false]; ] -> e
-	| [ (Unop op,p1); expr as e ] -> make_unop op e p1
-	| [ (Spread,p1); expr as e ] -> make_unop Spread e (punion p1 (pos e))
-	| [ (Binop OpSub,p1); expr as e ] ->
+	| [ (BkOpen,p1); [%let e = parse_array_decl ctx p1] ] -> expr_next ctx e s
+	| [ (Kwd Function,p1); [%let e = parse_function ctx p1 false]; ] -> e
+	| [ (Unop op,p1); [%let e = expr ctx] ] -> make_unop op e p1
+	| [ (Spread,p1); [%let e = expr ctx] ] -> make_unop Spread e (punion p1 (pos e))
+	| [ (Binop OpSub,p1); [%let e = expr ctx] ] ->
 		make_unop Neg e p1
 	(*/* removed unary + : this cause too much syntax errors go unnoticed, such as "a + + 1" (missing 'b')
 						without adding anything to the language
 	| [ (Binop OpAdd,p1) ] ->
 		(match%parser s with
-		| [ (Const (Int i),p); [%let e = expr_next (EConst (Int i),p)] ] -> e
-		| [ (Const (Float f),p); [%let e = expr_next (EConst (Float f),p)] ] -> e
+		| [ (Const (Int i),p); [%let e = expr_next ctx (EConst (Int i),p)] ] -> e
+		| [ (Const (Float f),p); [%let e = expr_next ctx (EConst (Float f),p)] ] -> e
 		| [ ] -> serror()) */*)
-	| [ (Kwd For,p); (POpen,_); secure_expr as it ] ->
+	| [ (Kwd For,p); (POpen,_); [%let it = secure_expr ctx] ] ->
 		let e = match%parser s with
-			| [ (PClose,_); secure_expr as e ] -> e
+			| [ (PClose,_); [%let e = secure_expr ctx] ] -> e
 			| [ ] ->
-				syntax_error (Expected [")"]) s (mk_null_expr (pos it))
+				syntax_error ctx (Expected [")"]) s (mk_null_expr (pos it))
 		in
 		(EFor (it,e),punion p (pos e))
-	| [ (Kwd If,p); (POpen,_); secure_expr as cond ] ->
+	| [ (Kwd If,p); (POpen,_); [%let cond = secure_expr ctx] ] ->
 		let e1 = match%parser s with
-			| [ (PClose,_); secure_expr as e1 ] -> e1
+			| [ (PClose,_); [%let e1 = secure_expr ctx] ] -> e1
 			| [ ] ->
-				syntax_error (Expected [")"]) s (mk_null_expr (pos cond))
+				syntax_error ctx (Expected [")"]) s (mk_null_expr (pos cond))
 		in
 		let e2 = (match%parser s with
-			| [ (Kwd Else,_); secure_expr as e2 ] -> Some e2
+			| [ (Kwd Else,_); [%let e2 = secure_expr ctx] ] -> Some e2
 			| [ ] ->
 				(* We check this in two steps to avoid the lexer missing tokens (#8565). *)
 				match Stream.npeek 1 s with
@@ -1522,7 +1522,7 @@ and expr s = match%parser s with
 					| [(Semicolon,_);(Kwd Else,_)] ->
 						Stream.junk s;
 						Stream.junk s;
-						Some (secure_expr s)
+						Some (secure_expr ctx s)
 					| _ ->
 						None
 					end
@@ -1532,196 +1532,196 @@ and expr s = match%parser s with
 		(EIf (cond,e1,e2), punion p (match e2 with None -> pos e1 | Some e -> pos e))
 	| [ (Kwd Return,p) ] ->
 		begin match%parser s with
-		| [ expr as e ] -> (EReturn (Some e),punion p (pos e))
+		| [ [%let e = expr ctx] ] -> (EReturn (Some e),punion p (pos e))
 		| [ ] ->
-			if would_skip_display_position p true s then (EReturn (Some (mk_null_expr (punion_next p s))),p)
+			if would_skip_display_position ctx p true s then (EReturn (Some (mk_null_expr (punion_next ctx p s))),p)
 			else (EReturn None,p)
 		end
 	| [ (Kwd Break,p) ] -> (EBreak,p)
 	| [ (Kwd Continue,p) ] -> (EContinue,p)
-	| [ (Kwd While,p1); (POpen,_); secure_expr as cond ] ->
+	| [ (Kwd While,p1); (POpen,_); [%let cond = secure_expr ctx] ] ->
 		let e = match%parser s with
-			| [ (PClose,_); secure_expr as e ] -> e
+			| [ (PClose,_); [%let e = secure_expr ctx] ] -> e
 			| [ ] ->
-				syntax_error (Expected [")"]) s (mk_null_expr (pos cond))
+				syntax_error ctx (Expected [")"]) s (mk_null_expr (pos cond))
 		in
 		(EWhile (cond,e,NormalWhile),punion p1 (pos e))
-	| [ (Kwd Do,p1); secure_expr as e ] ->
+	| [ (Kwd Do,p1); [%let e = secure_expr ctx] ] ->
 		begin match%parser s with
-			| [ (Kwd While,_); (POpen,_); secure_expr as cond ] ->
-				let p2 = expect_unless_resume_p PClose s in
+			| [ (Kwd While,_); (POpen,_); [%let cond = secure_expr ctx] ] ->
+				let p2 = expect_unless_resume_p ctx PClose s in
 				(EWhile (cond,e,DoWhile),punion p1 p2)
 			| [ ] ->
-				syntax_error (Expected ["while"]) s e (* ignore do *)
+				syntax_error ctx (Expected ["while"]) s e (* ignore do *)
 		end
-	| [ (Kwd Switch,p1); secure_expr as e ] ->
+	| [ (Kwd Switch,p1); [%let e = secure_expr ctx] ] ->
 		begin match%parser s with
-			| [ (BrOpen,_); [%let cases, def = parse_switch_cases e []] ] ->
+			| [ (BrOpen,_); [%let cases, def = parse_switch_cases ctx e []] ] ->
 				let p2 = match%parser s with
 					| [ (BrClose,p2) ] -> p2
 					| [ ] ->
 						(* Ignore missing } if we are resuming and "guess" the last position. *)
-						syntax_error (Expected ["}"]) s (pos (next_token s))
+						syntax_error ctx (Expected ["}"]) s (pos (next_token ctx s))
 				in
 				(ESwitch (e,cases,def),punion p1 p2)
 			| [ ] ->
-				syntax_error (Expected ["{"]) s (ESwitch(e,[],None),punion p1 (pos e))
+				syntax_error ctx (Expected ["{"]) s (ESwitch(e,[],None),punion p1 (pos e))
 		end
-	| [ (Kwd Try,p1); secure_expr as e; [%let cl,p2 = parse_catches e [] (pos e)] ] -> (ETry (e,cl),punion p1 p2)
-	| [ (IntInterval i,p1); expr as e2 ] -> make_binop OpInterval (EConst (Int (i, None)),p1) e2
-	| [ (Kwd Untyped,p1); secure_expr as e ] -> (EUntyped e,punion p1 (pos e))
-	| [ (Dollar v,p) ] -> expr_next (EConst (Ident ("$"^v)),p) s
-	| [ (Kwd Inline,p); secure_expr as e ] -> make_meta Meta.Inline [] e p
+	| [ (Kwd Try,p1); [%let e = secure_expr ctx]; [%let cl,p2 = parse_catches ctx e [] (pos e)] ] -> (ETry (e,cl),punion p1 p2)
+	| [ (IntInterval i,p1); [%let e2 = expr ctx] ] -> make_binop OpInterval (EConst (Int (i, None)),p1) e2
+	| [ (Kwd Untyped,p1); [%let e = secure_expr ctx] ] -> (EUntyped e,punion p1 (pos e))
+	| [ (Dollar v,p) ] -> expr_next ctx (EConst (Ident ("$"^v)),p) s
+	| [ (Kwd Inline,p); [%let e = secure_expr ctx] ] -> make_meta Meta.Inline [] e p
 
-and expr_next e1 s =
+and expr_next ctx e1 s =
 	try
-		expr_next' e1 s
+		expr_next' ctx e1 s
 	with Stream.Error msg when !in_display ->
-		handle_stream_error msg s;
+		handle_stream_error ctx msg s;
 		e1
 
-and expr_next' e1 s = match%parser s with
-	| [ (BrOpen,p1); expr as eparam; (BrClose,p2) ] when is_dollar_ident e1 ->
+and expr_next' ctx e1 s = match%parser s with
+	| [ (BrOpen,p1); [%let eparam = expr ctx]; (BrClose,p2) ] when is_dollar_ident e1 ->
 		(match fst e1 with
-		| EConst(Ident n) -> expr_next (EMeta((Meta.from_string n,[],snd e1),eparam), punion p1 p2) s
+		| EConst(Ident n) -> expr_next ctx (EMeta((Meta.from_string n,[],snd e1),eparam), punion p1 p2) s
 		| _ -> die "" __LOC__)
-	| [ (Dot,p); [%let e = parse_field e1 EFNormal p] ] -> e
-	| [ (QuestionDot,p); [%let e = parse_field e1 EFSafe p] ] -> e
-	| [ (POpen,p1); [%let e = parse_call_params (fun el p2 -> (ECall(e1,el)),punion (pos e1) p2) p1] ] -> expr_next e s
-	| [ (BkOpen,p1); secure_expr as e2 ] ->
-		let p2 = expect_unless_resume_p BkClose s in
-		let e2 = check_signature_mark e2 p1 p2 in
-		expr_next (EArray (e1,e2), punion (pos e1) p2) s
+	| [ (Dot,p); [%let e = parse_field ctx e1 EFNormal p] ] -> e
+	| [ (QuestionDot,p); [%let e = parse_field ctx e1 EFSafe p] ] -> e
+	| [ (POpen,p1); [%let e = parse_call_params ctx (fun el p2 -> (ECall(e1,el)),punion (pos e1) p2) p1] ] -> expr_next ctx e s
+	| [ (BkOpen,p1); [%let e2 = secure_expr ctx] ] ->
+		let p2 = expect_unless_resume_p ctx BkClose s in
+		let e2 = check_signature_mark ctx e2 p1 p2 in
+		expr_next ctx (EArray (e1,e2), punion (pos e1) p2) s
 	| [ (Arrow,pa) ] ->
-		let er = secure_expr s in
-		arrow_function (snd e1) [arrow_first_param e1 s] er s
+		let er = secure_expr ctx s in
+		arrow_function ctx (snd e1) [arrow_first_param ctx e1 s] er s
 	| [ (Binop OpGt,p1) ] ->
 		(match%parser s with
 		| [ (Binop OpGt,p2) ] when p1.pmax = p2.pmin ->
 			(match%parser s with
 			| [ (Binop OpGt,p3) ] when p2.pmax = p3.pmin ->
 				(match%parser s with
-				| [ (Binop OpAssign,p4); expr as e2 ] when p3.pmax = p4.pmin -> make_binop (OpAssignOp OpUShr) e1 e2
-				| [ secure_expr as e2 ] -> make_binop OpUShr e1 e2)
-			| [ (Binop OpAssign,p3); expr as e2 ] when p2.pmax = p3.pmin -> make_binop (OpAssignOp OpShr) e1 e2
-			| [ secure_expr as e2 ] -> make_binop OpShr e1 e2)
+				| [ (Binop OpAssign,p4); [%let e2 = expr ctx] ] when p3.pmax = p4.pmin -> make_binop (OpAssignOp OpUShr) e1 e2
+				| [ [%let e2 = secure_expr ctx] ] -> make_binop OpUShr e1 e2)
+			| [ (Binop OpAssign,p3); [%let e2 = expr ctx] ] when p2.pmax = p3.pmin -> make_binop (OpAssignOp OpShr) e1 e2
+			| [ [%let e2 = secure_expr ctx] ] -> make_binop OpShr e1 e2)
 		| [ (Binop OpAssign,p2) ] when p1.pmax = p2.pmin ->
-			make_binop OpGte e1 (secure_expr s)
-		| [ secure_expr as e2 ] ->
+			make_binop OpGte e1 (secure_expr ctx s)
+		| [ [%let e2 = secure_expr ctx] ] ->
 			make_binop OpGt e1 e2)
-	| [ (Binop op,_); secure_expr as e2 ] -> make_binop op e1 e2
-	| [ (Spread,_); secure_expr as e2 ] -> make_binop OpInterval e1 e2
+	| [ (Binop op,_); [%let e2 = secure_expr ctx] ] -> make_binop op e1 e2
+	| [ (Spread,_); [%let e2 = secure_expr ctx] ] -> make_binop OpInterval e1 e2
 	| [ (Unop op,p) ] when is_postfix e1 op ->
-		expr_next (EUnop (op,Postfix,e1), punion (pos e1) p) s
-	| [ (Question,_); expr as e2 ] ->
+		expr_next ctx (EUnop (op,Postfix,e1), punion (pos e1) p) s
+	| [ (Question,_); [%let e2 = expr ctx] ] ->
 		begin match%parser s with
-		| [ (DblDot,_); expr as e3 ] -> (ETernary (e1,e2,e3),punion (pos e1) (pos e3))
-		| [ ] -> syntax_error (Expected [":"]) s e2
+		| [ (DblDot,_); [%let e3 = expr ctx] ] -> (ETernary (e1,e2,e3),punion (pos e1) (pos e3))
+		| [ ] -> syntax_error ctx (Expected [":"]) s e2
 		end
-	| [ (Kwd In,_); expr as e2 ] ->
+	| [ (Kwd In,_); [%let e2 = expr ctx] ] ->
 		make_binop OpIn e1 e2
-	| [ (Const (Ident "is"),p_is); parse_complex_type as t ] ->
+	| [ (Const (Ident "is"),p_is); [%let t = parse_complex_type ctx] ] ->
 		let p1 = pos e1 in
 		let p2 = pos t in
 		let e_is = EIs (e1,t), (punion p1 p2) in
-		expr_next e_is s
+		expr_next ctx e_is s
 	| [ ] -> e1
 
-and parse_field e1 efk p s =
-	check_resume p (fun () -> (EDisplay (e1,DKDot),p)) (fun () ->
+and parse_field ctx e1 efk p s =
+	check_resume ctx p (fun () -> (EDisplay (e1,DKDot),p)) (fun () ->
 		begin match%parser s with
-		| [ (Kwd Macro,p2) ] when p.pmax = p2.pmin -> expr_next (EField (e1,"macro",efk) , punion (pos e1) p2) s
-		| [ (Kwd Extern,p2) ] when p.pmax = p2.pmin -> expr_next (EField (e1,"extern",efk) , punion (pos e1) p2) s
-		| [ (Kwd Function,p2) ] when p.pmax = p2.pmin -> expr_next (EField (e1,"function",efk) , punion (pos e1) p2) s
-		| [ (Kwd New,p2) ] when p.pmax = p2.pmin -> expr_next (EField (e1,"new",efk) , punion (pos e1) p2) s
-		| [ (Kwd k,p2) ] when !parsing_macro_cond && p.pmax = p2.pmin -> expr_next (EField (e1,s_keyword k,efk) , punion (pos e1) p2) s
-		| [ (Const (Ident f),p2) ] when p.pmax = p2.pmin -> expr_next (EField (e1,f,efk) , punion (pos e1) p2) s
-		| [ (Dollar v,p2) ] -> expr_next (EField (e1,"$"^v,efk) , punion (pos e1) p2) s
+		| [ (Kwd Macro,p2) ] when p.pmax = p2.pmin -> expr_next ctx (EField (e1,"macro",efk) , punion (pos e1) p2) s
+		| [ (Kwd Extern,p2) ] when p.pmax = p2.pmin -> expr_next ctx (EField (e1,"extern",efk) , punion (pos e1) p2) s
+		| [ (Kwd Function,p2) ] when p.pmax = p2.pmin -> expr_next ctx (EField (e1,"function",efk) , punion (pos e1) p2) s
+		| [ (Kwd New,p2) ] when p.pmax = p2.pmin -> expr_next ctx (EField (e1,"new",efk) , punion (pos e1) p2) s
+		| [ (Kwd k,p2) ] when !parsing_macro_cond && p.pmax = p2.pmin -> expr_next ctx (EField (e1,s_keyword k,efk) , punion (pos e1) p2) s
+		| [ (Const (Ident f),p2) ] when p.pmax = p2.pmin -> expr_next ctx (EField (e1,f,efk) , punion (pos e1) p2) s
+		| [ (Dollar v,p2) ] -> expr_next ctx (EField (e1,"$"^v,efk) , punion (pos e1) p2) s
 		| [ ] ->
 			(* turn an integer followed by a dot into a float *)
 			match e1 with
-			| (EConst (Int (v, None)),p2) when p2.pmax = p.pmin -> expr_next (EConst (Float (v ^ ".", None)),punion p p2) s
+			| (EConst (Int (v, None)),p2) when p2.pmax = p.pmin -> expr_next ctx (EConst (Float (v ^ ".", None)),punion p p2) s
 			| _ -> serror()
 		end
 	)
 
-and parse_guard = function%parser
-	| [ (Kwd If,p1); (POpen,_); expr as e; (PClose,_); ] ->
+and parse_guard ctx = function%parser
+	| [ (Kwd If,p1); (POpen,_); [%let e = expr ctx]; (PClose,_); ] ->
 		e
 
-and expr_or_var = function%parser
+and expr_or_var ctx = function%parser
 	| [ (Kwd Var,p1); dollar_ident as np; ] -> EVars [mk_evar np],punion p1 (snd np)
 	| [ (Kwd Final,p1); [%s s] ] ->
-		check_redundant_var p1 s;
+		check_redundant_var ctx p1 s;
 		begin match%parser s with
 			| [ dollar_ident as np; ] ->
 				EVars [mk_evar ~final:true np],punion p1 (snd np)
 			| [ ] ->
 				serror()
 		end
-	| [ secure_expr as e ] -> e
+	| [ [%let e = secure_expr ctx] ] -> e
 
-and parse_switch_cases eswitch cases s = match%parser s with
+and parse_switch_cases ctx eswitch cases s = match%parser s with
 	| [ (Kwd Default,p1); (DblDot,pdot) ] ->
-		let b,p2 = (block_with_pos [] p1 s) in
+		let b,p2 = (block_with_pos ctx [] p1 s) in
 		let b = match b with
 			| [] -> None,pdot
 			| _ -> let p = punion p1 p2 in Some ((EBlock b,p)),p
 		in
-		let l , def = parse_switch_cases eswitch cases s in
-		(match def with None -> () | Some _ -> syntax_error Duplicate_default ~pos:(Some p1) s ());
+		let l , def = parse_switch_cases ctx eswitch cases s in
+		(match def with None -> () | Some _ -> syntax_error ctx Duplicate_default ~pos:(Some p1) s ());
 		l , Some b
-	| [ (Kwd Case,p1); [%let el = psep Comma expr_or_var]; [%let eg = popt parse_guard] ] ->
-		let pdot = expect_unless_resume_p DblDot s in
-		if !was_auto_triggered then check_resume pdot (fun () -> ()) (fun () -> ());
+	| [ (Kwd Case,p1); [%let el = psep Comma (expr_or_var ctx)]; [%let eg = popt (parse_guard ctx)] ] ->
+		let pdot = expect_unless_resume_p ctx DblDot s in
+		if !was_auto_triggered then check_resume ctx pdot (fun () -> ()) (fun () -> ());
 		(match el with
-		| [] -> syntax_error (Custom "case without a pattern is not allowed") ~pos:(Some p1) s ([],None)
+		| [] -> syntax_error ctx (Custom "case without a pattern is not allowed") ~pos:(Some p1) s ([],None)
 		| _ ->
-			let b,p2 = (block_with_pos [] p1 s) in
+			let b,p2 = (block_with_pos ctx [] p1 s) in
 			let b,p = match b with
 				| [] -> None,punion p1 pdot
 				| _ -> let p = punion p1 p2 in Some ((EBlock b,p)),p
 			in
-			parse_switch_cases eswitch ((el,eg,b,p) :: cases) s
+			parse_switch_cases ctx eswitch ((el,eg,b,p) :: cases) s
 		)
 	| [ ] ->
 		List.rev cases , None
 
-and parse_catch etry = function%parser
+and parse_catch ctx etry = function%parser
 	| [ (Kwd Catch,p); (POpen,_); [%let name, pn = dollar_ident]; [%s s] ] ->
 		match%parser s with
-		| [ [%let t,pt = parse_type_hint]; (PClose,_); secure_expr as e ] -> ((name,pn),(Some (t,pt)),e,punion p (pos e)),(pos e)
-		| [ (PClose,_); secure_expr as e ] -> ((name,pn),None,e,punion p (pos e)),(pos e)
+		| [ [%let t,pt = parse_type_hint ctx]; (PClose,_); [%let e = secure_expr ctx] ] -> ((name,pn),(Some (t,pt)),e,punion p (pos e)),(pos e)
+		| [ (PClose,_); [%let e = secure_expr ctx] ] -> ((name,pn),None,e,punion p (pos e)),(pos e)
 		| [ (_,p) ] -> error Missing_type p
 
-and parse_catches etry catches pmax = function%parser
-	| [ [%let (catch,pmax) = parse_catch etry]; [%s s] ] -> parse_catches etry (catch :: catches) pmax s
+and parse_catches ctx etry catches pmax = function%parser
+	| [ [%let (catch,pmax) = parse_catch ctx etry]; [%s s] ] -> parse_catches ctx etry (catch :: catches) pmax s
 	| [ ] -> List.rev catches,pmax
 
-and parse_call_params f p1 s =
+and parse_call_params ctx f p1 s =
 	if not !in_display_file then begin
-		let el = psep_trailing Comma expr s in
+		let el = psep_trailing Comma (expr ctx) s in
 		match%parser s with
 		| [ (PClose,p2) ] -> f el p2
 		| [ ] ->
 			let expected = if el = [] then ["expression";")"] else [",";")"] in
-			syntax_error (Expected expected) s (f el (last_pos s))
+			syntax_error ctx (Expected expected) s (f el (last_pos ctx s))
 	end else begin
 		let rec parse_next_param acc p1 =
 			let e = try
-				expr s
+				expr ctx s
 			with
 			| Stream.Failure ->
 				let expected = "expression" :: (if acc = [] then [")"] else []) in
-				syntax_error (Expected expected) s ();
-				mk_null_expr (punion_next p1 s)
+				syntax_error ctx (Expected expected) s ();
+				mk_null_expr (punion_next ctx p1 s)
 			| Stream.Error msg ->
-				handle_stream_error msg s;
-				mk_null_expr (punion_next p1 s)
+				handle_stream_error ctx msg s;
+				mk_null_expr (punion_next ctx p1 s)
 			in
 			match%parser s with
 			| [ (PClose,p2) ] ->
-				let e = check_signature_mark e p1 p2 in
+				let e = check_signature_mark ctx e p1 p2 in
 				f (List.rev (e :: acc)) p2
 			| [ (Comma,p2)] ->
 				begin match%parser s with
@@ -1745,13 +1745,13 @@ and parse_call_params f p1 s =
 							f (List.rev (e :: acc)) p3
 						end
 					| [] ->
-						let e = check_signature_mark e p1 p2 in
+						let e = check_signature_mark ctx e p1 p2 in
 						parse_next_param (e :: acc) p2
 				end
 			| [ ] ->
-				let p2 = next_pos s in
-				syntax_error (Expected [",";")"]) s ();
-				let e = check_signature_mark e p1 p2 in
+				let p2 = next_pos ctx s in
+				syntax_error ctx (Expected [",";")"]) s ();
+				let e = check_signature_mark ctx e p1 p2 in
 				f (List.rev (e :: acc)) p2
 		in
 		match%parser s with
@@ -1762,39 +1762,39 @@ and parse_call_params f p1 s =
 (* Tries to parse a toplevel expression and defaults to a null expression when in display mode.
    This function always accepts in display mode and should only be used for expected expressions,
    not accepted ones! *)
-and secure_expr = function%parser
-	| [ expr as e ] -> e
+and secure_expr ctx = function%parser
+	| [ [%let e = expr ctx] ] -> e
 	| [ [%s s] ] ->
-		syntax_error (Expected ["expression"]) s (
-			let last = last_token s in
+		syntax_error ctx (Expected ["expression"]) s (
+			let last = last_token ctx s in
 			let plast = pos last in
 			let offset = match fst last with
 				| Const _ | Kwd _ | Dollar _ -> 1
 				| _ -> 0
 			in
 			let plast = {plast with pmin = plast.pmax + offset} in
-			mk_null_expr (punion_next plast s)
+			mk_null_expr (punion_next ctx plast s)
 		)
 
-let rec validate_macro_cond s e = match fst e with
+let rec validate_macro_cond ctx s e = match fst e with
 	| EConst (Ident _)
 	| EConst (String _)
 	| EConst (Int (_, _))
 	| EConst (Float (_, _))
 		-> e
-	| EUnop (op,p,e1) -> (EUnop (op, p, validate_macro_cond s e1), snd e)
-	| EBinop (op,e1,e2) -> (EBinop(op, (validate_macro_cond s e1), (validate_macro_cond s e2)), snd e)
-	| EParenthesis (e1) -> (EParenthesis (validate_macro_cond s e1), snd e)
-	| EField(e1,name,efk) -> (EField(validate_macro_cond s e1,name,efk), snd e)
-	| ECall ((EConst (Ident _),_) as i, args) -> (ECall (i,List.map (validate_macro_cond s) args),snd e)
-	| _ -> syntax_error (Custom ("Invalid conditional expression")) ~pos:(Some (pos e)) s ((EConst (Ident "false"),(pos e)))
+	| EUnop (op,p,e1) -> (EUnop (op, p, validate_macro_cond ctx s e1), snd e)
+	| EBinop (op,e1,e2) -> (EBinop(op, (validate_macro_cond ctx s e1), (validate_macro_cond ctx s e2)), snd e)
+	| EParenthesis (e1) -> (EParenthesis (validate_macro_cond ctx s e1), snd e)
+	| EField(e1,name,efk) -> (EField(validate_macro_cond ctx s e1,name,efk), snd e)
+	| ECall ((EConst (Ident _),_) as i, args) -> (ECall (i,List.map (validate_macro_cond ctx s) args),snd e)
+	| _ -> syntax_error ctx (Custom ("Invalid conditional expression")) ~pos:(Some (pos e)) s ((EConst (Ident "false"),(pos e)))
 
 let parse_macro_ident t p s =
 	if t = "display" then Hashtbl.replace special_identifier_files (Path.UniqueKey.create p.pfile) t;
 	let e = (EConst (Ident t),p) in
 	None, e
 
-let rec parse_macro_cond s =
+let rec parse_macro_cond ctx s =
 	parsing_macro_cond := true;
 	try
 		let cond = (match%parser s with
@@ -1808,10 +1808,10 @@ let rec parse_macro_cond s =
 				None, (EConst (Float (f, s)),p)
 			| [ (Kwd k,p) ] ->
 				parse_macro_ident (s_keyword k) p s
-			| [ (Unop op,p); [%let tk, e = parse_macro_cond] ] ->
+			| [ (Unop op,p); [%let tk, e = parse_macro_cond ctx] ] ->
 				tk, make_unop op e p
-			| [ (POpen,p1); [%let (e,p) = expr]; (PClose,p2) ] ->
-				None, (EParenthesis(validate_macro_cond s (e,p)),punion p1 p2)) in
+			| [ (POpen,p1); [%let (e,p) = expr ctx]; (PClose,p2) ] ->
+				None, (EParenthesis(validate_macro_cond ctx s (e,p)),punion p1 p2)) in
 		parsing_macro_cond := false;
 		cond
 	with e ->

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -1788,8 +1788,8 @@ let rec validate_macro_cond ctx s e = match fst e with
 	| ECall ((EConst (Ident _),_) as i, args) -> (ECall (i,List.map (validate_macro_cond ctx s) args),snd e)
 	| _ -> syntax_error ctx (Custom ("Invalid conditional expression")) ~pos:(Some (pos e)) s ((EConst (Ident "false"),(pos e)))
 
-let parse_macro_ident t p s =
-	if t = "display" then Hashtbl.replace special_identifier_files (Path.UniqueKey.create p.pfile) t;
+let parse_macro_ident ctx t p s =
+	if t = "display" then Option.may (fun h -> ThreadSafeHashtbl.replace h (Path.UniqueKey.create p.pfile) t) ctx.config.special_identifier_files;
 	let e = (EConst (Ident t),p) in
 	None, e
 
@@ -1798,7 +1798,7 @@ let rec parse_macro_cond ctx s =
 	try
 		let cond = (match%parser s with
 			| [ (Const (Ident t),p) ] ->
-				parse_macro_ident t p s
+				parse_macro_ident ctx t p s
 			| [ (Const (String(s,qs)),p) ] ->
 				None, (EConst (String(s,qs)),p)
 			| [ (Const (Int (i, s)),p) ] ->
@@ -1806,7 +1806,7 @@ let rec parse_macro_cond ctx s =
 			| [ (Const (Float (f, s)),p) ] ->
 				None, (EConst (Float (f, s)),p)
 			| [ (Kwd k,p) ] ->
-				parse_macro_ident (s_keyword k) p s
+				parse_macro_ident ctx (s_keyword k) p s
 			| [ (Unop op,p); [%let tk, e = parse_macro_cond ctx] ] ->
 				tk, make_unop op e p
 			| [ (POpen,p1); [%let (e,p) = expr ctx]; (PClose,p2) ] ->

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -1672,7 +1672,7 @@ and parse_switch_cases ctx eswitch cases s = match%parser s with
 		l , Some b
 	| [ (Kwd Case,p1); [%let el = psep Comma (expr_or_var ctx)]; [%let eg = popt (parse_guard ctx)] ] ->
 		let pdot = expect_unless_resume_p ctx DblDot s in
-		if !was_auto_triggered then check_resume ctx pdot (fun () -> ()) (fun () -> ());
+		if ctx.config.was_auto_triggered then check_resume ctx pdot (fun () -> ()) (fun () -> ());
 		(match el with
 		| [] -> syntax_error ctx (Custom "case without a pattern is not allowed") ~pos:(Some p1) s ([],None)
 		| _ ->

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -125,7 +125,6 @@ let check_redundant_var ctx p1 = function%parser
 let parsing_macro_cond = ref false
 
 let rec parse_file (ctx : parser_ctx) s =
-	last_doc := None;
 	match%parser s with
 	| [ (Kwd Package,_); parse_package as pack ] ->
 		begin match%parser s with
@@ -235,7 +234,7 @@ and parse_type_decl ctx mode s =
 	match%parser s with
 	| [ (Kwd Import,p1) ] -> parse_import ctx s p1
 	| [ (Kwd Using,p1) ] -> parse_using ctx s p1
-	| [ get_doc as doc; [%let meta = parse_meta ctx]; parse_common_flags as c ] ->
+	| [ [%let doc = get_doc ctx]; [%let meta = parse_meta ctx]; parse_common_flags as c ] ->
 		match%parser s with
 		| [ (Kwd Function,p1); dollar_ident as name; [%let pl = parse_constraint_params ctx]; (POpen,_); [%let args = psep_trailing Comma (parse_fun_param ctx)]; (PClose,_); [%let t = popt (parse_type_hint ctx)] ] ->
 			let e, p2 = (match%parser s with
@@ -880,7 +879,7 @@ and parse_type_anonymous ctx s =
 		if p0 = None then raise Stream.Failure else serror()
 
 and parse_enum ctx s =
-	let doc = get_doc s in
+	let doc = get_doc ctx s in
 	let meta = parse_meta ctx s in
 	match%parser s with
 	| [ [%let name, p1 = ident]; [%let params = parse_constraint_params ctx] ] ->
@@ -942,7 +941,7 @@ and parse_var_field_assignment ctx = function%parser
 	| [ ] -> serror()
 
 and parse_class_field ctx tdecl s =
-	let doc = get_doc s in
+	let doc = get_doc ctx s in
 	let meta = parse_meta ctx s in
 	match%parser s with
 	| [ [%let al = plist parse_cf_rights] ] ->

--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -153,7 +153,7 @@ and parse_type_decls ctx mode pmax pack acc s =
 			| _ -> ()
 		) acc;
 		raise (TypePath (pack,Some(name,true),b,p))
-	| Stream.Error msg when !in_display_file ->
+	| Stream.Error msg when ctx.config.in_display_file ->
 		Error msg
 	in
 	match result with
@@ -191,7 +191,7 @@ and parse_class_content ctx doc meta flags n p1 s =
 	let tl = parse_constraint_params ctx s in
 	let rec loop had_display p0 acc =
 		let check_display p1 =
-			if not had_display && !in_display_file && !display_mode = DMDefault && display_position#enclosed_in p1 then
+			if not had_display && ctx.config.in_display_file && ctx.config.display_mode = DMDefault && display_position#enclosed_in p1 then
 				syntax_completion (if List.mem HInterface n then SCInterfaceRelation else SCClassRelation) None (display_position#with_pos p1)
 		in
 		match%parser s with
@@ -445,7 +445,7 @@ and parse_using ctx s p1 =
 
 and parse_abstract_relations ctx =
 	let check_display p1 (ct,p2) =
-		if !in_display_file && p1.pmax < (display_position#get).pmin && p2.pmin >= (display_position#get).pmax then
+		if ctx.config.in_display_file && p1.pmax < (display_position#get).pmin && p2.pmin >= (display_position#get).pmax then
 			(* This means we skipped the display position between the to/from and the type-hint we parsed.
 			   Very weird case, it was probably a {} like in #7137. Let's discard it and use magic. *)
 			(magic_type_th (display_position#with_pos p2))
@@ -547,7 +547,7 @@ and parse_class_field_resume ctx acc tdecl s =
 			acc,last_pos ctx s
 
 and parse_class_fields ctx tdecl p1 s =
-	if not (!in_display_file) then begin
+	if not (ctx.config.in_display_file) then begin
 		let acc = plist (parse_class_field ctx tdecl) s in
 		let p2 = (match%parser s with
 			| [ (BrClose,p2) ] -> p2
@@ -734,7 +734,7 @@ and parse_type_path2 ctx p0 pack name p1 s : placed_type_path =
 			| None -> p1
 			| Some p -> punion p p1
 		in
-		if !in_display_file && display_position#enclosed_in p then begin
+		if ctx.config.in_display_file && display_position#enclosed_in p then begin
 			make_ptp (mk_type_path (List.rev pack,name)) p
 		end else
 			f()
@@ -793,7 +793,7 @@ and parse_type_path_or_const ctx plt = function%parser
 	| [ (Kwd False,p) ] -> TPExpr (EConst (Ident "false"),p)
 	| [ [%let e = expr ctx] ] -> TPExpr e
 	| [ [%s s] ] ->
-		if !in_display_file then begin
+		if ctx.config.in_display_file then begin
 			if would_skip_display_position ctx plt false s then begin
 				TPType (magic_type_th (display_position#with_pos plt))
 			end else
@@ -1143,7 +1143,7 @@ and block_with_pos' ctx acc f p s =
 	with
 		| Stream.Failure ->
 			List.rev acc,p
-		| Stream.Error msg when !in_display_file ->
+		| Stream.Error msg when ctx.config.in_display_file ->
 			handle_stream_error ctx msg s;
 			(block_with_pos ctx acc (next_pos ctx s) s)
 
@@ -1389,7 +1389,7 @@ and expr (ctx : parser_ctx) s = match%parser s with
 		begin try
 			make_meta name params (secure_expr ctx s) p
 		with
-		| Stream.Failure | Stream.Error _ when !in_display_file ->
+		| Stream.Failure | Stream.Error _ when ctx.config.in_display_file ->
 			let e = EConst (Ident "null"),null_pos in
 			make_meta name params e p
 		end
@@ -1575,7 +1575,7 @@ and expr (ctx : parser_ctx) s = match%parser s with
 and expr_next ctx e1 s =
 	try
 		expr_next' ctx e1 s
-	with Stream.Error msg when !in_display ->
+	with Stream.Error msg when ctx.config.in_display ->
 		handle_stream_error ctx msg s;
 		e1
 
@@ -1698,7 +1698,7 @@ and parse_catches ctx etry catches pmax = function%parser
 	| [ ] -> List.rev catches,pmax
 
 and parse_call_params ctx f p1 s =
-	if not !in_display_file then begin
+	if not ctx.config.in_display_file then begin
 		let el = psep_trailing Comma (expr ctx) s in
 		match%parser s with
 		| [ (PClose,p2) ] -> f el p2
@@ -1725,7 +1725,7 @@ and parse_call_params ctx f p1 s =
 			| [ (Comma,p2)] ->
 				begin match%parser s with
 					| [ (PClose, p3) ] ->
-						if (is_signature_display()) then begin
+						if (is_signature_display ctx) then begin
 							let prev_arg_pos = punion p1 p2 in
 							let comma_paren_pos = punion p2 p3 in
 							(* first check wether the display position is within the previous argument *)

--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -99,13 +99,15 @@ let newline ctx lexbuf =
 	cur.lline <- cur.lline + 1;
 	cur.llines <- (lexeme_end lexbuf,cur.lline) :: cur.llines
 
-let copy_file source dest =
-	dest.lline <- source.lline;
-	dest.lmaxline <- source.lmaxline;
-	dest.llines <- source.llines;
-	dest.lalines <- source.lalines;
-	dest.llast <- source.llast;
-	dest.llastindex <- source.llastindex
+let copy_file source = {
+	lfile = source.lfile;
+	lline = source.lline;
+	lmaxline = source.lmaxline;
+	llines = source.llines;
+	lalines = source.lalines;
+	llast = source.llast;
+	llastindex = source.llastindex;
+}
 
 let print_file file =
 	let sllines = String.concat ";" (List.map (fun (i1,i2) -> Printf.sprintf "(%i,%i)" i1 i2) file.llines) in

--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -34,7 +34,23 @@ type error_msg =
 
 exception Error of error_msg * pos
 
+type lexer_file = {
+	lfile : string;
+	mutable lline : int;
+	mutable lmaxline : int;
+	mutable llines : (int * int) list;
+	mutable lalines : (int * int) array;
+	mutable llast : int;
+	mutable llastindex : int;
+}
+
+type lexer_ctx = {
+	file : lexer_file;
+	buf : Buffer.t;
+}
+
 type xml_lexing_context = {
+	lexer_ctx : lexer_ctx;
 	open_tag : string;
 	close_tag : string;
 	lexbuf : Sedlexing.lexbuf;
@@ -52,16 +68,6 @@ let error_msg = function
 	| Invalid_option -> "Invalid regular expression option"
 	| Unterminated_markup -> "Unterminated markup literal"
 
-type lexer_file = {
-	lfile : string;
-	mutable lline : int;
-	mutable lmaxline : int;
-	mutable llines : (int * int) list;
-	mutable lalines : (int * int) array;
-	mutable llast : int;
-	mutable llastindex : int;
-}
-
 let make_file file =
 	{
 		lfile = file;
@@ -72,6 +78,26 @@ let make_file file =
 		llast = max_int;
 		llastindex = 0;
 	}
+
+let create_context file = {
+	file = file;
+	buf = Buffer.create 100;
+}
+
+let create_temp_ctx file =
+	create_context (make_file file)
+
+let all_files = ThreadSafeHashtbl.create 0
+
+let create_file_ctx file =
+	let f = make_file file in
+	ThreadSafeHashtbl.replace all_files file f;
+	create_context f
+
+let newline ctx lexbuf =
+	let cur = ctx.file in
+	cur.lline <- cur.lline + 1;
+	cur.llines <- (lexeme_end lexbuf,cur.lline) :: cur.llines
 
 let copy_file source dest =
 	dest.lline <- source.lline;
@@ -86,14 +112,8 @@ let print_file file =
 	let slalines = String.concat ";" (Array.to_list (Array.map (fun (i1,i2) -> Printf.sprintf "(%i,%i)" i1 i2) file.lalines)) in
 	Printf.sprintf "lfile: %s\nlline: %i\nlmaxline: %i\nllines: [%s]\nlalines: [%s]\nllast: %i\nllastindex: %i" file.lfile file.lline file.lmaxline sllines slalines file.llast file.llastindex
 
-let cur = ref (make_file "")
-
-let all_files = Hashtbl.create 0
-
-let buf = Buffer.create 100
-
-let error e pos =
-	raise (Error (e,{ pmin = pos; pmax = pos; pfile = !cur.lfile }))
+let error ctx e pos =
+	raise (Error (e,{ pmin = pos; pmax = pos; pfile = ctx.file.lfile }))
 
 let keywords =
 	let h = Hashtbl.create 3 in
@@ -156,31 +176,6 @@ let split_int_suffix s =
 let split_float_suffix s =
 	let (literal,suffix) = split_suffix s false in
 	Const (Float (literal,suffix))
-
-let init file =
-	let f = make_file file in
-	cur := f;
-	Hashtbl.replace all_files file f
-
-let save() =
-	!cur
-
-let reinit file =
-	let old_file = try Some (Hashtbl.find all_files file) with Not_found -> None in
-	let old_cur = !cur in
-	init file;
-	(fun () ->
-		cur := old_cur;
-		Option.may (Hashtbl.replace all_files file) old_file;
-	)
-
-let restore c =
-	cur := c
-
-let newline lexbuf =
-	let cur = !cur in
-	cur.lline <- cur.lline + 1;
-	cur.llines <- (lexeme_end lexbuf,cur.lline) :: cur.llines
 
 let find_line p f =
 	(* rebuild cache if we have a new line *)
@@ -268,11 +263,11 @@ let resolve_file_pos file =
 
 let find_file file =
 	try
-		Hashtbl.find all_files file
+		ThreadSafeHashtbl.find all_files file
 	with Not_found ->
 		try
 			let f = resolve_file_pos file in
-			Hashtbl.add all_files file f;
+			ThreadSafeHashtbl.add all_files file f;
 			f
 		with Sys_error _ ->
 			make_file file
@@ -284,24 +279,18 @@ let get_error_line p =
 	let l, _ = find_pos p in
 	l
 
-
 let get_error_line_if_exists p =
 	try
-		let file = Hashtbl.find all_files p.pfile in
+		let file = ThreadSafeHashtbl.find all_files p.pfile in
 		fst (find_line p.pmin file)
 	with Not_found ->
 		0
-
-let old_format = ref false
 
 let get_pos_coords p =
 	let file = find_file p.pfile in
 	let l1, p1 = find_line p.pmin file in
 	let l2, p2 = find_line p.pmax file in
-	if !old_format then
-		l1, p1, l2, p2
-	else
-		l1, p1+1, l2, p2+1
+	l1, p1+1, l2, p2+1
 
 let get_error_pos printer p =
 	if p.pmin = -1 then
@@ -314,28 +303,29 @@ let get_error_pos printer p =
 		end else
 			Printf.sprintf "%s lines %d-%d" (printer p.pfile l1) l1 l2
 ;;
+
 Globals.get_error_pos_ref := get_error_pos
 
-let reset() = Buffer.reset buf
-let contents() = Buffer.contents buf
-let store lexbuf = Buffer.add_string buf (lexeme lexbuf)
-let add c = Buffer.add_string buf c
+let reset ctx = Buffer.reset ctx.buf
+let contents ctx = Buffer.contents ctx.buf
+let store ctx lexbuf = Buffer.add_string ctx.buf (lexeme lexbuf)
+let add ctx c = Buffer.add_string ctx.buf c
 
-let mk_tok t pmin pmax =
-	t , { pfile = !cur.lfile; pmin = pmin; pmax = pmax }
+let mk_tok ctx t pmin pmax =
+	t , { pfile = ctx.file.lfile; pmin = pmin; pmax = pmax }
 
-let mk lexbuf t =
-	mk_tok t (lexeme_start lexbuf) (lexeme_end lexbuf)
+let mk ctx lexbuf t =
+	mk_tok ctx t (lexeme_start lexbuf) (lexeme_end lexbuf)
 
-let mk_ident lexbuf =
+let mk_ident ctx lexbuf =
 	let s = lexeme lexbuf in
-	mk lexbuf (Const (Ident s))
+	mk ctx lexbuf (Const (Ident s))
 
-let mk_keyword lexbuf kwd =
-	mk lexbuf (Kwd kwd)
+let mk_keyword ctx lexbuf kwd =
+	mk ctx lexbuf (Kwd kwd)
 
-let invalid_char lexbuf =
-	error (Invalid_character (Uchar.to_int (lexeme_char lexbuf 0))) (lexeme_start lexbuf)
+let invalid_char ctx lexbuf =
+	error ctx (Invalid_character (Uchar.to_int (lexeme_char lexbuf 0))) (lexeme_start lexbuf)
 
 let ident = [%sedlex.regexp?
 	(
@@ -408,7 +398,12 @@ let rec skip_header lexbuf =
 	| "" | eof -> ()
 	| _ -> die "" __LOC__
 
-let rec token lexbuf =
+let rec token ctx lexbuf =
+	let mk = mk ctx in
+	let token = token ctx in
+	let newline = newline ctx in
+	let mk_tok = mk_tok ctx in
+	let mk_keyword = mk_keyword ctx in
 	match%sedlex lexbuf with
 	| eof -> mk lexbuf Eof
 	| Plus (Chars " \t") -> token lexbuf
@@ -487,27 +482,27 @@ let rec token lexbuf =
 	| "@" -> mk lexbuf At
 
 	| "/*" ->
-		reset();
+		reset ctx;
 		let pmin = lexeme_start lexbuf in
-		let pmax = (try comment lexbuf with Exit -> error Unclosed_comment pmin) in
-		mk_tok (Comment (contents())) pmin pmax;
+		let pmax = (try comment ctx lexbuf with Exit -> error ctx Unclosed_comment pmin) in
+		mk_tok (Comment (contents ctx)) pmin pmax;
 	| '"' ->
-		reset();
+		reset ctx;
 		let pmin = lexeme_start lexbuf in
-		let pmax = (try string lexbuf with Exit -> error Unterminated_string pmin) in
-		let str = (try unescape (contents()) with Invalid_escape_sequence(c,i,msg) -> error (Invalid_escape (c,msg)) (pmin + i)) in
+		let pmax = (try string ctx lexbuf with Exit -> error ctx Unterminated_string pmin) in
+		let str = (try unescape (contents ctx) with Invalid_escape_sequence(c,i,msg) -> error ctx (Invalid_escape (c,msg)) (pmin + i)) in
 		mk_tok (Const (String(str,SDoubleQuotes))) pmin pmax;
 	| "'" ->
-		reset();
+		reset ctx;
 		let pmin = lexeme_start lexbuf in
-		let pmax = (try string2 lexbuf with Exit -> error Unterminated_string pmin) in
-		let str = (try unescape (contents()) with Invalid_escape_sequence(c,i,msg) -> error (Invalid_escape (c,msg)) (pmin + i)) in
+		let pmax = (try string2 ctx lexbuf with Exit -> error ctx Unterminated_string pmin) in
+		let str = (try unescape (contents ctx) with Invalid_escape_sequence(c,i,msg) -> error ctx (Invalid_escape (c,msg)) (pmin + i)) in
 		mk_tok (Const (String(str,SSingleQuotes))) pmin pmax;
 	| "~/" ->
-		reset();
+		reset ctx;
 		let pmin = lexeme_start lexbuf in
-		let options, pmax = (try regexp lexbuf with Exit -> error Unterminated_regexp pmin) in
-		let str = contents() in
+		let options, pmax = (try regexp ctx lexbuf with Exit -> error ctx Unterminated_regexp pmin) in
+		let str = contents ctx in
 		mk_tok (Const (Regexp (str,options))) pmin pmax;
 	| '#', ident ->
 		let v = lexeme lexbuf in
@@ -568,101 +563,101 @@ let rec token lexbuf =
 	| "new" -> mk_keyword lexbuf New
 	| "in" -> mk_keyword lexbuf In
 	| "cast" -> mk_keyword lexbuf Cast
-	| ident -> mk_ident lexbuf
+	| ident -> mk_ident ctx lexbuf
 	| idtype -> mk lexbuf (Const (Ident (lexeme lexbuf)))
-	| _ -> invalid_char lexbuf
+	| _ -> invalid_char ctx lexbuf
 
-and comment lexbuf =
+and comment ctx lexbuf =
 	match%sedlex lexbuf with
 	| eof -> raise Exit
-	| '\n' | '\r' | "\r\n" -> newline lexbuf; store lexbuf; comment lexbuf
+	| '\n' | '\r' | "\r\n" -> newline ctx lexbuf; store ctx lexbuf; comment ctx lexbuf
 	| "*/" -> lexeme_end lexbuf
-	| '*' -> store lexbuf; comment lexbuf
-	| Plus (Compl ('*' | '\n' | '\r')) -> store lexbuf; comment lexbuf
+	| '*' -> store ctx lexbuf; comment ctx lexbuf
+	| Plus (Compl ('*' | '\n' | '\r')) -> store ctx lexbuf; comment ctx lexbuf
 	| _ -> die "" __LOC__
 
-and string lexbuf =
+and string ctx lexbuf =
 	match%sedlex lexbuf with
 	| eof -> raise Exit
-	| '\n' | '\r' | "\r\n" -> newline lexbuf; store lexbuf; string lexbuf
-	| "\\\"" -> store lexbuf; string lexbuf
-	| "\\\\" -> store lexbuf; string lexbuf
-	| '\\' -> store lexbuf; string lexbuf
+	| '\n' | '\r' | "\r\n" -> newline ctx lexbuf; store ctx lexbuf; string ctx lexbuf
+	| "\\\"" -> store ctx lexbuf; string ctx lexbuf
+	| "\\\\" -> store ctx lexbuf; string ctx lexbuf
+	| '\\' -> store ctx lexbuf; string ctx lexbuf
 	| '"' -> lexeme_end lexbuf
-	| Plus (Compl ('"' | '\\' | '\r' | '\n')) -> store lexbuf; string lexbuf
+	| Plus (Compl ('"' | '\\' | '\r' | '\n')) -> store ctx lexbuf; string ctx lexbuf
 	| _ -> die "" __LOC__
 
-and string2 lexbuf =
+and string2 ctx lexbuf =
 	match%sedlex lexbuf with
 	| eof -> raise Exit
-	| '\n' | '\r' | "\r\n" -> newline lexbuf; store lexbuf; string2 lexbuf
-	| '\\' -> store lexbuf; string2 lexbuf
-	| "\\\\" -> store lexbuf; string2 lexbuf
-	| "\\'" -> store lexbuf; string2 lexbuf
+	| '\n' | '\r' | "\r\n" -> newline ctx lexbuf; store ctx lexbuf; string2 ctx lexbuf
+	| '\\' -> store ctx lexbuf; string2 ctx lexbuf
+	| "\\\\" -> store ctx lexbuf; string2 ctx lexbuf
+	| "\\'" -> store ctx lexbuf; string2 ctx lexbuf
 	| "'" -> lexeme_end lexbuf
-	| "$$" | "\\$" | '$' -> store lexbuf; string2 lexbuf
+	| "$$" | "\\$" | '$' -> store ctx lexbuf; string2 ctx lexbuf
 	| "${" ->
 		let pmin = lexeme_start lexbuf in
-		store lexbuf;
-		(try code_string lexbuf 0 with Exit -> error Unclosed_code pmin);
-		string2 lexbuf;
-	| Plus (Compl ('\'' | '\\' | '\r' | '\n' | '$')) -> store lexbuf; string2 lexbuf
+		store ctx lexbuf;
+		(try code_string ctx lexbuf 0 with Exit -> error ctx Unclosed_code pmin);
+		string2 ctx lexbuf;
+	| Plus (Compl ('\'' | '\\' | '\r' | '\n' | '$')) -> store ctx lexbuf; string2 ctx lexbuf
 	| _ -> die "" __LOC__
 
-and code_string lexbuf open_braces =
+and code_string ctx lexbuf open_braces =
 	match%sedlex lexbuf with
 	| eof -> raise Exit
-	| '\n' | '\r' | "\r\n" -> newline lexbuf; store lexbuf; code_string lexbuf open_braces
-	| '{' -> store lexbuf; code_string lexbuf (open_braces + 1)
-	| '/' -> store lexbuf; code_string lexbuf open_braces
+	| '\n' | '\r' | "\r\n" -> newline ctx lexbuf; store ctx lexbuf; code_string ctx lexbuf open_braces
+	| '{' -> store ctx lexbuf; code_string ctx lexbuf (open_braces + 1)
+	| '/' -> store ctx lexbuf; code_string ctx lexbuf open_braces
 	| '}' ->
-		store lexbuf;
-		if open_braces > 0 then code_string lexbuf (open_braces - 1)
+		store ctx lexbuf;
+		if open_braces > 0 then code_string ctx lexbuf (open_braces - 1)
 	| '"' ->
-		add "\"";
+		add ctx "\"";
 		let pmin = lexeme_start lexbuf in
-		(try ignore(string lexbuf) with Exit -> error Unterminated_string pmin);
-		add "\"";
-		code_string lexbuf open_braces
+		(try ignore(string ctx lexbuf) with Exit -> error ctx Unterminated_string pmin);
+		add ctx "\"";
+		code_string ctx lexbuf open_braces
 	| "'" ->
-		add "'";
+		add ctx "'";
 		let pmin = lexeme_start lexbuf in
-		(try ignore(string2 lexbuf) with Exit -> error Unterminated_string pmin);
-		add "'";
-		code_string lexbuf open_braces
+		(try ignore(string2 ctx lexbuf) with Exit -> error ctx Unterminated_string pmin);
+		add ctx "'";
+		code_string ctx lexbuf open_braces
 	| "/*" ->
 		let pmin = lexeme_start lexbuf in
-		let save = contents() in
-		reset();
-		(try ignore(comment lexbuf) with Exit -> error Unclosed_comment pmin);
-		reset();
-		Buffer.add_string buf save;
-		code_string lexbuf open_braces
-	| "//", Star (Compl ('\n' | '\r')) -> store lexbuf; code_string lexbuf open_braces
-	| Plus (Compl ('/' | '"' | '\'' | '{' | '}' | '\n' | '\r')) -> store lexbuf; code_string lexbuf open_braces
+		let save = contents ctx in
+		reset ctx;
+		(try ignore(comment ctx lexbuf) with Exit -> error ctx Unclosed_comment pmin);
+		reset ctx;
+		Buffer.add_string ctx.buf save;
+		code_string ctx lexbuf open_braces
+	| "//", Star (Compl ('\n' | '\r')) -> store ctx lexbuf; code_string ctx lexbuf open_braces
+	| Plus (Compl ('/' | '"' | '\'' | '{' | '}' | '\n' | '\r')) -> store ctx lexbuf; code_string ctx lexbuf open_braces
 	| _ -> die "" __LOC__
 
-and regexp lexbuf =
+and regexp ctx lexbuf =
 	match%sedlex lexbuf with
 	| eof | '\n' | '\r' -> raise Exit
-	| '\\', '/' -> add "/"; regexp lexbuf
-	| '\\', 'r' -> add "\r"; regexp lexbuf
-	| '\\', 'n' -> add "\n"; regexp lexbuf
-	| '\\', 't' -> add "\t"; regexp lexbuf
-	| '\\', ('\\' | '$' | '.' | '*' | '+' | '^' | '|' | '{' | '}' | '[' | ']' | '(' | ')' | '?' | '-' | '0'..'9') -> add (lexeme lexbuf); regexp lexbuf
-	| '\\', ('w' | 'W' | 'b' | 'B' | 's' | 'S' | 'd' | 'D' | 'x') -> add (lexeme lexbuf); regexp lexbuf
-	| '\\', ('u' | 'U'), ('0'..'9' | 'a'..'f' | 'A'..'F'), ('0'..'9' | 'a'..'f' | 'A'..'F'), ('0'..'9' | 'a'..'f' | 'A'..'F'), ('0'..'9' | 'a'..'f' | 'A'..'F') -> add (lexeme lexbuf); regexp lexbuf
-	| '\\', Compl '\\' -> error (Invalid_character (Uchar.to_int (lexeme_char lexbuf 0))) (lexeme_end lexbuf - 1)
-	| '/' -> regexp_options lexbuf, lexeme_end lexbuf
-	| Plus (Compl ('\\' | '/' | '\r' | '\n')) -> store lexbuf; regexp lexbuf
+	| '\\', '/' -> add  ctx"/"; regexp ctx lexbuf
+	| '\\', 'r' -> add  ctx"\r"; regexp ctx lexbuf
+	| '\\', 'n' -> add  ctx"\n"; regexp ctx lexbuf
+	| '\\', 't' -> add  ctx"\t"; regexp ctx lexbuf
+	| '\\', ('\\' | '$' | '.' | '*' | '+' | '^' | '|' | '{' | '}' | '[' | ']' | '(' | ')' | '?' | '-' | '0'..'9') -> add  ctx(lexeme lexbuf); regexp ctx lexbuf
+	| '\\', ('w' | 'W' | 'b' | 'B' | 's' | 'S' | 'd' | 'D' | 'x') -> add  ctx(lexeme lexbuf); regexp ctx lexbuf
+	| '\\', ('u' | 'U'), ('0'..'9' | 'a'..'f' | 'A'..'F'), ('0'..'9' | 'a'..'f' | 'A'..'F'), ('0'..'9' | 'a'..'f' | 'A'..'F'), ('0'..'9' | 'a'..'f' | 'A'..'F') -> add  ctx(lexeme lexbuf); regexp ctx lexbuf
+	| '\\', Compl '\\' -> error ctx (Invalid_character (Uchar.to_int (lexeme_char lexbuf 0))) (lexeme_end lexbuf - 1)
+	| '/' -> regexp_options ctx lexbuf, lexeme_end lexbuf
+	| Plus (Compl ('\\' | '/' | '\r' | '\n')) -> store ctx lexbuf; regexp ctx lexbuf
 	| _ -> die "" __LOC__
 
-and regexp_options lexbuf =
+and regexp_options ctx lexbuf =
 	match%sedlex lexbuf with
 	| 'g' | 'i' | 'm' | 's' | 'u' ->
 		let l = lexeme lexbuf in
-		l ^ regexp_options lexbuf
-	| 'a'..'z' -> error Invalid_option (lexeme_start lexbuf)
+		l ^ regexp_options ctx lexbuf
+	| 'a'..'z' -> error ctx Invalid_option (lexeme_start lexbuf)
 	| "" -> ""
 	| _ -> die "" __LOC__
 
@@ -672,13 +667,13 @@ and not_xml ctx depth in_open =
 	| eof ->
 		raise Exit
 	| '\n' | '\r' | "\r\n" ->
-		newline lexbuf;
-		store lexbuf;
+		newline ctx.lexer_ctx lexbuf;
+		store ctx.lexer_ctx lexbuf;
 		not_xml ctx depth in_open
 	(* closing tag *)
 	| '<','/',xml_name,'>' ->
 		let s = lexeme lexbuf in
-		Buffer.add_string buf s;
+		Buffer.add_string ctx.lexer_ctx.buf s;
 		(* If it matches our document close tag, finish or decrease depth. *)
 		if s = ctx.close_tag then begin
 			if depth = 0 then lexeme_end lexbuf
@@ -688,56 +683,57 @@ and not_xml ctx depth in_open =
 	(* opening tag *)
 	| '<',xml_name ->
 		let s = lexeme lexbuf in
-		Buffer.add_string buf s;
+		Buffer.add_string ctx.lexer_ctx.buf s;
 		(* If it matches our document open tag, increase depth and set in_open to true. *)
 		let depth,in_open = if s = ctx.open_tag then depth + 1,true else depth,false in
 		not_xml ctx depth in_open
 	(* /> *)
 	| '/','>' ->
 		let s = lexeme lexbuf in
-		Buffer.add_string buf s;
+		Buffer.add_string ctx.lexer_ctx.buf s;
 		(* We only care about this if we are still in the opening tag, i.e. if it wasn't closed yet.
 		   In that case, decrease depth and finish if it's 0. *)
 		let depth = if in_open then depth - 1 else depth in
 		if depth < 0 then lexeme_end lexbuf
 		else not_xml ctx depth false
 	| '<' | '/' | '>' ->
-		store lexbuf;
+		store ctx.lexer_ctx lexbuf;
 		not_xml ctx depth in_open
 	| Plus (Compl ('<' | '/' | '>' | '\n' | '\r')) ->
-		store lexbuf;
+		store ctx.lexer_ctx lexbuf;
 		not_xml ctx depth in_open
 	| _ ->
 		die "" __LOC__
 
-let rec sharp_token lexbuf =
+let rec sharp_token ctx lexbuf =
 	match%sedlex lexbuf with
-	| sharp_ident -> mk_ident lexbuf
-	| Plus (Chars " \t") -> sharp_token lexbuf
-	| "\r\n" -> newline lexbuf; sharp_token lexbuf
-	| '\n' | '\r' -> newline lexbuf; sharp_token lexbuf
+	| sharp_ident -> mk_ident ctx lexbuf
+	| Plus (Chars " \t") -> sharp_token ctx lexbuf
+	| "\r\n" -> newline ctx lexbuf; sharp_token ctx lexbuf
+	| '\n' | '\r' -> newline ctx lexbuf; sharp_token ctx lexbuf
 	| "/*" ->
-		reset();
+		reset ctx;
 		let pmin = lexeme_start lexbuf in
-		ignore(try comment lexbuf with Exit -> error Unclosed_comment pmin);
-		sharp_token lexbuf
-	| _ -> token lexbuf
+		ignore(try comment ctx lexbuf with Exit -> error ctx Unclosed_comment pmin);
+		sharp_token ctx lexbuf
+	| _ -> token ctx lexbuf
 
-let lex_xml p lexbuf =
+let lex_xml ctx p lexbuf =
 	let name,pmin = match%sedlex lexbuf with
 	| xml_name -> lexeme lexbuf,lexeme_start lexbuf
-	| _ -> invalid_char lexbuf
+	| _ -> invalid_char ctx lexbuf
 	in
-	if p + 1 <> pmin then invalid_char lexbuf;
-	Buffer.add_string buf ("<" ^ name);
+	if p + 1 <> pmin then invalid_char ctx lexbuf;
+	Buffer.add_string ctx.buf ("<" ^ name);
 	let open_tag = "<" ^ name in
 	let close_tag = "</" ^ name ^ ">" in
-	let ctx = {
+	let xml_ctx = {
+		lexer_ctx = ctx;
 		open_tag = open_tag;
 		close_tag = close_tag;
 		lexbuf = lexbuf;
 	} in
 	try
-		not_xml ctx 0 (name <> "") (* don't allow self-closing fragments *)
+		not_xml xml_ctx 0 (name <> "") (* don't allow self-closing fragments *)
 	with Exit ->
-		error Unterminated_markup p
+		error ctx Unterminated_markup p

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -78,6 +78,7 @@ type parser_config = {
 	in_display_file : bool;
 	display_mode : DisplayTypes.DisplayMode.t;
 	was_auto_triggered : bool;
+	special_identifier_files : (Path.UniqueKey.t,string) ThreadSafeHashtbl.t option;
 }
 
 type parser_ctx = {
@@ -139,12 +140,13 @@ let create_context lexer_ctx config in_macro code = {
 	config;
 }
 
-let create_config defines in_display in_display_file display_mode was_auto_triggered = {
+let create_config defines in_display in_display_file display_mode was_auto_triggered special_identifier_files = {
 	defines;
 	in_display;
 	in_display_file;
 	display_mode;
 	was_auto_triggered;
+	special_identifier_files;
 }
 
 let s_decl_flag = function
@@ -162,8 +164,6 @@ let syntax_completion kind so p =
 	raise (SyntaxCompletion(kind,DisplayTypes.make_subject so p))
 
 let error m p = raise (Error (m,p))
-
-let special_identifier_files : (Path.UniqueKey.t,string) Hashtbl.t = Hashtbl.create 0
 
 module TokenCache = struct
 	let cache = ref (DynArray.create ())

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -339,9 +339,9 @@ let rec make_meta name params ((v,p2) as e) p1 =
 	| _ -> EMeta((name,params,p1),e),punion p1 p2
 
 let handle_xml_literal p1 =
-	Lexer.reset();
-	let i = Lexer.lex_xml p1.pmin !code_ref in
-	let xml = Lexer.contents() in
+	let lctx = Lexer.create_temp_ctx p1.pfile in
+	let i = Lexer.lex_xml lctx p1.pmin !code_ref in
+	let xml = Lexer.contents lctx in
 	let e = EConst (String(xml,SDoubleQuotes)),{p1 with pmax = i} in (* STRINGTODO: distinct kind? *)
 	let e = make_meta Meta.Markup [] e p1 in
 	e

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -19,7 +19,6 @@
 
 open Ast
 open Globals
-open DisplayTypes.DisplayMode
 open DisplayPosition
 
 type preprocessor_error =
@@ -71,10 +70,18 @@ exception Error of error_msg * pos
 exception TypePath of string list * (string * bool) option * bool (* in import *) * pos
 exception SyntaxCompletion of syntax_completion * DisplayTypes.completion_subject
 
+type parser_config = {
+	defines : Define.define;
+	in_display : bool;
+	in_display_file : bool;
+	display_mode : DisplayTypes.DisplayMode.t;
+}
+
 type parser_ctx = {
 	lexer_ctx : Lexer.lexer_ctx;
 	syntax_errors : (error_msg * pos) list ref;
 	last_doc : (string * int) option ref;
+	config : parser_config;
 }
 
 let error_msg = function
@@ -111,10 +118,18 @@ type 'a parse_result =
 	(* Parsed non-display file with errors *)
 	| ParseError of 'a * parse_error * parse_error list
 
-let create_context lexer_ctx = {
+let create_context lexer_ctx config = {
 	lexer_ctx;
 	syntax_errors = ref [];
 	last_doc = ref None;
+	config;
+}
+
+let create_config defines in_display in_display_file display_mode = {
+	defines;
+	in_display;
+	in_display_file;
+	display_mode;
 }
 
 let s_decl_flag = function
@@ -163,32 +178,24 @@ let next_pos ctx s = pos (next_token ctx s)
 
 (* Global state *)
 
-let in_display = ref false
 let was_auto_triggered = ref false
-let display_mode = ref DMNone
+
 let in_macro = ref false
 let had_resume = ref false
 let code_ref = ref (Sedlexing.Utf8.from_string "")
 let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_subject) option ref = ref None
 
-(* Per-file state *)
-
-let in_display_file = ref false
-
 let reset_state () =
-	in_display := false;
 	was_auto_triggered := false;
-	display_mode := DMNone;
 	display_position#reset;
 	in_macro := false;
 	had_resume := false;
 	code_ref := Sedlexing.Utf8.from_string "";
-	delayed_syntax_completion := None;
-	in_display_file := false
+	delayed_syntax_completion := None
 
 let syntax_error_with_pos ctx error_msg p v =
 	let p = if p.pmax = max_int then {p with pmax = p.pmin + 1} else p in
-	if not !in_display then error error_msg p;
+	if not ctx.config.in_display then error error_msg p;
 	ctx.syntax_errors := (error_msg,p) :: !(ctx.syntax_errors);
 	v
 
@@ -273,7 +280,7 @@ let type_path sl in_import p = match sl with
 	| _ -> raise (TypePath (List.rev sl,None,in_import,p))
 
 let would_skip_display_position ctx p1 plus_one s =
-	if !in_display_file then match Stream.npeek 1 s with
+	if ctx.config.in_display_file then match Stream.npeek 1 s with
 		| [ (_,p2) ] ->
 			let p2 = {p2 with pmin = p1.pmax + (if plus_one then 1 else 0)} in
 			display_position#enclosed_in p2
@@ -367,20 +374,20 @@ let mk_null_expr p = (EConst(Ident "null"),p)
 let mk_display_expr e dk = (EDisplay(e,dk),(pos e))
 
 let is_completion ctx =
-	!display_mode = DMDefault
+	ctx.config.display_mode = DMDefault
 
 let is_signature_display ctx =
-	!display_mode = DMSignature
+	ctx.config.display_mode = DMSignature
 
 let check_resume ctx p fyes fno =
-	if is_completion () && !in_display_file && p.pmax = (display_position#get).pmin then begin
+	if is_completion ctx && ctx.config.in_display_file && p.pmax = (display_position#get).pmin then begin
 		had_resume := true;
 		fyes()
 	end else
 		fno()
 
 let check_resume_range ctx p s fyes fno =
-	if is_completion () && !in_display_file then begin
+	if is_completion ctx && ctx.config.in_display_file then begin
 		let pnext = next_pos ctx s in
 		if p.pmin < (display_position#get).pmin && pnext.pmin >= (display_position#get).pmax then
 			fyes pnext
@@ -401,7 +408,7 @@ let check_completion ctx p0 plus_one s =
 			None
 
 let check_type_decl_flag_completion ctx mode flags s =
-	if not !in_display_file || not (is_completion()) then raise Stream.Failure;
+	if not ctx.config.in_display_file || not (is_completion ctx) then raise Stream.Failure;
 	let mode () = match flags with
 		| [] ->
 			SCTypeDecl mode
@@ -422,7 +429,7 @@ let check_type_decl_flag_completion ctx mode flags s =
 				raise Stream.Failure
 
 let check_type_decl_completion ctx mode pmax s =
-	if !in_display_file && is_completion() then begin
+	if ctx.config.in_display_file && is_completion ctx then begin
 		let pmin = match Stream.peek s with
 			| Some (Eof,_) | None -> max_int
 			| Some tk -> (pos tk).pmin
@@ -440,7 +447,7 @@ let check_type_decl_completion ctx mode pmax s =
 	end
 
 let check_signature_mark ctx e p1 p2 =
-	if not (is_signature_display()) then e
+	if not (is_signature_display ctx) then e
 	else begin
 		let p = punion p1 p2 in
 		if true || not !was_auto_triggered then begin (* TODO: #6383 *)

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -89,6 +89,7 @@ type parser_ctx = {
 	code : Sedlexing.lexbuf;
 	mutable had_resume : bool;
 	delayed_syntax_completion : syntax_completion_on option ref;
+	cache : (token * pos) DynArray.t;
 	config : parser_config;
 }
 
@@ -137,6 +138,7 @@ let create_context lexer_ctx config in_macro code = {
 	code;
 	had_resume = false;
 	delayed_syntax_completion = ref None;
+	cache = DynArray.create ();
 	config;
 }
 
@@ -165,19 +167,9 @@ let syntax_completion kind so p =
 
 let error m p = raise (Error (m,p))
 
-module TokenCache = struct
-	let cache = ref (DynArray.create ())
-	let add (token : (token * pos)) = DynArray.add (!cache) token
-	let get index = DynArray.get (!cache) index
-	let clear () =
-		let old_cache = !cache in
-		cache := DynArray.create ();
-		(fun () -> cache := old_cache)
-end
-
 let last_token ctx s =
 	let n = Stream.count s in
-	TokenCache.get (if n = 0 then 0 else n - 1)
+	DynArray.get ctx.cache (if n = 0 then 0 else n - 1)
 
 let last_pos ctx s = pos (last_token ctx s)
 

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -74,6 +74,7 @@ exception SyntaxCompletion of syntax_completion * DisplayTypes.completion_subjec
 type parser_ctx = {
 	lexer_ctx : Lexer.lexer_ctx;
 	syntax_errors : (error_msg * pos) list ref;
+	last_doc : (string * int) option ref;
 }
 
 let error_msg = function
@@ -113,6 +114,7 @@ type 'a parse_result =
 let create_context lexer_ctx = {
 	lexer_ctx;
 	syntax_errors = ref [];
+	last_doc = ref None;
 }
 
 let s_decl_flag = function
@@ -172,7 +174,6 @@ let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_sub
 (* Per-file state *)
 
 let in_display_file = ref false
-let last_doc : (string * int) option ref = ref None
 
 let reset_state () =
 	in_display := false;
@@ -183,8 +184,7 @@ let reset_state () =
 	had_resume := false;
 	code_ref := Sedlexing.Utf8.from_string "";
 	delayed_syntax_completion := None;
-	in_display_file := false;
-	last_doc := None
+	in_display_file := false
 
 let syntax_error_with_pos ctx error_msg p v =
 	let p = if p.pmax = max_int then {p with pmax = p.pmin + 1} else p in
@@ -205,15 +205,15 @@ let handle_stream_error ctx msg s =
 	in
 	syntax_error ctx err ~pos s ()
 
-let get_doc s =
+let get_doc ctx s =
 	(* do the peek first to make sure we fetch the doc *)
 	match Stream.peek s with
 	| None -> None
 	| Some (tk,p) ->
-		match !last_doc with
+		match !(ctx.last_doc) with
 		| None -> None
 		| Some (d,pos) ->
-			last_doc := None;
+			ctx.last_doc := None;
 			Some d
 
 let unsupported_decl_flag decl flag pos ctx =

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -125,9 +125,7 @@ type parser_display_information = {
 }
 
 type 'a parse_result =
-	(* Parsed non-display-file without errors. *)
 	| ParseSuccess of 'a * parser_display_information
-	(* Parsed non-display file with errors *)
 	| ParseError of 'a * parse_error * parse_error list
 
 let create_context lexer_ctx config in_macro code = {

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -82,6 +82,8 @@ type parser_ctx = {
 	lexer_ctx : Lexer.lexer_ctx;
 	syntax_errors : (error_msg * pos) list ref;
 	last_doc : (string * int) option ref;
+	in_macro : bool;
+	mutable had_resume : bool;
 	config : parser_config;
 }
 
@@ -111,18 +113,22 @@ type parser_display_information = {
 	pd_errors : parse_error list;
 	pd_dead_blocks : (pos * expr) list;
 	pd_conditions : expr list;
+	pd_was_display_file : bool;
+	pd_had_resume : bool;
 }
 
 type 'a parse_result =
 	(* Parsed non-display-file without errors. *)
-	| ParseSuccess of 'a * bool * parser_display_information
+	| ParseSuccess of 'a * parser_display_information
 	(* Parsed non-display file with errors *)
 	| ParseError of 'a * parse_error * parse_error list
 
-let create_context lexer_ctx config = {
+let create_context lexer_ctx config in_macro = {
 	lexer_ctx;
 	syntax_errors = ref [];
 	last_doc = ref None;
+	in_macro;
+	had_resume = false;
 	config;
 }
 
@@ -180,15 +186,11 @@ let next_pos ctx s = pos (next_token ctx s)
 
 (* Global state *)
 
-let in_macro = ref false
-let had_resume = ref false
 let code_ref = ref (Sedlexing.Utf8.from_string "")
 let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_subject) option ref = ref None
 
 let reset_state () =
 	display_position#reset;
-	in_macro := false;
-	had_resume := false;
 	code_ref := Sedlexing.Utf8.from_string "";
 	delayed_syntax_completion := None
 
@@ -380,7 +382,7 @@ let is_signature_display ctx =
 
 let check_resume ctx p fyes fno =
 	if is_completion ctx && ctx.config.in_display_file && p.pmax = (display_position#get).pmin then begin
-		had_resume := true;
+		ctx.had_resume <- true;
 		fyes()
 	end else
 		fno()

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -66,9 +66,11 @@ type 'a sequence_parsing_result =
 	| End of pos
 	| Error of string
 
+type syntax_completion_on = syntax_completion * DisplayTypes.completion_subject
+
 exception Error of error_msg * pos
 exception TypePath of string list * (string * bool) option * bool (* in import *) * pos
-exception SyntaxCompletion of syntax_completion * DisplayTypes.completion_subject
+exception SyntaxCompletion of syntax_completion_on
 
 type parser_config = {
 	defines : Define.define;
@@ -85,6 +87,7 @@ type parser_ctx = {
 	in_macro : bool;
 	code : Sedlexing.lexbuf;
 	mutable had_resume : bool;
+	delayed_syntax_completion : syntax_completion_on option ref;
 	config : parser_config;
 }
 
@@ -116,6 +119,7 @@ type parser_display_information = {
 	pd_conditions : expr list;
 	pd_was_display_file : bool;
 	pd_had_resume : bool;
+	pd_delayed_syntax_completion : syntax_completion_on option;
 }
 
 type 'a parse_result =
@@ -131,6 +135,7 @@ let create_context lexer_ctx config in_macro code = {
 	in_macro;
 	code;
 	had_resume = false;
+	delayed_syntax_completion = ref None;
 	config;
 }
 
@@ -188,11 +193,8 @@ let next_pos ctx s = pos (next_token ctx s)
 
 (* Global state *)
 
-let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_subject) option ref = ref None
-
 let reset_state () =
-	display_position#reset;
-	delayed_syntax_completion := None
+	display_position#reset
 
 let syntax_error_with_pos ctx error_msg p v =
 	let p = if p.pmax = max_int then {p with pmax = p.pmin + 1} else p in
@@ -273,8 +275,8 @@ let magic_type_ct p = make_ptp_ct magic_type_path p
 
 let magic_type_th p = magic_type_ct p,p
 
-let delay_syntax_completion kind so p =
-	delayed_syntax_completion := Some(kind,DisplayTypes.make_subject so p)
+let delay_syntax_completion ctx kind so p =
+	ctx.delayed_syntax_completion := Some(kind,DisplayTypes.make_subject so p)
 
 let type_path sl in_import p = match sl with
 	| n :: l when n.[0] >= 'A' && n.[0] <= 'Z' -> raise (TypePath (List.rev l,Some (n,false),in_import,p));
@@ -443,7 +445,7 @@ let check_type_decl_completion ctx mode pmax s =
 			| Some(e,p) -> None,p
 			| _ -> None,p
 			in
-			delay_syntax_completion (SCTypeDecl mode) so p
+			delay_syntax_completion ctx (SCTypeDecl mode) so p
 		end
 	end
 

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -83,12 +83,12 @@ type parser_config = {
 
 type parser_ctx = {
 	lexer_ctx : Lexer.lexer_ctx;
-	syntax_errors : (error_msg * pos) list ref;
-	last_doc : (string * int) option ref;
+	mutable syntax_errors : (error_msg * pos) list;
+	mutable last_doc : (string * int) option;
 	in_macro : bool;
 	code : Sedlexing.lexbuf;
 	mutable had_resume : bool;
-	delayed_syntax_completion : syntax_completion_on option ref;
+	mutable delayed_syntax_completion : syntax_completion_on option;
 	cache : (token * pos) DynArray.t;
 	config : parser_config;
 }
@@ -132,12 +132,12 @@ type 'a parse_result =
 
 let create_context lexer_ctx config in_macro code = {
 	lexer_ctx;
-	syntax_errors = ref [];
-	last_doc = ref None;
+	syntax_errors = [];
+	last_doc = None;
 	in_macro;
 	code;
 	had_resume = false;
-	delayed_syntax_completion = ref None;
+	delayed_syntax_completion = None;
 	cache = DynArray.create ();
 	config;
 }
@@ -183,15 +183,13 @@ let next_token ctx s = match Stream.peek s with
 
 let next_pos ctx s = pos (next_token ctx s)
 
-(* Global state *)
-
 let reset_state () =
 	display_position#reset
 
 let syntax_error_with_pos ctx error_msg p v =
 	let p = if p.pmax = max_int then {p with pmax = p.pmin + 1} else p in
 	if not ctx.config.in_display then error error_msg p;
-	ctx.syntax_errors := (error_msg,p) :: !(ctx.syntax_errors);
+	ctx.syntax_errors <- (error_msg,p) :: ctx.syntax_errors;
 	v
 
 let syntax_error ctx error_msg ?(pos=None) s v =
@@ -212,10 +210,10 @@ let get_doc ctx s =
 	match Stream.peek s with
 	| None -> None
 	| Some (tk,p) ->
-		match !(ctx.last_doc) with
+		match ctx.last_doc with
 		| None -> None
 		| Some (d,pos) ->
-			ctx.last_doc := None;
+			ctx.last_doc <- None;
 			Some d
 
 let unsupported_decl_flag decl flag pos ctx =
@@ -268,7 +266,7 @@ let magic_type_ct p = make_ptp_ct magic_type_path p
 let magic_type_th p = magic_type_ct p,p
 
 let delay_syntax_completion ctx kind so p =
-	ctx.delayed_syntax_completion := Some(kind,DisplayTypes.make_subject so p)
+	ctx.delayed_syntax_completion <- Some(kind,DisplayTypes.make_subject so p)
 
 let type_path sl in_import p = match sl with
 	| n :: l when n.[0] >= 'A' && n.[0] <= 'Z' -> raise (TypePath (List.rev l,Some (n,false),in_import,p));

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -22,10 +22,6 @@ open Globals
 open DisplayTypes.DisplayMode
 open DisplayPosition
 
-type parser_ctx = {
-	lexer_ctx : Lexer.lexer_ctx;
-}
-
 type preprocessor_error =
 	| InvalidEnd
 	| InvalidElse
@@ -75,6 +71,11 @@ exception Error of error_msg * pos
 exception TypePath of string list * (string * bool) option * bool (* in import *) * pos
 exception SyntaxCompletion of syntax_completion * DisplayTypes.completion_subject
 
+type parser_ctx = {
+	lexer_ctx : Lexer.lexer_ctx;
+	syntax_errors : (error_msg * pos) list ref;
+}
+
 let error_msg = function
 	| Unexpected (Kwd k) -> "Unexpected keyword \""^(s_keyword k)^"\""
 	| Unexpected t -> "Unexpected "^(s_token t)
@@ -111,6 +112,7 @@ type 'a parse_result =
 
 let create_context lexer_ctx = {
 	lexer_ctx;
+	syntax_errors = ref [];
 }
 
 let s_decl_flag = function
@@ -171,7 +173,6 @@ let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_sub
 
 let in_display_file = ref false
 let last_doc : (string * int) option ref = ref None
-let syntax_errors = ref []
 
 let reset_state () =
 	in_display := false;
@@ -183,18 +184,17 @@ let reset_state () =
 	code_ref := Sedlexing.Utf8.from_string "";
 	delayed_syntax_completion := None;
 	in_display_file := false;
-	last_doc := None;
-	syntax_errors := []
+	last_doc := None
 
-let syntax_error_with_pos error_msg p v =
+let syntax_error_with_pos ctx error_msg p v =
 	let p = if p.pmax = max_int then {p with pmax = p.pmin + 1} else p in
 	if not !in_display then error error_msg p;
-	syntax_errors := (error_msg,p) :: !syntax_errors;
+	ctx.syntax_errors := (error_msg,p) :: !(ctx.syntax_errors);
 	v
 
 let syntax_error ctx error_msg ?(pos=None) s v =
 	let p = (match pos with Some p -> p | None -> next_pos ctx s) in
-	syntax_error_with_pos error_msg p v
+	syntax_error_with_pos ctx error_msg p v
 
 let handle_stream_error ctx msg s =
 	let err,pos = if msg = "Parse error." then begin
@@ -216,9 +216,9 @@ let get_doc s =
 			last_doc := None;
 			Some d
 
-let unsupported_decl_flag decl flag pos =
+let unsupported_decl_flag decl flag pos ctx =
 	let msg = (s_decl_flag flag) ^ " modifier is not supported for " ^ decl in
-	syntax_error_with_pos (Custom msg) pos None
+	syntax_error_with_pos ctx (Custom msg) pos None
 
 let unsupported_decl_flag_class = unsupported_decl_flag "classes"
 let unsupported_decl_flag_enum = unsupported_decl_flag "enums"
@@ -226,35 +226,35 @@ let unsupported_decl_flag_abstract = unsupported_decl_flag "abstracts"
 let unsupported_decl_flag_typedef = unsupported_decl_flag "typedefs"
 let unsupported_decl_flag_module_field = unsupported_decl_flag "module-level fields"
 
-let decl_flag_to_class_flag (flag,p) = match flag with
+let decl_flag_to_class_flag ctx (flag,p) = match flag with
 	| DPrivate -> Some HPrivate
 	| DExtern -> Some HExtern
 	| DFinal -> Some HFinal
-	| DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_class flag p
+	| DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_class flag p ctx
 
-let decl_flag_to_enum_flag (flag,p) = match flag with
+let decl_flag_to_enum_flag ctx (flag,p) = match flag with
 	| DPrivate -> Some EPrivate
 	| DExtern -> Some EExtern
-	| DFinal | DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_enum flag p
+	| DFinal | DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_enum flag p ctx
 
-let decl_flag_to_abstract_flag (flag,p) = match flag with
+let decl_flag_to_abstract_flag ctx (flag,p) = match flag with
 	| DPrivate -> Some AbPrivate
 	| DExtern -> Some AbExtern
-	| DFinal | DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_abstract flag p
+	| DFinal | DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_abstract flag p ctx
 
-let decl_flag_to_typedef_flag (flag,p) = match flag with
+let decl_flag_to_typedef_flag ctx (flag,p) = match flag with
 	| DPrivate -> Some TDPrivate
 	| DExtern -> Some TDExtern
-	| DFinal | DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_typedef flag p
+	| DFinal | DMacro | DDynamic | DInline | DPublic | DStatic | DOverload -> unsupported_decl_flag_typedef flag p ctx
 
-let decl_flag_to_module_field_flag (flag,p) = match flag with
+let decl_flag_to_module_field_flag ctx (flag,p) = match flag with
 	| DPrivate -> Some (APrivate,p)
 	| DMacro -> Some (AMacro,p)
 	| DDynamic -> Some (ADynamic,p)
 	| DInline -> Some (AInline,p)
 	| DOverload -> Some (AOverload,p)
 	| DExtern -> Some (AExtern,p)
-	| DFinal | DPublic | DStatic -> unsupported_decl_flag_module_field flag p
+	| DFinal | DPublic | DStatic -> unsupported_decl_flag_module_field flag p ctx
 
 let serror() = raise (Stream.Error "Parse error.")
 
@@ -452,8 +452,8 @@ let check_signature_mark ctx e p1 p2 =
 		end
 	end
 
-let convert_abstract_flags flags =
-	ExtList.List.filter_map decl_flag_to_abstract_flag flags
+let convert_abstract_flags ctx flags =
+	ExtList.List.filter_map (decl_flag_to_abstract_flag ctx) flags
 
 let no_keyword what s =
 	match Stream.peek s with

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -83,6 +83,7 @@ type parser_ctx = {
 	syntax_errors : (error_msg * pos) list ref;
 	last_doc : (string * int) option ref;
 	in_macro : bool;
+	code : Sedlexing.lexbuf;
 	mutable had_resume : bool;
 	config : parser_config;
 }
@@ -123,11 +124,12 @@ type 'a parse_result =
 	(* Parsed non-display file with errors *)
 	| ParseError of 'a * parse_error * parse_error list
 
-let create_context lexer_ctx config in_macro = {
+let create_context lexer_ctx config in_macro code = {
 	lexer_ctx;
 	syntax_errors = ref [];
 	last_doc = ref None;
 	in_macro;
+	code;
 	had_resume = false;
 	config;
 }
@@ -186,12 +188,10 @@ let next_pos ctx s = pos (next_token ctx s)
 
 (* Global state *)
 
-let code_ref = ref (Sedlexing.Utf8.from_string "")
 let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_subject) option ref = ref None
 
 let reset_state () =
 	display_position#reset;
-	code_ref := Sedlexing.Utf8.from_string "";
 	delayed_syntax_completion := None
 
 let syntax_error_with_pos ctx error_msg p v =
@@ -356,7 +356,7 @@ let rec make_meta name params ((v,p2) as e) p1 =
 
 let handle_xml_literal ctx p1 =
 	Lexer.reset ctx.lexer_ctx;
-	let i = Lexer.lex_xml ctx.lexer_ctx p1.pmin !code_ref in
+	let i = Lexer.lex_xml ctx.lexer_ctx p1.pmin ctx.code in
 	let xml = Lexer.contents ctx.lexer_ctx in
 	let e = EConst (String(xml,SDoubleQuotes)),{p1 with pmax = i} in (* STRINGTODO: distinct kind? *)
 	let e = make_meta Meta.Markup [] e p1 in

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -75,6 +75,7 @@ type parser_config = {
 	in_display : bool;
 	in_display_file : bool;
 	display_mode : DisplayTypes.DisplayMode.t;
+	was_auto_triggered : bool;
 }
 
 type parser_ctx = {
@@ -125,11 +126,12 @@ let create_context lexer_ctx config = {
 	config;
 }
 
-let create_config defines in_display in_display_file display_mode = {
+let create_config defines in_display in_display_file display_mode was_auto_triggered = {
 	defines;
 	in_display;
 	in_display_file;
 	display_mode;
+	was_auto_triggered;
 }
 
 let s_decl_flag = function
@@ -178,15 +180,12 @@ let next_pos ctx s = pos (next_token ctx s)
 
 (* Global state *)
 
-let was_auto_triggered = ref false
-
 let in_macro = ref false
 let had_resume = ref false
 let code_ref = ref (Sedlexing.Utf8.from_string "")
 let delayed_syntax_completion : (syntax_completion * DisplayTypes.completion_subject) option ref = ref None
 
 let reset_state () =
-	was_auto_triggered := false;
 	display_position#reset;
 	in_macro := false;
 	had_resume := false;
@@ -450,7 +449,7 @@ let check_signature_mark ctx e p1 p2 =
 	if not (is_signature_display ctx) then e
 	else begin
 		let p = punion p1 p2 in
-		if true || not !was_auto_triggered then begin (* TODO: #6383 *)
+		if true || not ctx.config.was_auto_triggered then begin (* TODO: #6383 *)
 			if encloses_position_gt display_position#get p then (mk_display_expr e DKMarked)
 			else e
 		end else begin

--- a/src/syntax/parser.ml
+++ b/src/syntax/parser.ml
@@ -22,6 +22,10 @@ open Globals
 open DisplayTypes.DisplayMode
 open DisplayPosition
 
+type parser_ctx = {
+	lexer_ctx : Lexer.lexer_ctx;
+}
+
 type preprocessor_error =
 	| InvalidEnd
 	| InvalidElse
@@ -105,6 +109,10 @@ type 'a parse_result =
 	(* Parsed non-display file with errors *)
 	| ParseError of 'a * parse_error * parse_error list
 
+let create_context lexer_ctx = {
+	lexer_ctx;
+}
+
 let s_decl_flag = function
 	| DPrivate -> "private"
 	| DExtern -> "extern"
@@ -133,21 +141,21 @@ module TokenCache = struct
 		(fun () -> cache := old_cache)
 end
 
-let last_token s =
+let last_token ctx s =
 	let n = Stream.count s in
 	TokenCache.get (if n = 0 then 0 else n - 1)
 
-let last_pos s = pos (last_token s)
+let last_pos ctx s = pos (last_token ctx s)
 
-let next_token s = match Stream.peek s with
+let next_token ctx s = match Stream.peek s with
 	| Some (Eof,p) ->
 		(Eof,p)
 	| Some tk -> tk
 	| None ->
-		let last_pos = pos (last_token s) in
+		let last_pos = pos (last_token ctx s) in
 		(Eof,last_pos)
 
-let next_pos s = pos (next_token s)
+let next_pos ctx s = pos (next_token ctx s)
 
 (* Global state *)
 
@@ -184,18 +192,18 @@ let syntax_error_with_pos error_msg p v =
 	syntax_errors := (error_msg,p) :: !syntax_errors;
 	v
 
-let syntax_error error_msg ?(pos=None) s v =
-	let p = (match pos with Some p -> p | None -> next_pos s) in
+let syntax_error ctx error_msg ?(pos=None) s v =
+	let p = (match pos with Some p -> p | None -> next_pos ctx s) in
 	syntax_error_with_pos error_msg p v
 
-let handle_stream_error msg s =
+let handle_stream_error ctx msg s =
 	let err,pos = if msg = "Parse error." then begin
-		let tk,pos = next_token s in
+		let tk,pos = next_token ctx s in
 		(Unexpected tk),Some pos
 	end else
 		(StreamError msg),None
 	in
-	syntax_error err ~pos s ()
+	syntax_error ctx err ~pos s ()
 
 let get_doc s =
 	(* do the peek first to make sure we fetch the doc *)
@@ -264,7 +272,7 @@ let type_path sl in_import p = match sl with
 	| n :: l when n.[0] >= 'A' && n.[0] <= 'Z' -> raise (TypePath (List.rev l,Some (n,false),in_import,p));
 	| _ -> raise (TypePath (List.rev sl,None,in_import,p))
 
-let would_skip_display_position p1 plus_one s =
+let would_skip_display_position ctx p1 plus_one s =
 	if !in_display_file then match Stream.npeek 1 s with
 		| [ (_,p2) ] ->
 			let p2 = {p2 with pmin = p1.pmax + (if plus_one then 1 else 0)} in
@@ -338,16 +346,16 @@ let rec make_meta name params ((v,p2) as e) p1 =
 	| ETernary (e1,e2,e3) -> ETernary (make_meta name params e1 p1 , e2, e3), punion p1 p2
 	| _ -> EMeta((name,params,p1),e),punion p1 p2
 
-let handle_xml_literal p1 =
-	let lctx = Lexer.create_temp_ctx p1.pfile in
-	let i = Lexer.lex_xml lctx p1.pmin !code_ref in
-	let xml = Lexer.contents lctx in
+let handle_xml_literal ctx p1 =
+	Lexer.reset ctx.lexer_ctx;
+	let i = Lexer.lex_xml ctx.lexer_ctx p1.pmin !code_ref in
+	let xml = Lexer.contents ctx.lexer_ctx in
 	let e = EConst (String(xml,SDoubleQuotes)),{p1 with pmax = i} in (* STRINGTODO: distinct kind? *)
 	let e = make_meta Meta.Markup [] e p1 in
 	e
 
-let punion_next p1 s =
-	let _,p2 = next_token s in
+let punion_next ctx p1 s =
+	let _,p2 = next_token ctx s in
 	{
 		pfile = p1.pfile;
 		pmin = p1.pmin;
@@ -358,22 +366,22 @@ let mk_null_expr p = (EConst(Ident "null"),p)
 
 let mk_display_expr e dk = (EDisplay(e,dk),(pos e))
 
-let is_completion () =
+let is_completion ctx =
 	!display_mode = DMDefault
 
-let is_signature_display () =
+let is_signature_display ctx =
 	!display_mode = DMSignature
 
-let check_resume p fyes fno =
+let check_resume ctx p fyes fno =
 	if is_completion () && !in_display_file && p.pmax = (display_position#get).pmin then begin
 		had_resume := true;
 		fyes()
 	end else
 		fno()
 
-let check_resume_range p s fyes fno =
+let check_resume_range ctx p s fyes fno =
 	if is_completion () && !in_display_file then begin
-		let pnext = next_pos s in
+		let pnext = next_pos ctx s in
 		if p.pmin < (display_position#get).pmin && pnext.pmin >= (display_position#get).pmax then
 			fyes pnext
 		else
@@ -381,18 +389,18 @@ let check_resume_range p s fyes fno =
 	end else
 		fno()
 
-let check_completion p0 plus_one s =
+let check_completion ctx p0 plus_one s =
 	match Stream.peek s with
 	| Some((Const(Ident name),p)) when display_position#enclosed_in p ->
 		Stream.junk s;
 		(Some(Some name,p))
 	| _ ->
-		if would_skip_display_position p0 plus_one s then
+		if would_skip_display_position ctx p0 plus_one s then
 			Some(None,DisplayPosition.display_position#with_pos p0)
 		else
 			None
 
-let check_type_decl_flag_completion mode flags s =
+let check_type_decl_flag_completion ctx mode flags s =
 	if not !in_display_file || not (is_completion()) then raise Stream.Failure;
 	let mode () = match flags with
 		| [] ->
@@ -407,13 +415,13 @@ let check_type_decl_flag_completion mode flags s =
 			the parser would fail otherwise anyway. *)
 		| Some((Const(Ident name),p)) when display_position#enclosed_in p -> syntax_completion (mode()) (Some name) p
 		| _ -> match flags with
-			| (_,p) :: _ when would_skip_display_position p true s ->
+			| (_,p) :: _ when would_skip_display_position ctx p true s ->
 				let flags = List.map fst flags in
 				syntax_completion (SCAfterTypeFlag flags) None (DisplayPosition.display_position#with_pos p)
 			| _ ->
 				raise Stream.Failure
 
-let check_type_decl_completion mode pmax s =
+let check_type_decl_completion ctx mode pmax s =
 	if !in_display_file && is_completion() then begin
 		let pmin = match Stream.peek s with
 			| Some (Eof,_) | None -> max_int
@@ -431,7 +439,7 @@ let check_type_decl_completion mode pmax s =
 		end
 	end
 
-let check_signature_mark e p1 p2 =
+let check_signature_mark ctx e p1 p2 =
 	if not (is_signature_display()) then e
 	else begin
 		let p = punion p1 p2 in

--- a/src/syntax/parserConfig.ml
+++ b/src/syntax/parserConfig.ml
@@ -9,4 +9,4 @@ let file_parser_config com file =
 	let open DisplayPosition in
 	let in_display = display_position#get <> null_pos in
 	let in_display_file = in_display && display_position#is_in_file (Path.UniqueKey.create file) in
-	Parser.create_config com.defines in_display in_display_file com.display.dms_kind com.was_auto_triggered (Some com.special_identifier_files)
+	Parser.create_config com.defines in_display in_display_file com.display.dms_kind com.parser_state.was_auto_triggered (Some com.parser_state.special_identifier_files)

--- a/src/syntax/parserConfig.ml
+++ b/src/syntax/parserConfig.ml
@@ -3,10 +3,10 @@ open Common
 open DisplayPosition
 
 let default_config defines =
-	Parser.create_config defines false false DMNone false
+	Parser.create_config defines false false DMNone false None
 
 let file_parser_config com file =
 	let open DisplayPosition in
 	let in_display = display_position#get <> null_pos in
 	let in_display_file = in_display && display_position#is_in_file (Path.UniqueKey.create file) in
-	Parser.create_config com.defines in_display in_display_file com.display.dms_kind com.was_auto_triggered
+	Parser.create_config com.defines in_display in_display_file com.display.dms_kind com.was_auto_triggered (Some com.special_identifier_files)

--- a/src/syntax/parserConfig.ml
+++ b/src/syntax/parserConfig.ml
@@ -1,0 +1,12 @@
+open Globals
+open Common
+open DisplayPosition
+
+let default_config defines =
+	Parser.create_config defines false false DMNone
+
+let file_parser_config com file =
+	let open DisplayPosition in
+	let in_display = display_position#get <> null_pos in
+	let in_display_file = in_display && display_position#is_in_file (Path.UniqueKey.create file) in
+	Parser.create_config com.defines in_display in_display_file com.display.dms_kind

--- a/src/syntax/parserConfig.ml
+++ b/src/syntax/parserConfig.ml
@@ -3,10 +3,10 @@ open Common
 open DisplayPosition
 
 let default_config defines =
-	Parser.create_config defines false false DMNone
+	Parser.create_config defines false false DMNone false
 
 let file_parser_config com file =
 	let open DisplayPosition in
 	let in_display = display_position#get <> null_pos in
 	let in_display_file = in_display && display_position#is_in_file (Path.UniqueKey.create file) in
-	Parser.create_config com.defines in_display in_display_file com.display.dms_kind
+	Parser.create_config com.defines in_display in_display_file com.display.dms_kind com.was_auto_triggered

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -393,19 +393,22 @@ let parse_string entry defines s p error inlined =
 		end;
 		syntax_errors := old_syntax_errors;
 	in
-	let lctx = if inlined then begin
-		begin try
-			let old_file = ThreadSafeHashtbl.find Lexer.all_files p.pfile in
-			let new_file = Lexer.make_file p.pfile in
-			Lexer.copy_file old_file new_file;
-			Lexer.create_context new_file
-		with Not_found ->
-			Lexer.create_temp_ctx p.pfile
-		end
-	end else begin
+	let lctx = if inlined then
+		(* In inline mode, we always work with a temp context. *)
+		Lexer.create_temp_ctx p.pfile
+	else begin
 		display_position#reset;
 		in_display_file := false;
-		Lexer.create_temp_ctx p.pfile
+		try
+			let old_file = ThreadSafeHashtbl.find Lexer.all_files p.pfile in
+			(* If the file exists we work with a copy of it. This prevents any mutations from messing
+				up the orignal state. Note that we still don't use a real file context here, so the
+				data is not added to all_files. *)
+			let new_file = Lexer.copy_file old_file in
+			Lexer.create_context new_file
+		with Not_found ->
+			(* Otherwise we have to work with a temp file. *)
+			Lexer.create_temp_ctx p.pfile
 	end in
 	let result = try
 		parse entry lctx defines (Sedlexing.Utf8.from_string s) p.pfile

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -210,6 +210,8 @@ end
 
 (* parse main *)
 let parse entry lctx defines code file =
+	let pctx = Parser.create_context lctx in
+	let entry = entry pctx in
 	let restore_cache = TokenCache.clear () in
 	let was_display = !in_display in
 	let was_display_file = !in_display_file in
@@ -241,7 +243,7 @@ let parse entry lctx defines code file =
 	let dbc = new dead_block_collector conds in
 	let sraw = Stream.from (fun _ -> Some (Lexer.sharp_token lctx code)) in
 	let preprocessor_error ppe pos tk =
-		syntax_error (Preprocessor_error ppe) ~pos:(Some pos) sraw tk
+		syntax_error pctx (Preprocessor_error ppe) ~pos:(Some pos) sraw tk
 	in
 	let rec next_token() = process_token (Lexer.token lctx code)
 
@@ -266,7 +268,7 @@ let parse entry lctx defines code file =
 			conds#cond_end (snd tk);
 			next_token()
 		| Sharp "elseif" ->
-			let _,(e,pe) = parse_macro_cond sraw in
+			let _,(e,pe) = parse_macro_cond pctx sraw in
 			conds#cond_elseif (e,pe) (snd tk);
 			dbc#open_dead_block pe;
 			let tk = skip_tokens (pos tk) false in
@@ -295,7 +297,7 @@ let parse entry lctx defines code file =
 			tk
 
 	and enter_macro is_if p =
-		let tk, e = parse_macro_cond sraw in
+		let tk, e = parse_macro_cond pctx sraw in
 		(if is_if then conds#cond_if e else conds#cond_elseif e p);
 		let tk = (match tk with None -> Lexer.token lctx code | Some tk -> tk) in
 		if is_true (eval defines e) then begin
@@ -313,7 +315,7 @@ let parse entry lctx defines code file =
 			Lexer.token lctx code
 		| Sharp "elseif" when not test ->
 			dbc#close_dead_block (pos tk);
-			let _,(e,pe) = parse_macro_cond sraw in
+			let _,(e,pe) = parse_macro_cond pctx sraw in
 			conds#cond_elseif (e,pe) (snd tk);
 			dbc#open_dead_block pe;
 			skip_tokens p test
@@ -330,7 +332,7 @@ let parse entry lctx defines code file =
 			dbc#close_dead_block (pos tk);
 			enter_macro false (snd tk)
 		| Sharp "if" ->
-			let _,e = parse_macro_cond sraw in
+			let _,e = parse_macro_cond pctx sraw in
 			conds#cond_if e;
 			dbc#open_dead_block (pos e);
 			let tk = skip_tokens p false in
@@ -374,7 +376,7 @@ let parse entry lctx defines code file =
 	with
 		| Stream.Error _
 		| Stream.Failure ->
-			let last = (match Stream.peek s with None -> last_token s | Some t -> t) in
+			let last = (match Stream.peek s with None -> last_token pctx s | Some t -> t) in
 			restore();
 			error (Unexpected (fst last)) (pos last)
 		| e ->

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -209,23 +209,18 @@ class dead_block_collector conds = object(self)
 end
 
 (* parse main *)
-let parse entry lctx defines code file =
-	let pctx = Parser.create_context lctx in
-	let entry = entry pctx in
+let parse config entry lctx code file =
+	let ctx = Parser.create_context lctx config in
+	let defines = config.defines in
+	let entry = entry ctx in
 	let restore_cache = TokenCache.clear () in
-	let was_display = !in_display in
-	let was_display_file = !in_display_file in
 	let old_code = !code_ref in
 	let old_macro = !in_macro in
 	code_ref := code;
-	in_display := display_position#get <> null_pos;
-	in_display_file := !in_display && display_position#is_in_file (Path.UniqueKey.create file);
 	let restore =
 		(fun () ->
 			restore_cache ();
-			in_display := was_display;
 			in_macro := old_macro;
-			in_display_file := was_display_file;
 			code_ref := old_code;
 		)
 	in
@@ -241,7 +236,7 @@ let parse entry lctx defines code file =
 	let dbc = new dead_block_collector conds in
 	let sraw = Stream.from (fun _ -> Some (Lexer.sharp_token lctx code)) in
 	let preprocessor_error ppe pos tk =
-		syntax_error pctx (Preprocessor_error ppe) ~pos:(Some pos) sraw tk
+		syntax_error ctx (Preprocessor_error ppe) ~pos:(Some pos) sraw tk
 	in
 	let rec next_token() = process_token (Lexer.token lctx code)
 
@@ -250,14 +245,14 @@ let parse entry lctx defines code file =
 		| Comment s ->
 			(* if encloses_resume (pos tk) then syntax_completion SCComment (pos tk); *)
 			let l = String.length s in
-			if l > 0 && s.[0] = '*' then pctx.last_doc := Some (String.sub s 1 (l - (if l > 1 && s.[l-1] = '*' then 2 else 1)), (snd tk).pmin);
+			if l > 0 && s.[0] = '*' then ctx.last_doc := Some (String.sub s 1 (l - (if l > 1 && s.[l-1] = '*' then 2 else 1)), (snd tk).pmin);
 			let tk = next_token() in
 			tk
 		| CommentLine s ->
-			if !in_display_file then begin
+			if ctx.config.in_display_file then begin
 				let p = pos tk in
 				(* Completion at the / should not pick up the comment (issue #9133) *)
-				let p = if is_completion() then {p with pmin = p.pmin + 1} else p in
+				let p = if is_completion ctx then {p with pmin = p.pmin + 1} else p in
 				(* The > 0 check is to deal with the special case of line comments at the beginning of the file (issue #10322) *)
 				if display_position#enclosed_in p && p.pmin > 0 then syntax_completion SCComment None (pos tk);
 			end;
@@ -266,7 +261,7 @@ let parse entry lctx defines code file =
 			conds#cond_end (snd tk);
 			next_token()
 		| Sharp "elseif" ->
-			let _,(e,pe) = parse_macro_cond pctx sraw in
+			let _,(e,pe) = parse_macro_cond ctx sraw in
 			conds#cond_elseif (e,pe) (snd tk);
 			dbc#open_dead_block pe;
 			let tk = skip_tokens (pos tk) false in
@@ -295,7 +290,7 @@ let parse entry lctx defines code file =
 			tk
 
 	and enter_macro is_if p =
-		let tk, e = parse_macro_cond pctx sraw in
+		let tk, e = parse_macro_cond ctx sraw in
 		(if is_if then conds#cond_if e else conds#cond_elseif e p);
 		let tk = (match tk with None -> Lexer.token lctx code | Some tk -> tk) in
 		if is_true (eval defines e) then begin
@@ -313,7 +308,7 @@ let parse entry lctx defines code file =
 			Lexer.token lctx code
 		| Sharp "elseif" when not test ->
 			dbc#close_dead_block (pos tk);
-			let _,(e,pe) = parse_macro_cond pctx sraw in
+			let _,(e,pe) = parse_macro_cond ctx sraw in
 			conds#cond_elseif (e,pe) (snd tk);
 			dbc#open_dead_block pe;
 			skip_tokens p test
@@ -330,7 +325,7 @@ let parse entry lctx defines code file =
 			dbc#close_dead_block (pos tk);
 			enter_macro false (snd tk)
 		| Sharp "if" ->
-			let _,e = parse_macro_cond pctx sraw in
+			let _,e = parse_macro_cond ctx sraw in
 			conds#cond_if e;
 			dbc#open_dead_block (pos e);
 			let tk = skip_tokens p false in
@@ -362,41 +357,41 @@ let parse entry lctx defines code file =
 			| Some (tok,p) ->
 				error (Unexpected tok) p (* This isn't *)
 		end;
-		let was_display_file = !in_display_file in
+		let was_display_file = ctx.config.in_display_file in
 		restore();
-		let pdi = {pd_errors = List.rev !(pctx.syntax_errors);pd_dead_blocks = dbc#get_dead_blocks;pd_conditions = conds#get_conditions} in
+		let pdi = {pd_errors = List.rev !(ctx.syntax_errors);pd_dead_blocks = dbc#get_dead_blocks;pd_conditions = conds#get_conditions} in
 		if was_display_file then
 			ParseSuccess(l,true,pdi)
-		else begin match List.rev !(pctx.syntax_errors) with
+		else begin match List.rev !(ctx.syntax_errors) with
 			| [] -> ParseSuccess(l,false,pdi)
 			| error :: errors -> ParseError(l,error,errors)
 		end
 	with
 		| Stream.Error _
 		| Stream.Failure ->
-			let last = (match Stream.peek s with None -> last_token pctx s | Some t -> t) in
+			let last = (match Stream.peek s with None -> last_token ctx s | Some t -> t) in
 			restore();
 			error (Unexpected (fst last)) (pos last)
 		| e ->
 			restore();
 			raise e
 
-let parse_string entry defines s p error inlined =
+let parse_string config entry s p error inlined =
 	let old_display = display_position#get in
-	let old_in_display_file = !in_display_file in
 	let restore() =
 		if not inlined then begin
 			display_position#set old_display;
-			in_display_file := old_in_display_file;
 		end;
 	in
 	let lctx = Lexer.create_temp_ctx p.pfile in
-	if not inlined then begin
+	let config = if not inlined then begin
 		display_position#reset;
-		in_display_file := false;
-	end;
+		{ config with in_display_file = false }
+	end else
+		config
+	in
 	let result = try
-		parse entry lctx defines (Sedlexing.Utf8.from_string s) p.pfile
+		parse config entry lctx (Sedlexing.Utf8.from_string s) p.pfile
 	with Error (e,pe) ->
 		restore();
 		error (error_msg e) (if inlined then pe else p)
@@ -410,9 +405,9 @@ let parse_string entry defines s p error inlined =
 	restore();
 	result
 
-let parse_expr_string defines s p error inl =
+let parse_expr_string config s p error inl =
 	let s = if p.pmin > 0 then (String.make p.pmin ' ') ^ s else s in
-	let result = parse_string expr defines s p error inl in
+	let result = parse_string config expr s p error inl in
 	if inl then
 		result
 	else begin

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -214,12 +214,6 @@ let parse config entry lctx code file =
 	let in_macro = Define.defined defines Define.Macro in
 	let ctx = Parser.create_context lctx config in_macro code in
 	let entry = entry ctx in
-	let restore_cache = TokenCache.clear () in
-	let restore =
-		(fun () ->
-			restore_cache ();
-		)
-	in
 	Lexer.skip_header code;
 
 	let sharp_error s p =
@@ -339,7 +333,7 @@ let parse config entry lctx code file =
 	in
 	let s = Stream.from (fun _ ->
 		let t = next_token() in
-		TokenCache.add t;
+		DynArray.add ctx.cache t;
 		Some t
 	) in
 	try
@@ -353,7 +347,6 @@ let parse config entry lctx code file =
 				error (Unexpected tok) p (* This isn't *)
 		end;
 		let was_display_file = ctx.config.in_display_file in
-		restore();
 		let pdi = {
 			pd_errors = List.rev !(ctx.syntax_errors);
 			pd_dead_blocks = dbc#get_dead_blocks;
@@ -372,11 +365,7 @@ let parse config entry lctx code file =
 		| Stream.Error _
 		| Stream.Failure ->
 			let last = (match Stream.peek s with None -> last_token ctx s | Some t -> t) in
-			restore();
 			error (Unexpected (fst last)) (pos last)
-		| e ->
-			restore();
-			raise e
 
 let parse_string config entry s p error inlined =
 	let old_display = display_position#get in

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -229,7 +229,6 @@ let parse entry lctx defines code file =
 			code_ref := old_code;
 		)
 	in
-	last_doc := None;
 	in_macro := Define.defined defines Define.Macro;
 	Lexer.skip_header code;
 
@@ -251,7 +250,7 @@ let parse entry lctx defines code file =
 		| Comment s ->
 			(* if encloses_resume (pos tk) then syntax_completion SCComment (pos tk); *)
 			let l = String.length s in
-			if l > 0 && s.[0] = '*' then last_doc := Some (String.sub s 1 (l - (if l > 1 && s.[l-1] = '*' then 2 else 1)), (snd tk).pmin);
+			if l > 0 && s.[0] = '*' then pctx.last_doc := Some (String.sub s 1 (l - (if l > 1 && s.[l-1] = '*' then 2 else 1)), (snd tk).pmin);
 			let tk = next_token() in
 			tk
 		| CommentLine s ->

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -394,8 +394,6 @@ let parse_string entry defines s p error inlined =
 		syntax_errors := old_syntax_errors;
 	in
 	let lctx = if inlined then begin
-		display_position#reset;
-		in_display_file := false;
 		begin try
 			let old_file = ThreadSafeHashtbl.find Lexer.all_files p.pfile in
 			let new_file = Lexer.make_file p.pfile in
@@ -404,9 +402,11 @@ let parse_string entry defines s p error inlined =
 		with Not_found ->
 			Lexer.create_temp_ctx p.pfile
 		end
-	end else
+	end else begin
+		display_position#reset;
+		in_display_file := false;
 		Lexer.create_temp_ctx p.pfile
-	in
+	end in
 	let result = try
 		parse entry lctx defines (Sedlexing.Utf8.from_string s) p.pfile
 	with Error (e,pe) ->

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -209,8 +209,7 @@ class dead_block_collector conds = object(self)
 end
 
 (* parse main *)
-let parse entry ctx code file =
-	let old = Lexer.save() in
+let parse entry lctx defines code file =
 	let restore_cache = TokenCache.clear () in
 	let was_display = !in_display in
 	let was_display_file = !in_display_file in
@@ -230,7 +229,7 @@ let parse entry ctx code file =
 		)
 	in
 	last_doc := None;
-	in_macro := Define.defined ctx Define.Macro;
+	in_macro := Define.defined defines Define.Macro;
 	Lexer.skip_header code;
 
 	let sharp_error s p =
@@ -240,11 +239,11 @@ let parse entry ctx code file =
 
 	let conds = new condition_handler in
 	let dbc = new dead_block_collector conds in
-	let sraw = Stream.from (fun _ -> Some (Lexer.sharp_token code)) in
+	let sraw = Stream.from (fun _ -> Some (Lexer.sharp_token lctx code)) in
 	let preprocessor_error ppe pos tk =
 		syntax_error (Preprocessor_error ppe) ~pos:(Some pos) sraw tk
 	in
-	let rec next_token() = process_token (Lexer.token code)
+	let rec next_token() = process_token (Lexer.token lctx code)
 
 	and process_token tk =
 		match fst tk with
@@ -280,7 +279,7 @@ let parse entry ctx code file =
 		| Sharp "if" ->
 			process_token (enter_macro true (snd tk))
 		| Sharp "error" ->
-			(match Lexer.token code with
+			(match Lexer.token lctx code with
 			| (Const (String(s,_)),p) -> error (Custom s) p
 			| _ -> error Unimplemented (snd tk))
 		| Sharp "line" ->
@@ -288,7 +287,7 @@ let parse entry ctx code file =
 				| (Const (Int (s, _)),p) -> (try int_of_string s with _ -> error (Custom ("Could not parse ridiculous line number " ^ s)) p)
 				| (t,p) -> error (Unexpected t) p
 			) in
-			!(Lexer.cur).Lexer.lline <- line - 1;
+			lctx.file.Lexer.lline <- line - 1;
 			next_token();
 		| Sharp s ->
 			sharp_error s (pos tk)
@@ -298,8 +297,8 @@ let parse entry ctx code file =
 	and enter_macro is_if p =
 		let tk, e = parse_macro_cond sraw in
 		(if is_if then conds#cond_if e else conds#cond_elseif e p);
-		let tk = (match tk with None -> Lexer.token code | Some tk -> tk) in
-		if is_true (eval ctx e) then begin
+		let tk = (match tk with None -> Lexer.token lctx code | Some tk -> tk) in
+		if is_true (eval defines e) then begin
 			tk
 		end else begin
 			dbc#open_dead_block (pos e);
@@ -311,7 +310,7 @@ let parse entry ctx code file =
 		| Sharp "end" ->
 			conds#cond_end (snd tk);
 			dbc#close_dead_block (pos tk);
-			Lexer.token code
+			Lexer.token lctx code
 		| Sharp "elseif" when not test ->
 			dbc#close_dead_block (pos tk);
 			let _,(e,pe) = parse_macro_cond sraw in
@@ -326,7 +325,7 @@ let parse entry ctx code file =
 		| Sharp "else" ->
 			conds#cond_else (snd tk);
 			dbc#close_dead_block (pos tk);
-			Lexer.token code
+			Lexer.token lctx code
 		| Sharp "elseif" ->
 			dbc#close_dead_block (pos tk);
 			enter_macro false (snd tk)
@@ -345,7 +344,7 @@ let parse entry ctx code file =
 		| _ ->
 			skip_tokens p test
 
-	and skip_tokens p test = skip_tokens_loop p test (Lexer.token code)
+	and skip_tokens p test = skip_tokens_loop p test (Lexer.token lctx code)
 
 	in
 	let s = Stream.from (fun _ ->
@@ -365,7 +364,6 @@ let parse entry ctx code file =
 		end;
 		let was_display_file = !in_display_file in
 		restore();
-		Lexer.restore old;
 		let pdi = {pd_errors = List.rev !syntax_errors;pd_dead_blocks = dbc#get_dead_blocks;pd_conditions = conds#get_conditions} in
 		if was_display_file then
 			ParseSuccess(l,true,pdi)
@@ -377,50 +375,40 @@ let parse entry ctx code file =
 		| Stream.Error _
 		| Stream.Failure ->
 			let last = (match Stream.peek s with None -> last_token s | Some t -> t) in
-			Lexer.restore old;
 			restore();
 			error (Unexpected (fst last)) (pos last)
 		| e ->
-			Lexer.restore old;
 			restore();
 			raise e
 
-let parse_string entry com s p error inlined =
-	let old = Lexer.save() in
-	let old_file = (try Some (Hashtbl.find Lexer.all_files p.pfile) with Not_found -> None) in
-	let restore_file_data =
-		let f = Lexer.make_file old.lfile in
-		Lexer.copy_file old f;
-		(fun () ->
-			Lexer.copy_file f old
-		)
-	in
+let parse_string entry defines s p error inlined =
 	let old_display = display_position#get in
 	let old_in_display_file = !in_display_file in
 	let old_syntax_errors = !syntax_errors in
 	syntax_errors := [];
 	let restore() =
-		(match old_file with
-		| None -> Hashtbl.remove Lexer.all_files p.pfile
-		| Some f -> Hashtbl.replace Lexer.all_files p.pfile f);
 		if not inlined then begin
 			display_position#set old_display;
 			in_display_file := old_in_display_file;
 		end;
 		syntax_errors := old_syntax_errors;
-		Lexer.restore old;
-		(* String parsing might mutate lexer_file information, e.g. from newline() calls. Here we
-		   restore the actual file data (issue #10763). *)
-		restore_file_data()
 	in
-	if inlined then
-		Lexer.init p.pfile
-	else begin
+	let lctx = if inlined then begin
 		display_position#reset;
 		in_display_file := false;
-	end;
+		begin try
+			let old_file = ThreadSafeHashtbl.find Lexer.all_files p.pfile in
+			let new_file = Lexer.make_file p.pfile in
+			Lexer.copy_file old_file new_file;
+			Lexer.create_context new_file
+		with Not_found ->
+			Lexer.create_temp_ctx p.pfile
+		end
+	end else
+		Lexer.create_temp_ctx p.pfile
+	in
 	let result = try
-		parse entry com (Sedlexing.Utf8.from_string s) p.pfile
+		parse entry lctx defines (Sedlexing.Utf8.from_string s) p.pfile
 	with Error (e,pe) ->
 		restore();
 		error (error_msg e) (if inlined then pe else p)
@@ -431,9 +419,9 @@ let parse_string entry com s p error inlined =
 	restore();
 	result
 
-let parse_expr_string com s p error inl =
+let parse_expr_string defines s p error inl =
 	let s = if p.pmin > 0 then (String.make p.pmin ' ') ^ s else s in
-	let result = parse_string expr com s p error inl in
+	let result = parse_string expr defines s p error inl in
 	if inl then
 		result
 	else begin

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -212,15 +212,12 @@ end
 let parse config entry lctx code file =
 	let defines = config.defines in
 	let in_macro = Define.defined defines Define.Macro in
-	let ctx = Parser.create_context lctx config in_macro in
+	let ctx = Parser.create_context lctx config in_macro code in
 	let entry = entry ctx in
 	let restore_cache = TokenCache.clear () in
-	let old_code = !code_ref in
-	code_ref := code;
 	let restore =
 		(fun () ->
 			restore_cache ();
-			code_ref := old_code;
 		)
 	in
 	Lexer.skip_header code;

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -360,6 +360,7 @@ let parse config entry lctx code file =
 			pd_conditions = conds#get_conditions;
 			pd_was_display_file = was_display_file;
 			pd_had_resume = ctx.had_resume;
+			pd_delayed_syntax_completion = !(ctx.delayed_syntax_completion);
 		} in
 		if was_display_file then
 			ParseSuccess(l,pdi)

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -393,23 +393,11 @@ let parse_string entry defines s p error inlined =
 		end;
 		syntax_errors := old_syntax_errors;
 	in
-	let lctx = if inlined then
-		(* In inline mode, we always work with a temp context. *)
-		Lexer.create_temp_ctx p.pfile
-	else begin
+	let lctx = Lexer.create_temp_ctx p.pfile in
+	if not inlined then begin
 		display_position#reset;
 		in_display_file := false;
-		try
-			let old_file = ThreadSafeHashtbl.find Lexer.all_files p.pfile in
-			(* If the file exists we work with a copy of it. This prevents any mutations from messing
-				up the orignal state. Note that we still don't use a real file context here, so the
-				data is not added to all_files. *)
-			let new_file = Lexer.copy_file old_file in
-			Lexer.create_context new_file
-		with Not_found ->
-			(* Otherwise we have to work with a temp file. *)
-			Lexer.create_temp_ctx p.pfile
-	end in
+	end;
 	let result = try
 		parse entry lctx defines (Sedlexing.Utf8.from_string s) p.pfile
 	with Error (e,pe) ->
@@ -418,6 +406,9 @@ let parse_string entry defines s p error inlined =
 	| Lexer.Error (e,pe) ->
 		restore();
 		error (Lexer.error_msg e) (if inlined then pe else p)
+	| exc ->
+		restore();
+		raise exc
 	in
 	restore();
 	result

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -210,21 +210,19 @@ end
 
 (* parse main *)
 let parse config entry lctx code file =
-	let ctx = Parser.create_context lctx config in
 	let defines = config.defines in
+	let in_macro = Define.defined defines Define.Macro in
+	let ctx = Parser.create_context lctx config in_macro in
 	let entry = entry ctx in
 	let restore_cache = TokenCache.clear () in
 	let old_code = !code_ref in
-	let old_macro = !in_macro in
 	code_ref := code;
 	let restore =
 		(fun () ->
 			restore_cache ();
-			in_macro := old_macro;
 			code_ref := old_code;
 		)
 	in
-	in_macro := Define.defined defines Define.Macro;
 	Lexer.skip_header code;
 
 	let sharp_error s p =
@@ -359,11 +357,17 @@ let parse config entry lctx code file =
 		end;
 		let was_display_file = ctx.config.in_display_file in
 		restore();
-		let pdi = {pd_errors = List.rev !(ctx.syntax_errors);pd_dead_blocks = dbc#get_dead_blocks;pd_conditions = conds#get_conditions} in
+		let pdi = {
+			pd_errors = List.rev !(ctx.syntax_errors);
+			pd_dead_blocks = dbc#get_dead_blocks;
+			pd_conditions = conds#get_conditions;
+			pd_was_display_file = was_display_file;
+			pd_had_resume = ctx.had_resume;
+		} in
 		if was_display_file then
-			ParseSuccess(l,true,pdi)
+			ParseSuccess(l,pdi)
 		else begin match List.rev !(ctx.syntax_errors) with
-			| [] -> ParseSuccess(l,false,pdi)
+			| [] -> ParseSuccess(l,pdi)
 			| error :: errors -> ParseError(l,error,errors)
 		end
 	with
@@ -416,6 +420,6 @@ let parse_expr_string config s p error inl =
 			(fst e,p)
 		in
 		match result with
-		| ParseSuccess(data,is_display_file,pdi) -> ParseSuccess(loop data,is_display_file,pdi)
+		| ParseSuccess(data,pdi) -> ParseSuccess(loop data,pdi)
 		| ParseError(data,error,errors) -> ParseError(loop data,error,errors)
 	end

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -234,7 +234,7 @@ let parse config entry lctx code file =
 		| Comment s ->
 			(* if encloses_resume (pos tk) then syntax_completion SCComment (pos tk); *)
 			let l = String.length s in
-			if l > 0 && s.[0] = '*' then ctx.last_doc := Some (String.sub s 1 (l - (if l > 1 && s.[l-1] = '*' then 2 else 1)), (snd tk).pmin);
+			if l > 0 && s.[0] = '*' then ctx.last_doc <- Some (String.sub s 1 (l - (if l > 1 && s.[l-1] = '*' then 2 else 1)), (snd tk).pmin);
 			let tk = next_token() in
 			tk
 		| CommentLine s ->
@@ -348,16 +348,16 @@ let parse config entry lctx code file =
 		end;
 		let was_display_file = ctx.config.in_display_file in
 		let pdi = {
-			pd_errors = List.rev !(ctx.syntax_errors);
+			pd_errors = List.rev ctx.syntax_errors;
 			pd_dead_blocks = dbc#get_dead_blocks;
 			pd_conditions = conds#get_conditions;
 			pd_was_display_file = was_display_file;
 			pd_had_resume = ctx.had_resume;
-			pd_delayed_syntax_completion = !(ctx.delayed_syntax_completion);
+			pd_delayed_syntax_completion = ctx.delayed_syntax_completion;
 		} in
 		if was_display_file then
 			ParseSuccess(l,pdi)
-		else begin match List.rev !(ctx.syntax_errors) with
+		else begin match List.rev ctx.syntax_errors with
 			| [] -> ParseSuccess(l,pdi)
 			| error :: errors -> ParseError(l,error,errors)
 		end

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -220,7 +220,6 @@ let parse entry lctx defines code file =
 	code_ref := code;
 	in_display := display_position#get <> null_pos;
 	in_display_file := !in_display && display_position#is_in_file (Path.UniqueKey.create file);
-	syntax_errors := [];
 	let restore =
 		(fun () ->
 			restore_cache ();
@@ -366,10 +365,10 @@ let parse entry lctx defines code file =
 		end;
 		let was_display_file = !in_display_file in
 		restore();
-		let pdi = {pd_errors = List.rev !syntax_errors;pd_dead_blocks = dbc#get_dead_blocks;pd_conditions = conds#get_conditions} in
+		let pdi = {pd_errors = List.rev !(pctx.syntax_errors);pd_dead_blocks = dbc#get_dead_blocks;pd_conditions = conds#get_conditions} in
 		if was_display_file then
 			ParseSuccess(l,true,pdi)
-		else begin match List.rev !syntax_errors with
+		else begin match List.rev !(pctx.syntax_errors) with
 			| [] -> ParseSuccess(l,false,pdi)
 			| error :: errors -> ParseError(l,error,errors)
 		end
@@ -386,14 +385,11 @@ let parse entry lctx defines code file =
 let parse_string entry defines s p error inlined =
 	let old_display = display_position#get in
 	let old_in_display_file = !in_display_file in
-	let old_syntax_errors = !syntax_errors in
-	syntax_errors := [];
 	let restore() =
 		if not inlined then begin
 			display_position#set old_display;
 			in_display_file := old_in_display_file;
 		end;
-		syntax_errors := old_syntax_errors;
 	in
 	let lctx = Lexer.create_temp_ctx p.pfile in
 	if not inlined then begin

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -192,7 +192,7 @@ let make_macro_com_api com mcom p =
 		);
 		register_file_contents = (fun file content ->
 			let f = Lexer.resolve_file_content_pos file content in
-			Hashtbl.add Lexer.all_files file f;
+			ThreadSafeHashtbl.add Lexer.all_files file f;
 		);
 		type_expr = (fun e ->
 			Interp.exc_string "unsupported"

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -99,7 +99,7 @@ let make_macro_com_api com mcom p =
 	let parse_metadata s p =
 		try
 			match ParserEntry.parse_string (ParserConfig.default_config com.defines) Grammar.parse_meta s null_pos raise_typing_error false with
-			| ParseSuccess(meta,_,_) -> meta
+			| ParseSuccess(meta,_) -> meta
 			| ParseError(_,_,_) -> raise_typing_error "Malformed metadata string" p
 		with _ ->
 			raise_typing_error "Malformed metadata string" p
@@ -169,8 +169,8 @@ let make_macro_com_api com mcom p =
 
 			try
 				let r = match ParserEntry.parse_expr_string (ParserConfig.file_parser_config com p.pfile) s p raise_typing_error inl with
-					| ParseSuccess(data,true,_) when inl -> data (* ignore errors when inline-parsing in display file *)
-					| ParseSuccess(data,_,_) -> data
+					| ParseSuccess(data,{pd_was_display_file = true}) when inl -> data (* ignore errors when inline-parsing in display file *)
+					| ParseSuccess(data,_) -> data
 					| ParseError _ -> Interp.exc_string "Invalid expression"
 				in
 				exit();
@@ -187,7 +187,7 @@ let make_macro_com_api com mcom p =
 		);
 		parse = (fun entry s ->
 			match ParserEntry.parse_string (ParserConfig.default_config com.defines) entry s null_pos raise_typing_error false with
-			| ParseSuccess(r,_,_) -> r
+			| ParseSuccess(r,_) -> r
 			| ParseError(_,(msg,p),_) -> Parser.error msg p
 		);
 		register_file_contents = (fun file content ->
@@ -302,7 +302,7 @@ let make_macro_api ctx mctx p =
 	let parse_metadata s p =
 		try
 			match ParserEntry.parse_string (ParserConfig.default_config mctx.com.defines) Grammar.parse_meta s null_pos raise_typing_error false with
-			| ParseSuccess(meta,_,_) -> meta
+			| ParseSuccess(meta,_) -> meta
 			| ParseError(_,_,_) -> raise_typing_error "Malformed metadata string" p
 		with _ ->
 			raise_typing_error "Malformed metadata string" p
@@ -1028,7 +1028,7 @@ let resolve_init_macro com e =
 	let e = try
 		if String.get e (String.length e - 1) = ';' then raise_typing_error "Unexpected ;" p;
 		begin match ParserEntry.parse_expr_string (ParserConfig.default_config com.defines) e p raise_typing_error false with
-		| ParseSuccess(data,_,_) -> data
+		| ParseSuccess(data,_) -> data
 		| ParseError(_,(msg,p),_) -> (Parser.error msg p)
 		end
 	with err ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -98,7 +98,7 @@ let make_macro_com_api com mcom p =
 	let timer_level = Timer.level_from_define com.defines Define.MacroTimes in
 	let parse_metadata s p =
 		try
-			match ParserEntry.parse_string Grammar.parse_meta com.defines s null_pos raise_typing_error false with
+			match ParserEntry.parse_string (ParserConfig.default_config com.defines) Grammar.parse_meta s null_pos raise_typing_error false with
 			| ParseSuccess(meta,_,_) -> meta
 			| ParseError(_,_,_) -> raise_typing_error "Malformed metadata string" p
 		with _ ->
@@ -168,7 +168,7 @@ let make_macro_com_api com mcom p =
 			let exit() = com.error_ext <- old in
 
 			try
-				let r = match ParserEntry.parse_expr_string com.defines s p raise_typing_error inl with
+				let r = match ParserEntry.parse_expr_string (ParserConfig.file_parser_config com p.pfile) s p raise_typing_error inl with
 					| ParseSuccess(data,true,_) when inl -> data (* ignore errors when inline-parsing in display file *)
 					| ParseSuccess(data,_,_) -> data
 					| ParseError _ -> Interp.exc_string "Invalid expression"
@@ -186,7 +186,7 @@ let make_macro_com_api com mcom p =
 				raise e
 		);
 		parse = (fun entry s ->
-			match ParserEntry.parse_string entry com.defines s null_pos raise_typing_error false with
+			match ParserEntry.parse_string (ParserConfig.default_config com.defines) entry s null_pos raise_typing_error false with
 			| ParseSuccess(r,_,_) -> r
 			| ParseError(_,(msg,p),_) -> Parser.error msg p
 		);
@@ -239,7 +239,7 @@ let make_macro_com_api com mcom p =
 			null_module
 		);
 		format_string = (fun s p ->
-			FormatString.format_string com.defines s p (fun e p -> (e,p))
+			FormatString.format_string (ParserConfig.file_parser_config com p.pfile) s p (fun e p -> (e,p))
 		);
 		cast_or_unify = (fun t e p ->
 			Interp.exc_string "unsupported"
@@ -301,7 +301,7 @@ let make_macro_com_api com mcom p =
 let make_macro_api ctx mctx p =
 	let parse_metadata s p =
 		try
-			match ParserEntry.parse_string Grammar.parse_meta ctx.com.defines s null_pos raise_typing_error false with
+			match ParserEntry.parse_string (ParserConfig.default_config mctx.com.defines) Grammar.parse_meta s null_pos raise_typing_error false with
 			| ParseSuccess(meta,_,_) -> meta
 			| ParseError(_,_,_) -> raise_typing_error "Malformed metadata string" p
 		with _ ->
@@ -1027,7 +1027,7 @@ let resolve_init_macro com e =
 	let p = fake_pos ("--macro " ^ e) in
 	let e = try
 		if String.get e (String.length e - 1) = ';' then raise_typing_error "Unexpected ;" p;
-		begin match ParserEntry.parse_expr_string com.defines e p raise_typing_error false with
+		begin match ParserEntry.parse_expr_string (ParserConfig.default_config com.defines) e p raise_typing_error false with
 		| ParseSuccess(data,_,_) -> data
 		| ParseError(_,(msg,p),_) -> (Parser.error msg p)
 		end

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -63,7 +63,7 @@ let type_function ctx (args : function_arguments) ret e do_display p =
 	end else begin
 		let is_display_debug = Meta.has (Meta.Custom ":debug.display") ctx.f.curfield.cf_meta in
 		if is_display_debug then print_endline ("before processing:\n" ^ (Expr.dump_with_pos e));
-		let e = if !Parser.had_resume then e else Display.preprocess_expr ctx.com e in
+		let e = if ctx.com.had_parser_resume then e else Display.preprocess_expr ctx.com e in
 		if is_display_debug then print_endline ("after processing:\n" ^ (Expr.dump_with_pos e));
 		type_expr ctx e NoValue
 	end in

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -63,7 +63,7 @@ let type_function ctx (args : function_arguments) ret e do_display p =
 	end else begin
 		let is_display_debug = Meta.has (Meta.Custom ":debug.display") ctx.f.curfield.cf_meta in
 		if is_display_debug then print_endline ("before processing:\n" ^ (Expr.dump_with_pos e));
-		let e = if ctx.com.had_parser_resume then e else Display.preprocess_expr ctx.com e in
+		let e = if ctx.com.parser_state.had_parser_resume then e else Display.preprocess_expr ctx.com e in
 		if is_display_debug then print_endline ("after processing:\n" ^ (Expr.dump_with_pos e));
 		type_expr ctx e NoValue
 	end in

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -294,7 +294,7 @@ module ModuleLevel = struct
 			with Not_found ->
 				if Sys.file_exists path then begin
 					let _,r = match !TypeloadParse.parse_hook com (ClassPaths.create_resolved_file path com.empty_class_path) p with
-						| ParseSuccess(data,_,_) -> data
+						| ParseSuccess(data,_) -> data
 						| ParseError(_,(msg,p),_) -> Parser.error msg p
 					in
 					List.iter (fun (d,p) -> match d with EImport _ | EUsing _ -> () | _ -> raise_typing_error "Only import and using is allowed in import.hx files" p) r;

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -47,8 +47,8 @@ let parse_file_from_lexbuf com file p lexbuf =
 			DisplayException.raise_module_symbols (DocumentSymbols.Printer.print_module_symbols com [file,ds] filter);
 		| _,ParseSuccess(_,({pd_was_display_file = true} as pdi)) ->
 			if pdi.pd_had_resume then
-				com.had_parser_resume <- true;
-			Atomic.set com.delayed_syntax_completion pdi.pd_delayed_syntax_completion
+				com.parser_state.had_parser_resume <- true;
+			Atomic.set com.parser_state.delayed_syntax_completion pdi.pd_delayed_syntax_completion
 		| _ ->
 			()
 	end;

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -45,8 +45,10 @@ let parse_file_from_lexbuf com file p lexbuf =
 		| DMModuleSymbols filter,(ParseSuccess(data,_)) when filter = None && DisplayPosition.display_position#is_in_file (com.file_keys#get file) ->
 			let ds = DocumentSymbols.collect_module_symbols None (filter = None) data in
 			DisplayException.raise_module_symbols (DocumentSymbols.Printer.print_module_symbols com [file,ds] filter);
-		| _,ParseSuccess(_,{pd_had_resume = true}) ->
-			com.had_parser_resume <- true
+		| _,ParseSuccess(_,({pd_was_display_file = true} as pdi)) ->
+			if pdi.pd_had_resume then
+				com.had_parser_resume <- true;
+			Atomic.set com.delayed_syntax_completion pdi.pd_delayed_syntax_completion
 		| _ ->
 			()
 	end;

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -33,14 +33,14 @@ exception DisplayInMacroBlock
 let parse_file_from_lexbuf com file p lexbuf =
 	incr stats.s_files_parsed;
 	let parse_result = try
-		ParserEntry.parse Grammar.parse_file (Lexer.create_file_ctx file) com.defines lexbuf file
+		ParserEntry.parse (ParserConfig.file_parser_config com file) Grammar.parse_file (Lexer.create_file_ctx file) lexbuf file
 	with
 		| Sedlexing.MalFormed ->
 			raise_typing_error "Malformed file. Source files must be encoded with UTF-8." (file_pos file)
 		| e ->
 			raise e
 	in
-	begin match !Parser.display_mode,parse_result with
+	begin match com.display.dms_kind,parse_result with
 		| DMModuleSymbols (Some ""),_ -> ()
 		| DMModuleSymbols filter,(ParseSuccess(data,_,_)) when filter = None && DisplayPosition.display_position#is_in_file (com.file_keys#get file) ->
 			let ds = DocumentSymbols.collect_module_symbols None (filter = None) data in

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -42,9 +42,11 @@ let parse_file_from_lexbuf com file p lexbuf =
 	in
 	begin match com.display.dms_kind,parse_result with
 		| DMModuleSymbols (Some ""),_ -> ()
-		| DMModuleSymbols filter,(ParseSuccess(data,_,_)) when filter = None && DisplayPosition.display_position#is_in_file (com.file_keys#get file) ->
+		| DMModuleSymbols filter,(ParseSuccess(data,_)) when filter = None && DisplayPosition.display_position#is_in_file (com.file_keys#get file) ->
 			let ds = DocumentSymbols.collect_module_symbols None (filter = None) data in
 			DisplayException.raise_module_symbols (DocumentSymbols.Printer.print_module_symbols com [file,ds] filter);
+		| _,ParseSuccess(_,{pd_had_resume = true}) ->
+			com.had_parser_resume <- true
 		| _ ->
 			()
 	end;
@@ -123,7 +125,7 @@ let resolve_module_file com m remap p =
 			| [] -> []
 		in
 		let meta = match parse_result with
-			| ParseSuccess((_,decls),_,_) -> loop decls
+			| ParseSuccess((_,decls),_) -> loop decls
 			| ParseError _ -> []
 		in
 		if not (Meta.has Meta.NoPackageRestrict meta) then begin
@@ -268,8 +270,8 @@ let handle_parser_result com p result =
 				com.has_error <- true
 	in
 	match result with
-		| ParseSuccess(data,is_display_file,pdi) ->
-			if is_display_file then begin
+		| ParseSuccess(data,pdi) ->
+			if pdi.pd_was_display_file then begin
 				begin match pdi.pd_errors with
 				| (msg,p) :: _ -> handle_parser_error msg p
 				| [] -> ()

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -31,10 +31,9 @@ open Error
 exception DisplayInMacroBlock
 
 let parse_file_from_lexbuf com file p lexbuf =
-	Lexer.init file;
 	incr stats.s_files_parsed;
 	let parse_result = try
-		ParserEntry.parse Grammar.parse_file com.defines lexbuf file
+		ParserEntry.parse Grammar.parse_file (Lexer.create_file_ctx file) com.defines lexbuf file
 	with
 		| Sedlexing.MalFormed ->
 			raise_typing_error "Malformed file. Source files must be encoded with UTF-8." (file_pos file)
@@ -229,7 +228,7 @@ module PdiHandler = struct
 		ParserEntry.is_true (ParserEntry.eval defines e)
 
 	let handle_pdi com pdi =
-		let macro_defines = adapt_defines_to_macro_context com.defines in
+		let macro_defines = adapt_defines_to_macro_context com.Common.defines in
 		let check = (if com.display.dms_kind = DMHover then
 			encloses_position_gt
 		else

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -626,7 +626,7 @@ and type_vars ctx vl p =
 		mk (TMeta((Meta.MergeBlock,[],p), e)) e.etype e.epos
 
 and format_string ctx s p =
-	FormatString.format_string ctx.com.defines s p (fun enext p ->
+	FormatString.format_string (ParserConfig.file_parser_config ctx.com p.pfile) s p (fun enext p ->
 		if ctx.f.in_display && DisplayPosition.display_position#enclosed_in p then
 			Display.preprocess_expr ctx.com (enext,p)
 		else

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -491,7 +491,7 @@ and display_expr ctx e_ast e dk mode with_type p =
 		raise_positions pl
 	| DMTypeDefinition ->
 		raise_position_of_type ctx e.etype
-	| DMDefault when not (!Parser.had_resume)->
+	| DMDefault when not ctx.com.had_parser_resume ->
 		let display_fields e_ast e1 so =
 			let l = match so with None -> 0 | Some s -> String.length s in
 			let fields = DisplayFields.collect ctx e_ast e1 dk with_type p in

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -491,7 +491,7 @@ and display_expr ctx e_ast e dk mode with_type p =
 		raise_positions pl
 	| DMTypeDefinition ->
 		raise_position_of_type ctx e.etype
-	| DMDefault when not ctx.com.had_parser_resume ->
+	| DMDefault when not ctx.com.parser_state.had_parser_resume ->
 		let display_fields e_ast e1 so =
 			let l = match so with None -> 0 | Some s -> String.length s in
 			let fields = DisplayFields.collect ctx e_ast e1 dk with_type p in


### PR DESCRIPTION
As a follow-up to #12123, the parser now has its own context and uses (almost) no global state, which should allow parallel parsing. I say "almost" because there's still the global `display_position` that I'll have to review separately.

There might be some intricacies here related to macro vs. non-macro context. In particular, `Parser.display_mode` had some significance that I might have isolated away now. The tests don't complain, but that doesn't always mean much when it comes to display stuff.

I'd also still like to handle the context passing differently. 99% of the changes in grammar.ml are about `ctx`, which would look much cleaner if we could handle it via `ppx_parser`. But if that's not an option, I'm willing to go this route too.