### PR TITLE
[tests] fix unit test 6059, 12047 not running

### DIFF
--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -633,6 +633,9 @@ let get_config com =
 			pf_add_final_return = true;
 			pf_supports_threads = true;
 			pf_supports_unicode = (defined Define.Cppia) || not (defined Define.DisableUnicodeStrings);
+			pf_exceptions = { default_config.pf_exceptions with
+				ec_avoid_wrapping = false
+			};
 			pf_scoping = { default_config.pf_scoping with
 				vs_flags = [NoShadowing];
 				vs_scope = FunctionScope;

--- a/tests/unit/src/unit/issues/Issue12047.hx
+++ b/tests/unit/src/unit/issues/Issue12047.hx
@@ -3,7 +3,7 @@ package unit.issues;
 import utest.Assert;
 
 class Issue12047 extends Test {
-	static function test() {
+	function test() {
 		try {
 			throwCatchWrap();
 		} catch (err:Issue12047) {

--- a/tests/unit/src/unit/issues/Issue6059.hx
+++ b/tests/unit/src/unit/issues/Issue6059.hx
@@ -3,9 +3,10 @@ package unit.issues;
 class Issue6059 extends Test {
 	public static inline function foo (name : B, ?id : B, data : Array<String>) : Void { }
 
-	public static function test () : Void {
+	function test () : Void {
 		Issue6059.foo ("", []); // -> stackoverflow
 		Issue6059.foo ("", null, []); // ok
+		utest.Assert.pass();
 	}
 }
 


### PR DESCRIPTION
`static function test` isn't run by unit test.

- cpp fail for 12047 (so https://github.com/HaxeFoundation/haxe/pull/12049 did not fix for cpp)