### PR TITLE
Fix remap vs module resolution for sub types

### DIFF
--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -327,7 +327,7 @@ let parse_module com m p =
 								in
 								mk_type_path ~params ~sub:(fst d.d_name) (!remap,snd m)
 						in
-						make_ptp_th_null tp
+						make_ptp_th tp (snd d.d_name)
 					end
 				},p) :: acc
 			in

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -325,7 +325,7 @@ let parse_module com m p =
 										TPType (make_ptp_th_null (mk_type_path ([],fst tp.tp_name)))
 									) d.d_params
 								in
-								mk_type_path ~params (!remap,fst d.d_name)
+								mk_type_path ~params ~sub:(fst d.d_name) (!remap,snd m)
 						in
 						make_ptp_th_null tp
 					end

--- a/tests/misc/projects/Issue12305/compile.hxml
+++ b/tests/misc/projects/Issue12305/compile.hxml
@@ -1,0 +1,3 @@
+-cp src
+-main Main
+--remap foo:haxe

--- a/tests/misc/projects/Issue12305/src/Main.hx
+++ b/tests/misc/projects/Issue12305/src/Main.hx
@@ -1,0 +1,5 @@
+import foo.display.Position.Range;
+
+function main() {
+	var loc:Null<Range> = null;
+}

--- a/tests/misc/projects/Issue12305/src/foo/display/Position.hx
+++ b/tests/misc/projects/Issue12305/src/foo/display/Position.hx
@@ -1,0 +1,39 @@
+package foo.display;
+
+/**
+	Position in a text document expressed as 1-based line and character offset.
+**/
+typedef Position = {
+	/**
+		Line position in a document (1-based).
+	**/
+	var line:Int;
+
+	/**
+		Character offset on a line in a document (1-based).
+	**/
+	var character:Int;
+}
+
+/**
+	A range in a text document expressed as (1-based) start and end positions.
+**/
+typedef Range = {
+	/**
+		The range's start position
+	**/
+	var start:Position;
+
+	/**
+		The range's end position
+	**/
+	var end:Position;
+}
+
+/**
+	Represents a location inside a resource, such as a line inside a text file.
+**/
+typedef Location = {
+	var file:FsPath;
+	var range:Range;
+}


### PR DESCRIPTION
Easy way to repro:
```
haxe -lib openfl -lib lime -js out.js --no-output --remap flash:openfl flash.utils.Object
```

Could likely be reduced to not need a lib at all, but I'm not available for that this week-end..
