### PR TITLE
[MessageReporting] Invert logic for color handling

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -885,10 +885,10 @@
 		"params": ["mode: classic | pretty | indent"]
 	},
 	{
-		"name": "MessageNoColor",
-		"define": "message.no-color",
+		"name": "MessageColor",
+		"define": "message.color",
 		"signatureNeutral": true,
-		"doc": "Disable ANSI color codes in message reporting."
+		"doc": "Enable ANSI color codes in message reporting."
 	},
 	{
 		"name": "MessageAbsolutePositions",

--- a/src/compiler/messageReporting.ml
+++ b/src/compiler/messageReporting.ml
@@ -142,7 +142,7 @@ let compiler_pretty_message_string defines ectx cm =
 
 		let gutter_len = (try String.length (Printf.sprintf "%d" (IntMap.find cm.cm_depth ectx.max_lines)) with Not_found -> 0) + 2 in
 
-		let no_color = Define.defined defines Define.MessageNoColor in
+		let no_color = not (Define.defined defines Define.MessageColor) in
 		let c_reset = if no_color then "" else "\x1b[0m" in
 		let c_bold = if no_color then "" else "\x1b[1m" in
 		let c_dim = if no_color then "" else "\x1b[2m" in

--- a/tests/misc/Issue11280/compile-fail.hxml
+++ b/tests/misc/Issue11280/compile-fail.hxml
@@ -1,3 +1,2 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/Issue11280/compile2-fail.hxml
+++ b/tests/misc/Issue11280/compile2-fail.hxml
@@ -1,3 +1,2 @@
 -main Main2
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/java/projects/Issue11095/pretty-fail.hxml
+++ b/tests/misc/java/projects/Issue11095/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue10623/pretty-fail.hxml
+++ b/tests/misc/projects/Issue10623/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue10844/user-defined-meta-pretty-fail.hxml
+++ b/tests/misc/projects/Issue10844/user-defined-meta-pretty-fail.hxml
@@ -1,4 +1,3 @@
 user-defined-meta-fail.hxml
 -D message.reporting=pretty
--D message.no-color
 

--- a/tests/misc/projects/Issue10863/compile.hxml
+++ b/tests/misc/projects/Issue10863/compile.hxml
@@ -1,5 +1,4 @@
 -main Main
 -js js.js
 -D message.reporting=pretty
--D message.no-color
 --no-output

--- a/tests/misc/projects/Issue11055/compile-pretty-fail.hxml
+++ b/tests/misc/projects/Issue11055/compile-pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11121/compile-fail.hxml
+++ b/tests/misc/projects/Issue11121/compile-fail.hxml
@@ -1,3 +1,2 @@
 --main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11162/compile-fail.hxml
+++ b/tests/misc/projects/Issue11162/compile-fail.hxml
@@ -1,3 +1,2 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11162/compile2-fail.hxml
+++ b/tests/misc/projects/Issue11162/compile2-fail.hxml
@@ -1,3 +1,2 @@
 -main Main2
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile.hxml
+++ b/tests/misc/projects/Issue11164/compile.hxml
@@ -1,3 +1,2 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile2-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile2-fail.hxml
@@ -1,3 +1,2 @@
 -main Main2
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile3-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile3-fail.hxml
@@ -1,3 +1,2 @@
 -main Main3
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile4-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile4-fail.hxml
@@ -1,3 +1,2 @@
 -main Main4
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile5-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile5-fail.hxml
@@ -1,3 +1,2 @@
 -main Main5
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile6-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile6-fail.hxml
@@ -1,3 +1,2 @@
 -main Main6
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11164/compile7-fail.hxml
+++ b/tests/misc/projects/Issue11164/compile7-fail.hxml
@@ -1,3 +1,2 @@
 -main Main7
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11417/compile-fail.hxml
+++ b/tests/misc/projects/Issue11417/compile-fail.hxml
@@ -1,3 +1,2 @@
 Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11417/compile1-fail.hxml
+++ b/tests/misc/projects/Issue11417/compile1-fail.hxml
@@ -1,3 +1,2 @@
 Main1
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11439/compile3-fail.hxml
+++ b/tests/misc/projects/Issue11439/compile3-fail.hxml
@@ -1,4 +1,3 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color
 -D message.absolute-positions

--- a/tests/misc/projects/Issue11679/compile-fail.hxml
+++ b/tests/misc/projects/Issue11679/compile-fail.hxml
@@ -1,3 +1,2 @@
 -main Main
--D message.no-color
 -D message.reporting=pretty

--- a/tests/misc/projects/Issue11700/compile-fail.hxml
+++ b/tests/misc/projects/Issue11700/compile-fail.hxml
@@ -2,4 +2,3 @@
 -cp src
 -main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11753/compile-fail.hxml
+++ b/tests/misc/projects/Issue11753/compile-fail.hxml
@@ -1,4 +1,3 @@
 -main Main
 --hl bin/main.hl
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue11753/compile.hxml
+++ b/tests/misc/projects/Issue11753/compile.hxml
@@ -1,4 +1,3 @@
 -main Main2
 --hl bin/main.hl
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue12167/compile-fail.hxml
+++ b/tests/misc/projects/Issue12167/compile-fail.hxml
@@ -1,3 +1,2 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue3188/compile.hxml
+++ b/tests/misc/projects/Issue3188/compile.hxml
@@ -1,3 +1,2 @@
 --macro Main.init()
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue5644/pretty-fail.hxml
+++ b/tests/misc/projects/Issue5644/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue5949/pretty-fail.hxml
+++ b/tests/misc/projects/Issue5949/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue6065/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6065/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue6584/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6584/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile5-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue6790/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6790/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue6796/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6796/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue6810/pretty-fail.hxml
+++ b/tests/misc/projects/Issue6810/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue7968/pretty-fail.hxml
+++ b/tests/misc/projects/Issue7968/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue8303/pretty-fail.hxml
+++ b/tests/misc/projects/Issue8303/pretty-fail.hxml
@@ -1,3 +1,2 @@
 compile-fail.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue8471/compile2-pretty.hxml
+++ b/tests/misc/projects/Issue8471/compile2-pretty.hxml
@@ -1,3 +1,2 @@
 compile2.hxml
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue9069/compile.hxml
+++ b/tests/misc/projects/Issue9069/compile.hxml
@@ -1,3 +1,2 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color

--- a/tests/misc/projects/Issue9430/compile-fail.hxml
+++ b/tests/misc/projects/Issue9430/compile-fail.hxml
@@ -1,3 +1,2 @@
 -main Main
 -D message.reporting=pretty
--D message.no-color


### PR DESCRIPTION
Original plan when making "pretty errors" the default was to have them without colors by default (to not break on terminal/etc. without ANSI code support), and let users enable colors if they want to.

This will technically impact most nightlies users, but the effect is limited (they will just lose colored output) and easy enough to fix.

`-D message.no-color` now does nothing; not having colors is the new default behavior
`-D message.color` is added instead to enable ANSI color codes in error reporting

Should probably be included in 4.3.8 if we ever release that