### PR TITLE
Generate ES6 arrows without `this` temp vars

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -581,6 +581,13 @@
 		"targets": ["TClass"]
 	},
 	{
+		"name": "JsFunction",
+		"metadata": ":js.function",
+		"doc": "Generate `function` keyword instead of arrow function in `-D js_es >= 6` mode to enable access to function scope `this`.",
+		"platforms": ["js"],
+		"targets": ["TExpr"]
+	},
+	{
 		"name": "LuaRequire",
 		"metadata": ":luaRequire",
 		"doc": "Generate Lua module require expression for given extern.",

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -517,6 +517,7 @@ let default_config =
 			vs_scope = BlockScope;
 			vs_flags = [];
 		};
+		pf_can_capture_this = true;
 		pf_supports_atomics = false;
 	}
 
@@ -551,6 +552,7 @@ let get_config com =
 					(if defined Define.JsUnflatten then ReserveAllTopLevelSymbols else ReserveAllTypesFlat)
 					:: if es6 then [NoShadowing; SwitchCasesNoBlocks;] else [VarHoisting; NoCatchVarShadowing];
 			};
+			pf_can_capture_this = es6;
 			pf_supports_atomics = true;
 		}
 	| Lua ->
@@ -562,7 +564,8 @@ let get_config com =
 			pf_supports_rest_args = true;
 			pf_exceptions = { default_config.pf_exceptions with
 				ec_avoid_wrapping = false;
-			}
+			};
+			pf_can_capture_this = false;
 		}
 	| Neko ->
 		{
@@ -577,7 +580,8 @@ let get_config com =
 			};
 			pf_exceptions = { default_config.pf_exceptions with
 				ec_avoid_wrapping = false
-			}
+			};
+			pf_can_capture_this = false;
 		}
 	| Flash ->
 		{
@@ -602,6 +606,7 @@ let get_config com =
 				vs_scope = FunctionScope;
 				vs_flags = [VarHoisting];
 			};
+			pf_can_capture_this = false;
 		}
 	| Php ->
 		{
@@ -641,6 +646,7 @@ let get_config com =
 				vs_flags = [NoShadowing];
 				vs_scope = FunctionScope;
 			};
+			pf_can_capture_this = false;
 			pf_supports_atomics = true;
 		}
 	| Jvm ->
@@ -664,6 +670,7 @@ let get_config com =
 				ec_wildcard_catch = (["java";"lang"],"Throwable");
 				ec_base_throw = (["java";"lang"],"RuntimeException");
 			};
+			pf_can_capture_this = false;
 			pf_supports_atomics = true;
 		}
 	| Python ->
@@ -688,6 +695,7 @@ let get_config com =
 				vs_scope = FunctionScope;
 				vs_flags = [VarHoisting]
 			};
+			pf_can_capture_this = false;
 		}
 	| Hl ->
 		{
@@ -702,7 +710,8 @@ let get_config com =
 			};
 			pf_exceptions = { default_config.pf_exceptions with
 				ec_avoid_wrapping = false
-			}
+			};
+			pf_can_capture_this = false;
 		}
 	| Eval ->
 		{
@@ -716,6 +725,7 @@ let get_config com =
 				ec_avoid_wrapping = false
 			};
 			pf_supports_atomics = true;
+			pf_can_capture_this = false;
 		}
 
 let memory_marker = [|Unix.time()|]

--- a/src/context/platformConfig.ml
+++ b/src/context/platformConfig.ml
@@ -118,6 +118,8 @@ type platform_config = {
 	pf_exceptions : exceptions_config;
 	(** the scoping of local variables *)
 	pf_scoping : var_scoping_config;
+	(** whether or not the target needs a variable to capture `this` *)
+	pf_can_capture_this : bool;
 	(** target supports atomic operations via haxe.Atomic **)
 	pf_supports_atomics : bool;
 }

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -558,6 +558,8 @@ and gen_expr ctx e =
 		| TBreak ->
 			print ctx "break _hx_loop%s" n;
 		| _ -> die "" __LOC__)
+	| TMeta ((Meta.JsFunction, [], _),{eexpr = TFunction f}) ->
+		gen_function ~hasJsFunction:true ctx f e.epos
 	| TMeta (_,e) ->
 		gen_expr ctx e
 	| TReturn eo ->
@@ -722,7 +724,7 @@ and gen_expr ctx e =
 	);
 	clear_mapping ()
 
