### PR TITLE
Move the logic behind Define.get_signature to define.json

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -85,6 +85,7 @@
 	{
 		"name": "DisableParallelism",
 		"define": "disable-parallelism",
+		"signatureNeutral": true,
 		"doc": "Disable all uses of parallelism in the compiler."
 	},
 	{

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -20,6 +20,7 @@
 		"name": "AnalyzerTimes",
 		"define": "times.analyzer",
 		"deprecatedDefine": "analyzer-times",
+		"signatureNeutral": true,
 		"doc": "Record detailed timers for the analyzer",
 		"params": ["level: 0 | 1 | 2"]
 	},
@@ -71,6 +72,7 @@
 	{
 		"name": "DisableHxbCache",
 		"define": "disable-hxb-cache",
+		"signatureNeutral": true,
 		"doc": "Use in-memory cache instead of hxb powered cache."
 	},
 	{
@@ -92,12 +94,14 @@
 	{
 		"name": "Display",
 		"define": "display",
+		"signatureNeutral": true,
 		"doc": "Activated during completion.",
 		"links": ["https://haxe.org/manual/cr-completion.html"]
 	},
 	{
 		"name": "DisplayStdin",
 		"define": "display-stdin",
+		"signatureNeutral": true,
 		"doc": "Read the contents of a file specified in `--display` from standard input."
 	},
 	{
@@ -114,12 +118,14 @@
 	{
 		"name": "Dump",
 		"define": "dump",
+		"signatureNeutral": true,
 		"doc": "Dump typed AST in dump subdirectory using specified mode or non-prettified default.",
 		"params": ["mode: pretty | record | position | legacy"]
 	},
 	{
 		"name": "DumpStage",
 		"define": "dump.stage",
+		"signatureNeutral": true,
 		"doc": "The compiler stage after which to generate the dump",
 		"params": ["stage: typing | casting | inlining | analyzing | dce"],
 		"default": "dce"
@@ -127,6 +133,7 @@
 	{
 		"name": "DumpPath",
 		"define": "dump-path",
+		"signatureNeutral": true,
 		"doc": "Path to generate dumps to (default: \"dump\").",
 		"default": "dump",
 		"params": ["path"]
@@ -134,11 +141,13 @@
 	{
 		"name": "DumpDependencies",
 		"define": "dump-dependencies",
+		"signatureNeutral": true,
 		"doc": "Dump the classes dependencies in a dump subdirectory."
 	},
 	{
 		"name": "DumpIgnoreVarIds",
 		"define": "dump-ignore-var-ids",
+		"signatureNeutral": true,
 		"doc": "Remove variable IDs from non-pretty dumps (helps with diff).",
 		"default": "1"
 	},
@@ -186,18 +195,21 @@
 		"name": "EvalTimes",
 		"define": "times.eval",
 		"deprecatedDefine": "eval-times",
+		"signatureNeutral": true,
 		"doc": "Record per-method execution times in macro/interp mode. Implies eval-stack.",
 		"platforms": ["eval"]
 	},
 	{
 		"name": "FailFast",
 		"define": "fail-fast",
+		"signatureNeutral": true,
 		"doc": "Abort compilation when first error occurs."
 	},
 	{
 		"name": "FilterTimes",
 		"define": "times.filter",
 		"deprecatedDefine": "filter-times",
+		"signatureNeutral": true,
 		"doc": "Record per-filter execution times upon --times."
 	},
 	{
@@ -316,7 +328,14 @@
 		"name": "HxbTimes",
 		"define": "times.hxb",
 		"deprecatedDefine": "hxb-times",
+		"signatureNeutral": true,
 		"doc": "Display hxb timing when used with `--times`."
+	},
+	{
+		"name": "HxbStats",
+		"define": "hxb.stats",
+		"signatureNeutral": true,
+		"doc": "Display some hxb related stats (only with compilation server)."
 	},
 	{
 		"name": "HxcppApiLevel",
@@ -555,6 +574,7 @@
 		"name": "MacroTimes",
 		"define": "times.macro",
 		"deprecatedDefine": "macro-times",
+		"signatureNeutral": true,
 		"doc": "Display per-macro timing when used with `--times`."
 	},
 	{
@@ -848,6 +868,7 @@
 	{
 		"name": "MessageReporting",
 		"define": "message.reporting",
+		"signatureNeutral": true,
 		"doc": "Select message reporting mode for compiler output. (default: pretty)",
 		"default": "pretty",
 		"params": ["mode: classic | pretty | indent"]
@@ -855,21 +876,25 @@
 	{
 		"name": "MessageNoColor",
 		"define": "message.no-color",
+		"signatureNeutral": true,
 		"doc": "Disable ANSI color codes in message reporting."
 	},
 	{
 		"name": "MessageAbsolutePositions",
 		"define": "message.absolute-positions",
+		"signatureNeutral": true,
 		"doc": "Use absolute character positions instead of line/columns for message reporting."
 	},
 	{
 		"name": "MessageLogFile",
 		"define": "message.log-file",
+		"signatureNeutral": true,
 		"doc": "Path to a text file to write message reporting to, in addition to regular output."
 	},
 	{
 		"name": "MessageLogFormat",
 		"define": "message.log-format",
+		"signatureNeutral": true,
 		"doc": "Select message reporting mode for message log file. (default: indent)",
 		"default": "indent",
 		"params": ["format: classic | pretty | indent"]

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -61,6 +61,7 @@
 	{
 		"name": "DceDebug",
 		"define": "dce-debug",
+		"signatureNeutral": true,
 		"doc": "Show DCE log.",
 		"links": ["https://haxe.org/manual/cr-dce.html"]
 	},
@@ -78,6 +79,7 @@
 	{
 		"name": "DisableHxbOptimizations",
 		"define": "disable-hxb-optimizations",
+		"signatureNeutral": true,
 		"doc": "Disable shortcuts used by hxb cache to speed up display requests."
 	},
 	{
@@ -607,6 +609,7 @@
 	{
 		"name": "NoCompilation",
 		"define": "no-compilation",
+		"signatureNeutral": true,
 		"doc": "Disable final compilation.",
 		"platforms": ["cpp", "hl"]
 	},

--- a/src/context/commonCache.ml
+++ b/src/context/commonCache.ml
@@ -122,7 +122,7 @@ let rec cache_context cs com =
 		| None -> ()
 		| Some com -> cache_context cs com
 	end;
-	if Define.raw_defined com.defines "hxb.stats" then
+	if Define.defined com.defines HxbStats then
 		HxbReader.dump_stats (platform_name com.platform) com.hxb_reader_stats
 
 let maybe_add_context_sign cs com desc =

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -155,15 +155,11 @@ let get_signature def =
 	| None ->
 		let defines = PMap.foldi (fun k v acc ->
 			(* don't make much difference between these special compilation flags *)
-			match String.concat "_" (ExtString.String.nsplit k "-") with
+			let sanitized = String.concat "_" (ExtString.String.nsplit k "-") in
 			(* If we add something here that might be used in conditional compilation it should be added to
-			   Parser.parse_macro_ident as well (issue #5682).
-			   Note that we should removed flags like use_rtti_doc here.
+			   Grammar.parse_macro_ident as well (issue #5682).
 			*)
-			| "display" | "use_rtti_doc" | "macro_times" | "display_details" | "no_copt" | "display_stdin" | "disable-hxb-cache" | "hxb.stats" | "fail_fast"
-			| "message.reporting" | "message.log_file" | "message.log_format" | "message.no_color"
-			| "dump" | "dump_dependencies" | "dump_ignore_var_ids" -> acc
-			| _ -> (k ^ "=" ^ v) :: acc
+			if DefineList.is_signature_neutral sanitized then acc else (k ^ "=" ^ v) :: acc
 		) def.values [] in
 		let str = String.concat "@" (List.sort compare defines) in
 		let s = Digest.string str in

--- a/src/core/define.ml
+++ b/src/core/define.ml
@@ -159,8 +159,9 @@ let get_signature def =
 			(* If we add something here that might be used in conditional compilation it should be added to
 			   Grammar.parse_macro_ident as well (issue #5682).
 			*)
-			if DefineList.is_signature_neutral sanitized then acc else (k ^ "=" ^ v) :: acc
+			if DefineList.is_signature_neutral sanitized then acc else (sanitized ^ "=" ^ v) :: acc
 		) def.values [] in
+		let defines = Ast.remove_duplicates (fun a b -> a != b) defines in
 		let str = String.concat "@" (List.sort compare defines) in
 		let s = Digest.string str in
 		def.defines_signature <- Some s;

--- a/src/prebuild.ml
+++ b/src/prebuild.ml
@@ -115,6 +115,7 @@ type parsed_define = {
 	d_deprecated : string option;
 	d_deprecated_define : string option;
 	d_default : string option;
+	d_signature_neutral : bool option;
 }
 let parse_define json =
 	let fields = match json with
@@ -131,6 +132,7 @@ let parse_define json =
 		d_deprecated = get_optional_field2 "deprecated" as_string fields;
 		d_deprecated_define = get_optional_field2 "deprecatedDefine" as_string fields;
 		d_default = get_optional_field2 "default" as_string fields;
+		d_signature_neutral = get_optional_field2 "signatureNeutral" as_bool fields;
 	}
 
 let parse_meta json =
@@ -204,6 +206,7 @@ let gen_option f = function
 let gen_define_info defines =
 	let deprecations = DynArray.create() in
 	let default_values = DynArray.create() in
+	let sig_neutral = DynArray.create() in
 	let define_str = List.map (function
 		def ->
 			let platforms_str = gen_platforms def.d_platforms in
@@ -233,12 +236,16 @@ let gen_define_info defines =
 					DynArray.add default_values (Printf.sprintf "\t(%S,%S)" define x);
 					[Printf.sprintf "DefaultValue(%s)" quoted]
 			in
+			(match def.d_signature_neutral with
+				| Some true -> DynArray.add sig_neutral (Printf.sprintf "| %S" (convert_define define))
+				| _ -> ());
 			"\t| " ^ def.d_name ^ " -> \"" ^ define ^ "\",(" ^ (Printf.sprintf "%S" def.d_doc) ^ ",[" ^ (String.concat "; " (platforms_str @ params_str @ links_str @ deprecated @ default)) ^ "])"
 	) defines in
 	(
 		String.concat "\n" define_str,
 		String.concat "\n" (DynArray.to_list deprecations),
-		String.concat ";\n" (DynArray.to_list default_values)
+		String.concat ";\n" (DynArray.to_list default_values),
+		String.concat " " (DynArray.to_list sig_neutral)
 	)
 
 let gen_meta_type metas =
@@ -379,10 +386,16 @@ match Array.to_list (Sys.argv) with
 		Printf.printf "type strict_defined =\n";
 		Printf.printf "%s" (gen_define_type defines);
 		Printf.printf "\n\t| Last\n\t| Custom of string\n\n";
-		let infos,deprecations,default_values = gen_define_info defines in
+		let infos,deprecations,default_values,sig_neutral = gen_define_info defines in
 		Printf.printf "let infos = function\n";
 		Printf.printf "%s" infos;
 		Printf.printf "\n\t| Last -> die \"\" __LOC__\n\t| Custom s -> s,(\"\",[])\n";
+		if sig_neutral = "" then
+			Printf.printf "let is_signature_neutral _ = false\n"
+		else begin
+			Printf.printf "let is_signature_neutral = function\n";
+			Printf.printf "\t%s -> true\n\t| _ -> false\n" sig_neutral;
+		end;
 		Printf.printf "\nlet deprecated_defines = [\n%s\n]\n" deprecations;
 		Printf.printf "\nlet default_values = [\n%s\n]\n" default_values;
 	| [_; "meta"; meta_path]->


### PR DESCRIPTION
Added optional `signatureNeutral` field to `define.json` to allow configuring what defines alter signatures from there instead of maintaining `Define.get_signature` with a hardcoded list of string defines.

Also:
* Removed handling for `use_rtti_doc` and `display_details` that have been removed a while ago
* Now computing signature with "sanitized" defines (`-D some-define` and `-D some_define` would give the same signature)
* Set defines other than `macro_times` as signature neutral
* Set other dump related defines as signature neutral

TODO:
* [x] Check if `no_copt` should be added to `define.json` (doesn't seem to be used anymore?)
  * It's been gone for nearly [5 years](https://github.com/HaxeFoundation/haxe/commit/c41f1b5cffc03b4e7b7783c34b4f3e7fa0f7e75e#diff-f725cab833cd378cb3685cdb2a45c207e15773014bedf6ee22ebbfdaa3ede84cL632) and nobody noticed, should be fine
* [x] Check if some other defines should have `"signatureNeutral": true`
* [x] Check behavior with deprecated defines?