### PR TITLE
[hl] Restore support for hashlink 1.12.0

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -26,6 +26,7 @@ open Type
 open Error
 open Gctx
 open Hlcode
+open Semver
 
 (* compiler *)
 
@@ -4168,9 +4169,10 @@ let create_context com =
 		| TAbstractDecl a -> a
 		| _ -> die "" __LOC__
 	in
+	let hl_ver = Gctx.defined_value_safe ~default:"" com Define.HlVer in
 	let ctx = {
 		com = com;
-		hl_ver = Gctx.defined_value_safe ~default:"" com Define.HlVer;
+		hl_ver = hl_ver;
 		optimize = not (Gctx.raw_defined com "hl_no_opt");
 		w_null_compare = Gctx.raw_defined com "hl_w_null_compare";
 		num_domains = Domain.recommended_domain_count ();
@@ -4198,7 +4200,13 @@ let create_context com =
 			ai32 = get_class "ArrayBytes_Int";
 			af32 = get_class "ArrayBytes_hl_F32";
 			af64 = get_class "ArrayBytes_Float";
-			ai64 = if Gctx.raw_defined com "hl_legacy32" then None else Some (get_class "ArrayBytes_hl_I64");
+			ai64 =
+				if Gctx.raw_defined com "hl_legacy32"
+					|| hl_ver <> "" && (Semver.compare_version (Semver.parse_version hl_ver) (Semver.parse_version "1.13.0")) = -1
+				then
+					None
+				else
+					Some (get_class "ArrayBytes_hl_I64");
 		};
 		base_class = get_class "Class";
 		base_enum = get_class "Enum";

--- a/std/hl/types/ArrayBase.hx
+++ b/std/hl/types/ArrayBase.hx
@@ -149,7 +149,7 @@ class ArrayBase extends ArrayAccess {
 		return a;
 	}
 
-	#if !hl_legacy32
+	#if (hl_ver >= version("1.13.0") && !hl_legacy32)
 	public static function allocI64(bytes:BytesAccess<I64>, length:Int) @:privateAccess {
 		var a:ArrayBytes.ArrayI64 = untyped $new(ArrayBytes.ArrayI64);
 		a.length = length;

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -362,6 +362,6 @@ typedef ArrayI32 = ArrayBytes<Int>;
 typedef ArrayUI16 = ArrayBytes<UI16>;
 typedef ArrayF32 = ArrayBytes<F32>;
 typedef ArrayF64 = ArrayBytes<Float>;
-#if !hl_legacy32
+#if (hl_ver >= version("1.13.0") && !hl_legacy32)
 typedef ArrayI64 = ArrayBytes<I64>;
 #end


### PR DESCRIPTION
Hashlink versions without this commit (i.e. pre 1.13.0) crash with a jit error: https://github.com/HaxeFoundation/hashlink/commit/6fdb71c2b06f194cdd40f712f535f6e5c21cef4c

```
JIT ERROR 4 (jit.c line 3712)
```