### PR TITLE
[js] Avoid optimizing Std.is away in api_inline.

### DIFF
--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -125,7 +125,7 @@ let api_inline (scom : SafeCom.t) c field params p =
 	let tint = scom.basic.tint in
 
 	match c.cl_path, field, params with
-	| ([],"Std"),("is" | "isOfType"),[o;t] | (["js"],"Boot"),"__instanceof",[o;t] when scom.platform = Js ->
+	| ([],"Std"),"isOfType",[o;t] | (["js"],"Boot"),"__instanceof",[o;t] when scom.platform = Js ->
 		let is_trivial e =
 			match e.eexpr with
 			| TConst _ | TLocal _ -> true

--- a/tests/misc/js/projects/Issue10870/Main.hx
+++ b/tests/misc/js/projects/Issue10870/Main.hx
@@ -1,0 +1,3 @@
+function main() {
+	Std.is("", String);
+}

--- a/tests/misc/js/projects/Issue10870/compile.hxml
+++ b/tests/misc/js/projects/Issue10870/compile.hxml
@@ -1,0 +1,3 @@
+-m Main
+-js out.js
+--no-output

--- a/tests/misc/js/projects/Issue10870/compile.hxml.stderr
+++ b/tests/misc/js/projects/Issue10870/compile.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:2: characters 2-20 : Warning : (WDeprecated) Std.is is deprecated. Use Std.isOfType instead.

--- a/tests/optimization/src/TestJs.hx
+++ b/tests/optimization/src/TestJs.hx
@@ -742,6 +742,14 @@ class TestJs {
 			offset = 3;
 		} while (notFalse);
 	}
+
+	@:js('
+		return typeof("") == "string";
+	')
+	@:haxe.warning("-WDeprecated")
+	static function testIs() {
+		return Std.is("", String);
+	}
 }
 
 class Issue9227 {


### PR DESCRIPTION
This allows deprecation checks to run.
Codegen does not change as Std.is is inline and calls Std.isOfType which is still special-cased.
(Std.isOfType itself still needs to be special-cased despite calling js.Boot.__instanceof because otherwise exception codegen changes slightly)
Added a codegen test and a test to verify the deprecation warning triggers.

Closes #10870 