### PR TITLE
Set default define values from define.json

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -54,6 +54,7 @@
 		"define": "dce",
 		"doc": "Set the dead code elimination mode. (default: std)",
 		"params": ["mode: std | full | no"],
+		"default": "std",
 		"links": ["https://haxe.org/manual/cr-dce.html"]
 	},
 	{
@@ -115,6 +116,7 @@
 		"name": "DumpPath",
 		"define": "dump-path",
 		"doc": "Path to generate dumps to (default: \"dump\").",
+		"default": "dump",
 		"params": ["path"]
 	},
 	{
@@ -125,7 +127,8 @@
 	{
 		"name": "DumpIgnoreVarIds",
 		"define": "dump-ignore-var-ids",
-		"doc": "Remove variable IDs from non-pretty dumps (helps with diff)."
+		"doc": "Remove variable IDs from non-pretty dumps (helps with diff).",
+		"default": "1"
 	},
 	{
 		"name": "DynamicInterfaceClosures",
@@ -138,6 +141,7 @@
 		"define": "eval-call-stack-depth",
 		"doc": "Set maximum call stack depth for eval. (default: 1000)",
 		"platforms": ["eval"],
+		"default": "1000",
 		"params": ["depth"]
 	},
 	{
@@ -151,6 +155,7 @@
 		"define": "eval-print-depth",
 		"doc": "Set maximum print depth (before replacing with '<...>') for eval. (default: 5)",
 		"platforms": ["eval"],
+		"default": "5",
 		"params": ["depth"]
 	},
 	{
@@ -239,6 +244,27 @@
 		"name": "Haxe",
 		"define": "haxe",
 		"doc": "The current Haxe version value in SemVer format.",
+		"reserved": true
+	},
+	{
+		"name": "Haxe3",
+		"define": "haxe3",
+		"doc": "The current Haxe major version is >= 3.",
+		"default": "1",
+		"reserved": true
+	},
+	{
+		"name": "Haxe4",
+		"define": "haxe4",
+		"doc": "The current Haxe major version is >= 4.",
+		"default": "1",
+		"reserved": true
+	},
+	{
+		"name": "Haxe5",
+		"define": "haxe5",
+		"doc": "The current Haxe major version is >= 5.",
+		"default": "1",
 		"reserved": true
 	},
 	{
@@ -484,6 +510,7 @@
 		"name": "LoopUnrollMaxCost",
 		"define": "loop-unroll-max-cost",
 		"doc": "Maximum cost (number of expressions * iterations) before loop unrolling is canceled. (default: 250)",
+		"default": "250",
 		"params": ["cost"]
 	},
 	{
@@ -810,6 +837,7 @@
 		"name": "MessageReporting",
 		"define": "message.reporting",
 		"doc": "Select message reporting mode for compiler output. (default: pretty)",
+		"default": "pretty",
 		"params": ["mode: classic | pretty | indent"]
 	},
 	{
@@ -831,6 +859,7 @@
 		"name": "MessageLogFormat",
 		"define": "message.log-format",
 		"doc": "Select message reporting mode for message log file. (default: indent)",
+		"default": "indent",
 		"params": ["format: classic | pretty | indent"]
 	}
 ]

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -232,12 +232,9 @@ module Setup = struct
 		let com = ctx.com in
 		ctx.com.print <- ctx.comm.write_out;
 		Common.define_value com Define.HaxeVer (Printf.sprintf "%.3f" (float_of_int version /. 1000.));
-		Common.raw_define com "haxe3";
-		Common.raw_define com "haxe4";
-		Common.raw_define com "haxe5";
 		Common.define_value com Define.Haxe s_version;
 		Common.raw_define com "true";
-		Common.define_value com Define.Dce "std";
+		List.iter (fun (k,v) -> Define.raw_define_value com.defines k v) DefineList.default_values;
 		com.info <- (fun ?(depth=0) ?(from_macro=false) msg p ->
 			message ctx (make_compiler_message ~from_macro msg p depth DKCompilerMessage Information)
 		);

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -31,16 +31,18 @@ type define_infos = {
 	d_origin : define_origin;
 	d_links : string list;
 	d_deprecated : string option;
+	d_default : string option;
 }
 
 let infos ?user_defines d =
 	let extract_infos (t, (doc, flags), origin) =
