### PR TITLE
Add `only_new` option to `haxe.macro.Context.onGenerate`

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -180,7 +180,7 @@ module Setup = struct
 		) com.defines.values;
 		Buffer.truncate buffer (Buffer.length buffer - 1);
 		Common.log com (Buffer.contents buffer);
-		com.callbacks#run com.error_ext com.callbacks#get_before_typer_create;
+		Common.run_callbacks com.error_ext com.callbacks#get_before_typer_create ();
 		TyperEntry.create com macros
 
 	let executable_path() =
@@ -310,7 +310,7 @@ let do_type ctx mctx actx display_file_dot_path =
 	CommonCache.lock_signature com "after_init_macros";
 	Option.may (fun mctx -> MacroContext.finalize_macro_api tctx mctx) mctx;
 	(try begin
-		com.callbacks#run com.error_ext com.callbacks#get_after_init_macros;
+		Common.run_callbacks com.error_ext com.callbacks#get_after_init_macros ();
 		run_or_diagnose ctx (fun () ->
 			if com.display.dms_kind <> DMNone then DisplayTexpr.check_display_file tctx cs;
 			List.iter (fun cpath ->
@@ -419,7 +419,7 @@ let compile ctx actx callbacks =
 		ServerMessage.compiler_stage com;
 	end;
 	Sys.catch_break false;
-	com.callbacks#run com.error_ext com.callbacks#get_after_generation;
+	Common.run_callbacks com.error_ext com.callbacks#get_after_generation ();
 	if not actx.no_output then begin
 		List.iter (fun c ->
 			let r = run_command ctx c in

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -45,12 +45,23 @@ type stats = {
 	s_macros_called : int ref;
 }
 
+let rec run_callbacks handle_error r v =
+	match !r with
+	| [] ->
+		()
+	| l ->
+		r := [];
+		List.iter (fun f -> try f v with Error.Error err -> handle_error err) (List.rev l);
+		run_callbacks handle_error r v
+
 class compiler_callbacks = object(self)
 	val before_typer_create = ref [];
 	val after_init_macros = ref [];
 	val mutable after_typing = [];
 	val before_save = ref [];
 	val after_save = ref [];
+	val before_save_only_new = ref [];
+	val after_save_only_new = ref [];
 	val after_filters = ref [];
 	val after_generation = ref [];
 	val mutable null_safety_report = [];
@@ -70,6 +81,12 @@ class compiler_callbacks = object(self)
 	method add_after_save (f : unit -> unit) : unit =
 		after_save := f :: !after_save
 
+	method add_before_save_only_new (f : module_type list -> unit) : unit =
+		before_save_only_new := f :: !before_save_only_new
+
+	method add_after_save_only_new (f : module_type list -> unit) : unit =
+		after_save_only_new := f :: !after_save_only_new
+
 	method add_after_filters (f : unit -> unit) : unit =
 		after_filters := f :: !after_filters
 
@@ -79,20 +96,13 @@ class compiler_callbacks = object(self)
 	method add_null_safety_report (f : (string*pos) list -> unit) : unit =
 		null_safety_report <- f :: null_safety_report
 
-	method run handle_error r =
-		match !r with
-		| [] ->
-			()
-		| l ->
-			r := [];
-			List.iter (fun f -> try f() with Error.Error err -> handle_error err) (List.rev l);
-			self#run handle_error r
-
 	method get_before_typer_create = before_typer_create
 	method get_after_init_macros = after_init_macros
 	method get_after_typing = after_typing
 	method get_before_save = before_save
 	method get_after_save = after_save
+	method get_before_save_only_new = before_save_only_new
+	method get_after_save_only_new = after_save_only_new
 	method get_after_filters = after_filters
 	method get_after_generation = after_generation
 	method get_null_safety_report = null_safety_report

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -268,7 +268,7 @@ let destruction (com : Common.context) scom ectx detail_times main rename_locals
 		)
 	);
 
-	com.callbacks#run com.error_ext com.callbacks#get_after_filters;
+	Common.run_callbacks com.error_ext com.callbacks#get_after_filters ();
 	Common.enter_stage com CFilteringDone
 
 let update_cache_dependencies ~close_monomorphs scom t =
@@ -511,7 +511,8 @@ let run com ectx main before_destruction =
 		)
 	);
 	with_timer com.timer_ctx detail_times "callbacks" None (fun () ->
-		com.callbacks#run com.error_ext com.callbacks#get_before_save;
+		Common.run_callbacks com.error_ext com.callbacks#get_before_save ();
+		Common.run_callbacks com.error_ext com.callbacks#get_before_save_only_new new_types;
 	);
 	Common.enter_stage com CSaveStart;
 	with_timer com.timer_ctx detail_times "save state" None (fun () ->
@@ -526,7 +527,8 @@ let run com ectx main before_destruction =
 	);
 	Common.enter_stage com CSaveDone;
 	with_timer com.timer_ctx detail_times "callbacks" None (fun () ->
-		com.callbacks#run com.error_ext com.callbacks#get_after_save;
+		Common.run_callbacks com.error_ext com.callbacks#get_after_save ();
+		Common.run_callbacks com.error_ext com.callbacks#get_after_save_only_new new_types;
 	);
 	before_destruction();
 	destruction com scom ectx detail_times main rename_locals_config com.types all_types_array

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -31,7 +31,7 @@ type 'value compiler_api = {
 	include_module : string -> unit;
 	after_init_macros : (unit -> unit) -> unit;
 	after_typing : (module_type list -> unit) -> unit;
