### PR TITLE
[std] Make `haxe.io.Input` and `haxe.io.Output` abstract classes

### DIFF
--- a/std/haxe/io/Input.hx
+++ b/std/haxe/io/Input.hx
@@ -29,7 +29,7 @@ package haxe.io;
 	All functions which read data throw `Eof` when the end of the stream
 	is reached.
 **/
-class Input {
+abstract class Input {
 	/**
 		Endianness (word byte order) used when reading numbers.
 

--- a/std/haxe/io/Output.hx
+++ b/std/haxe/io/Output.hx
@@ -28,7 +28,7 @@ package haxe.io;
 	methods. See `File.write` and `String.write` for two ways of creating an
 	Output.
 **/
-class Output {
+abstract class Output {
 	/**
 		Endianness (word byte order) used when writing numbers.
 


### PR DESCRIPTION
> [An Input is an abstract reader.](https://api.haxe.org/v/4.3.7/haxe/io/Input.html)

> [An Output is an abstract write.](https://api.haxe.org/v/4.3.7/haxe/io/Output.html)

The semantics now match the class documentation.

Note: Methods `readByte():Int` and `writeByte(Int):Void` respectively, which throw `NotImplementedException`s, are NOT marked abstract and are instead left as-is. That change would break compatibility with existing subclasses that use the `override` modifier on these methods.