### PR TITLE
Use com api for --interp

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -105,9 +105,9 @@ let parse_args com =
 		),"<name[=path]>","generate code for a custom target");
 		("Target",[],["-x"], Arg.String (fun cl ->
 			let cpath = Path.parse_type_path cl in
-			(match com.main.main_class with
+			(match com.main.main_path with
 				| Some c -> if cpath <> c then raise (Arg.Bad "Multiple --main classes specified")
-				| None -> com.main.main_class <- Some cpath);
+				| None -> com.main.main_path <- Some cpath);
 			actx.classes <- cpath :: actx.classes;
 			Common.define com Define.Interp;
 			set_platform com Eval "";
@@ -132,9 +132,9 @@ let parse_args com =
 			actx.hxb_libs <- lib :: actx.hxb_libs
 		),"<path>","add a hxb library");
 		("Compilation",["-m";"--main"],["-main"],Arg.String (fun cl ->
-			if com.main.main_class <> None then raise (Arg.Bad "Multiple --main classes specified");
+			if com.main.main_path <> None then raise (Arg.Bad "Multiple --main classes specified");
 			let cpath = Path.parse_type_path cl in
-			com.main.main_class <- Some cpath;
+			com.main.main_path <- Some cpath;
 			actx.classes <- cpath :: actx.classes
 		),"<class>","select startup class");
 		("Compilation",["-L";"--library"],["-lib"],Arg.String (fun _ -> ()),"<name[:ver]>","use a haxelib library");

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -340,8 +340,9 @@ let finalize_typing ctx tctx =
 	let main_module = Finalization.maybe_load_main tctx in
 	enter_stage com CFilteringStart;
 	ServerMessage.compiler_stage com;
-	let main, types, modules = run_or_diagnose ctx (fun () -> Finalization.generate tctx main_module) in
-	com.main.main_expr <- main;
+	let (main_expr,main_file),types,modules = run_or_diagnose ctx (fun () -> Finalization.generate tctx main_module) in
+	com.main.main_expr <- main_expr;
+	com.main.main_file <- main_file;
 	com.types <- types;
 	com.modules <- modules
 

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -131,7 +131,7 @@ let process_display_file com actx =
 			DPKNone
 		| DFPOnly when (DisplayPosition.display_position#get).pfile = file_input_marker ->
 			actx.classes <- [];
-			com.main.main_class <- None;
+			com.main.main_path <- None;
 			begin match com.file_contents with
 			| [_, Some input] ->
 				com.file_contents <- [];
@@ -142,7 +142,7 @@ let process_display_file com actx =
 		| dfp ->
 			if dfp = DFPOnly then begin
 				actx.classes <- [];
-				com.main.main_class <- None;
+				com.main.main_path <- None;
 			end;
 			let dpk = List.map (fun file_key ->
 				let real = Path.get_real_path (Path.UniqueKey.to_string file_key) in

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -716,7 +716,8 @@ let create timer_ctx compilation_step cs version args display_mode =
 		empty_class_path = new ClassPath.directory_class_path "" User;
 		class_paths = new ClassPaths.class_paths;
 		main = {
-			main_class = None;
+			main_path = None;
+			main_file = None;
 			main_expr = None;
 		};
 		package_rules = PMap.empty;
@@ -815,7 +816,8 @@ let clone com is_macro_context =
 			tstring = mk_mono();
 		};
 		main = {
-			main_class = None;
+			main_path = None;
+			main_file = None;
 			main_expr = None;
 		};
 		features = Hashtbl.create 0;
@@ -1041,7 +1043,7 @@ let get_entry_point com =
 		in
 		let e = Option.get com.main.main_expr in (* must be present at this point *)
 		(snd path, c, e)
-	) com.main.main_class
+	) com.main.main_path
 
 let make_unforced_lazy t_proc f where =
 	let r = ref (lazy_available t_dynamic) in

--- a/src/generators/gctx.ml
+++ b/src/generators/gctx.ml
@@ -3,7 +3,8 @@ open Type
 open Warning
 
 type context_main = {
-	mutable main_class : path option;
+	mutable main_path : path option;
+	mutable main_file : string option;
 	mutable main_expr : texpr option;
 }
 
