### PR TITLE
[std] hl fix Type.typeof(HI64) to return TInt

### DIFF
--- a/std/hl/_std/Type.hx
+++ b/std/hl/_std/Type.hx
@@ -212,7 +212,7 @@ class Type {
 		switch (t.kind) {
 			case HVoid:
 				return TNull;
-			case HUI8, HUI16, HI32:
+			case HUI8, HUI16, HI32, HI64:
 				return TInt;
 			case HF32, HF64:
 				return (v : Int) == (v:Float) ? TInt : TFloat;

--- a/tests/unit/src/unit/issues/Issue12264.hx
+++ b/tests/unit/src/unit/issues/Issue12264.hx
@@ -1,0 +1,11 @@
+package unit.issues;
+
+class Issue12264 extends Test {
+	function test() {
+		#if (cpp || jvm || hl)
+		eq(true, Type.typeof(0i64).match(TInt));
+		#else
+		eq(true, Type.typeof(0i64).match(TClass(_)));
+		#end
+	}
+}


### PR DESCRIPTION
`trace(Type.typeof(0i64));` was `TUnknown` -> now `TInt`.

Ref https://github.com/Aidan63/haxe/pull/140#issuecomment-2950246512