### PR TITLE
[js] implement haxe.io.ArrayBufferView.fromBytes()

### DIFF
--- a/std/js/_std/haxe/io/ArrayBufferView.hx
+++ b/std/js/_std/haxe/io/ArrayBufferView.hx
@@ -54,4 +54,12 @@ abstract ArrayBufferView(ArrayBufferViewData) {
 	public static inline function fromData(a:ArrayBufferViewData):ArrayBufferView {
 		return cast a;
 	}
+
+	public static function fromBytes(bytes:haxe.io.Bytes, pos = 0, ?length:Int):ArrayBufferView {
+		if (length == null)
+			length = bytes.length - pos;
+		if (pos < 0 || length < 0 || pos + length > bytes.length)
+			throw haxe.io.Error.OutsideBounds;
+		return ArrayBufferView.fromData(haxe.io.UInt8Array.fromBytes(bytes, pos, length).getData());
+	}
 }


### PR DESCRIPTION
`haxe.io.ArrayBufferView.fromBytes()` does not exist for JS target as per docs (and source code, ofc): https://api.haxe.org/haxe/io/ArrayBufferView.html

This PR implements `fromBytes()` for JS target based on how `fromBytes()` is implemented in `/std/haxe/io/ArrayBufferView`: https://github.com/HaxeFoundation/haxe/blob/e0b355c6be312c1b17382603f018cf52522ec651/std/haxe/io/ArrayBufferView.hx#L89.

`ArrayBufferViewData` for JS target is `js.lib.ArrayBufferView` which is a helper representing JS `TypedArray`. `Uint8Array` is one of the native JS typed arrays, and Haxe `UInt8ArrayData` has been used to implement `fromBytes` for JS in similar way it is in the source link above.

`UInt8ArrayData` for JS target does not unify with `ArrayBufferViewImpl` from the source link above, however the implementation in this post seems to work on JS target in my tests.