### PR TITLE
Allow overriding the default generation of rest arguments in js-es <= 5

### DIFF
--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -757,14 +757,16 @@ and gen_function ?(keyword="function") ctx f pos =
 			else begin
 				check_var_declaration v;
 				let non_rest_args = List.rev args_rev in
-				let args_decl = declare_rest_args_legacy ctx.com (List.length non_rest_args) v in
-				let body =
+				let body = if has_var_flag v VUsedByTyper then
+					let args_decl = declare_rest_args_legacy ctx.com (List.length non_rest_args) v in
 					let el =
 						match f.tf_expr.eexpr with
 						| TBlock el -> args_decl @ el
 						| _ -> args_decl @ [f.tf_expr]
 					in
 					mk (TBlock el) f.tf_expr.etype f.tf_expr.epos
+				else
+					f.tf_expr
 				in
 				{ f with tf_args = non_rest_args; tf_expr = body }, mk_non_rest_arg_names non_rest_args
 			end


### PR DESCRIPTION
This gives the option to use the code generated by the compiler or not.

```haxe
function rest( name : String, args : haxe.Rest<String> ) {
#if (js_es < 6)
	var args = js.Syntax.code("arguments"); // <-- overrides
	var i = 1;
#else
	var i = 0;
#end
    while(i < args.length)
        trace(name + " : " + args[i++]);
}
```

generated es5:

```js
function rest(name) {
	var args = arguments;
	var i = 1;	
	while(i < args.length) console.log(name + " : " + args[i++]);
}
```