### PR TITLE
Threadpool Atomic Shutdown

### DIFF
--- a/std/sys/thread/ElasticThreadPool.hx
+++ b/std/sys/thread/ElasticThreadPool.hx
@@ -42,8 +42,24 @@ class ElasticThreadPool implements IThreadPool {
 	public var maxThreadsCount:Int;
 	/** Indicates if `shutdown` method of this pool has been called. */
 	public var isShutdown(get,never):Bool;
+	function get_isShutdown():Bool {
+#if (target.atomics)
+		return _isShutdown.load();
+#else
+		_isShutdownMutex.acquire();
+		final current = _isShutdown;
+		_isShutdownMutex.release();
+		
+		return current;
+#end
+	}
+
+#if (target.atomics)
+	var _isShutdown = new haxe.atomic.AtomicBool(false);
+#else
 	var _isShutdown = false;
-	function get_isShutdown():Bool return _isShutdown;
+	var _isShutdownMutex = new sys.thread.Mutex();
+#end
 
 	final pool:Array<Worker> = [];
 	final queue = new Deque<()->Void>();
@@ -69,8 +85,17 @@ class ElasticThreadPool implements IThreadPool {
 		Throws an exception if the pool is shut down.
 	**/
 	public function run(task:()->Void):Void {
-		if(_isShutdown)
+#if (target.atomics)
+		if(_isShutdown.load()) {
+#else
+		_isShutdownMutex.acquire();
+		final current = _isShutdown;
+		_isShutdownMutex.release();
+
+		if (current) {
+#end
 			throw new ThreadPoolException('Task is rejected. Thread pool is shut down.');
+		}
 		if(task == null)
 			throw new ThreadPoolException('Task to run must not be null.');
 
@@ -109,9 +134,23 @@ class ElasticThreadPool implements IThreadPool {
 		Multiple calls to this method have no effect.
 	**/
 	public function shutdown():Void {
-		if(_isShutdown) return;
-		mutex.acquire();
+#if (target.atomics)
+		if(_isShutdown.compareExchange(false, true)) {
+			return;
+		}
+#else
+		_isShutdownMutex.acquire();
+		if (_isShutdown) {
+			_isShutdownMutex.release();
+
+			return;
+		}
+
 		_isShutdown = true;
+		_isShutdownMutex.release();
+#end
+
+		mutex.acquire();
 		for(worker in pool) {
 			worker.shutdown();
 		}

--- a/std/sys/thread/FixedThreadPool.hx
+++ b/std/sys/thread/FixedThreadPool.hx
@@ -34,14 +34,30 @@ import haxe.Exception;
 **/
 @:coreApi
 class FixedThreadPool implements IThreadPool {
+#if (target.atomics)
+	var _isShutdown = new haxe.atomic.AtomicBool(false);
+#else
+	var _isShutdown = false;
+	var _isShutdownMutex = new sys.thread.Mutex();
+#end
+
 	/* Amount of threads in this pool. */
 	public var threadsCount(get,null):Int;
 	function get_threadsCount():Int return threadsCount;
 
 	/** Indicates if `shutdown` method of this pool has been called. */
 	public var isShutdown(get,never):Bool;
-	var _isShutdown = false;
-	function get_isShutdown():Bool return _isShutdown;
+	function get_isShutdown():Bool {
+#if (target.atomics)
+		return _isShutdown.load();
+#else
+		_isShutdownMutex.acquire();
+		final current = _isShutdown;
+		_isShutdownMutex.release();
+		
+		return current;
+#end
+	}
 
 	final pool:Array<Worker>;
 	final poolMutex = new Mutex();
@@ -63,8 +79,17 @@ class FixedThreadPool implements IThreadPool {
 		Throws an exception if the pool is shut down.
 	**/
 	public function run(task:()->Void):Void {
-		if(_isShutdown)
+#if (target.atomics)
+		if(_isShutdown.load()) {
+#else
+		_isShutdownMutex.acquire();
+		final current = _isShutdown;
+		_isShutdownMutex.release();
+
+		if (current) {
+#end
 			throw new ThreadPoolException('Task is rejected. Thread pool is shut down.');
+		}
 		if(task == null)
 			throw new ThreadPoolException('Task to run must not be null.');
 		queue.add(task);
@@ -78,11 +103,27 @@ class FixedThreadPool implements IThreadPool {
 		Multiple calls to this method have no effect.
 	**/
 	public function shutdown():Void {
-		if(_isShutdown) return;
+#if (target.atomics)
+		if(false == _isShutdown.compareExchange(false, true)) {
+			for(_ in pool) {
+				queue.add(shutdownTask);
+			}	
+		}
+#else
+		_isShutdownMutex.acquire();
+		if (_isShutdown) {
+			_isShutdownMutex.release();
+
+			return;
+		}
+
 		_isShutdown = true;
+		_isShutdownMutex.release();
+
 		for(_ in pool) {
 			queue.add(shutdownTask);
 		}
+#end
 	}
 
 	static function shutdownTask():Void {

--- a/std/sys/thread/FixedThreadPool.hx
+++ b/std/sys/thread/FixedThreadPool.hx
@@ -104,10 +104,8 @@ class FixedThreadPool implements IThreadPool {
 	**/
 	public function shutdown():Void {
 #if (target.atomics)
-		if(false == _isShutdown.compareExchange(false, true)) {
-			for(_ in pool) {
-				queue.add(shutdownTask);
-			}	
+		if(_isShutdown.compareExchange(false, true)) {
+			return;
 		}
 #else
 		_isShutdownMutex.acquire();
@@ -119,11 +117,11 @@ class FixedThreadPool implements IThreadPool {
 
 		_isShutdown = true;
 		_isShutdownMutex.release();
+#end
 
 		for(_ in pool) {
 			queue.add(shutdownTask);
 		}
-#end
 	}
 
 	static function shutdownTask():Void {


### PR DESCRIPTION
Updates the two `IThreadPool` implementations to use either an atomic bool or a mutex to ensure we get memory barriers around access to that value. There are some other things which should be made atomic in the `ElasticThreadPool` but I want to wait until hxcpp has an atomic object before I do that.