-		let params = ref [] and pfs = ref [] and links = ref [] and deprecated = ref None in
+		let params = ref [] and pfs = ref [] and links = ref [] and deprecated = ref None and default = ref None in
 		List.iter (function
 			| HasParam s -> params := s :: !params
 			| Platforms fl -> pfs := fl @ !pfs
 			| Link url -> links := url :: !links
 			| Deprecated s -> deprecated := Some s
+			| DefaultValue s -> default := Some s
 		) flags;
 		(t, {
 			d_doc = doc;
@@ -49,6 +51,7 @@ let infos ?user_defines d =
 			d_origin = origin;
 			d_links = !links;
 			d_deprecated = !deprecated;
+			d_default = !default;
 		})
 	in
 

--- a/src/prebuild.ml
+++ b/src/prebuild.ml
@@ -114,6 +114,7 @@ type parsed_define = {
 	d_links: string list;
 	d_deprecated : string option;
 	d_deprecated_define : string option;
+	d_default : string option;
 }
 let parse_define json =
 	let fields = match json with
@@ -129,6 +130,7 @@ let parse_define json =
 		d_links = get_optional_field "links" as_links [] fields;
 		d_deprecated = get_optional_field2 "deprecated" as_string fields;
 		d_deprecated_define = get_optional_field2 "deprecatedDefine" as_string fields;
+		d_default = get_optional_field2 "default" as_string fields;
 	}
 
 let parse_meta json =
@@ -201,6 +203,7 @@ let gen_option f = function
 
 let gen_define_info defines =
 	let deprecations = DynArray.create() in
+	let default_values = DynArray.create() in
 	let define_str = List.map (function
 		def ->
 			let platforms_str = gen_platforms def.d_platforms in
@@ -222,9 +225,21 @@ let gen_define_info defines =
 					DynArray.add deprecations (Printf.sprintf "\t(%S,DueTo(%S));" define x);
 					[Printf.sprintf "Deprecated(%s)" quoted]
 			in
-			"\t| " ^ def.d_name ^ " -> \"" ^ define ^ "\",(" ^ (Printf.sprintf "%S" def.d_doc) ^ ",[" ^ (String.concat "; " (platforms_str @ params_str @ links_str @ deprecated)) ^ "])"
+			let default = match def.d_default with
+				| None ->
+					[]
+				| Some x ->
+					let quoted = Printf.sprintf "%S" x in
+					DynArray.add default_values (Printf.sprintf "\t(%S,%S)" define x);
+					[Printf.sprintf "DefaultValue(%s)" quoted]
+			in
+			"\t| " ^ def.d_name ^ " -> \"" ^ define ^ "\",(" ^ (Printf.sprintf "%S" def.d_doc) ^ ",[" ^ (String.concat "; " (platforms_str @ params_str @ links_str @ deprecated @ default)) ^ "])"
 	) defines in
-	String.concat "\n" define_str,String.concat "\n" (DynArray.to_list deprecations)
+	(
+		String.concat "\n" define_str,
+		String.concat "\n" (DynArray.to_list deprecations),
+		String.concat ";\n" (DynArray.to_list default_values)
+	)
 
 let gen_meta_type metas =
 	String.concat "\n" (List.map (function
@@ -298,6 +313,7 @@ type define_parameter =
 	| Platforms of platform list
 	| Link of string
 	| Deprecated of string
+	| DefaultValue of string
 
 type define_deprecation =
 	| DueTo of string
@@ -363,11 +379,12 @@ match Array.to_list (Sys.argv) with
 		Printf.printf "type strict_defined =\n";
 		Printf.printf "%s" (gen_define_type defines);
 		Printf.printf "\n\t| Last\n\t| Custom of string\n\n";
-		let infos,deprecations = gen_define_info defines in
+		let infos,deprecations,default_values = gen_define_info defines in
 		Printf.printf "let infos = function\n";
 		Printf.printf "%s" infos;
 		Printf.printf "\n\t| Last -> die \"\" __LOC__\n\t| Custom s -> s,(\"\",[])\n";
 		Printf.printf "\nlet deprecated_defines = [\n%s\n]\n" deprecations;
+		Printf.printf "\nlet default_values = [\n%s\n]\n" default_values;
 	| [_; "meta"; meta_path]->
 		let metas = parse_file_array meta_path parse_meta in
 		Printf.printf "%s" meta_header;


### PR DESCRIPTION
Also sets `-D dump-ignore-var-ids` by default (see #12126).

Next steps could be:
* Remove `(default: x)` from defines doc and add it from `default` field instead
* Handle platform-specific defines with default values