### PR TITLE
[eval] fix weird env issue when closures trigger build macro that ends up failing

### DIFF
--- a/src/macro/eval/evalEmitter.ml
+++ b/src/macro/eval/evalEmitter.ml
@@ -759,33 +759,36 @@ let process_arguments fl vl env =
 
 let create_function_noret ctx eci exec fl vl =
 	let env = push_environment ctx eci in
-	process_arguments fl vl env;
-	let v = exec env in
-	pop_environment ctx env;
-	v
+	Std.finally (fun () -> pop_environment ctx env) (fun () ->
+		process_arguments fl vl env;
+		exec env
+	) ()
 
 let create_function ctx eci exec fl vl =
 	let env = push_environment ctx eci in
-	process_arguments fl vl env;
-	let v = try exec env with Return v -> v in
-	pop_environment ctx env;
-	v
+	Std.finally (fun () -> pop_environment ctx env) (fun () ->
+		process_arguments fl vl env;
+		let v = try exec env with Return v -> v in
+		v
+	) ()
 
 let create_closure_noret ctx eci refs exec fl vl =
 	let env = push_environment ctx eci in
-	Array.iter (fun (i,vr) -> env.env_captures.(i) <- vr) refs;
-	process_arguments fl vl env;
-	let v = exec env in
-	pop_environment ctx env;
-	v
+	Std.finally (fun () -> pop_environment ctx env) (fun () ->
+		Array.iter (fun (i,vr) -> env.env_captures.(i) <- vr) refs;
+		process_arguments fl vl env;
+		let v = exec env in
+		v
+	) ()
 
 let create_closure refs ctx eci exec fl vl =
 	let env = push_environment ctx eci in
-	Array.iter (fun (i,vr) -> env.env_captures.(i) <- vr) refs;
-	process_arguments fl vl env;
-	let v = try exec env with Return v -> v in
-	pop_environment ctx env;
-	v
+	Std.finally (fun () -> pop_environment ctx env) (fun () ->
+		Array.iter (fun (i,vr) -> env.env_captures.(i) <- vr) refs;
+		process_arguments fl vl env;
+		let v = try exec env with Return v -> v in
+		v
+	) ()
 
 let emit_closure ctx mapping eci hasret exec fl env =
 	let refs = Array.map (fun (i,slot) -> i,emit_capture_read slot env) mapping in

--- a/src/macro/eval/evalEmitter.ml
+++ b/src/macro/eval/evalEmitter.ml
@@ -768,8 +768,7 @@ let create_function ctx eci exec fl vl =
 	let env = push_environment ctx eci in
 	Std.finally (fun () -> pop_environment ctx env) (fun () ->
 		process_arguments fl vl env;
-		let v = try exec env with Return v -> v in
-		v
+		try exec env with Return v -> v
 	) ()
 
 let create_closure_noret ctx eci refs exec fl vl =
@@ -777,8 +776,7 @@ let create_closure_noret ctx eci refs exec fl vl =
 	Std.finally (fun () -> pop_environment ctx env) (fun () ->
 		Array.iter (fun (i,vr) -> env.env_captures.(i) <- vr) refs;
 		process_arguments fl vl env;
-		let v = exec env in
-		v
+		exec env
 	) ()
 
 let create_closure refs ctx eci exec fl vl =
@@ -786,8 +784,7 @@ let create_closure refs ctx eci exec fl vl =
 	Std.finally (fun () -> pop_environment ctx env) (fun () ->
 		Array.iter (fun (i,vr) -> env.env_captures.(i) <- vr) refs;
 		process_arguments fl vl env;
-		let v = try exec env with Return v -> v in
-		v
+		try exec env with Return v -> v
 	) ()
 
 let emit_closure ctx mapping eci hasret exec fl env =


### PR DESCRIPTION
Did not add a test because I couldn't isolate the mess that was happening on shiro codebase :sweat_smile: (was ending with a compiler failure)

This is a variant of #11679, but somehow going through an eval closure :shrug: 