### PR TITLE
[hlc] Fix identifier conflicts with windows.h macros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -799,7 +799,7 @@ jobs:
     needs: mac-build-universal
     runs-on: macos-latest
     env:
-      PLATFORM: mac-arm64
+      PLATFORM: mac-universal
       TEST: ${{matrix.target}}
       HXCPP_COMPILE_CACHE: ~/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
@@ -814,10 +814,7 @@ jobs:
           submodules: recursive
       - uses: actions/download-artifact@v4
         with:
-          # install the arm64-only binaries for HL to avoid issues with Rosetta
-          # the sys tests invoke Haxe, which invokes haxelib, which requires neko
-          # invoking the universal version of haxelib from an x86_64 process fails because neko is arm64-only
-          name: ${{ matrix.target == 'hl' && 'macArmBinaries' || 'macBinaries' }}
+          name: macBinaries
           path: macBinaries
 
       - name: Install Neko from S3

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -452,7 +452,7 @@ jobs:
     needs: mac-build-universal
     runs-on: macos-latest
     env:
-      PLATFORM: mac-arm64
+      PLATFORM: mac-universal
       TEST: ${{matrix.target}}
       HXCPP_COMPILE_CACHE: ~/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
@@ -467,10 +467,7 @@ jobs:
           submodules: recursive
       - uses: actions/download-artifact@v4
         with:
-          # install the arm64-only binaries for HL to avoid issues with Rosetta
-          # the sys tests invoke Haxe, which invokes haxelib, which requires neko
-          # invoking the universal version of haxelib from an x86_64 process fails because neko is arm64-only
-          name: ${{ matrix.target == 'hl' && 'macArmBinaries' || 'macBinaries' }}
+          name: macBinaries
           path: macBinaries
 
       @import install-neko-unix.yml

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -1923,11 +1923,12 @@ let write_c com file (code:code) gnames num_domains =
 	let line = linec ctx and expr = exprc ctx and sline fmt = Printf.ksprintf (linec ctx) fmt and sexpr fmt = Printf.ksprintf (exprc ctx) fmt in
 	define ctx "#define HLC_BOOT";
 	define ctx "#include <hlc.h>";
-	line "#include <hlc_main.c>";
 	line "";
 	line "#ifndef HL_MAKE";
 	List.iter (sline "#  include <%s>") gctx.cfiles;
 	line "#endif";
+	line "";
+	line "#include <hlc_main.c>";
 	line "";
 	expr "void hl_init_hashes()";
 	expr "void hl_init_roots()";

--- a/tests/misc/hl/projects/Issue11419/Main.hx
+++ b/tests/misc/hl/projects/Issue11419/Main.hx
@@ -1,0 +1,9 @@
+/**
+	"SOCKET_ERROR" is reserved as a macro in windows.h, but hopefully our
+	code shouldn't be affected.
+**/
+final SOCKET_ERROR = "SOCKET_ERROR";
+
+function main() {
+	trace(SOCKET_ERROR);
+}

--- a/tests/misc/hl/projects/Issue11419/compile.hxml
+++ b/tests/misc/hl/projects/Issue11419/compile.hxml
@@ -1,3 +1,2 @@
 --main Main
 --hl out/main.c
--D hlgen.makefile=vs2022

--- a/tests/misc/hl/projects/Issue11419/compile.hxml
+++ b/tests/misc/hl/projects/Issue11419/compile.hxml
@@ -1,0 +1,3 @@
+--main Main
+--hl out/main.c
+-D hlgen.makefile=vs2022

--- a/tests/misc/src/Main.hx
+++ b/tests/misc/src/Main.hx
@@ -14,7 +14,7 @@ typedef Result = {
 
 class Main {
 	static public function main() {
-		var result:Result = compileProjects();
+		var result:Result = compileProjects(Sys.args());
 		Sys.println('Done running ${result.count} tests with ${result.failures} failures');
 		if(result.count > 20 && result.failures > 0) {
 			Sys.println('SUMMARY:');
@@ -23,7 +23,7 @@ class Main {
 		Sys.exit(result.failures);
 	}
 
-	static public function compileProjects():Result {
+	static public function compileProjects(args:Array<String>):Result {
 		var count = 0;
 		var failures = 0;
 		var failuresSummary = [];
@@ -47,7 +47,7 @@ class Main {
 					var expectFailure = file.endsWith("-fail.hxml");
 					var expectStdout = if (FileSystem.exists('$file.stdout')) prepareExpectedOutput(File.getContent('$file.stdout')) else null;
 					var expectStderr = if (FileSystem.exists('$file.stderr')) prepareExpectedOutput(File.getContent('$file.stderr')) else null;
-					var result = runCommand("haxe", ["-D", "message.reporting=classic", file], expectFailure, expectStdout, expectStderr);
+					var result = runCommand("haxe", ["-D", "message.reporting=classic", file].concat(args), expectFailure, expectStdout, expectStderr);
 					++count;
 					if (!result.success) {
 						failures++;

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -168,9 +168,12 @@ class Hl {
 		buildAndRun("compile.hxml", "bin/reservedKeywords");
 
 		changeDirectory(miscHlDir);
-		runCommand("haxe", ["run.hxml"].concat([ "-D",
-			if (systemName == "Windows") "hlgen.makefile=vs2022"
-			else "hlgen.makefile=make"
-		]));
+		if (systemName == "Windows") {
+			runCommand("haxe", ["run.hxml", "-D", "hlgen.makefile=vs2022"]);
+		} else if (systemName == "Mac") {
+			runCommand("arch", ["-x86_64", "haxe", "run.hxml", "-D", "hlgen.makefile=make"]);
+		} else {
+			runCommand("haxe", ["run.hxml", "-D", "hlgen.makefile=make"]);
+		}
 	}
 }

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -75,8 +75,8 @@ class Hl {
 
 		haxelibDev("hashlink", '$hlSrc/other/haxelib/');
 
+		Sys.putEnv("HASHLINK", hlInstallDir);
 		if (systemName == "Windows") {
-			Sys.putEnv("HASHLINK", hlInstallDir);
 			Sys.putEnv("HASHLINK_SRC", hlSrc);
 			Sys.putEnv("HASHLINK_BIN", hlInstallBinDir);
 		}
@@ -168,6 +168,9 @@ class Hl {
 		buildAndRun("compile.hxml", "bin/reservedKeywords");
 
 		changeDirectory(miscHlDir);
-		runCommand("haxe", ["run.hxml"]);
+		runCommand("haxe", ["run.hxml"].concat([ "-D",
+			if (systemName == "Windows") "hlgen.makefile=vs2022"
+			else "hlgen.makefile=make"
+		]));
 	}
 }

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -76,6 +76,7 @@ class Hl {
 		haxelibDev("hashlink", '$hlSrc/other/haxelib/');
 
 		if (systemName == "Windows") {
+			Sys.putEnv("HASHLINK", hlInstallDir);
 			Sys.putEnv("HASHLINK_SRC", hlSrc);
 			Sys.putEnv("HASHLINK_BIN", hlInstallBinDir);
 		}


### PR DESCRIPTION
`hlc_main.c` includes `windows.h`, which defines macros that can conflict with user code. By placing it below the source file includes, we avoid this being an issue. See #11419 and https://github.com/HaxeFoundation/hashlink/issues/716#issuecomment-3146082284.

Note, this has to be combined with the hashlink patch to remove `windows.h` from `hl.h` to have any benefit: https://github.com/HaxeFoundation/hashlink/pull/804. Otherwise, `windows.h` will be included above anyway from `hlc.h`. The test I've added should also only pass after that PR is merged.