### PR TITLE
Add saturn to haxe.opam and dune

### DIFF
--- a/haxe.opam
+++ b/haxe.opam
@@ -35,5 +35,6 @@ depends: [
   "ipaddr"
   "terminal_size"
   "domainslib"
+  "saturn"
   "thread-local-storage"
 ]

--- a/haxe.opam
+++ b/haxe.opam
@@ -34,7 +34,7 @@ depends: [
   "luv" {>= "0.5.13"}
   "ipaddr"
   "terminal_size"
-  "domainslib"
+  "domainslib" {>= "0.5.2"}
   "saturn"
   "thread-local-storage"
 ]

--- a/src/dune
+++ b/src/dune
@@ -22,7 +22,7 @@
 		unix ipaddr str bigarray threads dynlink
 		xml-light extlib sha terminal_size
 		luv
-		domainslib thread-local-storage
+		domainslib saturn thread-local-storage
 	)
 	(modules (:standard \ haxe prebuild))
 	(preprocess (per_module


### PR DESCRIPTION
Unless add a constraint for domainslib >= 0.5.1, older versions may be installed which did not have saturn as a sub dependency. Since we use saturn directly, it makes sense to add it anyway