### PR TITLE
[tests] Restrict BigInt tests; they're taking far too long atm

### DIFF
--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -69,7 +69,9 @@ function main() {
 		#if (!php && !lua)
 		new TestHttps(),
 		#end
+		#if (hl || jvm)
 		new TestBigInt(),
+		#end
 		#if !no_pattern_matching
 		new TestMatch(),
 		#end


### PR DESCRIPTION
Will need to investigate more and actually fix the issues, but that is pretty contained to BigInt, and some targets are fine (lua, php, python are the worst, but only hl and jvm seem really fine).

Something seems very wrong, and seeing lua timings for example going from 5min to 1h during #10750 was a big hint :sweat_smile: 

As @Apprentice-Alchemist identified:
> Further testing seems to indicate that the String -> BigInt conversions are the bottleneck.

cc @flashultra 