### PR TITLE
[hl] don't use unsafe cast for method with type param return type

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2327,25 +2327,9 @@ and eval_expr ctx e =
 		(match !def_ret with
 		| None ->
 			let rt = to_type ctx e.etype in
-			let is_valid_method t =
-				match follow t with
-				| TFun (_,rt) ->
-					(match follow rt with
-					| TInst({ cl_kind = KTypeParameter ttp },_) ->
-						(* don't allow if we have a constraint virtual, see hxbit.Serializer.getRef *)
-						not (List.exists (fun t -> match to_type ctx t with HVirtual _ -> true | _ -> false) (get_constraints ttp))
-					| _ -> false)
-				| _ ->
-					false
-			in
-			(match ec.eexpr with
-			| TField (_, FInstance(_,_,{ cf_kind = Method (MethNormal|MethInline); cf_type = t })) when is_valid_method t ->
-				(* let's trust the compiler when it comes to casting the return value from a type parameter *)
-				unsafe_cast_to ctx ret rt e.epos
-			| _ ->
-				cast_to ~force:true ctx ret rt e.epos)
-		| Some r ->
-			r)
+			cast_to ~force:true ctx ret rt e.epos
+		| Some r -> r
+		)
 	| TField (ec,FInstance({ cl_path = [],"Array" },[t],{ cf_name = "length" })) when to_type ctx t = HDyn ->
 		let r = alloc_tmp ctx HI32 in
 		op ctx (OCall1 (r,alloc_fun_path ctx (["hl";"types"],"ArrayDyn") "get_length", eval_null_check ctx ec));

--- a/tests/unit/src/unit/TestHL.hx
+++ b/tests/unit/src/unit/TestHL.hx
@@ -1,6 +1,47 @@
 package unit;
 
+class Box {
+	var value:Dynamic;
+
+	public function new(value:Dynamic) {
+		this.value = value;
+	}
+
+	public function get<T>():T {
+		return value;
+	}
+}
+
+interface IFoo {}
+
+class Foo implements IFoo {
+	public function new() {}
+}
+
+class Bar {
+	public var val:Int;
+}
+
 class TestHL extends Test {
+	function testRetTypeTP() {
+		var box = new Box(new Foo());
+		try {
+			var bar:Bar = box.get();
+			trace(bar.val);
+			assert("Expected cast failure");
+		} catch(e: haxe.Exception) {
+			eq(e.message, "Can't cast unit.Foo to unit.Bar");
+		}
+	}
+
+	function testRetTypeTPIFace() {
+		var foo = new Foo();
+		var ifoo: IFoo = foo;
+		var box = new Box(ifoo);
+		var bar:Foo = box.get();
+		// important: eq must not be used as casting the values to dynamic papers over some issues
+		t(foo == bar);
+	}
 
 	//private function refTest(i:hl.types.Ref<Int>):Void
 	//{


### PR DESCRIPTION
This optimization, introduced in https://github.com/HaxeFoundation/haxe/commit/00c1d7add5f29bb147b5d159c2faae3d52bc1bdd, is not safe as the value returned by the function may not match the expected type.
Example: caller expects an object (HOBJ), function returns a virtual (HVIRT).

Closes HaxeFoundation/hashlink#825