-and gen_function ?(keyword="function") ctx f pos =
+and gen_function ?(keyword="function") ?(hasJsFunction=false) ctx f pos =
 	let old = ctx.in_value, ctx.in_loop in
 	ctx.in_value <- None;
 	ctx.in_loop <- false;
@@ -760,7 +762,15 @@ and gen_function ?(keyword="function") ctx f pos =
 		| _ ->
 			f, mk_non_rest_arg_names f.tf_args
 	in
-	print ctx "%s(%s) " keyword (String.concat "," args);
+	let can_be_arrow =
+		keyword = "function" &&
+		ctx.es_version >= 6 &&
+		not hasJsFunction
+	in
+	if can_be_arrow then
+		print ctx "(%s) => " (String.concat "," args)
+	else
+		print ctx "%s(%s) " keyword (String.concat "," args);
 	gen_expr ctx (fun_block ctx f pos);
 	ctx.in_value <- fst old;
 	ctx.in_loop <- snd old;
@@ -831,6 +841,7 @@ and gen_value ctx e =
 	| TNew _
 	| TUnop _
 	| TFunction _
+	| TMeta ((Meta.JsFunction, [], _),_)
 	| TIdent _ ->
 		gen_expr ctx e
 	| TMeta (_,e1) ->

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -465,6 +465,7 @@ and encode_platform_config pc =
 		"supportsRestArgs", vbool pc.pf_supports_rest_args;
 		"exceptions", encode_exceptions_config pc.pf_exceptions;
 		"scoping", encode_var_scoping_config pc.pf_scoping;
+		"canCaptureThis", vbool pc.pf_can_capture_this;
 		"supportsAtomics", vbool pc.pf_supports_atomics;
 	]
 
@@ -1750,6 +1751,7 @@ let decode_platform_config v =
 		pf_supports_rest_args = decode_bool (field v "supportsRestArgs");
 		pf_exceptions = exception_config;
 		pf_scoping = var_scoping_config;
+		pf_can_capture_this = decode_bool (field v "canCaptureThis");
 		pf_supports_atomics = decode_bool (field v "supportsAtomics");
 	}
 

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -483,7 +483,7 @@ object(self)
 			_inlined_vars <- vars; (* Order is reversed due to tail-recursion *)
 		in
 		match ethis.eexpr with
-		| TConst TNull ->
+		| TConst TNull | TConst TThis ->
 			set_inlined_vars params f.tf_args;
 			None
 		| _ ->
@@ -713,7 +713,8 @@ let rec type_inline (ictx : inline_context) cf f ethis params tret config p ?(se
 				l.i_read <- l.i_read + (if !in_loop then 2 else 1);
 				{ e with eexpr = TLocal l.i_subst }
 			| None ->
-				raise_typing_error "Could not inline `this` outside of an instance context" po
+				{ e with eexpr = TConst TThis }
+				(* raise_typing_error "Could not inline `this` outside of an instance context" po *)
 			)
 		| TVar (v,eo) ->
 			if has_var_flag v VStatic then raise_typing_error "Inline functions cannot have static locals" v.v_pos;

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1541,6 +1541,14 @@ and type_meta ?(mode=MGet) ctx m e1 with_type p =
 		| (Meta.NullSafety,_,_) ->
 			let e = e() in
 			{e with eexpr = TMeta(m,e)}
+		| (Meta.JsFunction, [],pos) when ctx.com.platform=Js ->
+			let e = e() in
+			begin match e.eexpr with
+				| TFunction f ->
+					{e with eexpr = TMeta(m,e)}
+				| _ ->
+					raise_typing_error "@:js.function can be applied only to anonymous functions" pos
+			end
 		| (Meta.BypassAccessor,_,p) ->
 			let old_counter = ctx.e.bypass_accessor in
 			ctx.e.bypass_accessor <- old_counter + 1;

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -149,10 +149,17 @@ let is_lower_ident s p =
 	with Invalid_argument msg -> raise_typing_error msg p
 
 let get_this ctx p =
+	let has_jsfun_meta metas =
+		ctx.com.platform == Js && List.exists (fun (name,args,pos) ->
+			match name with
+				| Meta.JsFunction -> true
+				| _ -> false
+				) metas
+	in
 	match ctx.e.curfun with
 	| FunStatic ->
 		raise_typing_error "Cannot access this from a static function" p
-	| FunMemberClassLocal | FunMemberAbstractLocal ->
+	| FunMemberClassLocal | FunMemberAbstractLocal when not ctx.com.config.pf_can_capture_this || has_jsfun_meta ctx.f.meta ->
 		let v = match ctx.f.vthis with
 			| None ->
 				let v = if ctx.e.curfun = FunMemberAbstractLocal then begin
