### PR TITLE
[nullsafety] Non-nullable check warnings

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -131,6 +131,11 @@
 		"parent": "WParser"
 	},
 	{
+		"name": "WRedundantNullCheck",
+		"doc": "Value can't be null, so comparison with null is excessive",
+		"parent": "WTyper"
+	},
+	{
 		"name": "WHxb",
 		"doc": "Hxb (either --hxb output or haxe compiler cache) related warnings"
 	},

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -55,6 +55,11 @@
 		"generic": true
 	},
 	{
+		"name": "WNullSafety",
+		"doc": "Warnings related to null safety",
+		"generic": true
+	},
+	{
 		"name": "WDeprecated",
 		"doc": "This is deprecated and should no longer be used"
 	},
@@ -133,7 +138,8 @@
 	{
 		"name": "WRedundantNullCheck",
 		"doc": "Value can't be null, so comparison with null is excessive",
-		"parent": "WTyper"
+		"parent": "WNullSafety",
+		"enabled": false
 	},
 	{
 		"name": "WHxb",

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -78,7 +78,7 @@ class compiler_callbacks = object(self)
 	method add_after_generation (f : unit -> unit) : unit =
 		after_generation := f :: !after_generation
 
-	method add_null_safety_report (f : (string*pos) list -> unit) : unit =
+	method add_null_safety_report (f : (WarningList.warning option*string*pos) list -> unit) : unit =
 		null_safety_report <- f :: null_safety_report
 
 	method run handle_error r =

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -78,7 +78,7 @@ class compiler_callbacks = object(self)
 	method add_after_generation (f : unit -> unit) : unit =
 		after_generation := f :: !after_generation
 
-	method add_null_safety_report (f : (WarningList.warning option*string*pos) list -> unit) : unit =
+	method add_null_safety_report (f : (string*pos) list -> (WarningList.warning*string*pos) list -> unit) : unit =
 		null_safety_report <- f :: null_safety_report
 
 	method run handle_error r =

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2412,12 +2412,16 @@ let macro_api ccom get_api =
 		);
 		"on_null_safety_report", vfun1 (fun f ->
 			let f = prepare_callback f 1 in
-			(ccom()).callbacks#add_null_safety_report (fun (errors:(WarningList.warning option*string*pos) list) ->
-				let encode_item (wtype,msg,pos) =
-					let wtype = match wtype with | Some _ -> "warning" | None -> "error" in
-					encode_obj [("type", encode_string wtype); ("msg", encode_string msg); ("pos", encode_pos pos)]
+			(ccom()).callbacks#add_null_safety_report (fun errors warnings ->
+				let encode_item kind (msg,pos) =
+					encode_obj [("type", encode_string kind); ("msg", encode_string msg); ("pos", encode_pos pos)]
 				in
-				ignore(f [encode_array (List.map encode_item errors)])
+				let encode_warning (w,msg,pos) =
+					encode_item "warning" (msg,pos)
+				in
+				let errors = List.map (encode_item "error") errors in
+				let warnings = List.map encode_warning warnings in
+				ignore(f [encode_array (errors @ warnings)])
 			);
 			vnull
 		);

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2412,9 +2412,10 @@ let macro_api ccom get_api =
 		);
 		"on_null_safety_report", vfun1 (fun f ->
 			let f = prepare_callback f 1 in
-			(ccom()).callbacks#add_null_safety_report (fun (errors:(string*pos) list) ->
-				let encode_item (msg,pos) =
-					encode_obj [("msg", encode_string msg); ("pos", encode_pos pos)]
+			(ccom()).callbacks#add_null_safety_report (fun (errors:(WarningList.warning option*string*pos) list) ->
+				let encode_item (wtype,msg,pos) =
+					let wtype = match wtype with | Some _ -> "warning" | None -> "error" in
+					encode_obj [("type", encode_string wtype); ("msg", encode_string msg); ("pos", encode_pos pos)]
 				in
 				ignore(f [encode_array (List.map encode_item errors)])
 			);

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -6,21 +6,35 @@ open Error
 type safety_message = {
 	sm_msg : string;
 	sm_pos : pos;
-	sm_type : WarningList.warning option
+	sm_module : module_def;
+}
+
+type safety_warning = {
+	sw_warning : WarningList.warning;
+	sw_options : warning_option list list;
+	sw_msg : string;
+	sw_pos : pos;
+	sw_module : module_def;
 }
 
 type safety_report = {
 	mutable sr_errors : safety_message list;
-	mutable sr_warnings: safety_message list;
+	mutable sr_warnings: safety_warning list;
 }
 
