### PR TITLE
[hl] use classpaths relative_path for get_relative_path

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -333,18 +333,8 @@ let make_debug ctx arr =
 		| true -> if (Filename.is_relative p.pfile)
 			then Filename.concat (Sys.getcwd()) p.pfile
 			else p.pfile
-		| false -> try
-			(* lookup relative path *)
-			let len = String.length p.pfile in
-			let base = ctx.com.class_paths#find (fun path ->
-				let path = path#path in
-				let l = String.length path in
-				len > l && String.sub p.pfile 0 l = path
-			) in
-			let l = String.length base#path in
-			String.sub p.pfile l (len - l)
-		with Not_found ->
-			p.pfile
+		| false ->
+			ctx.com.class_paths#relative_path p.pfile
 	in
 	let pos = ref (0,0,Globals.null_pos) in
 	let cur_file = ref 0 in


### PR DESCRIPTION
Fixes https://github.com/HaxeFoundation/haxe/issues/12215

> HL omits the `src/` part when there is a `-cp src`

~~CPP does not remove it because there is a bug on the relativePath function used by cpp, where `src/` is given as a relative path inside `class_paths`, but the pfile is first turn into absolute path before comparison~~

https://github.com/HaxeFoundation/haxe/blob/c11b679090b0347edcbfe5df43f5fc16a8122acd/src/generators/cpp/cppContext.ml#L94-L96

~~With this change, hl and cpp share the same relative path function, which ignore `src/` when there is a `-cp src`.~~

~~Don't know where should I change for jvm though.~~

Use the same relative_path function as hxcpp & trace. This still guarantee relative the same std and lib path. This also fix hl's std relative path detection error (caused by an empty classpath before std).