### PR TITLE
Remove typer context from filters

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -399,10 +399,10 @@ let compile ctx actx callbacks =
 					()
 		);
 		if is_diagnostics com then
-			filter ctx tctx ectx (fun () -> DisplayProcessing.handle_display_after_finalization ctx tctx display_file_dot_path)
+			filter ctx com ectx (fun () -> DisplayProcessing.handle_display_after_finalization ctx tctx display_file_dot_path)
 		else begin
 			DisplayProcessing.handle_display_after_finalization ctx tctx display_file_dot_path;
-			filter ctx tctx ectx (fun () -> ());
+			filter ctx com ectx (fun () -> ());
 		end;
 		if ctx.has_error then raise Abort;
 		if is_compilation then Generate.check_auxiliary_output com actx;

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -315,9 +315,9 @@ let process_global_display_mode com tctx =
 	promote_type_hints tctx;
 	match com.display.dms_kind with
 	| DMUsage (with_definition,_,_) ->
-		FindReferences.find_references tctx com with_definition
+		FindReferences.find_references com with_definition
 	| DMImplementation ->
-		FindReferences.find_implementations tctx com
+		FindReferences.find_implementations com
 	| DMModuleSymbols filter ->
 		let open CompilationCache in
 		let cs = com.cs in
@@ -359,7 +359,7 @@ let handle_display_after_finalization ctx tctx display_file_dot_path =
 	| RMDiagnostics _ ->
 		DisplayOutput.emit_diagnostics com
 	| RMStatistics ->
-		DisplayOutput.emit_statistics tctx
+		DisplayOutput.emit_statistics com
 	| RMNone ->
 		()
 	end

--- a/src/context/display/findReferences.ml
+++ b/src/context/display/findReferences.ml
@@ -8,8 +8,8 @@ let find_possible_references tctx cs =
 	let name,_,kind = Display.ReferencePosition.get () in
 	ignore(SyntaxExplorer.explore_uncached_modules tctx cs [name,kind])
 
-let find_references tctx com with_definition pos_filters =
-	let symbols,relations = Timer.time com.timer_ctx ["display";"references";"collect"] (Statistics.collect_statistics tctx pos_filters) true in
+let find_references com with_definition pos_filters =
+	let symbols,relations = Timer.time com.timer_ctx ["display";"references";"collect"] (Statistics.collect_statistics com pos_filters) true in
 	let rec loop acc (relations:(Statistics.relation * pos) list) = match relations with
 		| (Statistics.Referenced,p) :: relations when not (List.mem p acc) -> loop (p :: acc) relations
 		| _ :: relations -> loop acc relations
@@ -119,14 +119,14 @@ let rec collect_reference_positions com (name,pos,kind) =
 	| _ ->
 		[name,pos,kind]
 
-let find_references tctx com with_definition =
+let find_references com with_definition =
 	let pos_filters =
 		List.fold_left (fun acc (_,p,_) ->
 			if p = null_pos then acc
 			else Statistics.SFPos p :: acc
 		) [] (collect_reference_positions com (Display.ReferencePosition.get ()))
 	in
-	let usages = find_references tctx com with_definition pos_filters in
+	let usages = find_references com with_definition pos_filters in
 	let usages =
 		List.sort (fun p1 p2 ->
 			let c = compare p1.pfile p2.pfile in
@@ -135,8 +135,8 @@ let find_references tctx com with_definition =
 	in
 	DisplayException.raise_positions usages
 
-let find_implementations tctx com name pos kind =
-	let symbols,relations = Timer.time com.timer_ctx ["display";"implementations";"collect"] (Statistics.collect_statistics tctx [SFPos pos]) false in
+let find_implementations com name pos kind =
+	let symbols,relations = Timer.time com.timer_ctx ["display";"implementations";"collect"] (Statistics.collect_statistics com [SFPos pos]) false in
 	let rec loop acc relations = match relations with
 		| ((Statistics.Implemented | Statistics.Overridden | Statistics.Extended),p) :: relations -> loop (p :: acc) relations
 		| _ :: relations -> loop acc relations
@@ -155,7 +155,7 @@ let find_implementations tctx com name pos kind =
 	Display.ReferencePosition.reset();
 	DisplayException.raise_positions usages
 
-let find_implementations tctx com =
+let find_implementations com =
 	let name,pos,kind = Display.ReferencePosition.get () in
-	if pos <> null_pos then find_implementations tctx com name pos kind
+	if pos <> null_pos then find_implementations com name pos kind
 	else DisplayException.raise_positions []

--- a/src/context/display/statistics.ml
+++ b/src/context/display/statistics.ml
@@ -15,7 +15,7 @@ type statistics_filter =
 	| SFPos of pos
 	| SFFile of string
 
-let collect_statistics ctx pos_filters with_expressions =
+let collect_statistics com pos_filters with_expressions =
 	let relations = Hashtbl.create 0 in
 	let symbols = Hashtbl.create 0 in
 	let handled_modules = Hashtbl.create 0 in
@@ -25,7 +25,7 @@ let collect_statistics ctx pos_filters with_expressions =
 			try
 				Hashtbl.find paths path
 			with Not_found ->
-				let unique = ctx.com.file_keys#get path in
+				let unique = com.file_keys#get path in
 				Hashtbl.add paths path unique;
 				unique
 		)
