### PR TITLE
[hl] Fix abstract Array with inline dyn length segfault

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2332,7 +2332,9 @@ and eval_expr ctx e =
 		)
 	| TField (ec,FInstance({ cl_path = [],"Array" },[t],{ cf_name = "length" })) when to_type ctx t = HDyn ->
 		let r = alloc_tmp ctx HI32 in
-		op ctx (OCall1 (r,alloc_fun_path ctx (["hl";"types"],"ArrayDyn") "get_length", eval_null_check ctx ec));
+		let a = eval_to ctx ec (class_type ctx ctx.array_impl.adyn [] false) in
+		op ctx (ONullCheck a);
+		op ctx (OCall1 (r, alloc_fun_path ctx (["hl";"types"],"ArrayDyn") "get_length", a));
 		r
 	| TField (ec,a) ->
 		let r = alloc_tmp ctx (to_type ctx (field_type ctx a e.epos)) in

--- a/tests/unit/src/unit/issues/Issue12380.hx
+++ b/tests/unit/src/unit/issues/Issue12380.hx
@@ -1,0 +1,29 @@
+package unit.issues;
+
+using Issue12380.ArrayExtensions;
+private class ArrayExtensions {
+	public static inline function isEmpty(a : Array<Any>) : Bool {
+		return a.length == 0;
+	}
+}
+
+@:forward(push)
+private abstract IPolygon(Array<IPoint>) from Array<IPoint> to Array<IPoint> {
+}
+
+private class IPoint {
+	public var x : Int;
+	public var y : Int;
+	public inline function new(x = 0, y = 0) {
+		this.x = x;
+		this.y = y;
+	}
+}
+
+class Issue12380 extends Test {
+	function test() {
+		var shape : IPolygon = [];
+		shape.push(new IPoint(0, 1));
+		f(shape.isEmpty());
+	}
+}


### PR DESCRIPTION
See test for repro.

hl-check gives `Check failure at fun@3750 @D - Register 1(hl.types.ArrayObj) should be hl.types.ArrayDyn and not hl.types.ArrayObj` on compilation, and the program access violation on runtime when accessing `.length`.

This ArrayObj tries to access ArrayDyn seems to come from `inline` and abstract(Array<Obj>), where haxe compiler generate the following dump

```
[Field:Int]
	[Local shape(0):IPolygon:IPolygon]
	[FInstance:Int]
		Array<Any>
		length:Int
```