### PR TITLE
Describe `Deque` as "output-restricted."

### DIFF
--- a/std/sys/thread/Deque.hx
+++ b/std/sys/thread/Deque.hx
@@ -27,8 +27,8 @@ package sys.thread;
 #end
 
 /**
-	A Deque is a queue with a `pop` method that can block until an element is
-	available. It is commonly used to synchronize threads.
+	A Deque is an output-restricted double-ended queue with a `pop` method that can
+	block until an element is available. It is commonly used to synchronize threads.
  */
 @:coreApi extern class Deque<T> {
 	/**

--- a/std/sys/thread/Deque.hx
+++ b/std/sys/thread/Deque.hx
@@ -27,8 +27,8 @@ package sys.thread;
 #end
 
 /**
-	A Deque is a double-ended queue with a `pop` method that can block until
-	an element is available. It is commonly used to synchronize threads.
+	A Deque is a queue with a `pop` method that can block until an element is
+	available. It is commonly used to synchronize threads.
  */
 @:coreApi extern class Deque<T> {
 	/**


### PR DESCRIPTION
Despite its name, `Deque` is a regular one-way queue. "Double-ended" implies you can add to and remove from either end, which isn't the case. It's far too late to change the name, so I'll settle for making the documentation more accurate.