@@ -209,7 +209,7 @@ let collect_statistics ctx pos_filters with_expressions =
 		List.iter f com.types;
 		Option.may loop (com.get_macros())
 	in
-	loop ctx.com;
+	loop com;
 	(* find things *)
 	let f = function
 		| TClassDecl c ->
@@ -254,7 +254,7 @@ let collect_statistics ctx pos_filters with_expressions =
 		List.iter f com.types;
 		Option.may loop (com.get_macros())
 	in
-	loop ctx.com;
+	loop com;
 	(* TODO: Using syntax-exploration here is technically fine, but I worry about performance in real codebases. *)
 	(* let find_symbols = Hashtbl.fold (fun _ kind acc ->
 		let name = string_of_symbol kind in

--- a/src/context/safeCom.ml
+++ b/src/context/safeCom.ml
@@ -106,7 +106,7 @@ let add_warning scom w msg p =
 	| WMDisable ->
 		()
 
-let run_expression_filters_safe scom detail_times filters t =
+let run_expression_filters_safe ?(ignore_processed_status=false) scom detail_times filters t =
 	let run scom identifier e =
 		try
 			List.fold_left (fun e (filter_name,f) ->
@@ -124,7 +124,7 @@ let run_expression_filters_safe scom detail_times filters t =
 	| TClassDecl c ->
 		let scom = {scom with curclass = c} in
 		let rec process_field cf =
-			if not (has_class_field_flag cf CfPostProcessed) then begin
+			if ignore_processed_status || not (has_class_field_flag cf CfPostProcessed) then begin
 				let scom = {scom with curfield = cf} in
 				(match cf.cf_expr with
 				| Some e when not (FilterContext.is_removable_field scom.is_macro_context cf) ->
@@ -147,6 +147,18 @@ let run_expression_filters_safe scom detail_times filters t =
 	| TEnumDecl _ -> ()
 	| TTypeDecl _ -> ()
 	| TAbstractDecl _ -> ()
+
+let adapt_scom_to_mt scom mt = match mt with
+	| TClassDecl c ->
+		{scom with curclass = c}
+	| _ ->
+		scom
+
+let run_type_filters_safe scom filters types =
+	List.iter (fun t ->
+		let scom = adapt_scom_to_mt scom t in
+		List.iter (fun f -> f scom t) filters
+	) types
 
 let needs_inline scom c cf =
 	cf.cf_kind = Method MethInline && (scom.doinline || Typecore.is_forced_inline c cf)

--- a/src/filters/exception/saveStacks.ml
+++ b/src/filters/exception/saveStacks.ml
@@ -72,17 +72,17 @@ let insert_save_stacks com ectx =
 			else e
 		)
 
-let insert_save_stacks tctx ectx =
+let insert_save_stacks com ectx scom =
 	match ectx with
 	| Some ctx ->
-		insert_save_stacks tctx.com {ctx with scom = SafeCom.of_typer tctx}
+		insert_save_stacks com {ctx with scom = scom}
 	| None ->
 		(fun e -> e)
 
 (**
 	Adds `this.__shiftStack()` calls to constructors of classes which extend `haxe.Exception`
 *)
-let patch_constructors tctx ectx =
+let patch_constructors ectx =
 	match ectx.haxe_exception_type with
 	(* Add only if `__shiftStack` method exists *)
 	| TInst(cls,_) when PMap.mem "__shiftStack" cls.cl_fields ->
@@ -108,7 +108,7 @@ let patch_constructors tctx ectx =
 						make_call ectx.scom efield [] rt p
 					| _ -> raise_typing_error "haxe.Exception.__shiftStack is expected to be an instance method" p
 				in
-				TypeloadFunction.add_constructor tctx cls true cls.cl_name_pos;
+				(* TypeloadFunction.add_constructor tctx cls true cls.cl_name_pos; *) (* TODO: why? *)
 				Option.may (fun cf -> ignore(follow cf.cf_type)) cls.cl_constructor;
 				(match cls.cl_constructor with
 				| Some ({ cf_expr = Some e_ctor } as ctor) ->
@@ -122,7 +122,7 @@ let patch_constructors tctx ectx =
 						| TFunction fn ->
 							Some { e_ctor with
 								eexpr = TFunction { fn with
-									tf_expr = mk (TBlock [add fn.tf_expr; shift_stack fn.tf_expr.epos]) tctx.t.tvoid fn.tf_expr.epos
+									tf_expr = mk (TBlock [add fn.tf_expr; shift_stack fn.tf_expr.epos]) ectx.scom.basic.tvoid fn.tf_expr.epos
 								}
 							}
 						| _ -> die "" __LOC__
@@ -134,9 +134,9 @@ let patch_constructors tctx ectx =
 		)
 	| _ -> (fun _ -> ())
 
-let patch_constructors tctx ectx =
+let patch_constructors ectx scom =
 	match ectx with
 	| Some ctx ->
-		patch_constructors tctx {ctx with scom = SafeCom.of_typer tctx}
+		patch_constructors {ctx with scom = scom}
 	| None ->
 		(fun _ -> ())

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -180,9 +180,8 @@ let iter_expressions fl mt =
 
 open FilterContext
 
-let destruction tctx scom ectx detail_times main locals =
-	let com = tctx.com in
-	with_timer tctx.com.timer_ctx detail_times "type 2" None (fun () ->
+let destruction com scom ectx detail_times main locals =
+	with_timer com.timer_ctx detail_times "type 2" None (fun () ->
 		(* PASS 2: type filters pre-DCE *)
 		List.iter (fun t ->
 			FiltersCommon.remove_generic_base t;
@@ -193,7 +192,7 @@ let destruction tctx scom ectx detail_times main locals =
 		) com.types;
 	);
 	enter_stage com CDceStart;
-	with_timer tctx.com.timer_ctx detail_times "dce" None (fun () ->
+	with_timer com.timer_ctx detail_times "dce" None (fun () ->
 		(* DCE *)
 		let dce_mode = try Common.defined_value com Define.Dce with _ -> "no" in
 		let dce_mode = match dce_mode with
@@ -207,36 +206,29 @@ let destruction tctx scom ectx detail_times main locals =
 	enter_stage com CDceDone;
 	(* PASS 3: type filters post-DCE *)
 	List.iter
-		(run_expression_filters
+		(SafeCom.run_expression_filters_safe
 			~ignore_processed_status:true
-			tctx
+			scom
 			detail_times
 			(* This has to run after DCE, or otherwise its condition always holds. *)
-			["insert_save_stacks",(fun tctx -> SaveStacks.insert_save_stacks tctx ectx)]
+			["insert_save_stacks",SaveStacks.insert_save_stacks com ectx]
 		)
 		com.types;
 	let type_filters = [
-		(fun tctx -> SaveStacks.patch_constructors tctx ectx); (* TODO: I don't believe this should load_instance anything at this point... *)
+		SaveStacks.patch_constructors ectx;
 		(fun _ -> check_private_path com);
 		(fun _ -> Native.apply_native_paths);
 		(fun _ -> add_rtti com);
-		(match com.platform with | Jvm -> (fun _ _ -> ()) | _ -> (fun tctx mt -> AddFieldInits.add_field_inits tctx.c.curclass.cl_path locals scom mt));
+		(match com.platform with | Jvm -> (fun _ _ -> ()) | _ -> (fun scom mt -> AddFieldInits.add_field_inits scom.curclass.cl_path locals scom mt));
 		(match com.platform with Hl -> (fun _ _ -> ()) | _ -> (fun _ -> add_meta_field com));
 		(fun _ -> check_void_field);
 		(fun _ -> (match com.platform with | Cpp -> promote_first_interface_to_super | _ -> (fun _ -> ())));
 		(fun _ -> commit_features com);
 		(fun _ -> (if com.config.pf_reserved_type_paths <> [] then check_reserved_type_paths com else (fun _ -> ())));
 	] in
-	with_timer tctx.com.timer_ctx detail_times "type 3" None (fun () ->
-		List.iter (fun t ->
-			let tctx = match t with
-				| TClassDecl c ->
-					TyperManager.clone_for_class tctx c
-				| _ ->
-					tctx
-			in
-			List.iter (fun f -> f tctx t) type_filters
-		) com.types;
+	with_timer com.timer_ctx detail_times "type 3" None (fun () ->
+		(* These aren't actually safe. The logic works fine regardless, we just can't parallelize this at the moment. *)
+		SafeCom.run_type_filters_safe scom type_filters com.types
 	);
 	com.callbacks#run com.error_ext com.callbacks#get_after_filters;
 	enter_stage com CFilteringDone
@@ -489,4 +481,4 @@ let run tctx ectx main before_destruction =
 		com.callbacks#run com.error_ext com.callbacks#get_after_save;
 	);
 	before_destruction();
-	destruction tctx scom ectx detail_times main rename_locals_config
+	destruction com scom ectx detail_times main rename_locals_config

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -20,7 +20,6 @@
 open Ast
 open Common
 open Type
-open Typecore
 open Error
 open Globals
 open FiltersCommon
@@ -417,8 +416,7 @@ let run_safe_filters ectx (scom : SafeCom.t) new_types_array cv_wrapper_impl ren
 	(* enter_stage com CAnalyzerDone; *)
 	Parallel.ParallelArray.iter pool (SafeCom.run_expression_filters_safe scom detail_times filters_after_analyzer) new_types_array
 
-let run tctx ectx main before_destruction =
-	let com = tctx.com in
+let run com ectx main before_destruction =
 	let scom = SafeCom.of_com com in
 	let detail_times = Timer.level_from_define com.defines Define.FilterTimes in
 	let new_types = List.filter (fun t ->

--- a/src/filters/filtersCommon.ml
+++ b/src/filters/filtersCommon.ml
@@ -37,47 +37,6 @@ let is_overridden cls field =
 	in
 	List.exists (fun d -> loop_inheritance d) cls.cl_descendants
 
-let run_expression_filters ?(ignore_processed_status=false) ctx detail_times filters t =
-	let com = ctx.com in
-	let run (ctx : typer) identifier e =
-		List.fold_left (fun e (filter_name,f) ->
-			(try
-				FilterContext.with_timer ctx.com.timer_ctx detail_times filter_name identifier (fun () -> f ctx e)
-			with Failure msg ->
-				com.error msg e.epos;
-				e)
-		) e filters
-	in
-	match t with
-	| TClassDecl c when FilterContext.is_removable_class c -> ()
-	| TClassDecl c ->
-		let ctx = TyperManager.clone_for_module ctx (TypeloadModule.make_curmod ctx.com ctx.g c.cl_module) in
-		let ctx = TyperManager.clone_for_class ctx c in
-		let rec process_field cf =
-			if ignore_processed_status || not (has_class_field_flag cf CfPostProcessed) then begin
-				let ctx = TyperManager.clone_for_field ctx cf cf.cf_params in
-				(match cf.cf_expr with
-				| Some e when not (FilterContext.is_removable_field com.is_macro_context cf) ->
-					let identifier = Printf.sprintf "%s.%s" (s_type_path c.cl_path) cf.cf_name in
-					cf.cf_expr <- Some (run ctx (Some identifier) e);
-				| _ -> ());
-			end;
-			List.iter process_field cf.cf_overloads
-		in
-		List.iter process_field c.cl_ordered_fields;
-		List.iter process_field c.cl_ordered_statics;
-		(match c.cl_constructor with
-		| None -> ()
-		| Some f -> process_field f);
-		(match TClass.get_cl_init c with
-		| None -> ()
-		| Some e ->
-			let identifier = Printf.sprintf "%s.__init__" (s_type_path c.cl_path) in
-			TClass.set_cl_init c (run ctx (Some identifier) e))
-	| TEnumDecl _ -> ()
-	| TTypeDecl _ -> ()
-	| TAbstractDecl _ -> ()
-
 let is_cached com t =
 	let m = (t_infos t).mt_module.m_extra in
 	m.m_processed <> 0 && m.m_processed < com.compilation_step

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -655,16 +655,17 @@ and flush_macro_context mint mctx =
 			"captured_vars",(fun scom -> CapturedVars.captured_vars scom cv_wrapper_impl);
 		] in
 		let type_filters = [
-			FiltersCommon.remove_generic_base;
-			SaveStacks.patch_constructors mctx ectx;
-			(fun mt -> AddFieldInits.add_field_inits mctx.c.curclass.cl_path (RenameVars.init mctx.com.config mctx.com.types) scom mt);
-			Filters.update_cache_dependencies ~close_monomorphs:false mctx.com;
-			minimal_restore;
-			maybe_apply_native_paths
+			(fun _ -> FiltersCommon.remove_generic_base);
+			SaveStacks.patch_constructors ectx;
+			(fun _ -> (fun mt -> AddFieldInits.add_field_inits mctx.c.curclass.cl_path (RenameVars.init mctx.com.config mctx.com.types) scom mt));
+			(fun _ -> Filters.update_cache_dependencies ~close_monomorphs:false mctx.com);
+			(fun _ -> minimal_restore);
+			(fun _ -> maybe_apply_native_paths);
 		] in
 		let ready = fun t ->
+			let scom = SafeCom.adapt_scom_to_mt scom t in
 			FiltersCommon.apply_filters_once mctx scom expr_filters t;
-			List.iter (fun f -> f t) type_filters
+			List.iter (fun f -> f scom t) type_filters
 		in
 		(try Interp.add_types mint types ready
 		with Error err -> raise (Fatal_error err));


### PR DESCRIPTION
Just a few changes so that we don't need a typer context for filters at all.