### PR TITLE
[nullsafety] Non-nullable check warnings

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -126,6 +126,11 @@
 		"enabled": false
 	},
 	{
+		"name": "WRedundantNullCheck",
+		"doc": "Value can't be null, so comparison with null is excessive",
+		"parent": "WTyper"
+	},
+	{
 		"name": "WHxb",
 		"doc": "Hxb (either --hxb output or haxe compiler cache) related warnings"
 	},

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -76,7 +76,7 @@ class compiler_callbacks = object(self)
 	method add_after_generation (f : unit -> unit) : unit =
 		after_generation := f :: !after_generation
 
-	method add_null_safety_report (f : (string*pos) list -> unit) : unit =
+	method add_null_safety_report (f : (WarningList.warning option*string*pos) list -> unit) : unit =
 		null_safety_report <- f :: null_safety_report
 
 	method run handle_error r =

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2375,9 +2375,10 @@ let macro_api ccom get_api =
 		);
 		"on_null_safety_report", vfun1 (fun f ->
 			let f = prepare_callback f 1 in
-			(ccom()).callbacks#add_null_safety_report (fun (errors:(string*pos) list) ->
-				let encode_item (msg,pos) =
-					encode_obj [("msg", encode_string msg); ("pos", encode_pos pos)]
+			(ccom()).callbacks#add_null_safety_report (fun (errors:(WarningList.warning option*string*pos) list) ->
+				let encode_item (wtype,msg,pos) =
+					let wtype = match wtype with | Some _ -> "warning" | None -> "error" in
+					encode_obj [("type", encode_string wtype); ("msg", encode_string msg); ("pos", encode_pos pos)]
 				in
 				ignore(f [encode_array (List.map encode_item errors)])
 			);

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -455,8 +455,13 @@ let rec contains_unsafe_meta metadata =
 let rec contains_safe_meta metadata =
 	match metadata with
 		| [] -> false
-		| (Meta.NullSafety, [], _) :: _
-		| (Meta.NullSafety, [(EConst (Ident ("Loose" | "Strict" | "StrictThreaded")), _)], _) :: _  -> true
+		| (Meta.NullSafety, args, _) :: rest ->
+			let is_safe_mode = match args with
+				| [] -> true
+				| (EConst (Ident ("Loose" | "Strict" | "StrictThreaded")), _) :: _ -> true
+				| _ -> false
+			in
+			is_safe_mode || contains_safe_meta rest
 		| _ :: rest -> contains_safe_meta rest
 
 let safety_enabled meta =
@@ -468,8 +473,8 @@ let get_safety_config (metadata:Ast.metadata) : safety_config =
 			| EArrayDecl list, p ->
 				List.fold_left (fun acc e ->
 					match e with
-					| (EConst (Ident "WarnNonNullable"), _) -> SOWarnNonNullable :: opts
-					| _ -> opts
+					| (EConst (Ident "WarnNonNullable"), _) -> SOWarnNonNullable :: acc
+					| _ -> acc
 				) opts list
 			| _ -> opts
 		) options args

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -5,16 +5,23 @@ open Type
 type safety_message = {
 	sm_msg : string;
 	sm_pos : pos;
+	sm_type : WarningList.warning option
 }
 
 type safety_report = {
 	mutable sr_errors : safety_message list;
+	mutable sr_warnings: safety_message list;
 }
 
 let add_error report msg pos =
