### PR TITLE
Copy cf kind when assigning object

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -693,29 +693,35 @@ and type_object_decl ctx fl with_type p =
 		let fl = List.map (fun ((n,pn,qs),e) ->
 			let is_valid = Lexer.is_valid_identifier n in
 			if PMap.mem n !fields then raise_typing_error ("Duplicate field in object declaration : " ^ n) pn;
-			let is_final = ref false in
-			let e = try
-				let t = match !dynamic_parameter with
-					| Some t -> t
+			let e,cfo = try
+				let t,cfo = match !dynamic_parameter with
+					| Some t ->
+						t,None
 					| None ->
 						let cf = PMap.find n field_map in
-						if (has_class_field_flag cf CfFinal) then is_final := true;
 						if ctx.f.in_display && DisplayPosition.display_position#enclosed_in pn then DisplayEmitter.display_field ctx Unknown CFSMember cf pn;
-						cf.cf_type
+						cf.cf_type,Some cf
 				in
 				let e = type_expr ctx e (WithType.with_structure_field t n) in
 				let e = AbstractCast.cast_or_unify ctx t e e.epos in
 				let e = if is_null t && not (is_null e.etype) then mk (TCast(e,None)) (ctx.t.tnull e.etype) e.epos else e in
-				(try type_eq EqStrict e.etype t; e with Unify_error _ -> mk (TCast (e,None)) t e.epos)
+				(try type_eq EqStrict e.etype t; e with Unify_error _ -> mk (TCast (e,None)) t e.epos),cfo
 			with Not_found ->
 				if is_valid then
 					extra_fields := (n,pn) :: !extra_fields;
-				type_expr ctx e WithType.value
+				type_expr ctx e WithType.value,None
 			in
 			if is_valid then begin
 				if starts_with n '$' then raise_typing_error "Field names starting with a dollar are not allowed" p;
 				let cf = mk_field n e.etype (punion pn e.epos) pn in
-				if !is_final then add_class_field_flag cf CfFinal;
+				begin match cfo with
+					| Some cf' ->
+						(* If we're assigning to an existing field, copy some of its characteristics *)
+						if has_class_field_flag cf' CfFinal then add_class_field_flag cf CfFinal;
+						cf.cf_kind <- cf'.cf_kind;
+					| None ->
+						()
+				end;
 				fields := PMap.add n cf !fields;
 			end;
 			((n,pn,qs),e)

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -1059,8 +1059,7 @@ private class AnonFields {
 
 	final anon:AnonDefaultNever = {
 		name: "",
-		// TODO should fail
-		version: null
+		version: shouldFail(null)
 	};
 	final anon2:{name:String, version:String} = {
 		name: "",


### PR DESCRIPTION
In https://github.com/HaxeFoundation/haxe/issues/12179#issuecomment-2816354141 we found that assigning an object to something might cause `type_iseq` to be `false` afterwards. This is because the generated class field of the object has a different `cf_type`. I don't see why it should have.

This is a generalization of https://github.com/HaxeFoundation/haxe/commit/3a76be2d03b259f344c0561b0bf5ae84fc55b808 where we already inherited the `final` flag for fields. It does feel correct to inherit `cf_type` too, the only problem I can see is that this could introduce new kinds of `FAnon` fields that didn't exist previously.

Edit: Indeed, genhl hates this which is what I expected. Will have to wait for @yuxiaomao to return after Easter to see what she thinks about this!