### PR TITLE
haxe.Timer.milliseconds

### DIFF
--- a/libs/extc/extc.ml
+++ b/libs/extc/extc.ml
@@ -51,6 +51,8 @@ external zlib_crc32 : bytes -> int -> int32 = "zlib_crc32"
 
 external time : unit -> float = "sys_time"
 
+external timestamp_ms : unit -> int64 = "sys_timestamp_ms"
+
 external getch : bool -> int = "sys_getch"
 
 external filetime : string -> float = "sys_filetime"

--- a/libs/extc/extc_stubs.c
+++ b/libs/extc/extc_stubs.c
@@ -487,11 +487,14 @@ CAMLprim value get_real_path( value path ) {
 #define TimeSpecToSeconds(ts) (double)ts.tv_sec + (double)ts.tv_nsec / 1000000000.0
 #endif
 
+#ifdef WIN32
+static LARGE_INTEGER freq;
+static int freq_init = -1;
+#endif
+
 CAMLprim value sys_time() {
 #ifdef _WIN32
 #define EPOCH_DIFF	(134774*24*60*60.0)
-	static LARGE_INTEGER freq;
-	static int freq_init = -1;
 	LARGE_INTEGER counter;
 	if( freq_init == -1 )
 		freq_init = QueryPerformanceFrequency(&freq);
@@ -530,6 +533,26 @@ CAMLprim value sys_time() {
 	struct timespec t;
 	clock_gettime(CLOCK_MONOTONIC, &t);
 	return caml_copy_double(TimeSpecToSeconds(t));
+#endif
+}
+
+CAMLprim value sys_timestamp_ms() {
+#ifdef _WIN32
+	if (-1 == freq_init) {
+		freq_init = QueryPerformanceFrequency(&freq);
+	}
+
+	LARGE_INTEGER time;
+	QueryPerformanceCounter(&time);
+
+	return caml_copy_int64(time.QuadPart * 1000LL / freq.QuadPart);
+#else
+	struct timespec ts;
+	if (clock_gettime(CLOCK_MONOTONIC, &ts)) {
+		caml_failwith("Failed to get time from the monotonic clock");
+	}
+
+	return caml_copy_int64(ts.tv_sec * 1000 + (ts.tv_nsec / 1000000));
 #endif
 }
 

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2709,6 +2709,8 @@ module StdSys = struct
 		)
 
 	let time = vfun0 (fun () -> vfloat (catch_unix_error Unix.gettimeofday()))
+
+	let timestamp_ms = vfun0 (fun () -> vint64 (Extc.timestamp_ms()))
 end
 
 module StdThread = struct
@@ -3727,6 +3729,7 @@ let init_standard_library builtins =
 		"stdout",StdSys.stdout;
 		"systemName",StdSys.systemName;
 		"time",StdSys.time;
+		"timestamp_ms",StdSys.timestamp_ms;
 	] [];
 	init_fields builtins (["eval";"vm"],"NativeThread") [
 		"delay",StdThread.delay;

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2710,7 +2710,7 @@ module StdSys = struct
 
 	let time = vfun0 (fun () -> vfloat (catch_unix_error Unix.gettimeofday()))
 
-	let timestamp_ms = vfun0 (fun () -> vint64 (Extc.timestamp_ms()))
+	let timestamp_ms = vfun0 (fun () -> EvalIntegers.encode_haxe_i64_direct (* TODO: use vint64 once that works *) (Extc.timestamp_ms()))
 end
 
 module StdThread = struct

--- a/src/macro/eval/evalValue.ml
+++ b/src/macro/eval/evalValue.ml
@@ -347,6 +347,7 @@ let vfield_closure v f = VFieldClosure(v,f)
 let vobject o = VObject o
 let vint i = VInt32 (Int32.of_int i)
 let vint32 i = VInt32 i
+let vint64 i = VInt64 i
 let vfloat f = VFloat f
 let venum_value e = VEnumValue e
 let vnative_string s = VNativeString s

--- a/std/eval/_std/Sys.hx
+++ b/std/eval/_std/Sys.hx
@@ -75,6 +75,8 @@ class Sys {
 
 	extern static public function time():Float;
 
+	extern static function timestamp_ms():haxe.Int64;
+
 	extern static public function cpuTime():Float;
 
 	extern static public function programPath():String;

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -22,6 +22,7 @@
 
 package haxe;
 
+import haxe.Int64;
 #if (target.threaded && !cppia)
 import sys.thread.Thread;
 import sys.thread.EventLoop;
@@ -193,6 +194,34 @@ class Timer {
 		return Sys.time();
 		#else
 		return 0;
+		#end
+	}
+
+	/**
+	 * Returns a monotonically increasing timestamp with millisecond resolution.
+	 * 
+	 * The precision and epoch of the timer is platform defined.
+	 */
+	public static inline function milliseconds():Int64 {
+		#if flash
+		return flash.Lib.getTimer();
+		#elseif js
+		#if nodejs
+		var hrtime = js.Syntax.code('process.hrtime()'); // [seconds, remaining nanoseconds]
+		return hrtime[0] * 1000 + (hrtime[1] / 1000000i64);
+		#else
+		return @:privateAccess HxOverrides.now();
+		#end
+		#elseif cpp
+		return untyped __global__.__time_stamp_ms();
+		#elseif python
+		return python.lib.Time.perf_counter_ns() / 1000000i64;
+		#elseif hl
+		return hl.Api.timestampMs();
+		#elseif jvm
+		return java.lang.System.nanoTime() / 1000000i64;
+		#else
+		return Std.int(stamp() * 1000);
 		#end
 	}
 }

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -210,7 +210,7 @@ class Timer {
 		var hrtime = js.Syntax.code('process.hrtime()'); // [seconds, remaining nanoseconds]
 		return hrtime[0] * 1000 + (hrtime[1] / 1000000i64);
 		#else
-		return @:privateAccess HxOverrides.now();
+		return Std.int(@:privateAccess HxOverrides.now());
 		#end
 		#elseif cpp
 		return untyped __global__.__time_stamp_ms();

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -215,7 +215,11 @@ class Timer {
 		#elseif cpp
 		return untyped __global__.__time_stamp_ms();
 		#elseif python
+		#if (python_version >= 3.7)
 		return python.lib.Time.perf_counter_ns() / 1000000i64;
+		#else
+		return Std.int(stamp() * 1000);
+		#end
 		#elseif hl
 		return hl.Api.timestampMs();
 		#elseif jvm

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -220,6 +220,8 @@ class Timer {
 		return hl.Api.timestampMs();
 		#elseif jvm
 		return java.lang.System.nanoTime() / 1000000i64;
+		#elseif eval
+		return @:privateAccess Sys.timestamp_ms();
 		#else
 		return Std.int(stamp() * 1000);
 		#end

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -227,7 +227,7 @@ class Timer {
 		#elseif eval
 		return @:privateAccess Sys.timestamp_ms();
 		#else
-		return Std.int(stamp() * 1000);
+		return Int64.mul(Int64.fromFloat(stamp()), 1000);
 		#end
 	}
 }

--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -44,7 +44,7 @@ import sys.thread.EventLoop;
 
 	Notice for threaded targets:
 	`Timer` instances require threads they were created in to run with Haxe's event loops.
-	Main thread of a Haxe program always contains an event loop. For other cases use 
+	Main thread of a Haxe program always contains an event loop. For other cases use
 	`sys.thread.Thread.createWithEventLoop` and `sys.thread.Thread.runWithEventLoop` methods.
 **/
 class Timer {
@@ -199,7 +199,7 @@ class Timer {
 
 	/**
 	 * Returns a monotonically increasing timestamp with millisecond resolution.
-	 * 
+	 *
 	 * The precision and epoch of the timer is platform defined.
 	 */
 	public static inline function milliseconds():Int64 {
@@ -220,7 +220,7 @@ class Timer {
 		#else
 		return Std.int(stamp() * 1000);
 		#end
-		#elseif hl
+		#elseif (hl && hl_ver >= version("1.16.0"))
 		return hl.Api.timestampMs();
 		#elseif jvm
 		return java.lang.System.nanoTime() / 1000000i64;

--- a/std/hl/Api.hx
+++ b/std/hl/Api.hx
@@ -58,5 +58,6 @@ extern class Api {
 		return _registerGUIDName(guid,@:privateAccess name.bytes);
 	}
 	#end
-	
+	@:hlNative('std', 'sys_timestamp_ms')
+	static function timestampMs():haxe.Int64;
 }

--- a/std/hl/Api.hx
+++ b/std/hl/Api.hx
@@ -52,12 +52,14 @@ extern class Api {
 	#if (hl_ver >= version("1.13.0"))
 	@:hlNative("?std", "sys_has_debugger") static function hasDebugger() : Bool;
 	#end
-	#if (hl_ver >= version("1.15.0"))	
+	#if (hl_ver >= version("1.15.0"))
 	@:hlNative("?std", "register_guid_name") private static function _registerGUIDName( guid : hl.I64, bytes : hl.Bytes ) : Void;
 	static inline function registerGUIDName( guid : GUID, name : String ) {
 		return _registerGUIDName(guid,@:privateAccess name.bytes);
 	}
 	#end
+	#if (hl_ver >= version("1.16.0"))
 	@:hlNative('std', 'sys_timestamp_ms')
 	static function timestampMs():haxe.Int64;
+	#end
 }

--- a/std/python/lib/Time.hx
+++ b/std/python/lib/Time.hx
@@ -30,4 +30,5 @@ extern class Time {
 	static function clock():Float;
 	static function sleep(t:Float):Void;
 	static function mktime(s:StructTime):Float;
+	static function perf_counter_ns():Int;
 }


### PR DESCRIPTION
Adds a millisecond resolution timer function.

https://github.com/HaxeFoundation/hxcpp/pull/1234
https://github.com/HaxeFoundation/hashlink/pull/790

Things todo:

- I don't know anything about hl so don't know what the versioning requirements are like.
- It falls back to using `haxe.Timer.stamp` and just multiplying by 1000.
- Eval could use it's own implementation. Is there an existing c/c++ file I could add the implementation to or do I have to learn how ocaml ffi works?
- Neko could get it's own implementation but I'm not sure it's worth it. The one concern I have is that it might not be monotonic on Windows. Neko uses `GetSystemTime` for `haxe.Timer.stamp` on Windows which is the UTC wall clock, so subject to NTP stuff.
- Pythons implementation requires python 3.7, is there a define or something for specifying the generated python version? We could use the fallback behavour if you want to target less than that.