### PR TITLE
[cpp] Do not generate toString in __scriptableFunctions

### DIFF
--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -977,18 +977,20 @@ let generate_managed_class base_ctx tcpp_class =
     if List.length tcpp_class.tcl_functions > 0 || List.length tcpp_class.tcl_static_functions > 0 then (
 
       let dump_script is_static f acc =
-        let signature = generate_script_function is_static f.tcf_field ("__s_" ^ f.tcf_field.cf_name) f.tcf_name in
-        let superCall = if is_static then "0" else "__s_" ^ f.tcf_field.cf_name ^ "<true>" in
-        let named =
-          Printf.sprintf
-            "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", %s HXCPP_CPPIA_SUPER_ARG(%s))"
-            f.tcf_field.cf_name
-            f.tcf_field.cf_name
-            signature
-            (if is_static then "true" else "false")
-            superCall in
+        if f.tcf_name <> "toString" then
+          let signature = generate_script_function is_static f.tcf_field ("__s_" ^ f.tcf_field.cf_name) f.tcf_name in
+          let superCall = if is_static then "0" else "__s_" ^ f.tcf_field.cf_name ^ "<true>" in
+          let named =
+            Printf.sprintf
+              "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", %s HXCPP_CPPIA_SUPER_ARG(%s))"
+              f.tcf_field.cf_name
+              f.tcf_field.cf_name
+              signature
+              (if is_static then "true" else "false")
+              superCall in
 
-        named :: acc
+          named :: acc
+        else acc
       in
 
       let sigs =

--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -970,14 +970,14 @@ let generate_managed_class base_ctx tcpp_class =
     in
 
     flatten_tcpp_class_functions
-    |> List.filter (fun f -> f.tcf_name <> "toString")
+    |> List.filter (fun f -> f.tcf_name <> "toString") (* toString is provided by HX_DEFINE_SCRIPTABLE *)
     |> ExtList.List.iteri dump_script_func;
     output_cpp "};\n\n";
 
     if List.length tcpp_class.tcl_functions > 0 || List.length tcpp_class.tcl_static_functions > 0 then (
 
       let dump_script is_static f acc =
-        if f.tcf_name <> "toString" then
+        if f.tcf_name <> "toString" then (* toString implicitly overrides hx::Object::toString *)
           let signature = generate_script_function is_static f.tcf_field ("__s_" ^ f.tcf_field.cf_name) f.tcf_name in
           let superCall = if is_static then "0" else "__s_" ^ f.tcf_field.cf_name ^ "<true>" in
           let named =

--- a/tests/unit/src/scripthost/Issue12374.hx
+++ b/tests/unit/src/scripthost/Issue12374.hx
@@ -1,0 +1,19 @@
+package scripthost;
+
+#if cpp
+@:keep class HostParent {
+	public function new() {}
+
+	function toString() {
+		return "HostParent.toString()";
+	}
+
+	public function methodA() {
+		return 'HostParent.methodA()';
+	}
+
+	public function methodB() {
+		return 'HostParent.methodB()';
+	}
+}
+#end

--- a/tests/unit/src/scripthost/Issue12374.hx
+++ b/tests/unit/src/scripthost/Issue12374.hx
@@ -1,7 +1,7 @@
 package scripthost;
 
 #if cpp
-@:keep class HostParent {
+@:keep class HostParent12374 {
 	public function new() {}
 
 	function toString() {

--- a/tests/unit/src/unit/issues/Issue12374.hx
+++ b/tests/unit/src/unit/issues/Issue12374.hx
@@ -14,7 +14,7 @@ class Issue12374 extends Test {
 }
 
 #if cppia
-private class ScriptChild extends HostParent {
+private class ScriptChild extends HostParent12374 {
 	override function methodA() {
 		return 'ScriptChild.methodA()';
 	}

--- a/tests/unit/src/unit/issues/Issue12374.hx
+++ b/tests/unit/src/unit/issues/Issue12374.hx
@@ -1,0 +1,22 @@
+package unit.issues;
+
+import scripthost.Issue12374;
+
+class Issue12374 extends Test {
+	#if cppia
+	public function test() {
+		var child:ScriptChild = new ScriptChild();
+		eq(Std.string(child), 'HostParent.toString()');
+		eq(child.methodA(), 'ScriptChild.methodA()');
+		eq(child.methodB(), 'HostParent.methodB()');
+	}
+	#end
+}
+
+#if cppia
+private class ScriptChild extends HostParent {
+	public override function methodA() {
+		return 'ScriptChild.methodA()';
+	}
+}
+#end

--- a/tests/unit/src/unit/issues/Issue12374.hx
+++ b/tests/unit/src/unit/issues/Issue12374.hx
@@ -6,16 +6,16 @@ class Issue12374 extends Test {
 	#if cppia
 	public function test() {
 		var child:ScriptChild = new ScriptChild();
-		eq(Std.string(child), 'HostParent.toString()');
-		eq(child.methodA(), 'ScriptChild.methodA()');
-		eq(child.methodB(), 'HostParent.methodB()');
+		eq('HostParent.toString()', Std.string(child));
+		eq('ScriptChild.methodA()', child.methodA());
+		eq('HostParent.methodB()', child.methodB());
 	}
 	#end
 }
 
 #if cppia
 private class ScriptChild extends HostParent {
-	public override function methodA() {
+	override function methodA() {
 		return 'ScriptChild.methodA()';
 	}
 }


### PR DESCRIPTION
Closes #12374.

Haxe classes do not need to put it in `__scriptableFunctions` because it is already added by `::hx::Object`'s:
https://github.com/HaxeFoundation/hxcpp/blob/1618253d7bb2dd8eea1bc7ffcd612452df76a7b7/src/hx/Object.cpp#L123

This allows the vtable mapping generated on lines 972-974 (which already filters out `toString`) to be consistent with what is generated by cppia from iterating through `__scriptableFunctions`.

See also #5502.

Test would make more sense in misc, however those are not set up for cppia.