### PR TITLE
[cppia] Add tests for missing retyping in function calls

### DIFF
--- a/src/generators/cpp/cppRetyper.ml
+++ b/src/generators/cpp/cppRetyper.ml
@@ -1130,12 +1130,10 @@ let expression ctx request_type function_args function_type expression_tree forI
               let retyper_ctx, retypedArgs = retype_function_args retyper_ctx args arg_types in
               (retyper_ctx, CppCall (func, retypedArgs), returnType)
             | CppEnumField (enum, field) ->
-              (* TODO - proper re-typing *)
               let arg_types = List.map (fun a -> cpp_type_of a.etype) args in
               let retyper_ctx, retypedArgs = retype_function_args retyper_ctx args arg_types in
               ( retyper_ctx, CppCall (FuncEnumConstruct (enum, field), retypedArgs), cppType )
             | CppSuper _ ->
-              (* TODO - proper re-typing *)
               let arg_types = List.map (fun a -> cpp_type_of a.etype) args in
               let retyper_ctx, retypedArgs = retype_function_args retyper_ctx args arg_types in
               ( retyper_ctx, CppCall (FuncSuperConstruct retypedFunc.cpptype, retypedArgs), TCppVoid )

--- a/tests/unit/src/unit/issues/Issue9990.hx
+++ b/tests/unit/src/unit/issues/Issue9990.hx
@@ -1,7 +1,5 @@
 package unit.issues;
 
-import utest.Assert;
-
 private function wrap<T>(a:Array<T>):Array<T> {
 	return a;
 }

--- a/tests/unit/src/unit/issues/Issue9990.hx
+++ b/tests/unit/src/unit/issues/Issue9990.hx
@@ -38,7 +38,6 @@ private enum MyEnum {
 	Value(arr:Array<Int>);
 }
 
-// Main test class
 class Issue9990 extends Test {
 	function checkArray(array:Array<Int>) {
 		eq(10, array[0]);

--- a/tests/unit/src/unit/issues/Issue9990.hx
+++ b/tests/unit/src/unit/issues/Issue9990.hx
@@ -112,7 +112,7 @@ class Issue9990 extends Test {
 	}
 
 	function testObjectDeclaration() {
-		var obj = {
+		final obj = {
 			value: wrap([10, 20, 30])
 		};
 		// The generator always converts to Array<Int> on dynamic field access

--- a/tests/unit/src/unit/issues/Issue9990.hx
+++ b/tests/unit/src/unit/issues/Issue9990.hx
@@ -1,0 +1,122 @@
+package unit.issues;
+
+import utest.Assert;
+
+private function wrap<T>(a:Array<T>):Array<T> {
+	return a;
+}
+
+private class Parent {
+	public var value:Null<Array<Int>>;
+
+	public function new(?a:Array<Int>) {
+		value = a?.copy();
+	}
+
+	public function method(a:Array<Int>):Array<Int> {
+		return a.copy();
+	}
+}
+
+private class Child extends Parent {
+	public function new(?a:Array<Int>) {
+		super(a != null ? wrap(a) : null);
+	}
+
+	override public function method(a:Array<Int>):Array<Int> {
+		return super.method(wrap(a));
+	}
+
+	// the type parameter here triggers a static cast on return
+	public function forStaticCast<T>(a:Array<Int>):T {
+		value = a.copy();
+		return cast this;
+	}
+}
+
+private enum MyEnum {
+	Value(arr:Array<Int>);
+}
+
+// Main test class
+class Issue9990 extends Test {
+	function checkArray(array:Array<Int>) {
+		eq(10, array[0]);
+		eq(20, array[1]);
+		eq(30, array[2]);
+		eq(3, array.length);
+	}
+
+	function testInstanceMethodCast() {
+		final child = new Child();
+		final result:Child = child.forStaticCast(wrap([10, 20, 30]));
+		checkArray(result.value);
+	}
+
+	function testSuperMethod() {
+		final child = new Child();
+		final result = child.method([10, 20, 30]);
+		checkArray(result);
+	}
+
+	function extractEnumArg(e:MyEnum) {
+		return switch (e) {
+			case Value(a): a.copy();
+		};
+	}
+
+	function testEnumConstruct() {
+		final e = MyEnum.Value(wrap([10, 20, 30]));
+		final result = extractEnumArg(e);
+		checkArray(result);
+	}
+
+	function testSuperConstructor() {
+		final child = new Child([10, 20, 30]);
+		checkArray(child.value);
+	}
+
+	function extractArray(array:Array<Array<Int>>) {
+		return array[0].copy();
+	}
+
+	function testArrayDeclaration() {
+		final arr:Array<Array<Int>> = [wrap([10, 20, 30])];
+		final result = extractArray(arr);
+		checkArray(result);
+	}
+
+	// these tests passed before, but are here for good measure:
+
+	function testMapSet() {
+		final map:Map<Int, Array<Int>> = [];
+
+		map[0] = wrap([10, 20, 30]);
+
+		// map.get uses a type parameter so it will convert to Array<Int> anyway
+		final result = map[0].copy();
+		checkArray(result);
+	}
+
+	function testDynamicFieldCall() {
+		final obj:{
+			function method(arr:Array<Int>):Array<Int>;
+		} = new Parent();
+		// cppia automatically handles Array<Dynamic> -> Array<Int> conversion for dynamic methods calls anyway
+		final result = obj.method(wrap([10, 20, 30]));
+		checkArray(result);
+	}
+
+	function extractObject(obj:{ value: Array<Int> }) {
+		return obj.value.copy();
+	}
+
+	function testObjectDeclaration() {
+		var obj = {
+			value: wrap([10, 20, 30])
+		};
+		// The generator always converts to Array<Int> on dynamic field access
+		final result = extractObject(obj);
+		checkArray(result);
+	}
+}


### PR DESCRIPTION
This fixes #9990, which crashes due to a missing `TODATAARRAY` instruction, which is required to convert the resulting dynamic array back into an int array.

Before:
```
3	30				CALLSUPER 1  1 1 
3	30					CALLSTATIC 5  6 1 
3	30						TODYNARRAY 
3	30							VAR 6681
```
vs after:
```
3	30				CALLSUPER 1  1 1 
3	30					TODATAARRAY 2 
3	30						CALLSTATIC 5  6 1 
3	30							TODYNARRAY 
3	30								VAR 6681
```




I imagine the same issue can occur with other types of calls, so I will look into that before marking this as ready.

Some of those `(* TODO - proper re-typing *)` comments also look a bit worrying...