@@ -169,7 +176,7 @@ let get_this ctx p =
 				v
 		in
 		mk (TLocal v) ctx.c.tthis p
-	| FunMemberAbstract ->
+	| FunMemberAbstract | FunMemberAbstractLocal ->
 		let v = (try PMap.find "this" ctx.f.locals with Not_found -> raise_typing_error "Cannot reference this abstract here" p) in
 		mk (TLocal v) v.v_type p
 	| FunConstructor | FunMember when TyperManager.is_coroutine_context ctx ->
@@ -182,7 +189,7 @@ let get_this ctx p =
 				v
 		in
 		mk (TLocal v) ctx.c.tthis p
-	| FunConstructor | FunMember ->
+	| FunConstructor | FunMember | FunMemberClassLocal ->
 		mk (TConst TThis) ctx.c.tthis p
 
 let get_stored_typed_expr ctx id =

--- a/std/haxe/macro/PlatformConfig.hx
+++ b/std/haxe/macro/PlatformConfig.hx
@@ -91,6 +91,10 @@ typedef PlatformConfig = {
 	**/
 	final supportsAtomics:Bool;
 
+	/**
+		Whether or not the target needs a variable to capture `this`
+	**/
+	final canCaptureThis:Bool;
 }
 
 enum CapturePolicy {

--- a/std/js/_std/HxOverrides.hx
+++ b/std/js/_std/HxOverrides.hx
@@ -123,10 +123,10 @@ class HxOverrides {
 			return {
 				cur: 0,
 				arr: a,
-				hasNext: function() {
+				hasNext: @:js.function function() {
 					return __this__.cur < __this__.arr.length;
 				},
-				next: function() {
+				next: @:js.function function() {
 					return __this__.arr[__this__.cur++];
 				}
 			};

--- a/std/js/_std/Reflect.hx
+++ b/std/js/_std/Reflect.hx
@@ -110,7 +110,7 @@
 	}
 
 	public static function makeVarArgs<T>(f:Array<Dynamic>->T):Dynamic {
-		return function() {
+		return @:js.function function() {
 			var a = untyped Array.prototype.slice.call(js.Syntax.code("arguments"));
 			return f(a);
 		};

--- a/std/js/_std/haxe/ds/IntMap.hx
+++ b/std/js/_std/haxe/ds/IntMap.hx
@@ -124,10 +124,10 @@ package haxe.ds;
 		return untyped {
 			ref: h,
 			it: keys(),
-			hasNext: function() {
+			hasNext: @:js.function function() {
 				return __this__.it.hasNext();
 			},
-			next: function() {
+			next: @:js.function function() {
 				var i = __this__.it.next();
 				return __this__.ref[i];
 			}

--- a/std/js/_std/haxe/ds/ObjectMap.hx
+++ b/std/js/_std/haxe/ds/ObjectMap.hx
@@ -149,10 +149,10 @@ class ObjectMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
 		return untyped {
 			ref: h,
 			it: keys(),
-			hasNext: function() {
+			hasNext: @:js.function function() {
 				return __this__.it.hasNext();
 			},
-			next: function() {
+			next: @:js.function function() {
 				var i = __this__.it.next();
 				return __this__.ref[getId(i)];
 			}

--- a/tests/misc/projects/Issue11128/hxtest/Init.hx
+++ b/tests/misc/projects/Issue11128/hxtest/Init.hx
@@ -7,6 +7,7 @@ class Init {
 	// Default, except everything has been set to `true`.
 	public static var intendedConfig: PlatformConfig = {
 		supportsAtomics: true,
+		canCaptureThis: true,
 		thisBeforeSuper: true,
 		scoping: {
 			scope: BlockScope,


### PR DESCRIPTION
Removes `this` temp vars for ES6 mode, functions that need function-scope `this` can be marked with
```haxe
callback(@:js.function function() { // generate `function` in js instead of `() => {}`
// uses js.Lib.nativeThis, js.Syntax.code, etc
});
```

This is also port of `pf_can_capture_this` branch, so `this` capturing state is:
js-es5/python not supported
js-es6/php works
eval/lua/jvm/hl/cpp requires additional fixes, currently disabled

Closes https://github.com/HaxeFoundation/haxe/issues/10352
See https://github.com/HaxeFoundation/haxe/issues/9773