### PR TITLE
Improve GC stats tracking

### DIFF
--- a/src/compiler/serverMessage.ml
+++ b/src/compiler/serverMessage.ml
@@ -24,6 +24,7 @@ type server_message_options = {
 	mutable print_signature : bool;
 	mutable print_display_position : bool;
 	mutable print_stats : bool;
+	mutable print_gc_stats : bool;
 	mutable print_message : bool;
 	mutable print_socket_message : bool;
 	mutable print_uncaught_error : bool;
@@ -51,6 +52,7 @@ let config = {
 	print_signature = false;
 	print_display_position = false;
 	print_stats = false;
+	print_gc_stats = false;
 	print_message = false;
 	print_socket_message = false;
 	print_uncaught_error = false;
@@ -143,7 +145,7 @@ let message s =
 	if config.print_message then print_endline ("> " ^ s)
 
 let gc_stats time stats_before did_compact space_overhead =
-	if config.print_stats then begin
+	if config.print_stats || config.print_gc_stats then begin
 		let stats = Gc.quick_stat() in
 		print_endline (Printf.sprintf "GC %s done in %.2fs with space_overhead = %i\n\tbefore: %s\n\tafter: %s"
 			(if did_compact then "compaction" else "collection")
@@ -180,6 +182,7 @@ let enable_all () =
 	config.print_signature <- true;
 	config.print_display_position <- true;
 	config.print_stats <- true;
+	config.print_gc_stats <- true;
 	config.print_message <- true;
 	config.print_socket_message <- true;
 	config.print_uncaught_error <- true;
@@ -205,6 +208,7 @@ let set_by_name name value = match name with
 	| "signature" -> config.print_signature <- value;
 	| "displayPosition" -> config.print_display_position <- value;
 	| "stats" -> config.print_stats <- value;
+	| "gcStats" -> config.print_gc_stats <- value;
 	| "message" -> config.print_message <- value;
 	| "socketMessage" -> config.print_socket_message <- value;
 	| "uncaughtError" -> config.print_uncaught_error <- value;

--- a/src/context/display/displayMemory.ml
+++ b/src/context/display/displayMemory.ml
@@ -7,6 +7,8 @@ open Type
 let get_memory_json (cs : CompilationCache.t) mreq =
 	begin match mreq with
 	| MCache ->
+		let t0 = Extc.time() in
+		let stats = Gc.stat() in
 		let old_gc = Gc.get() in
 		Gc.set { old_gc with
 			Gc.max_overhead = 0;
@@ -14,6 +16,7 @@ let get_memory_json (cs : CompilationCache.t) mreq =
 		};
 		Gc.compact();
 		Gc.set old_gc;
+		ServerMessage.gc_stats (Extc.time() -. t0) stats true 0;
 		let stat = Gc.quick_stat() in
 		let size = (float_of_int stat.Gc.heap_words) *. (float_of_int (Sys.word_size / 8)) in
 		let cache_mem = cs#get_pointers in


### PR DESCRIPTION
Allows to display only GC stats in server logs, and also print GC compaction stats when triggered by `server/memory` requests