### PR TITLE
[hxb] Add minor version handling, increase current version

### DIFF
--- a/src/compiler/hxb/hxbData.ml
+++ b/src/compiler/hxb/hxbData.ml
@@ -123,16 +123,16 @@ let error (s : string) =
 	raise (HxbFailure s)
 
 (*
-	With the exception of 1.0 => 2.x because we introduced minor version in 2.1,
-	major versions are incompatible with each other, while minor version mismatch
+	Major versions are incompatible with each other, while minor version mismatch
 	will be handled by the reader (for retro compatibility only)
 
 	When further bumping hxb major:
-	- code related to the 1.0 => 2.0 exception can be dropped (`if major == 1 then 2 else major` in `HxbReader.read`)
-	- all minor checks in hxb reader become obsolete and can be dropped too
+	- all minor checks in hxb reader become obsolete and can be dropped
+	- (only when moving to 3.0) hxb_major checks in hxbReader can be removed
+	- (only when moving to 3.0) hxb_major check in HxbReader.read must be uncommented
 *)
 let hxb_major = 2
-let hxb_minor = 1
+let hxb_minor = 0
 
 let write_header ch =
 	IO.nwrite_string ch "hxb";

--- a/src/compiler/hxb/hxbData.ml
+++ b/src/compiler/hxb/hxbData.ml
@@ -128,7 +128,7 @@ let error (s : string) =
 	will be handled by the reader (for retro compatibility only)
 
 	When further bumping hxb major:
-	- code related to the 1.0 => 2.0 exception can be dropped (see `HxbReader.read`)
+	- code related to the 1.0 => 2.0 exception can be dropped (`if major == 1 then 2 else major` in `HxbReader.read`)
 	- all minor checks in hxb reader become obsolete and can be dropped too
 *)
 let hxb_major = 2

--- a/src/compiler/hxb/hxbData.ml
+++ b/src/compiler/hxb/hxbData.ml
@@ -122,11 +122,22 @@ let error (s : string) =
 	Printf.eprintf "[error] %s\n" s;
 	raise (HxbFailure s)
 
-let hxb_version = 1
+(*
+	With the exception of 1.0 => 2.x because we introduced minor version in 2.1,
+	major versions are incompatible with each other, while minor version mismatch
+	will be handled by the reader (for retro compatibility only)
+
+	When further bumping hxb major:
+	- code related to the 1.0 => 2.0 exception can be dropped (see `HxbReader.read`)
+	- all minor checks in hxb reader become obsolete and can be dropped too
+*)
+let hxb_major = 2
+let hxb_minor = 1
 
 let write_header ch =
 	IO.nwrite_string ch "hxb";
-	IO.write_byte ch hxb_version
+	IO.write_byte ch hxb_major;
+	IO.write_byte ch hxb_minor
 
 let write_chunk_prefix kind length ch =
 	IO.nwrite ch (Bytes.unsafe_of_string (string_of_chunk_kind kind));

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -152,6 +152,7 @@ class hxb_reader
 = object(self)
 	val mutable api = Obj.magic ""
 	val mutable full_restore = true
+	val mutable hxb_major = HxbData.hxb_major (* can be removed once we move to version 3.0 *)
 	val mutable hxb_minor = HxbData.hxb_minor
 	val mutable current_module = null_module
 
@@ -1584,7 +1585,9 @@ class hxb_reader
 		a.a_write <- self#read_option (fun () -> self#read_field_ref);
 		a.a_call <- self#read_option (fun () -> self#read_field_ref);
 		a.a_constructor <- self#read_option (fun () -> self#read_field_ref);
