### PR TITLE
DynamicAccess iteration null safety fix

### DIFF
--- a/std/haxe/iterators/DynamicAccessIterator.hx
+++ b/std/haxe/iterators/DynamicAccessIterator.hx
@@ -47,6 +47,10 @@ class DynamicAccessIterator<T> {
 		See `Iterator.next`
 	**/
 	public inline function next():T {
-		return access[keys[index++]];
+		final key = keys[index++];
+		// inline with value cast breaks iterator (see #9100)
+		@:nullSafety(Off)
+		final value:T = access[key];
+		return value;
 	}
 }

--- a/std/haxe/iterators/DynamicAccessKeyValueIterator.hx
+++ b/std/haxe/iterators/DynamicAccessKeyValueIterator.hx
@@ -47,7 +47,10 @@ class DynamicAccessKeyValueIterator<T> {
 		See `Iterator.next`
 	**/
 	public inline function next():{key:String, value:T} {
-		var key = keys[index++];
-		return {value: (access[key] : T), key: key};
+		final key = keys[index++];
+		// inline with value cast breaks iterator (see #9100)
+		@:nullSafety(Off)
+		final value:T = access[key];
+		return {value: value, key: key};
 	}
 }

--- a/tests/nullsafety/src/cases/TestLoose.hx
+++ b/tests/nullsafety/src/cases/TestLoose.hx
@@ -1,5 +1,6 @@
 package cases;
 
+import haxe.DynamicAccess;
 import Validator.shouldFail;
 
 typedef NotNullAnon = {
@@ -150,6 +151,17 @@ class TestLoose {
 		for (i in 0...1) {
 			var i:String = staticVar ?? continue;
 			var i2:String = staticVar ?? break;
+		}
+	}
+
+	static function dynamicAccessIteration_shouldPass():Void {
+		var a = new DynamicAccess<String>();
+		var b = new DynamicAccess<String>();
+		for (value in a) {
+			b["a"] = value;
+		}
+		for (key => value in a) {
+			b[key] = value;
 		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/HaxeFoundation/haxe/issues/9100

But probably should be handled properly at null safety filter instead. I wonder why null safety was designed to run after inlining.