@@ -109,7 +110,7 @@ let get_entry_point gctx =
 		in
 		let e = Option.get gctx.main.main_expr in (* must be present at this point *)
 		(snd path, c, e)
-	) gctx.main.main_class
+	) gctx.main.main_path
 
 let get_es_version defines =
 	try int_of_string (Define.defined_value defines Define.JsEs) with _ -> 0

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -429,7 +429,7 @@ let generate_source ctx =
      end;
    end;
 
-   let output_name = match  common_ctx.main.main_class with
+   let output_name = match  common_ctx.main.main_path with
    | Some path -> (snd path)
    | _ -> "output" in
 

--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -2863,7 +2863,7 @@ let generate com boot_name =
 		try_scope_reg = None;
 		for_call = false;
 	} in
-	let types = if ctx.swc && com.main.main_class = None then
+	let types = if ctx.swc && com.main.main_path = None then
 		(*
 			make sure that both Boot and RealBoot are the first two classes in the SWC
 			this way initializing RealBoot will also run externs __init__ blocks before

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2636,12 +2636,11 @@ module StdSys = struct
 	let programPath = vfun0 (fun () ->
 		let ctx = get_ctx() in
 		let com = ctx.curapi.get_com() in
-		match com.main.main_class with
-		| None -> vnull
-		| Some p ->
-			match ctx.curapi.get_type (s_type_path p) with
-			| Some(Type.TInst (c, _)) -> create_unknown (Extc.get_full_path c.Type.cl_pos.Globals.pfile)
-			| _ -> vnull
+		match com.main.main_file with
+		| Some file ->
+			create_unknown (Extc.get_full_path file)
+		| None ->
+			vnull
 	)
 
 	let putEnv = vfun2 (fun s -> function

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2246,7 +2246,7 @@ let macro_api ccom get_api =
 				"platform", encode_platform com.platform;
 				"platformConfig", encode_platform_config com.config;
 				"stdPath", encode_array (List.map (fun path -> encode_string path#path) com.class_paths#get_std_paths);
-				"mainClass", (match com.main.main_class with None -> vnull | Some path -> encode_path path);
+				"mainClass", (match com.main.main_path with None -> vnull | Some path -> encode_path path);
 				"packageRules", encode_string_map encode_package_rule com.package_rules;
 			]
 		);

--- a/src/typing/finalization.ml
+++ b/src/typing/finalization.ml
@@ -8,7 +8,7 @@ open Typecore
 (* ---------------------------------------------------------------------- *)
 (* FINALIZATION *)
 
-let maybe_load_main tctx = match tctx.com.main.main_class with
+let maybe_load_main tctx = match tctx.com.main.main_path with
 	| Some path ->
 		Some (Typeload.load_module tctx path null_pos)
 	| None ->
@@ -17,7 +17,8 @@ let maybe_load_main tctx = match tctx.com.main.main_class with
 
 let get_main ctx main_module types =
 	match main_module with
-	| None -> None
+	| None ->
+		None,None
 	| Some main_module ->
 		let p = null_pos in
 		let path = main_module.m_path in
@@ -83,7 +84,7 @@ let get_main ctx main_module types =
 			| [e] -> e
 			| _ -> mk (TBlock exprs) ctx.t.tvoid p
 		in
-		Some main
+		Some main,Some (Path.UniqueKey.lazy_path main_module.m_extra.m_file)
 
 let finalize ctx =
 	flush_pass ctx.g PFinal ("final",[]);
@@ -203,6 +204,6 @@ let sort_types com (modules : module_lut) =
 	List.iter (fun m -> List.iter loop m.m_types) sorted_modules;
 	List.rev !types, sorted_modules
 
-let generate ctx main_class =
+let generate ctx main_path =
 	let types,modules = sort_types ctx.com ctx.com.module_lut in
-	get_main ctx main_class types,types,modules
+	get_main ctx main_path types,types,modules

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -105,6 +105,12 @@ let make_macro_com_api com mcom p =
 		with _ ->
 			raise_typing_error "Malformed metadata string" p
 	in
+	let bad_stage () =
+		if com.stage < CInitMacrosDone then
+			Interp.exc_string "This API cannot be used in initialization macros"
+		else
+			Interp.exc_string "This API cannot be used in the interpreter run-time"
+	in
 	{
 		MacroApi.pos = p;
 		get_com = (fun () -> com);
@@ -119,19 +125,19 @@ let make_macro_com_api com mcom p =
 		);
 		init_macros_done = (fun () -> com.stage >= CInitMacrosDone);
 		get_type = (fun s ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		resolve_type = (fun t p ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		resolve_complex_type = (fun t ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_module = (fun s ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		include_module = (fun s ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		after_init_macros = (fun f ->
 			com.callbacks#add_after_init_macros (fun () ->
@@ -196,7 +202,7 @@ let make_macro_com_api com mcom p =
 			ThreadSafeHashtbl.add Lexer.all_files file f;
 		);
 		type_expr = (fun e ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		store_typed_expr = (fun te ->
 			let p = te.epos in
@@ -204,37 +210,37 @@ let make_macro_com_api com mcom p =
 		);
 		allow_package = (fun v -> Common.allow_package com v);
 		get_local_type = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_expected_type = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_call_arguments = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_local_method = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_local_using = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_local_imports = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_local_vars = (fun () ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		get_build_fields = (fun() ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		define_type = (fun v mdep ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		define_module = (fun m types imports usings ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		module_dependency = (fun mpath file ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		current_module = (fun() ->
 			null_module
@@ -243,7 +249,7 @@ let make_macro_com_api com mcom p =
 			FormatString.format_string (ParserConfig.file_parser_config com p.pfile) s p (fun e p -> (e,p))
 		);
 		cast_or_unify = (fun t e p ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		add_global_metadata = (fun s1 s2 config p ->
 			let meta = parse_metadata s2 p in
@@ -253,7 +259,7 @@ let make_macro_com_api com mcom p =
 			) meta;
 		);
 		add_module_check_policy = (fun sl il b ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		register_define = (fun s data -> Define.register_user_define com.user_defines s data);
 		register_metadata = (fun s data -> Meta.register_user_meta com.user_metas s data);
@@ -263,10 +269,10 @@ let make_macro_com_api com mcom p =
 		decode_type = Interp.decode_type;
 		display_error = display_error com;
 		with_imports = (fun imports usings f ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		with_options = (fun opts f ->
-			Interp.exc_string "unsupported"
+			bad_stage ()
 		);
 		info = (fun ?(depth=0) msg p ->
 			com.info ~depth msg p

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -1074,7 +1074,7 @@ let finalize_macro_api tctx mctx =
 
 let interpret ctx =
 	let mctx = get_macro_context ctx in
-	let mctx = Interp.create ctx.com (make_macro_api ctx mctx null_pos) false in
+	let mctx = Interp.create ctx.com (make_macro_com_api ctx.com mctx.com null_pos) false in
 	Interp.add_types mctx ctx.com.types (fun t -> ());
 	match ctx.com.main.main_expr with
 		| None -> ()

--- a/tests/misc/projects/Issue12131/Main.hx
+++ b/tests/misc/projects/Issue12131/Main.hx
@@ -1,0 +1,3 @@
+function main() {
+	trace(haxe.macro.Context.getLocalClass());
+}

--- a/tests/misc/projects/Issue12131/compile-fail.hxml
+++ b/tests/misc/projects/Issue12131/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue12131/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue12131/compile-fail.hxml.stderr
@@ -1,0 +1,2 @@
+haxe/macro/Context.hx:???: Uncaught exception This API cannot be used in the interpreter run-time
+Main.hx:2: characters 8-42 : Called from here


### PR DESCRIPTION
I noticed that we set up a typer macro API when running `--interp`, which seems a bit silly. With this change we're instead using the com API, which has reduced functionality.

This means that now something like `Context.getLocalClass()` will just throw `"unsupported"` at us, which isn't the greatest user experience. I'd like to do something similar to what we did for init macros, where the compiler complains about us being in the wrong stage for the API we're using. 