-		if hxb_minor >= 1 then
+		(* Note: this special case uses a hxb_major check, but all future checks should compare hxb_minor instead. *)
+		(* See https://github.com/HaxeFoundation/haxe/pull/12365 *)
+		if hxb_major >= 2 then
 			a.a_default <- self#read_option (fun () ->
 				let fctx = self#start_texpr in
 				let e = self#read_texpr fctx in
@@ -2116,13 +2119,14 @@ class hxb_reader
 		if (Bytes.to_string (read_bytes ch 3)) <> "hxb" then
 			raise (HxbFailure "magic");
 
-		(* Note: as minor version was only added in 2.1, version "1" is now considered to be "2.0" *)
-		(* Still displaying it as "1.0" in version mismatch error, hence `major` vs `hxb_major` vars *)
-		let major = read_byte ch in
-		hxb_minor <- if major == 1 then 0 else read_byte ch;
-		let hxb_major = if major == 1 then 2 else major in
-		if hxb_major <> HxbData.hxb_major || hxb_minor > HxbData.hxb_minor then
-			raise (HxbFailure (Printf.sprintf "version mismatch: hxb version %i.%i, reader version %i.%i" major hxb_minor HxbData.hxb_major HxbData.hxb_minor));
+		hxb_major <- read_byte ch;
+		hxb_minor <- if hxb_major == 1 then 0 else read_byte ch; (* minor version was only added in 2.0 *)
+
+		(* Disabled for retro compatibility with haxe 5.0-preview.1 *)
+		(* Must be uncommented when we move to hxb version 3.0 *)
+		(* See https://github.com/HaxeFoundation/haxe/pull/12365 *)
+		(* if hxb_major <> HxbData.hxb_major || hxb_minor > HxbData.hxb_minor then *)
+			(* raise (HxbFailure (Printf.sprintf "version mismatch: hxb version %i.%i, reader version %i.%i" major hxb_minor HxbData.hxb_major HxbData.hxb_minor)); *)
 
 		(fun end_chunk ->
 			let rec loop () =

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -152,6 +152,7 @@ class hxb_reader
 = object(self)
 	val mutable api = Obj.magic ""
 	val mutable full_restore = true
+	val mutable hxb_minor = 0
 	val mutable current_module = null_module
 
 	val mutable ch = BytesWithPosition.create (Bytes.create 0)
@@ -2113,9 +2114,14 @@ class hxb_reader
 		ch <- BytesWithPosition.create bytes;
 		if (Bytes.to_string (read_bytes ch 3)) <> "hxb" then
 			raise (HxbFailure "magic");
-		let version = read_byte ch in
-		if version <> hxb_version then
-			raise (HxbFailure (Printf.sprintf "version mismatch: hxb version %i, reader version %i" version hxb_version));
+
+		(* Note: as minor version was only added in 2.1, version "1" is now considered to be "2.0" *)
+		let major = read_byte ch in
+		hxb_minor <- if major == 1 then 0 else read_byte ch;
+		let major = if major == 1 then 2 else major in
+		if major <> HxbData.hxb_major || hxb_minor > HxbData.hxb_minor then
+			raise (HxbFailure (Printf.sprintf "version mismatch: hxb version %i.%i, reader version %i.%i" major hxb_minor HxbData.hxb_major HxbData.hxb_minor));
+
 		(fun end_chunk ->
 			let rec loop () =
 				let (name,size) = self#read_chunk_prefix in

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -1584,10 +1584,11 @@ class hxb_reader
 		a.a_write <- self#read_option (fun () -> self#read_field_ref);
 		a.a_call <- self#read_option (fun () -> self#read_field_ref);
 		a.a_constructor <- self#read_option (fun () -> self#read_field_ref);
-		a.a_default <- self#read_option (fun () -> 
-			let fctx = self#start_texpr in
-			let e = self#read_texpr fctx in
-			Lazy.from_val e);
+		if hxb_minor >= 1 then
+			a.a_default <- self#read_option (fun () ->
+				let fctx = self#start_texpr in
+				let e = self#read_texpr fctx in
+				Lazy.from_val e);
 
 		a.a_ops <- self#read_list (fun () ->
 			let i = read_byte ch in

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -2117,10 +2117,11 @@ class hxb_reader
 			raise (HxbFailure "magic");
 
 		(* Note: as minor version was only added in 2.1, version "1" is now considered to be "2.0" *)
+		(* Still displaying it as "1.0" in version mismatch error, hence `major` vs `hxb_major` vars *)
 		let major = read_byte ch in
 		hxb_minor <- if major == 1 then 0 else read_byte ch;
-		let major = if major == 1 then 2 else major in
-		if major <> HxbData.hxb_major || hxb_minor > HxbData.hxb_minor then
+		let hxb_major = if major == 1 then 2 else major in
+		if hxb_major <> HxbData.hxb_major || hxb_minor > HxbData.hxb_minor then
 			raise (HxbFailure (Printf.sprintf "version mismatch: hxb version %i.%i, reader version %i.%i" major hxb_minor HxbData.hxb_major HxbData.hxb_minor));
 
 		(fun end_chunk ->

--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -152,7 +152,7 @@ class hxb_reader
 = object(self)
 	val mutable api = Obj.magic ""
 	val mutable full_restore = true
-	val mutable hxb_minor = 0
+	val mutable hxb_minor = HxbData.hxb_minor
 	val mutable current_module = null_module
 
 	val mutable ch = BytesWithPosition.create (Bytes.create 0)

--- a/src/compiler/hxb/hxbWriterConfig.ml
+++ b/src/compiler/hxb/hxbWriterConfig.ml
@@ -5,7 +5,8 @@ type writer_target_config = {
 	mutable generate : bool;
 	mutable exclude : string list list;
 	mutable include' : string list list;
-	mutable hxb_version : int;
+	mutable hxb_major : int;
+	mutable hxb_minor : int;
 	mutable generate_docs : bool;
 }
 
@@ -19,7 +20,8 @@ let create_target_config () = {
 	generate = true;
 	exclude = [];
 	include'= [];
-	hxb_version = HxbData.hxb_version;
+	hxb_major = HxbData.hxb_major;
+	hxb_minor = HxbData.hxb_minor;
 	generate_docs = true;
 }
 
@@ -47,7 +49,12 @@ module WriterConfigReader (API : DataReaderApi.DataReaderApi) = struct
 					config.include'<- List.map (fun data -> ExtString.String.nsplit (API.read_string data) ".") l
 				)
 			| "hxbVersion" ->
-				config.hxb_version <- API.read_int data
+				config.hxb_major <- API.read_int data;
+				config.hxb_minor <- 0
+			| "hxbMajor" ->
+				config.hxb_major <- API.read_int data
+			| "hxbMinor" ->
+				config.hxb_minor <- API.read_int data
 			| "generateDocumentation" ->
 				config.generate_docs <- API.read_bool data
 			| s ->
@@ -80,7 +87,9 @@ module WriterConfigWriter (API : DataWriterApi.DataWriterApi) = struct
 			"generate",API.write_bool config.generate;
 			"exclude",API.write_array (List.map (fun sl -> API.write_string (String.concat "." sl)) config.exclude);
 			"include",API.write_array (List.map (fun sl -> API.write_string (String.concat "." sl)) config.include');
-			"hxbVersion",API.write_int config.hxb_version;
+			"hxbVersion",API.write_int config.hxb_major;
+			"hxbMajor",API.write_int config.hxb_major;
+			"hxbMinor",API.write_int config.hxb_minor;
 			"generateDocumentation",API.write_bool config.generate_docs;
 		]
 


### PR DESCRIPTION
Some changes had an impact on hxb writing/reading (latest being #12351) without changing hxb version number, meaning using hxb-lib with haxe versions from before and after that PR led to compiler failures or HxbFailure errors.

- hxb file created with preview1 / nightlies before [#12351](https://github.com/HaxeFoundation/haxe/pull/12351), and read with this PR :white_check_mark: 
- hxb file created with nightlies between [#12351](https://github.com/HaxeFoundation/haxe/pull/12351) and this PR, and read with this PR :x: (hxb failure like when reading with preview1.. not sure this can be avoided easily but the commit range should be small enough)
- hxb file created with this PR and read with previous nightlies/preview1: :x: ("proper" hxb version mismatch error)
- hxb file created with this PR  and read with a minor set to a higher value (to simulate future haxe compiler) :white_check_mark: 

The `hxbWriterConfig.ml` situation is a bit weird.. and possibly not even needed. I have no idea what external tool might be using `hxbVersion` from it in any way atm; maybe @PXshadow ? Two alternatives there:
* drop `hxbVersion` field from there entirely, and only deal with `hxbMajor` / `hxbMinor`
* use `hxbVersion` (for major) and `hxbMinor`, which is a weird combo but doesn't duplicate stuff