### PR TITLE
Avoid lhs cast on ambiguous operators

### DIFF
--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -638,8 +638,19 @@ let type_non_assign_op ctx op e1 e2 is_assign_op abstract_overload_only with_typ
 	in
 	let e1 = type_expr ctx e1 wt in
 	let e1 = match wt with
-		| WithType.WithType(t,_) -> AbstractCast.cast_or_unify ctx t e1 e1.epos
-		| _ -> e1
+		| WithType.WithType(t,_) ->
+			let has_matching_op a =
+				List.exists (fun (o,_) -> o = op) a.a_ops
+			in
+			begin match follow e1.etype with
+				| TAbstract(a,tl) when has_matching_op a ->
+					(* The operator could be ambiguous, let's not cast (issue #12145). *)
+					e1
+				| _ ->
+					AbstractCast.cast_or_unify ctx t e1 e1.epos
+			end
+		| _ ->
+			e1
 	in
 	let result = if abstract_overload_only then begin
 		let e2 = type_binop_rhs ctx op e1 e2 is_assign_op with_type p in

--- a/tests/unit/src/unit/issues/Issue12145.hx
+++ b/tests/unit/src/unit/issues/Issue12145.hx
@@ -1,0 +1,39 @@
+package unit.issues;
+
+import utest.Assert;
+
+@:structInit
+final private class PointImpl {
+	public var x:Float;
+}
+
+@:forward
+private abstract Point(PointImpl) from PointImpl to PointImpl {
+	@:op(a - b)
+	public function sub_p(p:Point):Vec
+		return {x: this.x - p.x};
+}
+
+@:structInit
+final private class VecImpl {
+	public var x:Float;
+}
+
+@:forward
+private abstract Vec(VecImpl) from VecImpl to VecImpl {
+	// comment out this function and compilation will succeed
+	@:op(a - b)
+	public function sub_v(v:Vec):Vec
+		return {x: this.x - v.x};
+}
+
+class Issue12145 extends Test {
+	function test() {
+		final a:Point = {x: 2};
+		final b:Point = {x: 1};
+		// success if remove the :Vec, and even determines the correct type
+		// however the same scenario can be repro'd by passing the result of the subtraction to a function which accepts Vec
+		final c:Vec = a - b;
+		feq(1.0, c.x);
+	}
+}


### PR DESCRIPTION
This reverts the change that originally addressed #10981 because doing this isn't sound, as #12145 demonstrates.

We'll have to talk about this though because I fully expect it to blow up Bordeaux.