### PR TITLE
Optimize EventLoop.insertEventByTime

### DIFF
--- a/std/sys/thread/EventLoop.hx
+++ b/std/sys/thread/EventLoop.hx
@@ -28,6 +28,7 @@ class EventLoop {
 	final waitLock = new Lock();
 	var promisedEventsCount = 0;
 	var regularEvents:Null<RegularEvent>;
+	var lastRegularEvent:Null<RegularEvent>;
 	var isMainThread:Bool;
 	static var CREATED : Bool;
 
@@ -53,12 +54,20 @@ class EventLoop {
 		switch regularEvents {
 			case null:
 				regularEvents = event;
+				lastRegularEvent = null;
 			case current:
 				var previous = null;
+				if (lastRegularEvent != null && lastRegularEvent.nextRunTime <= event.nextRunTime) {
+					lastRegularEvent.next = event;
+					event.previous = lastRegularEvent;
+					lastRegularEvent = event;
+					return;
+				}
 				while(true) {
 					if(current == null) {
 						previous.next = event;
 						event.previous = previous;
+						lastRegularEvent = event;
 						break;
 					} else if(event.nextRunTime < current.nextRunTime) {
 						event.next = current;
@@ -66,7 +75,7 @@ class EventLoop {
 						switch previous {
 							case null:
 								regularEvents = event;
-								case _:
+							case _:
 								event.previous = previous;
 								previous.next = event;
 								current.previous = event;


### PR DESCRIPTION
I noticed on the coroutine branch that inserting a large number of events in an EventLoop is really slow. The reason is that events are implemented as a linked list, with the last element being at the end. This requires iterating the entire list when inserting an element at the end, which I think is what's happening in the majority of cases.

This change remembers the last element of the list and first checks if our new element time should be appended to it. My coroutine stress test goes from 1500% overhead to 110%, which is a pretty good outcome.

We could still create pathological problem cases by inserting a single event far in the future, in which case this optimization would never trigger. A way to address this would be to walk the list from both ends at the same time, but I'll save that for "later".