### PR TITLE
[ci] Upgrade to mbedtls 3 to fix mac cmake error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -595,7 +595,7 @@ jobs:
           cmake --build build
           sudo cmake --install build
           cd ..
-          curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
+          curl -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$MBEDTLS_VERSION/mbedtls-$MBEDTLS_VERSION.tar.bz2 | tar xz
           cd mbedtls-$MBEDTLS_VERSION
           cmake -B build -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -DENABLE_TESTING=OFF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -579,7 +579,7 @@ jobs:
 
       - name: Install dependencies
         env:
-          # For compatibility with macOS 10.13
+          # Build from source for compatibility with macOS 10.13
           ZLIB_VERSION: 1.3.1
           MBEDTLS_VERSION: 3.6.4
           PCRE2_VERSION: 10.45

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -581,7 +581,7 @@ jobs:
         env:
           # For compatibility with macOS 10.13
           ZLIB_VERSION: 1.3.1
-          MBEDTLS_VERSION: 2.28.10
+          MBEDTLS_VERSION: 3.6.4
           PCRE2_VERSION: 10.45
           CMAKE_BUILD_TYPE: Release
           CMAKE_GENERATOR: Ninja

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -1,6 +1,6 @@
 - name: Install dependencies
   env:
-    # For compatibility with macOS 10.13
+    # Build from source for compatibility with macOS 10.13
     ZLIB_VERSION: 1.3.1
     MBEDTLS_VERSION: 3.6.4
     PCRE2_VERSION: 10.45

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -16,7 +16,7 @@
     cmake --build build
     sudo cmake --install build
     cd ..
-    curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
+    curl -L https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$MBEDTLS_VERSION/mbedtls-$MBEDTLS_VERSION.tar.bz2 | tar xz
     cd mbedtls-$MBEDTLS_VERSION
     cmake -B build -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
       -DENABLE_TESTING=OFF

--- a/extra/github-actions/build-mac.yml
+++ b/extra/github-actions/build-mac.yml
@@ -2,7 +2,7 @@
   env:
     # For compatibility with macOS 10.13
     ZLIB_VERSION: 1.3.1
-    MBEDTLS_VERSION: 2.28.10
+    MBEDTLS_VERSION: 3.6.4
     PCRE2_VERSION: 10.45
     CMAKE_BUILD_TYPE: Release
     CMAKE_GENERATOR: Ninja


### PR DESCRIPTION
This solves this error when building

```
$ cmake -B build -DCMAKE_OSX_ARCHITECTURES=arm64 -DENABLE_TESTING=OFF
CMake Error at CMakeLists.txt:23 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```

mbedtls 2.28 is no longer supported and linux is already building with mbedtls 3.