### PR TITLE
Add position and error message to decode_error.txt

### DIFF
--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -43,6 +43,7 @@ let safe_decode com v expected t p f =
 	let raise_decode_error s =
 		let path = [Dump.dump_path com.defines;"decoding_error"] in
 		let ch = Path.create_file false ".txt" [] path  in
+		Printf.fprintf ch "%s: %s\n" (TPrinting.Printer.s_pos p) s;
 		let errors = Interp.handle_decoding_error (output_string ch) v t in
 		List.iter (fun (s,i) -> Printf.fprintf ch "\nline %i: %s" i s) (List.rev errors);
 		close_out ch;

--- a/tests/misc/projects/Issue11632/compile-test.hxml.stdout
+++ b/tests/misc/projects/Issue11632/compile-test.hxml.stdout
@@ -1,3 +1,4 @@
+Main.hx: 51-58: Eval runtime exception: Null Access
 {
 	access: null
 	doc: null


### PR DESCRIPTION
If we miss the error for some reason (happening from display requests or something?), it's hard to know what it is about..