-	on_generate : (Type.t list -> unit) -> bool -> unit;
+	on_generate : (Type.t list -> unit) -> bool -> bool -> unit;
 	after_generate : (unit -> unit) -> unit;
 	on_type_not_found : (string -> 'value) -> unit;
 	parse_string : string -> Globals.pos -> bool -> Ast.expr;
@@ -1901,9 +1901,9 @@ let macro_api ccom get_api =
 			(get_api()).after_typing (fun tl -> ignore(f [encode_array (List.map encode_module_type tl)]));
 			vnull
 		);
-		"on_generate", vfun2 (fun f b ->
+		"on_generate", vfun3 (fun f persistent only_new ->
 			let f = prepare_callback f 1 in
-			(get_api()).on_generate (fun tl -> ignore(f [encode_array (List.map encode_type tl)])) (decode_bool b);
+			(get_api()).on_generate (fun tl -> ignore(f [encode_array (List.map encode_type tl)])) (decode_bool persistent) (decode_bool only_new);
 			vnull
 		);
 		"on_after_generate", vfun1 (fun f ->

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -149,10 +149,15 @@ let make_macro_com_api com mcom p =
 				macro_timer com.timer_ctx timer_level ["afterTyping"] None f tl;
 			)
 		);
-		on_generate = (fun f b ->
-			(if b then com.callbacks#add_before_save else com.callbacks#add_after_save) (fun() ->
-				macro_timer com.timer_ctx timer_level ["onGenerate"] None f (List.map type_of_module_type com.types);
-			)
+		on_generate = (fun f persistent only_new ->
+			if only_new then
+				(if persistent then com.callbacks#add_before_save_only_new else com.callbacks#add_after_save_only_new) (fun tl ->
+					macro_timer com.timer_ctx timer_level ["onGenerate"] None f (List.map type_of_module_type tl);
+				)
+			else
+				(if persistent then com.callbacks#add_before_save else com.callbacks#add_after_save) (fun () ->
+					macro_timer com.timer_ctx timer_level ["onGenerate"] None f (List.map type_of_module_type com.types);
+				)
 		);
 		after_generate = (fun f ->
 			com.callbacks#add_after_generation (fun() ->

--- a/std/haxe/macro/Context.hx
+++ b/std/haxe/macro/Context.hx
@@ -436,7 +436,9 @@ class Context {
 		compiler's typing phase, just before its generation phase.
 
 		The callback receives an `Array` containing all types which are about
-		to be generated. Modifications are limited to metadata, it is mainly
+		to be generated, unless `onlyNew` is set to `true` in which case the callback
+		only receives types that were not cached by the compilation server.
+		Modifications are limited to metadata, it is mainly
 		intended to obtain information.
 
 		By default, the callback is made before types are stored in the compilation
@@ -447,8 +449,8 @@ class Context {
 
 		*Note*: the callback is still invoked when generation is disabled with  `--no-output`.
 	**/
-	public static function onGenerate(callback:Array<Type>->Void, persistent:Bool = true) {
-		load("on_generate", 2)(callback, persistent);
+	public static function onGenerate(callback:Array<Type>->Void, persistent:Bool = true, onlyNew:Bool = false) {
+		load("on_generate", 3)(callback, persistent, onlyNew);
 	}
 
 	/**


### PR DESCRIPTION
If `only_new` is set to true then only new types (aka not cached) will be passed to the callback.

@SomeRanDev wants this for Reflaxe.