### PR TITLE
Atomic object for hxcpp

### DIFF
--- a/std/cpp/_std/haxe/atomic/AtomicObject.hx
+++ b/std/cpp/_std/haxe/atomic/AtomicObject.hx
@@ -1,0 +1,59 @@
+package haxe.atomic;
+
+private class AtomicObjectImpl<T> {
+	public final lock : sys.thread.Mutex;
+
+	public var obj : T;
+
+	public function new(obj) {
+		this.lock = new sys.thread.Mutex();
+		this.obj  = obj;
+	}
+}
+
+abstract AtomicObject<T:{}>(AtomicObjectImpl<T>) {
+	public function new(value:T) {
+		this = new AtomicObjectImpl(value);
+	}
+
+	public function compareExchange(expected:T, replacement:T):T {
+		this.lock.acquire();
+		return if (this.obj == expected) {
+			final current = this.obj;
+			this.obj = replacement;
+			this.lock.release();
+
+			current;
+		} else {
+			final current = this.obj;
+			this.lock.release();
+			
+			current;
+		}
+	}
+
+	public function exchange(value:T):T {
+		this.lock.acquire();
+		final current = this.obj;
+		this.obj = value;
+		this.lock.release();
+
+		return current;
+	}
+
+	public function load():T {
+		this.lock.acquire();
+		final current = this.obj;
+		this.lock.release();
+
+		return current;
+	}
+
+	public function store(value:T):T {
+		this.lock.acquire();
+		this.obj = value;
+		this.lock.release();
+
+		return value;
+	}
+}

--- a/std/haxe/atomic/AtomicObject.hx
+++ b/std/haxe/atomic/AtomicObject.hx
@@ -4,8 +4,8 @@ package haxe.atomic;
 #error "This target does not support atomic operations."
 #end
 
-#if (js || cpp)
-#error "JavaScript and Hxcpp do not support AtomicObject"
+#if js
+#error "JavaScript does not support AtomicObject"
 #end
 
 /**

--- a/tests/unit/src/unitstd/haxe/atomic/AtomicObject.unit.hx
+++ b/tests/unit/src/unitstd/haxe/atomic/AtomicObject.unit.hx
@@ -1,4 +1,4 @@
-#if (target.atomics && !(js || cpp))
+#if (target.atomics && !js)
 var a = new haxe.atomic.AtomicObject("Hey World!");
 
 a.load() == "Hey World!";


### PR DESCRIPTION
Here's a quick lock based atomic object for hxcpp. I plan on adding a "proper" one at some point, probably after #11981 is done since switching the atomics over to use that might be a good test, but this should do for now.

All thats left now for `AtomicObject` is js, could we just implement an atomic object for js with no locks either...?