### PR TITLE
Add hint to update build tools when the smart string check is triggered

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -470,7 +470,7 @@
 		"platforms": ["cpp"]
 	},
 	{
-		"name": "HxcppSmartStings",
+		"name": "HxcppSmartStrings",
 		"define": "hxcpp-smart-strings",
 		"doc": "Use wide strings in hxcpp. (Turned on by default unless `-D disable-unicode-strings` is specified.)",
 		"platforms": ["cpp"]

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -354,8 +354,8 @@ let parse_args com =
 				end;
 			with Not_found ->
 				raise (Arg.Bad new_msg));
-		if com.platform = Globals.Cpp && not (Define.defined com.defines DisableUnicodeStrings) && not (Define.defined com.defines HxcppSmartStings) then begin
-			Define.define com.defines HxcppSmartStings;
+		if com.platform = Globals.Cpp && not (Define.defined com.defines DisableUnicodeStrings) && not (Define.defined com.defines HxcppSmartStrings) then begin
+			Define.define com.defines HxcppSmartStrings;
 		end;
 		if Define.raw_defined com.defines "gen_hx_classes" then begin
 			(* TODO: this is something we're gonna remove once we have something nicer for generating flash externs *)

--- a/src/generators/cpp/cppStrings.ml
+++ b/src/generators/cpp/cppStrings.ml
@@ -68,7 +68,7 @@ let strq ctx s =
     else "(" ^ split s "" ^ ")"
   in
 
-  if Gctx.defined ctx Define.HxcppSmartStings && has_utf8_chars s then (
+  if Gctx.defined ctx Define.HxcppSmartStrings && has_utf8_chars s then (
     let b = Buffer.create 0 in
 
     let add ichar =

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -159,7 +159,7 @@ let write_build_data common_ctx filename classes main_deps boot_deps build_extra
    output_string buildfile ("<set name=\"HAXE_OUTPUT\" value=\"" ^ exe_name ^ "\" />\n");
    output_string buildfile "<include name=\"${HXCPP}/build-tool/BuildCommon.xml\"/>\n";
    output_string buildfile build_extra;
-   if (Gctx.defined common_ctx Define.HxcppSmartStings) then
+   if (Gctx.defined common_ctx Define.HxcppSmartStrings) then
       output_string buildfile ("<error value=\"Hxcpp is out of date - please update, and/or rebuild your build tools\" unlessApi=\"" ^ api_string ^ "\" />\n");
    output_string buildfile "</xml>\n";
    close_out buildfile

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -160,7 +160,7 @@ let write_build_data common_ctx filename classes main_deps boot_deps build_extra
    output_string buildfile "<include name=\"${HXCPP}/build-tool/BuildCommon.xml\"/>\n";
    output_string buildfile build_extra;
    if (Gctx.defined common_ctx Define.HxcppSmartStings) then
-      output_string buildfile ("<error value=\"Hxcpp is out of date - please update, and/or update your build tools\" unlessApi=\"" ^ api_string ^ "\" />\n");
+      output_string buildfile ("<error value=\"Hxcpp is out of date - please update, and/or rebuild your build tools\" unlessApi=\"" ^ api_string ^ "\" />\n");
    output_string buildfile "</xml>\n";
    close_out buildfile
 

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -159,6 +159,8 @@ let write_build_data common_ctx filename classes main_deps boot_deps build_extra
    output_string buildfile ("<set name=\"HAXE_OUTPUT\" value=\"" ^ exe_name ^ "\" />\n");
    output_string buildfile "<include name=\"${HXCPP}/build-tool/BuildCommon.xml\"/>\n";
    output_string buildfile build_extra;
+   if (Gctx.defined common_ctx Define.HxcppSmartStings) then
+      output_string buildfile ("<error value=\"Hxcpp is out of date - please update, and/or update your build tools\" unlessApi=\"" ^ api_string ^ "\" />\n");
    output_string buildfile "</xml>\n";
    close_out buildfile
 

--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -159,8 +159,6 @@ let write_build_data common_ctx filename classes main_deps boot_deps build_extra
    output_string buildfile ("<set name=\"HAXE_OUTPUT\" value=\"" ^ exe_name ^ "\" />\n");
    output_string buildfile "<include name=\"${HXCPP}/build-tool/BuildCommon.xml\"/>\n";
    output_string buildfile build_extra;
-   if (Gctx.defined common_ctx Define.HxcppSmartStings) then
-      output_string buildfile ("<error value=\"Hxcpp is out of date - please update\" unlessApi=\"" ^ api_string ^ "\" />\n");
    output_string buildfile "</xml>\n";
    close_out buildfile
 


### PR DESCRIPTION
**The information below is out of date**: refer to @tobil4sk 's [response](https://github.com/HaxeFoundation/haxe/pull/12344#issuecomment-3166020404) and commits below that

~
~

I'm unable to compile hxcpp without removing the smart string check, on the latest Haxe nightly version, and newest git version for hxcpp.
``Haxe Compiler 5.0.0-preview.1+ff3f3ef``
```sh
% haxelib git hxcpp https://github.com/haxefoundation/hxcpp
You already have hxcpp version git installed.
Library hxcpp version git already up to date
  Current version is now git
Done

% haxe build.hxml
haxelib run hxcpp Build.xml haxe -Danalyzer_optimize="1" -Ddump.stage="dce" -Ddump_ignore_var_ids="1" -Ddump_path="dump" -Deval_call_stack_depth="1000" -Deval_print_depth="5" -Dhaxe="5.0.0-preview.1" -Dhaxe3="1" -Dhaxe4="1" -Dhaxe5="1" -Dhaxe_ver="5.000" -Dhxcpp_api_level="500" -Dhxcpp_smart_strings="1" -Dloop_unroll_max_cost="250" -Dmessage.log_format="indent" -Dmessage.reporting="pretty" -Dsource_header="Generated by Haxe 5.0.0-preview.1+ff3f3ef" -Dstatic="1" -Dtarget.atomics="1" -Dtarget.name="cpp" -Dtarget.static="1" -Dtarget.sys="1" -Dtarget.threaded="1" -Dtarget.unicode="1" -Dtarget.utf16="1" -Dutf16="1" -Isrc/ -I -I/usr/local/lib/haxe/std/cpp/_std/ -I/usr/local/lib/haxe/std/
Error: Hxcpp is out of date - please update
[ERROR] (unknown position)

   | Error: Build failed
```

``-Dhxcpp_smart_strings="1"`` is still in the compilation.

This is the ``build.hxml``:
```hxml
-cp src
-D analyzer-optimize
-main Main # simple hello world
--cpp bin/cpp
```