### PR TITLE
Use parentheses when an arrow function's argument has a default value.

### DIFF
--- a/std/haxe/macro/Printer.hx
+++ b/std/haxe/macro/Printer.hx
@@ -212,7 +212,7 @@ class Printer {
 
 	public function printFunction(func:Function, ?kind:FunctionKind) {
 		var skipParentheses = switch func.args {
-			case [{type: null}]: kind == FArrow;
+			case [{type: null, value: null}]: kind == FArrow;
 			case _: false;
 		}
 		return (func.params == null ? "" : func.params.length > 0 ? "<" + func.params.map(printTypeParamDecl).join(", ") + ">" : "")


### PR DESCRIPTION
Otherwise, printing `macro (a = 1) -> a` results in "?a = 1 -> a", which isn't valid Haxe.