### PR TITLE
[ci] run hl tests on macos-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -797,21 +797,16 @@ jobs:
 
   mac-test:
     needs: mac-build-universal
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     env:
-      PLATFORM: mac${{ matrix.os == 'macos-latest' && '-arm64' || '' }}
+      PLATFORM: mac-arm64
       TEST: ${{matrix.target}}
       HXCPP_COMPILE_CACHE: ~/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        target: [macro, js, cpp, jvm, php, python, lua, flash, neko]
-        include:
-          - target: hl
-            os: macos-13
-            BREW_PACKAGES: ninja
+        target: [macro, js, cpp, jvm, php, python, lua, flash, neko, hl]
 
     steps:
       - uses: actions/checkout@main
@@ -819,7 +814,10 @@ jobs:
           submodules: recursive
       - uses: actions/download-artifact@v4
         with:
-          name: macBinaries
+          # install the arm64-only binaries for HL to avoid issues with Rosetta
+          # the sys tests invoke Haxe, which invokes haxelib, which requires neko
+          # invoking the universal version of haxelib from an x86_64 process fails because neko is arm64-only
+          name: ${{ matrix.target == 'hl' && 'macArmBinaries' || 'macBinaries' }}
           path: macBinaries
 
       - name: Install Neko from S3
@@ -862,10 +860,6 @@ jobs:
           set -ex
           mkdir ~/haxelib
           haxelib setup ~/haxelib
-
-      - name: Install homebrew packages
-        if: matrix.BREW_PACKAGES
-        run: brew install ${{matrix.BREW_PACKAGES}}
 
       - name: Test
         run: |

--- a/extra/github-actions/test-mac.yml
+++ b/extra/github-actions/test-mac.yml
@@ -20,10 +20,6 @@
     mkdir ~/haxelib
     haxelib setup ~/haxelib
 
-- name: Install homebrew packages
-  if: matrix.BREW_PACKAGES
-  run: brew install ${{matrix.BREW_PACKAGES}}
-
 - name: Test
   run: |
     # disable invalid Unicode filenames on APFS

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -450,21 +450,16 @@ jobs:
 
   mac-test:
     needs: mac-build-universal
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     env:
-      PLATFORM: mac${{ matrix.os == 'macos-latest' && '-arm64' || '' }}
+      PLATFORM: mac-arm64
       TEST: ${{matrix.target}}
       HXCPP_COMPILE_CACHE: ~/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
-        target: [macro, js, cpp, jvm, php, python, lua, flash, neko]
-        include:
-          - target: hl
-            os: macos-13
-            BREW_PACKAGES: ninja
+        target: [macro, js, cpp, jvm, php, python, lua, flash, neko, hl]
 
     steps:
       - uses: actions/checkout@main
@@ -472,7 +467,10 @@ jobs:
           submodules: recursive
       - uses: actions/download-artifact@v4
         with:
-          name: macBinaries
+          # install the arm64-only binaries for HL to avoid issues with Rosetta
+          # the sys tests invoke Haxe, which invokes haxelib, which requires neko
+          # invoking the universal version of haxelib from an x86_64 process fails because neko is arm64-only
+          name: ${{ matrix.target == 'hl' && 'macArmBinaries' || 'macBinaries' }}
           path: macBinaries
 
       @import install-neko-unix.yml

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -39,15 +39,17 @@ class Hl {
 			case "Linux":
 				Linux.requireAptPackages(["libpng-dev", "libjpeg-turbo8-dev", "libturbojpeg", "zlib1g-dev", "libvorbis-dev", "libsqlite3-dev"]);
 			case "Mac":
-				runNetworkCommand("brew", ["update", '--auto-update']);
-				runNetworkCommand("brew", ["bundle", '--file=${hlSrc}/Brewfile']);
 			case "Windows":
 				//pass
 		}
 
 		FileSystem.createDirectory(hlBuild);
-		final generator = systemName == "Windows" ? ["-DCMAKE_SYSTEM_VERSION=10.0.19041.0"] : ["-GNinja"];
-		runCommand("cmake", generator.concat([
+		final args = systemName == "Windows" ? ["-DCMAKE_SYSTEM_VERSION=10.0.19041.0"] : ["-GNinja"];
+		if (systemName == "Mac") {
+			args.push("-DDOWNLOAD_DEPENDENCIES=ON");
+			args.push("-DCMAKE_OSX_ARCHITECTURES=x86_64");
+		}
+		runCommand("cmake", args.concat([
 			"-DBUILD_TESTING=OFF",
 			"-DWITH_DIRECTX=OFF",
 			"-DWITH_FMT=ON",
@@ -86,7 +88,11 @@ class Hl {
 			return;
 
 		final compiler = if (systemName == "Mac") "clang" else "gcc";
-		final extraCompilerFlags = if (systemName == "Windows") ["-ldbghelp", "-municode"] else [];
+		final extraCompilerFlags = switch (systemName) {
+			case "Windows": ["-ldbghelp", "-municode"];
+			case "Mac": ["-arch", "x86_64"];
+			case _: [];
+		};
 
 		runCommand(compiler, [
 			"-o", '$dir/$filename.exe',


### PR DESCRIPTION
With the impending shut down of macOS 13 runners (https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down) there are no free Intel runners left.
Fortunately Rosetta still works.