-let add_error report msg pos =
-	let error = { sm_type = None; sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
+let add_error report m msg pos =
+	let error = { sm_msg = ("Null safety: " ^ msg); sm_pos = pos; sm_module = m; } in
 	if not (List.mem error report.sr_errors) then
 		report.sr_errors <- error :: report.sr_errors;;
 
-let add_warning report wtype msg pos =
-	let warning = { sm_type = Some wtype; sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
+let add_warning report m wtype options msg pos =
+	let warning = {
+		sw_warning = wtype;
+		sw_options = options;
+		sw_msg = ("Null safety: " ^ msg);
+		sw_pos = pos;
+		sw_module = m;
+	} in
 	if not (List.mem warning report.sr_warnings) then
 		report.sr_warnings <- warning :: report.sr_warnings;
 
@@ -484,16 +498,16 @@ let get_safety_mode (metadata:Ast.metadata) =
 		| Some mode -> mode
 		| None -> SMOff
 
-let rec validate_safety_meta report (metadata:Ast.metadata) =
+let rec validate_safety_meta report m (metadata:Ast.metadata) =
 	match metadata with
 		| [] -> ()
 		| (Meta.NullSafety, args, pos) :: rest ->
 			(match args with
 				| ([] | [(EConst (Ident ("Off" | "Loose" | "Strict" | "StrictThreaded")), _)]) -> ()
-				| _ -> add_error report "Invalid argument for @:nullSafety meta" pos
+				| _ -> add_error report m "Invalid argument for @:nullSafety meta" pos
 			);
-			validate_safety_meta report rest
-		| _ :: rest -> validate_safety_meta report rest
+			validate_safety_meta report m rest
+		| _ :: rest -> validate_safety_meta report m rest
 
 (**
 	Check if specified `field` represents a `var` field which will exist at runtime.
@@ -1067,7 +1081,7 @@ class local_safety (mode:safety_mode) =
 (**
 	This class is used to recursively check typed expressions for null-safety
 *)
-class expr_checker mode immediate_execution report =
+class expr_checker m mode immediate_execution report options =
 	object (self)
 		val local_safety = new local_safety mode
 		val mutable return_types = []
@@ -1090,13 +1104,13 @@ class expr_checker mode immediate_execution report =
 							if p <> null_pos then p
 							else get_first_valid_pos rest
 				in
-				add_error report msg (get_first_valid_pos positions)
+				add_error report m msg (get_first_valid_pos positions)
 			end
 
 		method error_unify (trace:unify_error list) p =
 			if not is_pretending then begin
 				let msg = (BetterErrors.better_error_message trace) in
-				add_error report msg p
+				add_error report m msg p
 			end
 		(**
 			Register a warning
@@ -1110,7 +1124,8 @@ class expr_checker mode immediate_execution report =
 							if p <> null_pos then p
 							else get_first_valid_pos rest
 				in
-				add_warning report wtype msg (get_first_valid_pos positions)
+				(* TODO field options *)
+				add_warning report m wtype options msg (get_first_valid_pos positions)
 			end
 
 		method private check_binop_redundant_null_checks e =
@@ -1119,6 +1134,7 @@ class expr_checker mode immediate_execution report =
 				| TBinop ((OpEq | OpNotEq), expr, { eexpr = TConst TNull })
 				| TBinop(OpAssignOp OpNullCoal, expr, _)
 				| TBinop (OpNullCoal, expr, _) ->
+					(* TODO field options *)
 					if not (is_nullable_type ~dynamic_is_nullable:true expr.etype) then
 						self#warning
 							WRedundantNullCheck
@@ -1274,7 +1290,7 @@ class expr_checker mode immediate_execution report =
 				| TThrow expr -> self#check_throw expr e.epos
 				| TCast (expr, _) -> self#check_cast expr e.etype e.epos
 				| TMeta (m, _) when contains_unsafe_meta [m] -> ()
-				| TMeta ((Meta.NullSafety, _, _) as m, e) -> validate_safety_meta report [m]; self#check_expr e
+				| TMeta ((Meta.NullSafety, _, _) as m_meta, e) -> validate_safety_meta report m [m_meta]; self#check_expr e
 				| TMeta (_, e) -> self#check_expr e
 				| TEnumIndex idx -> self#check_enum_index idx e.epos
 				| TEnumParameter (e, _, _) -> self#check_expr e (** Checking enum value itself is not needed here because this expr always follows after TEnumIndex *)
@@ -1606,20 +1622,22 @@ class expr_checker mode immediate_execution report =
 	end
 
 class class_checker cls immediate_execution report (main_expr : texpr option) =
+	let m = cls.cl_module in
 	let cls_meta = cls.cl_meta @ (match cls.cl_kind with KAbstractImpl a -> a.a_meta | _ -> []) in
 	object (self)
 			val is_safe_class = (safety_enabled cls_meta)
-			val mutable checker = new expr_checker SMLoose immediate_execution report
+			(* TODO: field meta *)
+			val mutable checker = new expr_checker m SMLoose immediate_execution report (Warning.from_meta cls_meta)
 			val mutable mode : safety_mode option = None
 		(**
 			Entry point for checking a class
 		*)
 		method check =
-			validate_safety_meta report cls_meta;
+			validate_safety_meta report m cls_meta;
 			if is_safe_class && (not (has_class_flag cls CExtern)) && (not (has_class_flag cls CInterface)) then
 				self#check_var_fields;
 			let check_field is_static f = if not (has_class_field_flag f CfPostProcessed) then begin
-				validate_safety_meta report f.cf_meta;
+				validate_safety_meta report m f.cf_meta;
 				match (get_safety_mode (cls_meta @ f.cf_meta)) with
 					| SMOff -> ()
 					| mode ->
@@ -1682,7 +1700,8 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 		*)
 		method private get_checker mode =
 			if checker#get_mode <> mode then
-				checker <- new expr_checker mode immediate_execution report;
+				(* TODO field meta *)
+				checker <- new expr_checker m mode immediate_execution report (Warning.from_meta cls_meta);
 			checker
 		(**
 			Check if field should be checked by null safety
@@ -1710,7 +1729,7 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 		*)
 		method check_var_fields =
 			let check_field is_static field =
-				validate_safety_meta report field.cf_meta;
+				validate_safety_meta report m field.cf_meta;
 				if
 					should_be_initialized field
 					&& not (is_nullable_type field.cf_type)
@@ -1875,20 +1894,22 @@ let run (com:Common.context) (types:module_type list) =
 	match com.callbacks#get_null_safety_report with
 		| [] ->
 			List.iter (fun warn ->
-				com.warning (Option.get warn.sm_type) [] warn.sm_msg warn.sm_pos
+				Common.module_warning com warn.sw_module warn.sw_warning warn.sw_options warn.sw_msg warn.sw_pos
 			) (List.rev report.sr_warnings);
-
 			List.iter (fun err ->
 				Common.display_error com err.sm_msg err.sm_pos
-			) (List.rev report.sr_errors)
+			) (List.rev report.sr_errors);
 		| callbacks ->
-			let warnings =
-				List.map (fun warn -> (warn.sm_type, warn.sm_msg, warn.sm_pos)) report.sr_warnings
-			in
 			let errors =
-				List.map (fun err -> (err.sm_type, err.sm_msg, err.sm_pos)) report.sr_errors
+				List.map (fun err -> (err.sm_msg, err.sm_pos)) report.sr_errors
 			in
-			let all = warnings @ errors in
-			List.iter (fun fn -> fn all) callbacks
+			let warnings =
+				List.filter_map (fun w ->
+					match Warning.get_mode w.sw_warning (w.sw_options @ com.warning_options) with
+					| WMEnable -> Some (w.sw_warning, w.sw_msg, w.sw_pos)
+					| WMDisable -> None
+				) report.sr_warnings
+			in
+			List.iter (fun fn -> fn errors warnings) callbacks
 
 ;;

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1129,7 +1129,7 @@ class expr_checker m mode immediate_execution report options =
 			end
 
 		method private check_binop_redundant_null_checks e =
-			match e.eexpr with
+			match (skip e).eexpr with
 				| TBinop ((OpEq | OpNotEq), { eexpr = TConst TNull }, expr)
 				| TBinop ((OpEq | OpNotEq), expr, { eexpr = TConst TNull })
 				| TBinop(OpAssignOp OpNullCoal, expr, _)
@@ -1140,6 +1140,9 @@ class expr_checker m mode immediate_execution report options =
 							WRedundantNullCheck
 							("The operand type is not nullable, so null-check should be redundant.")
 							[expr.epos; e.epos];
+				| TBinop (op, left_expr, right_expr) ->
+					self#check_binop_redundant_null_checks left_expr;
+					self#check_binop_redundant_null_checks right_expr;
 				| _ -> ()
 		(**
 			Check if `e` is nullable even if the type is reported not-nullable.

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -6,16 +6,23 @@ open Error
 type safety_message = {
 	sm_msg : string;
 	sm_pos : pos;
+	sm_type : WarningList.warning option
 }
 
 type safety_report = {
 	mutable sr_errors : safety_message list;
+	mutable sr_warnings: safety_message list;
 }
 
 let add_error report msg pos =
-	let error = { sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
+	let error = { sm_type = None; sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
 	if not (List.mem error report.sr_errors) then
-		report.sr_errors <- error :: report.sr_errors;
+		report.sr_errors <- error :: report.sr_errors;;
+
+let add_warning report wtype msg pos =
+	let warning = { sm_type = Some wtype; sm_msg = ("Null safety: " ^ msg); sm_pos = pos; } in
+	if not (List.mem warning report.sr_warnings) then
+		report.sr_warnings <- warning :: report.sr_warnings;
 
 type scope_type =
 	| STNormal
@@ -457,7 +464,7 @@ let rec contains_safe_meta metadata =
 let safety_enabled meta =
 	(contains_safe_meta meta) && not (contains_unsafe_meta meta)
 
-let safety_mode (metadata:Ast.metadata) =
+let get_safety_mode (metadata:Ast.metadata) =
 	let rec traverse mode meta =
 		match mode, meta with
 			| Some SMOff, _
@@ -1067,7 +1074,6 @@ class expr_checker mode immediate_execution report =
 		val mutable in_closure = false
 		(* if this flag is `true` then spotted errors and warnings will not be reported *)
 		val mutable is_pretending = false
-		(* val mutable cnt = 0 *)
 		(**
 			Get safety mode for this expression checker
 		*)
@@ -1092,6 +1098,33 @@ class expr_checker mode immediate_execution report =
 				let msg = (BetterErrors.better_error_message trace) in
 				add_error report msg p
 			end
+		(**
+			Register a warning
+		*)
+		method warning wtype msg (positions:Globals.pos list) =
+			if not is_pretending then begin
+				let rec get_first_valid_pos positions =
+					match positions with
+						| [] -> null_pos
+						| p :: rest ->
+							if p <> null_pos then p
+							else get_first_valid_pos rest
+				in
+				add_warning report wtype msg (get_first_valid_pos positions)
+			end
+
+		method private check_binop_redundant_null_checks e =
+			match e.eexpr with
+				| TBinop ((OpEq | OpNotEq), { eexpr = TConst TNull }, expr)
+				| TBinop ((OpEq | OpNotEq), expr, { eexpr = TConst TNull })
+				| TBinop(OpAssignOp OpNullCoal, expr, _)
+				| TBinop (OpNullCoal, expr, _) ->
+					if not (is_nullable_type ~dynamic_is_nullable:true expr.etype) then
+						self#warning
+							WRedundantNullCheck
+							("The operand type is not nullable, so null-check should be redundant.")
+							[expr.epos; e.epos];
+				| _ -> ()
 		(**
 			Check if `e` is nullable even if the type is reported not-nullable.
 			Haxe type system lies sometimes.
@@ -1216,7 +1249,9 @@ class expr_checker mode immediate_execution report =
 				| TConst _ -> ()
 				| TLocal _ -> ()
 				| TArray (arr, idx) -> self#check_array_access arr idx e.epos
-				| TBinop (op, left_expr, right_expr) -> self#check_binop op left_expr right_expr e.epos
+				| TBinop (op, left_expr, right_expr) ->
+					self#check_binop_redundant_null_checks e;
+					self#check_binop op left_expr right_expr e.epos
 				| TField (target, access) -> self#check_field target access e.epos
 				| TTypeExpr _ -> ()
 				| TParenthesis e -> self#check_expr e
@@ -1585,7 +1620,7 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 				self#check_var_fields;
 			let check_field is_static f = if not (has_class_field_flag f CfPostProcessed) then begin
 				validate_safety_meta report f.cf_meta;
-				match (safety_mode (cls_meta @ f.cf_meta)) with
+				match (get_safety_mode (cls_meta @ f.cf_meta)) with
 					| SMOff -> ()
 					| mode ->
 						(match f.cf_expr with
@@ -1596,7 +1631,7 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 						self#check_accessors is_static f
 			end in
 			if is_safe_class then
-				Option.may ((self#get_checker (safety_mode cls_meta))#check_root_expr) (TClass.get_cl_init cls);
+				Option.may ((self#get_checker (get_safety_mode cls_meta))#check_root_expr) (TClass.get_cl_init cls);
 			Option.may (check_field false) cls.cl_constructor;
 			List.iter (check_field false) cls.cl_ordered_fields;
 			List.iter (check_field true) cls.cl_ordered_statics;
@@ -1639,7 +1674,7 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 			match mode with
 				| Some mode -> mode
 				| None ->
-					let m = safety_mode cls_meta in
+					let m = get_safety_mode cls_meta in
 					mode <- Some m;
 					m
 		(**
@@ -1822,7 +1857,10 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 *)
 let run (com:Common.context) (types:module_type list) =
 	let report = Timer.time com.timer_ctx ["null safety"] (fun () ->
-		let report = { sr_errors = [] } in
+		let report = {
+			sr_errors = [];
+			sr_warnings = [];
+		} in
 		let immediate_execution = new immediate_execution in
 		let traverse module_type =
 			match module_type with
@@ -1836,11 +1874,21 @@ let run (com:Common.context) (types:module_type list) =
 	) () in
 	match com.callbacks#get_null_safety_report with
 		| [] ->
-			List.iter (fun err -> Common.display_error com err.sm_msg err.sm_pos) (List.rev report.sr_errors)
+			List.iter (fun warn ->
+				com.warning (Option.get warn.sm_type) [] warn.sm_msg warn.sm_pos
+			) (List.rev report.sr_warnings);
+
+			List.iter (fun err ->
+				Common.display_error com err.sm_msg err.sm_pos
+			) (List.rev report.sr_errors)
 		| callbacks ->
-			let errors =
-				List.map (fun err -> (err.sm_msg, err.sm_pos)) report.sr_errors
+			let warnings =
+				List.map (fun warn -> (warn.sm_type, warn.sm_msg, warn.sm_pos)) report.sr_warnings
 			in
-			List.iter (fun fn -> fn errors) callbacks
+			let errors =
+				List.map (fun err -> (err.sm_type, err.sm_msg, err.sm_pos)) report.sr_errors
+			in
+			let all = warnings @ errors in
+			List.iter (fun fn -> fn all) callbacks
 
 ;;

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -25,7 +25,7 @@ type safety_report = {
 let add_error report m msg pos =
 	let error = { sm_msg = ("Null safety: " ^ msg); sm_pos = pos; sm_module = m; } in
 	if not (List.mem error report.sr_errors) then
-		report.sr_errors <- error :: report.sr_errors;;
+		report.sr_errors <- error :: report.sr_errors
 
 let add_warning report m wtype options msg pos =
 	let warning = {
@@ -36,7 +36,7 @@ let add_warning report m wtype options msg pos =
 		sw_module = m;
 	} in
 	if not (List.mem warning report.sr_warnings) then
-		report.sr_warnings <- warning :: report.sr_warnings;
+		report.sr_warnings <- warning :: report.sr_warnings
 
 type scope_type =
 	| STNormal

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1786,7 +1786,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 		Texpr.type_constant ctx.com.basic c p
 	| EBinop (OpNullCoal,e1,e2) ->
 		let vr = new value_reference ctx in
-		let e1 = type_expr ctx (Expr.ensure_block e1) with_type in
+		let e1 = type_expr ctx (Expr.ensure_block e1) WithType.value in
 		let e2 = type_expr ctx (Expr.ensure_block e2) (WithType.with_type e1.etype) in
 		let tmin,cast = get_if_then_else_operands ctx e1 e2 with_type in
 		let e2 = cast e2 in
@@ -1796,7 +1796,6 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 			| TAbstract({a_path = [],"Null"},[t]) -> tmin
 			| _ -> follow_without_type tmin
 		in
-		let e1_null_t = ctx.t.tnull e1.etype in
 		let var_name = match WithType.get_expected_name with_type with
 			| None
 			(* TODO: why does this happen? *)
@@ -1805,8 +1804,8 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 			| Some name ->
 				name
 		in
-		let e1 = vr#as_var var_name {e1 with etype = e1_null_t} in
-		let e_null = Builder.make_null e1_null_t e1.epos in
+		let e1 = vr#as_var var_name e1 in
+		let e_null = Builder.make_null e1.etype e1.epos in
 		let e_cond = mk (TBinop(OpNotEq,e1,e_null)) ctx.t.tbool e1.epos in
 		let e_if = mk (TIf(e_cond,cast e1,Some e2)) iftype p in
 		vr#to_texpr e_if

--- a/tests/misc/cpp/projects/Pull12231/Main.hx
+++ b/tests/misc/cpp/projects/Pull12231/Main.hx
@@ -1,0 +1,11 @@
+function main() {
+		var a = 0 ?? 1;
+}
+function test2():Void {
+	var a = 1;
+	var b = a ?? 0;
+}
+function test3():Void {
+	var a = 1;
+	a ??= 0;
+}

--- a/tests/misc/cpp/projects/Pull12231/compile-fail.hxml
+++ b/tests/misc/cpp/projects/Pull12231/compile-fail.hxml
@@ -1,0 +1,3 @@
+--main Main
+--cpp bin/cpp
+-D analyzer-optimize

--- a/tests/misc/cpp/projects/Pull12231/compile-fail.hxml.stderr
+++ b/tests/misc/cpp/projects/Pull12231/compile-fail.hxml.stderr
@@ -1,0 +1,3 @@
+Main.hx:10: characters 2-3 : On static platforms, null can't be used as basic type Int
+Main.hx:6: characters 10-11 : On static platforms, null can't be used as basic type Int
+Main.hx:2: characters 11-12 : On static platforms, null can't be used as basic type Int

--- a/tests/nullsafety/src/Validator.hx
+++ b/tests/nullsafety/src/Validator.hx
@@ -2,19 +2,21 @@
 import haxe.macro.Context;
 import haxe.macro.Expr;
 
-typedef SafetyMessage = {msg:String, pos:Position}
-typedef ExpectedMessage = {symbol:String, pos:Position}
+typedef SafetyMessage = {type:String, msg:String, pos:Position}
+typedef ExpectedMessage = {type:String, symbol:String, pos:Position}
 #end
 
 class Validator {
 #if macro
 	static var expectedErrors:Array<ExpectedMessage> = [];
+	static var expectedWarnings:Array<ExpectedMessage> = [];
 
 	static dynamic function onNullSafetyReport(callback:(errors:Array<SafetyMessage>)->Void):Void {
 	}
 
 	static public function register() {
 		expectedErrors = [];
+		expectedWarnings = [];
 		onNullSafetyReport = @:privateAccess Context.load("on_null_safety_report", 1);
 		onNullSafetyReport(validate);
 	}
@@ -25,7 +27,13 @@ class Validator {
 				if(meta.name == ':shouldFail') {
 					var fieldPosInfos = Context.getPosInfos(field.pos);
 					fieldPosInfos.min = Context.getPosInfos(meta.pos).max + 1;
-					expectedErrors.push({symbol: field.name, pos:Context.makePosition(fieldPosInfos)});
+					expectedErrors.push({type: "error", symbol: field.name, pos:Context.makePosition(fieldPosInfos)});
+					break;
+				}
+				if(meta.name == ':shouldWarn') {
+					var fieldPosInfos = Context.getPosInfos(field.pos);
+					fieldPosInfos.min = Context.getPosInfos(meta.pos).max + 1;
+					expectedWarnings.push({type: "warning", symbol: field.name, pos:Context.makePosition(fieldPosInfos)});
 					break;
 				}
 			}
@@ -34,7 +42,7 @@ class Validator {
 	}
 
 	static function validate(errors:Array<SafetyMessage>) {
-		var errors = check(expectedErrors.copy(), errors.copy());
+		var errors = check(expectedErrors.concat(expectedWarnings), errors.copy());
 		if(errors.ok) {
 			Sys.println('${errors.passed} expected errors spotted');
 			Sys.println('Compile-time tests passed.');
@@ -50,6 +58,7 @@ class Validator {
 			var actualEvent = actual[i];
 			var wasExpected = false;
 			for(expectedEvent in expected) {
+				if (expectedEvent.type != actualEvent.type) continue;
 				if(posContains(expectedEvent.pos, actualEvent.pos)) {
 					expected.remove(expectedEvent);
 					wasExpected = true;
@@ -85,7 +94,12 @@ class Validator {
 #end
 
 	macro static public function shouldFail(expr:Expr):Expr {
-		expectedErrors.push({symbol:Context.getLocalMethod(), pos:expr.pos});
+		expectedErrors.push({type: "error", symbol:Context.getLocalMethod(), pos:expr.pos});
+		return expr;
+	}
+
+	macro static public function shouldWarn(expr:Expr):Expr {
+		expectedWarnings.push({type: "warning", symbol:Context.getLocalMethod(), pos:expr.pos});
 		return expr;
 	}
 }

--- a/tests/nullsafety/src/cases/TestLoose.hx
+++ b/tests/nullsafety/src/cases/TestLoose.hx
@@ -1,6 +1,7 @@
 package cases;
 
 import Validator.shouldFail;
+import Validator.shouldWarn;
 
 typedef NotNullAnon = {
 	a:String
@@ -133,7 +134,7 @@ class TestLoose {
 	}
 
 	static function nullCoal_returnNull_shouldPass(token:{children:Array<Int>}):Null<Bool> {
-		final children = token.children ?? return null;
+		final children = shouldWarn(token.children ?? return null);
 		var i = children.length;
 		return null;
 	}

--- a/tests/nullsafety/src/cases/TestLoose.hx
+++ b/tests/nullsafety/src/cases/TestLoose.hx
@@ -134,7 +134,7 @@ class TestLoose {
 	}
 
 	static function nullCoal_returnNull_shouldPass(token:{children:Array<Int>}):Null<Bool> {
-		final children = shouldWarn(token.children ?? return null);
+		final children = token.children ?? return null;
 		var i = children.length;
 		return null;
 	}

--- a/tests/nullsafety/src/cases/TestNonNullable.hx
+++ b/tests/nullsafety/src/cases/TestNonNullable.hx
@@ -1,0 +1,60 @@
+package cases;
+
+import Validator.shouldWarn;
+import Validator.shouldFail;
+
+typedef Data = {
+	var foo:String;
+}
+
+class TestNonNullable {
+	static function main() {
+		final foo = 0;
+		if (shouldWarn(foo) == null) {}
+
+		final dyn:Dynamic = null;
+		if (dyn == null) {}
+
+		final dyn:Any = 1;
+		if (shouldWarn(dyn) == null) {}
+
+		var data:Data = haxe.Json.parse("{}");
+		data.foo.length;
+
+		switch shouldWarn(data.foo) {
+			case null if (shouldWarn(data.foo) == null):
+				final v = shouldWarn(data.foo) == null;
+		}
+
+		final v = shouldWarn(data.foo) == null;
+		shouldWarn(data.foo) != null && true;
+		true && shouldWarn(data.foo) != null;
+		data.foo != null || true;
+		true || shouldWarn(data.foo) != null;
+
+		throw shouldWarn(data.foo) == null;
+
+		function foo():Bool {
+			return shouldWarn(data.foo) == null;
+		}
+
+		while (shouldWarn(data.foo) == null) {}
+
+		shouldWarn(data.foo) ??= "";
+		final foo = shouldWarn(data.foo ?? "");
+		if (null == shouldWarn(data.foo)) {
+			trace(1);
+		}
+		if (shouldWarn(data.foo) == null) {
+			data.foo = "default";
+		}
+	}
+}
+
+@:build(Validator.checkFields())
+class BasicErrors {
+	@:shouldFail static var foo2:Int;
+	public function new() {
+		shouldFail(var foo:Int = null);
+	}
+}

--- a/tests/nullsafety/src/cases/TestNonNullable.hx
+++ b/tests/nullsafety/src/cases/TestNonNullable.hx
@@ -7,6 +7,7 @@ typedef Data = {
 	var foo:String;
 }
 
+@:haxe.warning("+WRedundantNullCheck")
 class TestNonNullable {
 	static function main() {
 		final foo = 0;

--- a/tests/nullsafety/src/cases/TestNonNullable.hx
+++ b/tests/nullsafety/src/cases/TestNonNullable.hx
@@ -30,8 +30,9 @@ class TestNonNullable {
 		final v = shouldWarn(data.foo) == null;
 		shouldWarn(data.foo) != null && true;
 		true && shouldWarn(data.foo) != null;
-		data.foo != null || true;
-		true || shouldWarn(data.foo) != null;
+		shouldWarn(data.foo) != null || false;
+		false || shouldWarn(data.foo) != null;
+		(shouldWarn(data.foo) != null || false) || false;
 
 		throw shouldWarn(data.foo) == null;
 

--- a/tests/nullsafety/test.hxml
+++ b/tests/nullsafety/test.hxml
@@ -5,8 +5,10 @@ cases.TestStrictThreaded
 cases.TestLoose
 cases.TestSafeFieldInUnsafeClass
 cases.TestAbstract
+cases.TestNonNullable
 
 --macro nullSafety('cases.TestLoose', Loose)
 --macro nullSafety('cases.TestStrict', Strict)
 --macro nullSafety('cases.TestStrictThreaded', StrictThreaded)
+--macro nullSafety('cases.TestNonNullable', Loose)
 --macro Validator.register()

--- a/tests/unit/src/unit/TestNullCoalescing.hx
+++ b/tests/unit/src/unit/TestNullCoalescing.hx
@@ -111,7 +111,9 @@ class TestNullCoalescing extends Test {
 
 	function test() {
 		count = 0;
+		#if !static
 		eq(true, 0 != 1 ?? 2);
+		#end
 		var a = call() ?? "default";
 		eq(count, 1);
 
@@ -175,11 +177,13 @@ class TestNullCoalescing extends Test {
 		final a = nullString;
 		eq(a ?? "2", "2");
 
+		#if !static
 		eq(1 ?? 2, 1);
+		#end
 		eq("1" ?? "2", "1");
 
 		final arr = [];
-		function item(n) {
+		function item(n):Null<Int> {
 			arr.push(n);
 			return n;
 		}
@@ -362,7 +366,7 @@ class TestNullCoalescing extends Test {
 
 	static macro function mut() {
 		mutI++;
-		return macro mutI;
+		return macro(mutI : Null<Int>);
 	}
 
 	static macro function getMut() {

--- a/tests/unit/src/unit/issues/Issue11144.hx
+++ b/tests/unit/src/unit/issues/Issue11144.hx
@@ -2,7 +2,9 @@ package unit.issues;
 
 class Issue11144 extends Test {
 	function test() {
-		t(false ?? false || true); // false
-		t((false ?? false) || true); // true
+		final vfalse:Null<Bool> = false;
+		final vtrue:Null<Bool> = true;
+		t(vfalse ?? vfalse || vtrue);
+		t((vfalse ?? vfalse) || vtrue);
 	}
 }


### PR DESCRIPTION
Cannot undestand problem with warning diagnostics, need some help:
(nullsafety warnings will stay if there is nullsafety errors btw)
```haxe
@:nullSafety
@:haxe.warning("-WRedundantNullCheck")
class Main {
	static function main() {
		new Main();
	}

	function new() {
		final foo = "1";
		// this warning doesn't react on WRedundantNullCheck
		// and also hides after vscode tab swap
		final v = foo ?? "0";

		final foo = 1;
		// no warning because of Null<Int> cast in operator
		// probably can be fixed with some @:nonNullable internal meta on expr
		final v = foo ?? 0;

		// working warning example
		final f:Int;
		function name():Void {
			f + 1;
		}
	}
}
```

Closes https://github.com/HaxeFoundation/haxe/issues/7816