-	let error = { sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
+	let error = { sm_type = None; sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
 	if not (List.mem error report.sr_errors) then
-		report.sr_errors <- error :: report.sr_errors;
+		report.sr_errors <- error :: report.sr_errors;;
+
+let add_warning report wtype msg pos =
+	let warning = { sm_type = Some wtype; sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
+	if not (List.mem warning report.sr_warnings) then
+		report.sr_warnings <- warning :: report.sr_warnings;
 
 type scope_type =
 	| STNormal
@@ -35,6 +42,14 @@ type safety_mode =
 	| SMLoose
 	| SMStrict
 	| SMStrictThreaded
+
+type safety_option =
+	| SOWarnNonNullable
+
+type safety_config = {
+	mode : safety_mode;
+	options : safety_option list;
+}
 
 (**
 	Terminates compiler process and prints user-friendly instructions about filing an issue in compiler repo.
@@ -447,35 +462,70 @@ let rec contains_safe_meta metadata =
 let safety_enabled meta =
 	(contains_safe_meta meta) && not (contains_unsafe_meta meta)
 
-let safety_mode (metadata:Ast.metadata) =
-	let rec traverse mode meta =
-		match mode, meta with
-			| Some SMOff, _
-			| _, [] -> mode
-			| _, (Meta.NullSafety, [(EConst (Ident "Off"), _)], _) :: _ ->
-				Some SMOff
-			| None, (Meta.NullSafety, ([] | [(EConst (Ident "Loose"), _)]), _) :: rest ->
-				traverse (Some SMLoose) rest
-			| _, (Meta.NullSafety, [(EConst (Ident "Strict"), _)], _) :: rest ->
-				traverse (Some SMStrict) rest
-			| _, (Meta.NullSafety, [(EConst (Ident "StrictThreaded"), _)], _) :: rest ->
-				traverse (Some SMStrictThreaded) rest
-			| _, _ :: rest ->
-				traverse mode rest
+let get_safety_config (metadata:Ast.metadata) : safety_config =
+	let parse_options args options =
+		List.fold_left (fun opts -> function
+			| EArrayDecl list, p ->
+				List.fold_left (fun acc e ->
+					match e with
+					| (EConst (Ident "WarnNonNullable"), _) -> SOWarnNonNullable :: opts
+					| _ -> opts
+				) opts list
+			| _ -> opts
+		) options args
 	in
-	match traverse None metadata with
-		| Some mode -> mode
-		| None -> SMOff
+	let rec traverse mode options meta =
+		match meta with
+			| [] -> (mode, options)
+			| (Meta.NullSafety, args, pos) :: rest ->
+				let new_mode, new_options = match args with
+					| [] ->
+						(Some SMLoose, parse_options args options)
+					| (EConst (Ident "Off"), _) :: args ->
+						(Some SMOff, parse_options args options)
+					| (EConst (Ident "Loose"), _) :: args ->
+						(Some SMLoose, parse_options args options)
+					| (EConst (Ident "Strict"), _) :: args ->
+						(Some SMStrict, parse_options args options)
+					| (EConst (Ident "StrictThreaded"), _) :: args ->
+						(Some SMStrictThreaded, parse_options args options)
+					| args ->
+						(mode, parse_options args options)
+				in
+				traverse new_mode new_options rest
+			| _ :: rest ->
+				traverse mode options rest
+	in
+	let (mode, options) = traverse None [] metadata in
+	match mode with
+		| Some mode -> { mode = mode; options = options }
+		| None -> {mode = SMOff; options = []}
 
 let rec validate_safety_meta report (metadata:Ast.metadata) =
+	let validate_options e =
+		match e with
+			| EArrayDecl list, p ->
+				List.iter (fun e ->
+					match e with
+						| (EConst (Ident "WarnNonNullable"), _) -> ()
+						| _ -> add_error report "Invalid option. Valid options: WarnNonNullable" (snd e)
+				) list
+			| (arg, p) -> add_error report "Invalid option. Should be array like [WarnNonNullable]" p
+	in
 	match metadata with
-		| [] -> ()
 		| (Meta.NullSafety, args, pos) :: rest ->
 			(match args with
-				| ([] | [(EConst (Ident ("Off" | "Loose" | "Strict" | "StrictThreaded")), _)]) -> ()
+				| (EConst (Ident ("Off" | "Loose" | "Strict" | "StrictThreaded")), _) :: options :: tail ->
+					validate_options options;
+					List.iter (fun (arg, pos) ->
+						add_error report "Invalid argument for @:nullSafety meta" pos
+					) tail
+				| (EConst (Ident ("Off" | "Loose" | "Strict" | "StrictThreaded")), _) :: _ -> ()
+				| [] -> ()
 				| _ -> add_error report "Invalid argument for @:nullSafety meta" pos
 			);
 			validate_safety_meta report rest
+		| [] -> ()
 		| _ :: rest -> validate_safety_meta report rest
 
 (**
@@ -1046,18 +1096,18 @@ class local_safety (mode:safety_mode) =
 (**
 	This class is used to recursively check typed expressions for null-safety
 *)
-class expr_checker mode immediate_execution report =
+class expr_checker (config : safety_config) immediate_execution report =
 	object (self)
-		val local_safety = new local_safety mode
+		val local_safety = new local_safety config.mode
 		val mutable return_types = []
 		val mutable in_closure = false
 		(* if this flag is `true` then spotted errors and warnings will not be reported *)
 		val mutable is_pretending = false
-		(* val mutable cnt = 0 *)
+		val warn_non_nullable = List.mem SOWarnNonNullable config.options
 		(**
-			Get safety mode for this expression checker
+			Get safety config for this expression checker
 		*)
-		method get_mode = mode
+		method get_config = config
 		(**
 			Register an error
 		*)
@@ -1072,6 +1122,33 @@ class expr_checker mode immediate_execution report =
 				in
 				add_error report msg (get_first_valid_pos positions)
 			end
+		(**
+			Register a warning
+		*)
+		method warning wtype msg (positions:Globals.pos list) =
+			if not is_pretending then begin
+				let rec get_first_valid_pos positions =
+					match positions with
+						| [] -> null_pos
+						| p :: rest ->
+							if p <> null_pos then p
+							else get_first_valid_pos rest
+				in
+				add_warning report wtype msg (get_first_valid_pos positions)
+			end
+
+		method private check_binop_redundant_null_checks e =
+			if warn_non_nullable then match e.eexpr with
+					| TBinop ((OpEq | OpNotEq), { eexpr = TConst TNull }, expr)
+					| TBinop ((OpEq | OpNotEq), expr, { eexpr = TConst TNull })
+					| TBinop(OpAssignOp OpNullCoal, expr, _)
+					| TBinop (OpNullCoal, expr, _) ->
+						if not (is_nullable_type ~dynamic_is_nullable:true expr.etype) then
+							self#warning
+								WRedundantNullCheck
+								("The operand type is not nullable, so null-check should be redundant.")
+								[expr.epos; e.epos];
+					| _ -> ()
 		(**
 			Check if `e` is nullable even if the type is reported not-nullable.
 			Haxe type system lies sometimes.
@@ -1180,7 +1257,9 @@ class expr_checker mode immediate_execution report =
 				| TConst _ -> ()
 				| TLocal _ -> ()
 				| TArray (arr, idx) -> self#check_array_access arr idx e.epos
-				| TBinop (op, left_expr, right_expr) -> self#check_binop op left_expr right_expr e.epos
+				| TBinop (op, left_expr, right_expr) ->
+					self#check_binop_redundant_null_checks e;
+					self#check_binop op left_expr right_expr e.epos
 				| TField (target, access) -> self#check_field target access e.epos
 				| TTypeExpr _ -> ()
 				| TParenthesis e -> self#check_expr e
@@ -1315,7 +1394,7 @@ class expr_checker mode immediate_execution report =
 		method private check_function ?(immediate_execution=false) fn =
 			local_safety#function_declared immediate_execution fn;
 			return_types <- fn.tf_type :: return_types;
-			if immediate_execution || mode = SMLoose then
+			if immediate_execution || config.mode = SMLoose then
 				begin
 					let original_safe_locals = local_safety#get_safe_locals_copy in
 					(* Start pretending to ignore errors *)
@@ -1538,8 +1617,8 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 	let cls_meta = cls.cl_meta @ (match cls.cl_kind with KAbstractImpl a -> a.a_meta | _ -> []) in
 	object (self)
 			val is_safe_class = (safety_enabled cls_meta)
-			val mutable checker = new expr_checker SMLoose immediate_execution report
-			val mutable mode = None
+			val mutable checker = new expr_checker { mode = SMLoose; options = [] } immediate_execution report
+			val mutable config : safety_config option = None
 		(**
 			Entry point for checking a class
 		*)
@@ -1549,18 +1628,18 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 				self#check_var_fields;
 			let check_field is_static f = if not (has_class_field_flag f CfPostProcessed) then begin
 				validate_safety_meta report f.cf_meta;
-				match (safety_mode (cls_meta @ f.cf_meta)) with
-					| SMOff -> ()
-					| mode ->
+				match (get_safety_config (cls_meta @ f.cf_meta)) with
+					| { mode = SMOff; } -> ()
+					| config ->
 						(match f.cf_expr with
 							| None -> ()
 							| Some expr ->
-								(self#get_checker mode)#check_root_expr expr
+								(self#get_checker config)#check_root_expr expr
 						);
 						self#check_accessors is_static f
 			end in
 			if is_safe_class then
-				Option.may ((self#get_checker (safety_mode cls_meta))#check_root_expr) (TClass.get_cl_init cls);
+				Option.may ((self#get_checker (get_safety_config cls_meta))#check_root_expr) (TClass.get_cl_init cls);
 			Option.may (check_field false) cls.cl_constructor;
 			List.iter (check_field false) cls.cl_ordered_fields;
 			List.iter (check_field true) cls.cl_ordered_statics;
@@ -1588,28 +1667,28 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 									match accessor.cf_expr with
 										| Some ({ eexpr = TFunction fn } as accessor_expr) ->
 											let fn = { fn with tf_type = field.cf_type } in
-											(self#get_checker self#class_safety_mode)#check_root_expr { accessor_expr with eexpr = TFunction fn }
+											(self#get_checker self#class_safety_config)#check_root_expr { accessor_expr with eexpr = TFunction fn }
 										| _ -> ()
 					in
 					if read_access = AccCall then check_accessor "get_";
 					if write_access = AccCall then check_accessor "set_"
 				| _ -> ()
 		(**
-			Get safety mode for the current class
+			Get safety config for the current class
 		*)
-		method private class_safety_mode =
-			match mode with
-				| Some mode -> mode
+		method private class_safety_config =
+			match config with
+				| Some config -> config
 				| None ->
-					let m = safety_mode cls_meta in
-					mode <- Some m;
-					m
+					let cfg = get_safety_config cls_meta in
+					config <- Some cfg;
+					cfg
 		(**
-			Get an instance of expression checker with safety mode set to `mode`
+			Get an instance of expression checker with safety config set to `config`
 		*)
-		method private get_checker mode =
-			if checker#get_mode <> mode then
-				checker <- new expr_checker mode immediate_execution report;
+		method private get_checker (config : safety_config) =
+			if checker#get_config <> config then
+				checker <- new expr_checker config immediate_execution report;
 			checker
 		(**
 			Check if field should be checked by null safety
@@ -1784,7 +1863,10 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 *)
 let run (com:Common.context) (types:module_type list) =
 	let report = Timer.time com.timer_ctx ["null safety"] (fun () ->
-		let report = { sr_errors = [] } in
+		let report = {
+			sr_errors = [];
+			sr_warnings = [];
+		} in
 		let immediate_execution = new immediate_execution in
 		let traverse module_type =
 			match module_type with
@@ -1798,11 +1880,21 @@ let run (com:Common.context) (types:module_type list) =
 	) () in
 	match com.callbacks#get_null_safety_report with
 		| [] ->
-			List.iter (fun err -> Common.display_error com err.sm_msg err.sm_pos) (List.rev report.sr_errors)
+			List.iter (fun warn ->
+				com.warning (Option.get warn.sm_type) [] warn.sm_msg warn.sm_pos
+			) (List.rev report.sr_warnings);
+
+			List.iter (fun err ->
+				Common.display_error com err.sm_msg err.sm_pos
+			) (List.rev report.sr_errors)
 		| callbacks ->
-			let errors =
-				List.map (fun err -> (err.sm_msg, err.sm_pos)) report.sr_errors
+			let warnings =
+				List.map (fun warn -> (warn.sm_type, warn.sm_msg, warn.sm_pos)) report.sr_warnings
 			in
-			List.iter (fun fn -> fn errors) callbacks
+			let errors =
+				List.map (fun err -> (err.sm_type, err.sm_msg, err.sm_pos)) report.sr_errors
+			in
+			let all = warnings @ errors in
+			List.iter (fun fn -> fn all) callbacks
 
 ;;

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -320,8 +320,9 @@ class Compiler {
 		@param path A package, module or sub-type dot path to enable null safety for.
 		@param recursive If true, recurses into sub-packages for package paths.
 	**/
-	public static function nullSafety(path:String, mode:NullSafetyMode = Loose, recursive:Bool = true) {
-		addGlobalMetadata(path, '@:nullSafety($mode)', recursive);
+	public static function nullSafety(path:String, mode:NullSafetyMode = Loose, ?options:Array<NullSafetyOption>, recursive:Bool = true) {
+		if (options == null) addGlobalMetadata(path, '@:nullSafety($mode)', recursive);
+		else addGlobalMetadata(path, '@:nullSafety($mode, $options)', recursive);
 	}
 
 	/**
@@ -531,6 +532,22 @@ enum abstract NullSafetyMode(String) to String {
 		The only nullable thing could be safe are local variables.
 	**/
 	var StrictThreaded;
+}
+
+enum abstract NullSafetyOption(String) to String {
+	/**
+		Issues warnings when performing explicit null checks (`== null` or `!= null`) on expressions
+		that are known to be non-nullable according to their type.
+		E.g.
+		```haxe
+		final nonNullable = "hello";
+		if (nonNullable != null) { // warning
+			trace(nonNullable);
+		}
+		final foo = nonNullable ?? "default"; // warning
+		```
+**/
+	var WarnNonNullable;
 }
 
 typedef MetadataDescription = {

--- a/tests/nullsafety/src/Validator.hx
+++ b/tests/nullsafety/src/Validator.hx
@@ -2,19 +2,21 @@
 import haxe.macro.Context;
 import haxe.macro.Expr;
 
-typedef SafetyMessage = {msg:String, pos:Position}
-typedef ExpectedMessage = {symbol:String, pos:Position}
+typedef SafetyMessage = {type:String, msg:String, pos:Position}
+typedef ExpectedMessage = {type:String, symbol:String, pos:Position}
 #end
 
 class Validator {
 #if macro
 	static var expectedErrors:Array<ExpectedMessage> = [];
+	static var expectedWarnings:Array<ExpectedMessage> = [];
 
 	static dynamic function onNullSafetyReport(callback:(errors:Array<SafetyMessage>)->Void):Void {
 	}
 
 	static public function register() {
 		expectedErrors = [];
+		expectedWarnings = [];
 		onNullSafetyReport = @:privateAccess Context.load("on_null_safety_report", 1);
 		onNullSafetyReport(validate);
 	}
@@ -25,7 +27,13 @@ class Validator {
 				if(meta.name == ':shouldFail') {
 					var fieldPosInfos = Context.getPosInfos(field.pos);
 					fieldPosInfos.min = Context.getPosInfos(meta.pos).max + 1;
-					expectedErrors.push({symbol: field.name, pos:Context.makePosition(fieldPosInfos)});
+					expectedErrors.push({type: "error", symbol: field.name, pos:Context.makePosition(fieldPosInfos)});
+					break;
+				}
+				if(meta.name == ':shouldWarn') {
+					var fieldPosInfos = Context.getPosInfos(field.pos);
+					fieldPosInfos.min = Context.getPosInfos(meta.pos).max + 1;
+					expectedWarnings.push({type: "warning", symbol: field.name, pos:Context.makePosition(fieldPosInfos)});
 					break;
 				}
 			}
@@ -34,7 +42,7 @@ class Validator {
 	}
 
 	static function validate(errors:Array<SafetyMessage>) {
-		var errors = check(expectedErrors.copy(), errors.copy());
+		var errors = check(expectedErrors.concat(expectedWarnings), errors.copy());
 		if(errors.ok) {
 			Sys.println('${errors.passed} expected errors spotted');
 			Sys.println('Compile-time tests passed.');
@@ -50,6 +58,7 @@ class Validator {
 			var actualEvent = actual[i];
 			var wasExpected = false;
 			for(expectedEvent in expected) {
+				if (expectedEvent.type != actualEvent.type) continue;
 				if(posContains(expectedEvent.pos, actualEvent.pos)) {
 					expected.remove(expectedEvent);
 					wasExpected = true;
@@ -85,7 +94,12 @@ class Validator {
 #end
 
 	macro static public function shouldFail(expr:Expr):Expr {
-		expectedErrors.push({symbol:Context.getLocalMethod(), pos:expr.pos});
+		expectedErrors.push({type: "error", symbol:Context.getLocalMethod(), pos:expr.pos});
+		return expr;
+	}
+
+	macro static public function shouldWarn(expr:Expr):Expr {
+		expectedWarnings.push({type: "warning", symbol:Context.getLocalMethod(), pos:expr.pos});
 		return expr;
 	}
 }

--- a/tests/nullsafety/src/cases/TestNonNullable.hx
+++ b/tests/nullsafety/src/cases/TestNonNullable.hx
@@ -1,13 +1,13 @@
 package cases;
 
 import Validator.shouldWarn;
+import Validator.shouldFail;
 
 typedef Data = {
 	var foo:String;
 }
 
-@:nullSafety(Loose, [WarnNonNullable])
-class Main {
+class TestNonNullable {
 	static function main() {
 		final foo = 0;
 		if (shouldWarn(foo) == null) {}
@@ -48,5 +48,13 @@ class Main {
 		if (shouldWarn(data.foo) == null) {
 			data.foo = "default";
 		}
+	}
+}
+
+@:build(Validator.checkFields())
+class BasicErrors {
+	@:shouldFail static var foo2:Int;
+	public function new() {
+		shouldFail(var foo:Int = null);
 	}
 }

--- a/tests/nullsafety/src/cases/TestNonNullable.hx
+++ b/tests/nullsafety/src/cases/TestNonNullable.hx
@@ -1,0 +1,52 @@
+package cases;
+
+import Validator.shouldWarn;
+
+typedef Data = {
+	var foo:String;
+}
+
+@:nullSafety(Loose, [WarnNonNullable])
+class Main {
+	static function main() {
+		final foo = 0;
+		if (shouldWarn(foo) == null) {}
+
+		final dyn:Dynamic = null;
+		if (dyn == null) {}
+
+		final dyn:Any = 1;
+		if (shouldWarn(dyn) == null) {}
+
+		var data:Data = haxe.Json.parse("{}");
+		data.foo.length;
+
+		switch shouldWarn(data.foo) {
+			case null if (shouldWarn(data.foo) == null):
+				final v = shouldWarn(data.foo) == null;
+		}
+
+		final v = shouldWarn(data.foo) == null;
+		shouldWarn(data.foo) != null && true;
+		true && shouldWarn(data.foo) != null;
+		data.foo != null || true;
+		true || shouldWarn(data.foo) != null;
+
+		throw shouldWarn(data.foo) == null;
+
+		function foo():Bool {
+			return shouldWarn(data.foo) == null;
+		}
+
+		while (shouldWarn(data.foo) == null) {}
+
+		shouldWarn(data.foo) ??= "";
+		final foo = shouldWarn(data.foo ?? "");
+		if (null == shouldWarn(data.foo)) {
+			trace(1);
+		}
+		if (shouldWarn(data.foo) == null) {
+			data.foo = "default";
+		}
+	}
+}

--- a/tests/nullsafety/test.hxml
+++ b/tests/nullsafety/test.hxml
@@ -5,6 +5,7 @@ cases.TestStrictThreaded
 cases.TestLoose
 cases.TestSafeFieldInUnsafeClass
 cases.TestAbstract
+cases.TestNonNullable
 
 --macro nullSafety('cases.TestLoose', Loose)
 --macro nullSafety('cases.TestStrict', Strict)

--- a/tests/nullsafety/test.hxml
+++ b/tests/nullsafety/test.hxml
@@ -10,4 +10,5 @@ cases.TestNonNullable
 --macro nullSafety('cases.TestLoose', Loose)
 --macro nullSafety('cases.TestStrict', Strict)
 --macro nullSafety('cases.TestStrictThreaded', StrictThreaded)
+--macro nullSafety('cases.TestNonNullable', Loose, [WarnNonNullable])
 --macro Validator.register()


### PR DESCRIPTION
Implements additional argument for `@:nullSafety` to enable non-nullable null-check warnings.

```haxe
@:nullSafety(Loose, [WarnNonNullable])
function main() {
	final foo = 0;
	if (foo == null) {} // warn
	final bar = foo ?? 0; // warn

	var test:Int;
	function name():Void trace(test);
}
```

It would be nice to also disable nullsafety second argument meta validation for 4.3.7 release, so using new meta arg will be backward compatible.

Closes https://github.com/HaxeFoundation/haxe/issues/7816