### PR TITLE
Make parallelism opt-in instead of opt-out for now 

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -83,10 +83,10 @@
 		"doc": "Disable shortcuts used by hxb cache to speed up display requests."
 	},
 	{
-		"name": "DisableParallelism",
-		"define": "disable-parallelism",
+		"name": "EnableParallelism",
+		"define": "enable-parallelism",
 		"signatureNeutral": true,
-		"doc": "Disable all uses of parallelism in the compiler."
+		"doc": "Enable experimental uses of parallelism in the compiler."
 	},
 	{
 		"name": "DisableUnicodeStrings",

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -270,7 +270,7 @@ module Setup = struct
 end
 
 let check_defines com =
-	if defined com Define.DisableParallelism then Parallel.enable := false;
+	if defined com Define.EnableParallelism then Parallel.enable := true;
 	PMap.iter (fun k v ->
 		try
 			let reason = Hashtbl.find Define.deprecation_lut k in

--- a/src/context/parallel.ml
+++ b/src/context/parallel.ml
@@ -1,4 +1,4 @@
-let enable = ref true
+let enable = ref false
 
 let run_parallel_for num_domains ?(chunk_size=0) length f =
 	if not !enable then begin


### PR DESCRIPTION
We have detected memory leaks (when using compilation server) linked to the recently added parallelism, which also might hint at some things going wrong in other ways.

While we'll want to go this route in the near future, I think it would be better to make parallelism opt-in instead of opt-out for the time being, and make it opt-out again later once it's stabilized. This would allow us to release the preview even if parallelism issues are not fully resolved yet (or not fully "battle tested").

~~Note that this PR is currently based on #12251 (I made the define signature neutral) which should be merged first. See the [actual diff](https://github.com/HaxeFoundation/haxe/commit/ed0dcb3770ce28f51a57dec4c4fc45515733c2eb) for this PR.~~