### PR TITLE
Assignement in condition warning

### DIFF
--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -84,6 +84,12 @@
 		"parent": "WTyper"
 	},
 	{
+		"name": "WConditionAssignBool",
+		"doc": "Using the result of an bool assignment as a condition",
+		"parent": "WTyper",
+		"enabled": false
+	},
+	{
 		"name": "WVarShadow",
 		"doc": "A local variable hides another by using the same name",
 		"parent": "WTyper",

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -79,6 +79,11 @@
 		"parent": "WTyper"
 	},
 	{
+		"name": "WConditionAssign",
+		"doc": "Using the result of an assignment as a condition without parentheses",
+		"parent": "WTyper"
+	},
+	{
 		"name": "WVarShadow",
 		"doc": "A local variable hides another by using the same name",
 		"parent": "WTyper",

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -80,7 +80,7 @@
 	},
 	{
 		"name": "WConditionAssign",
-		"doc": "Using the result of an assignment as a condition without parentheses",
+		"doc": "Using the result of an assignment as a condition",
 		"parent": "WTyper"
 	},
 	{

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1518,18 +1518,15 @@ and make_if_then_else ctx e0 e1 e2 with_type p =
 	mk (TIf (e0,e1,Some e2)) t p
 
 and warn_assign_in_condition ctx cond =
-	let rec skip_without_parentheses e = match e.eexpr with
-		| TMeta(_,e1) | TBlock [e1] | TCast(e1,None) -> skip e1
-		| _ -> e in
 	let rec is_assign e =
-		let e = skip_without_parentheses e in
+		let e = Texpr.skip e in
 		match e.eexpr with
 			| TBinop (OpAssign, _, rhs) ->
 				let t = follow rhs.etype in
 				let is_bool = ExtType.is_bool t in
-				let is_null = match (skip_without_parentheses rhs).eexpr with | TConst TNull -> true | _ -> false in
+				let is_null = match (Texpr.skip rhs).eexpr with | TConst TNull -> true | _ -> false in
 				if is_bool || is_null then
-					warning ctx WConditionAssign "Using the result of an assignment as a condition without parentheses" e.epos
+					warning ctx WConditionAssign "Using the result of an assignment as a condition" e.epos
 			| TBinop ((OpBoolAnd | OpBoolOr), e1, e2) ->
 				is_assign e1;
 				is_assign e2;
@@ -1547,7 +1544,6 @@ and type_if ctx e e1 e2 with_type is_ternary p =
 	let e = type_expr ctx e WithType.value in
 	if is_ternary then begin match e.eexpr with
 		| TConst TNull -> raise_typing_error "Cannot use null as ternary condition" e.epos
-		| TParenthesis e -> warn_assign_in_condition ctx e;
 		| _ -> ()
 	end;
 	let e = AbstractCast.cast_or_unify ctx ctx.t.tbool e e.epos in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1517,10 +1517,37 @@ and make_if_then_else ctx e0 e1 e2 with_type p =
 	let e2 = cast e2 in
 	mk (TIf (e0,e1,Some e2)) t p
 
+and warn_assign_in_condition ctx cond =
+	let rec skip_without_parentheses e = match e.eexpr with
+		| TMeta(_,e1) | TBlock [e1] | TCast(e1,None) -> skip e1
+		| _ -> e in
+	let rec is_assign e =
+		let e = skip_without_parentheses e in
+		match e.eexpr with
+			| TBinop (OpAssign, _, rhs) ->
+				let t = follow rhs.etype in
+				let is_bool = ExtType.is_bool t in
+				let is_null = match (skip_without_parentheses rhs).eexpr with | TConst TNull -> true | _ -> false in
+				if is_bool || is_null then
+					warning ctx WConditionAssign "Using the result of an assignment as a condition without parentheses" e.epos
+			| TBinop ((OpBoolAnd | OpBoolOr), e1, e2) ->
+				is_assign e1;
+				is_assign e2;
+			| TBlock el ->
+				let rec last = function
+					| [] -> ()
+					| [e] -> is_assign e;
+					| _ :: rest -> last rest in
+				last el;
+			| _ -> ()
+	in
+	if not ctx.f.untyped then is_assign cond;
+
 and type_if ctx e e1 e2 with_type is_ternary p =
 	let e = type_expr ctx e WithType.value in
 	if is_ternary then begin match e.eexpr with
 		| TConst TNull -> raise_typing_error "Cannot use null as ternary condition" e.epos
+		| TParenthesis e -> warn_assign_in_condition ctx e;
 		| _ -> ()
 	end;
 	let e = AbstractCast.cast_or_unify ctx ctx.t.tbool e e.epos in
@@ -1896,6 +1923,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 	| EWhile (cond,e,NormalWhile) ->
 		let old_loop = ctx.e.in_loop in
 		let cond = type_expr ctx cond WithType.value in
+		warn_assign_in_condition ctx cond;
 		let cond = AbstractCast.cast_or_unify ctx ctx.t.tbool cond p in
 		ctx.e.in_loop <- true;
 		let e = type_expr ctx (Expr.ensure_block e) WithType.NoValue in
@@ -1907,6 +1935,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 		let e = type_expr ctx (Expr.ensure_block e) WithType.NoValue in
 		ctx.e.in_loop <- old_loop;
 		let cond = type_expr ctx cond WithType.value in
+		warn_assign_in_condition ctx cond;
 		let cond = AbstractCast.cast_or_unify ctx ctx.t.tbool cond cond.epos in
 		mk (TWhile (cond,e,DoWhile)) ctx.t.tvoid p
 	| ESwitch (e1,cases,def) ->

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1521,12 +1521,17 @@ and warn_assign_in_condition ctx cond =
 	let rec is_assign e =
 		let e = Texpr.skip e in
 		match e.eexpr with
-			| TBinop (OpAssign, _, rhs) ->
-				let t = follow rhs.etype in
-				let is_bool = ExtType.is_bool t in
-				let is_null = match (Texpr.skip rhs).eexpr with | TConst TNull -> true | _ -> false in
-				if is_bool || is_null then
-					warning ctx WConditionAssign "Using the result of an assignment as a condition" e.epos
+			| TBinop (OpAssign, lhs, rhs) ->
+				let lt = follow lhs.etype in
+				let is_bool = ExtType.is_bool lt in
+				if lt == t_dynamic || is_bool then
+					let rt = follow rhs.etype in
+					let is_rhs_bool = ExtType.is_bool rt in
+					let is_null = match (Texpr.skip rhs).eexpr with | TConst TNull -> true | _ -> false in
+					if is_rhs_bool && not is_null then
+						warning ctx WConditionAssignBool "Using the result of an bool assignment as a condition" e.epos
+					else
+						warning ctx WConditionAssign "Using the result of an assignment as a condition" e.epos
 			| TBinop ((OpBoolAnd | OpBoolOr), e1, e2) ->
 				is_assign e1;
 				is_assign e2;
@@ -1542,6 +1547,7 @@ and warn_assign_in_condition ctx cond =
 
 and type_if ctx e e1 e2 with_type is_ternary p =
 	let e = type_expr ctx e WithType.value in
+	warn_assign_in_condition ctx e;
 	if is_ternary then begin match e.eexpr with
 		| TConst TNull -> raise_typing_error "Cannot use null as ternary condition" e.epos
 		| _ -> ()

--- a/tests/misc/eval/projects/Issue8634/Main2.hx
+++ b/tests/misc/eval/projects/Issue8634/Main2.hx
@@ -1,0 +1,28 @@
+class Main2 {
+	static function main() {
+		var foo = false;
+		var foo2 = false;
+
+		var value = (foo = foo2) ? true : false;
+		if (foo = foo2) {}
+		if (foo = true) {}
+		if (foo = null) {} // WConditionAssign
+		if ({123; foo = true;}) {}
+
+		while (foo = false) {}
+		do {} while (foo = false);
+
+		if ((foo = null) && (foo = true)) {}
+		if ((foo = null) && ((foo = true) && (foo = true))) {}
+
+		var dyn:Dynamic = false;
+		var dyn2:Dynamic = null;
+		if (dyn = 1) {}
+		if (dyn = dyn2) {}
+		if (dyn = null) {}
+		if (dyn = false) {} // WConditionAssignBool
+
+		// no warning
+		if ({foo = true; true;}) {}
+	}
+}

--- a/tests/misc/eval/projects/Issue8634/compile-fail2.hxml
+++ b/tests/misc/eval/projects/Issue8634/compile-fail2.hxml
@@ -1,0 +1,4 @@
+--main Main2
+--interp
+-w +WConditionAssignBool
+-D message.reporting=classic

--- a/tests/misc/eval/projects/Issue8634/compile-fail2.hxml.stderr
+++ b/tests/misc/eval/projects/Issue8634/compile-fail2.hxml.stderr
@@ -1,0 +1,16 @@
+Main2.hx:6: characters 16-26 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:7: characters 7-17 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:8: characters 7-17 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:9: characters 7-17 : Warning : (WConditionAssign) Using the result of an assignment as a condition
+Main2.hx:10: characters 13-23 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:12: characters 10-21 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:13: characters 16-27 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:15: characters 8-18 : Warning : (WConditionAssign) Using the result of an assignment as a condition
+Main2.hx:15: characters 24-34 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:16: characters 8-18 : Warning : (WConditionAssign) Using the result of an assignment as a condition
+Main2.hx:16: characters 25-35 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:16: characters 41-51 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition
+Main2.hx:20: characters 7-14 : Warning : (WConditionAssign) Using the result of an assignment as a condition
+Main2.hx:21: characters 7-17 : Warning : (WConditionAssign) Using the result of an assignment as a condition
+Main2.hx:22: characters 7-17 : Warning : (WConditionAssign) Using the result of an assignment as a condition
+Main2.hx:23: characters 7-18 : Warning : (WConditionAssignBool) Using the result of an bool assignment as a condition


### PR DESCRIPTION
There is also some idea to skip warning when you wrap condition in additional parentheses in first commit.
Related to https://github.com/HaxeFoundation/haxe/issues/8634
```haxe
var foo = false;
var foo2 = false;
// warning for these cases
var value = (foo = foo2) ? true : false;
if (foo = true) {}
if (foo = null) {}
if ({123; foo = true;}) {}

while (foo = true) {}
do {} while (foo = true);

var dyn:Dynamic = false;
if (dyn = null) {}
if (dyn = false) {}

if ((foo = null) && (foo = true)) {}
if ((foo = null) && ((foo = true) && (foo = true))) {}

// no warning
if ({foo = true; true;}) {}
```