### PR TITLE
Use Mpsc for DCE

### DIFF
--- a/src/core/ds/nowOrLater.ml
+++ b/src/core/ds/nowOrLater.ml
@@ -1,13 +1,13 @@
+module Mpsc = Saturn.Single_consumer_queue
+
 type t = {
 	now : Mutex.t;
-	later: (unit -> unit) Queue.t;
-	later_mutex : Mutex.t;
+	later: (unit -> unit) Mpsc.t;
 }
 
 let create () = {
 	now = Mutex.create ();
-	later = Queue.create ();
-	later_mutex = Mutex.create ();
+	later = Mpsc.create ();
 }
 
 let try_now nol f =
@@ -15,11 +15,11 @@ let try_now nol f =
 		f();
 		Mutex.unlock nol.now
 	end else begin
-		Mutex.protect nol.later_mutex (fun () -> Queue.push f nol.later)
+		Mpsc.push nol.later f
 	end
 
 let handle_later nol =
-	let rec loop () = match Queue.take_opt nol.later with
+	let rec loop () = match Mpsc.pop_opt nol.later with
 		| Some f ->
 			f ();
 			loop ()


### PR DESCRIPTION
With the opam dependency problems resolved, we can now use the saturn data structures. This uses the multi-producer-single-consumer queue for DCE, which should at least not be slower than a mutexed queue.