### PR TITLE
[typer] delay add_constructor

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1797,5 +1797,5 @@ let init_class ctx_c cctx c p herits fields =
 	end;
 	if not has_struct_init then
 		(* add_constructor does not deal with overloads correctly *)
-		if not com.config.pf_overload then TypeloadFunction.add_constructor ctx_c c cctx.force_constructor p;
+		if not com.config.pf_overload then delay_late ctx_c.g PConnectField (fun() -> TypeloadFunction.add_constructor ctx_c c cctx.force_constructor p);
 	finalize_class cctx

--- a/tests/misc/projects/Issue12357/compile-hxb.hxml
+++ b/tests/misc/projects/Issue12357/compile-hxb.hxml
@@ -1,0 +1,4 @@
+-cp src
+-main Main
+-hl bin/dummy.hl
+--hxb bin/hxb.zip

--- a/tests/misc/projects/Issue12357/compile-with-hxblib.hxml
+++ b/tests/misc/projects/Issue12357/compile-with-hxblib.hxml
@@ -1,0 +1,5 @@
+-cp src
+--hxb-lib bin/hxb.zip
+-main Main
+MyException
+-hl bin/dummy.hl

--- a/tests/misc/projects/Issue12357/src/Main.hx
+++ b/tests/misc/projects/Issue12357/src/Main.hx
@@ -1,0 +1,1 @@
+function main() {}

--- a/tests/misc/projects/Issue12357/src/MyException.hx
+++ b/tests/misc/projects/Issue12357/src/MyException.hx
@@ -1,0 +1,1 @@
+class MyException extends haxe.Exception {}


### PR DESCRIPTION
When parent class is coming from hxb, `add_constructor` on child classes could happen "too early" and deal with not fully restored parent fields, leading to ugly issues.

Closes #12357 (and #12008 which I already closed as duplicate)