### PR TITLE
Add StringTools.binary(..)

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -439,6 +439,38 @@ class StringTools {
 		#end
 		return s;
 	}
+	
+	/**
+		Encodes `n` into a binary representation.
+		If `digits` is specified, the resulting String is padded with "0" until
+		its `length` equals `digits`.
+	**/
+	public static function binary(n:Int, ?digits:Int) {
+		#if flash
+		var n:UInt = n;
+		var s:String = untyped n.toString(2);
+		s = s.toUpperCase();
+		#else
+		var s = "";
+		do {
+			s = ((n & 1) == 1 ? "1" : "0") + s;
+			n >>>= 1;
+		} while (n > 0);
+		#end
+		#if python
+		if (digits != null && s.length < digits) {
+			var diff = digits - s.length;
+			for (_ in 0...diff) {
+				s = "0" + s;
+			}
+		}
+		#else
+		if (digits != null)
+			while (s.length < digits)
+				s = "0" + s;
+		#end
+		return s;
+	}
 
 	/**
 		Returns the character code at position `index` of String `s`, or an

--- a/std/php/_std/StringTools.hx
+++ b/std/php/_std/StringTools.hx
@@ -116,6 +116,16 @@ import haxe.iterators.StringKeyValueIterator;
 			s = lpad(s, '0', digits);
 		return s.toUpperCase();
 	}
+	
+	public static function binary(n:Int, ?digits:Int):String {
+		var s = Global.decbin(n);
+		var len = 32;
+		if (Global.strlen(s) > (null == digits ? len : (len = digits > len ? digits : len)))
+			s = s.substr(-len);
+		else if (digits != null)
+			s = lpad(s, '0', digits);
+		return s.toUpperCase();
+	}
 
 	public static function fastCodeAt(s:String, index:Int):Int {
 		var char:NativeString = (index == 0 ? s : Global.mb_substr(s, index, 1));

--- a/tests/unit/src/unitstd/StringTools.unit.hx
+++ b/tests/unit/src/unitstd/StringTools.unit.hx
@@ -110,6 +110,22 @@ StringTools.hex(0xABCDEF, 7) == "0ABCDEF";
 StringTools.hex( -1, 8) == "FFFFFFFF";
 StringTools.hex( -481400000, 8) == "E34E6B40";
 
+// binary
+StringTools.binary(0, 0) == "0";
+StringTools.binary(0, 1) == "0";
+StringTools.binary(0, 2) == "00";
+StringTools.binary(1, 2) == "01";
+StringTools.binary(4564562) == "10001011010011001010010";
+StringTools.binary(4564562, 0) == "10001011010011001010010";
+StringTools.binary(4564562, 1) == "10001011010011001010010";
+StringTools.binary( -1) == "11111111111111111111111111111111";
+StringTools.binary( -2) == "11111111111111111111111111111110";
+#if haxe5
+StringTools.binary(0b101010111100110111101111, 7) == "101010111100110111101111";
+#end
+StringTools.binary( -1, 8) == "11111111111111111111111111111111";
+StringTools.binary( -481400000, 8) == "11100011010011100110101101000000";
+
 // contains
 var s = "foo1bar";
 StringTools.contains(s, '') == true;


### PR DESCRIPTION
Since Haxe 5 it is possible to initialize a value like ```var i = 0b100000000000000001;``` (similar to hex ```var i = 0x10001;```).
Currently, ```StringTools.hex``` exists, but there is no similar function for binary representation.
This pull request adds ```StringTools.binary(...)```