### PR TITLE
Fix rosetta error when installing haxe on arm64 mac

### DIFF
--- a/extra/mac-installer/pkg/Distribution
+++ b/extra/mac-installer/pkg/Distribution
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <installer-script minSpecVersion="1.000000" authoringTool="com.apple.PackageMaker" authoringToolVersion="3.0.6" authoringToolBuild="201">
     <title>Haxe Toolkit %%VERLONG%%</title>
-    <options customize="never" allow-external-scripts="no"/>
+    <options customize="never" allow-external-scripts="no" hostArchitectures="x86_64,arm64" />
     <domains enable_localSystem="true"/>
     <background file="background" alignment="bottomleft" scaling="none"/>
     <license file="License"/>


### PR DESCRIPTION
This should resolve an error where arm64 mac users cannot install haxe without rosetta, despite haxe having full native arm64 support.

See: https://developer.apple.com/forums/thread/667672