### PR TITLE
[std] hl haxe.io.BytesBuffer.__expand check overflow

### DIFF
--- a/std/hl/_std/haxe/io/BytesBuffer.hx
+++ b/std/hl/_std/haxe/io/BytesBuffer.hx
@@ -47,9 +47,11 @@ class BytesBuffer {
 	}
 
 	function __expand(req:Int):Void {
-		var nsize = (size * 3) >> 1;
+		var nsize = (size * 3) >>> 1;
 		if (nsize < req)
 			nsize = req;
+		if (nsize < pos)
+			throw "Can't expand " + (size >> 10) + "K";
 		var b2 = new hl.Bytes(nsize);
 		b2.blit(0, b, 0, pos);
 		b = b2;


### PR DESCRIPTION
by Nicolas

Without this, the program give access violation on expand very large buffer.