### PR TITLE
Avoid some capture variable wrapping in non-loops

### DIFF
--- a/src/filters/safe/capturedVars.ml
+++ b/src/filters/safe/capturedVars.ml
@@ -277,10 +277,11 @@ let captured_vars scom impl e =
 			(try
 				let d = PMap.find v.v_id !vars in
 				(* different depth - needs wrap *)
-				if d <> !depth then
+				if d <> !depth then begin
+					used := PMap.add v.v_id v !used;
 					mark_assigned v
 				(* same depth but assigned after being used on a different depth - needs wrap *)
-				else if PMap.mem v.v_id !used then
+				end else if PMap.mem v.v_id !used then
 					mark_assigned v
 				else
 					check_loop_var v true

--- a/src/filters/safe/capturedVars.ml
+++ b/src/filters/safe/capturedVars.ml
@@ -227,6 +227,7 @@ let captured_vars scom impl e =
 		let used = ref PMap.empty in
 		let assigned = ref PMap.empty in
 		let depth = ref 0 in
+		let in_loop = ref false in
 		let rec collect_vars = function
 		| Block f ->
 			let old = !vars in
@@ -234,7 +235,10 @@ let captured_vars scom impl e =
 			vars := old;
 		| Loop f ->
 			let old = !vars in
+			let old_loop = !in_loop in
+			in_loop := true;
 			f collect_vars;
+			in_loop := old_loop;
 			vars := old;
 		| Function f ->
 			incr depth;
@@ -247,7 +251,7 @@ let captured_vars scom impl e =
 				let d = PMap.find v.v_id !vars in
 				if d <> !depth then begin
 					used := PMap.add v.v_id v !used;
-					if has_var_flag v VAssigned then assigned := PMap.add v.v_id v !assigned;
+					if has_var_flag v VAssigned && !in_loop then assigned := PMap.add v.v_id v !assigned;
 				end
 			with Not_found -> ())
 		| Assign v ->
@@ -261,7 +265,7 @@ let captured_vars scom impl e =
 				(* same depth but assigned after being used on a different depth - needs wrap *)
 				else if PMap.mem v.v_id !used then
 					assigned := PMap.add v.v_id v !assigned
-				else
+				else if !in_loop then
 					add_var_flag v VAssigned;
 			with Not_found -> ())
 		in

--- a/src/filters/safe/capturedVars.ml
+++ b/src/filters/safe/capturedVars.ml
@@ -225,9 +225,26 @@ let captured_vars scom impl e =
 	and all_vars e =
 		let vars = ref PMap.empty in
 		let used = ref PMap.empty in
+		let in_loop = ref false in
+		let loop_vars = ref PMap.empty in
 		let assigned = ref PMap.empty in
 		let depth = ref 0 in
-		let in_loop = ref false in
+		let mark_assigned v =
+			assigned := PMap.add v.v_id v !assigned;
+			(* Remove from vars lookup because we're done with it *)
+			vars := PMap.remove v.v_id !vars;
+		in
+		let check_loop_var v is_assign =
+			try
+				let is_assign' = PMap.find v.v_id !loop_vars in
+				(* If we have both read and write in the same loop we need to wrap. *)
+				if is_assign <> is_assign' then mark_assigned v
+			with Not_found ->
+				loop_vars := PMap.add v.v_id is_assign !loop_vars
+		in
+		let check_loop_var v is_assign =
+			if !in_loop then check_loop_var v is_assign
+		in
 		let rec collect_vars = function
 		| Block f ->
 			let old = !vars in
@@ -235,10 +252,12 @@ let captured_vars scom impl e =
 			vars := old;
 		| Loop f ->
 			let old = !vars in
+			let old_loop_vars = !loop_vars in
 			let old_loop = !in_loop in
 			in_loop := true;
 			f collect_vars;
 			in_loop := old_loop;
+			loop_vars := old_loop_vars;
 			vars := old;
 		| Function f ->
 			incr depth;
@@ -250,23 +269,21 @@ let captured_vars scom impl e =
 			(try
 				let d = PMap.find v.v_id !vars in
 				if d <> !depth then begin
+					check_loop_var v false;
 					used := PMap.add v.v_id v !used;
-					if has_var_flag v VAssigned && !in_loop then assigned := PMap.add v.v_id v !assigned;
 				end
 			with Not_found -> ())
 		| Assign v ->
 			(try
 				let d = PMap.find v.v_id !vars in
 				(* different depth - needs wrap *)
-				if d <> !depth then begin
-					used := PMap.add v.v_id v !used;
-					assigned := PMap.add v.v_id v !assigned;
-				end
+				if d <> !depth then
+					mark_assigned v
 				(* same depth but assigned after being used on a different depth - needs wrap *)
 				else if PMap.mem v.v_id !used then
-					assigned := PMap.add v.v_id v !assigned
-				else if !in_loop then
-					add_var_flag v VAssigned;
+					mark_assigned v
+				else
+					check_loop_var v true
 			with Not_found -> ())
 		in
 		local_usage collect_vars e;


### PR DESCRIPTION
I noticed on the coroutine branch that we're wrapping values in this specific scenario:

```haxe
function main() {
	var a = 0;
	a = 1; // removing this avoids the wrapping
	function f() {
		trace(a);
	}
	f();
}
```

The current implementation marks the variable as `VAssigned` when coming across the `a = 1`, and then upon usage in a closure it demands the wrapping. I don't see why this should be necessary unless both the assignment and the usage are inside a loop, because otherwise the assignment is indistinguishable from the original declaration.

Come to think of it, even this check isn't specific enough because the wrapping should only be necessary if both appear in the _same_ loop:

```haxe
function main() {
	var a = 0;
	while (Math.random() > 0.5) {
		a = 1;
	}
	function f() {
		while (Math.random() > 0.5) {
			trace(a);
		}
	}
	f();
}

```

There's no reason to wrap here, but we do because both assignment and usage are in a loop. 