### PR TITLE
Fix bad completion cache in `call(new |)`

### DIFF
--- a/src/syntax/grammar.ml
+++ b/src/syntax/grammar.ml
@@ -1107,7 +1107,7 @@ and parse_constraint_param ctx s =
 
 and parse_type_path_or_resume ctx p1 s =
 	let check_resume exc =
-		if would_skip_display_position ctx p1 true s then begin
+		if is_completion ctx && would_skip_display_position ctx p1 true s then begin
 			let p = display_position#with_pos p1 in
 			make_ptp magic_type_path p,true
 		end else

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -194,7 +194,7 @@ let load_type_def' ctx pack mname tname p =
 	load a type or a subtype definition
 *)
 let load_type_def ctx p t =
-	if t = Parser.magic_type_path then
+	if t = Parser.magic_type_path && ctx.com.display.dms_kind = DMDefault then
 		raise_fields (DisplayToplevel.collect ctx TKType NoValue true) CRTypeHint (DisplayTypes.make_subject None p);
 	(* The type name is the module name or the module sub-type name *)
 	let tname = match t.tsub with None -> t.tname | Some n -> n in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -194,7 +194,7 @@ let load_type_def' ctx pack mname tname p =
 	load a type or a subtype definition
 *)
 let load_type_def ctx p t =
-	if t = Parser.magic_type_path && ctx.com.display.dms_kind = DMDefault then
+	if t = Parser.magic_type_path then
 		raise_fields (DisplayToplevel.collect ctx TKType NoValue true) CRTypeHint (DisplayTypes.make_subject None p);
 	(* The type name is the module name or the module sub-type name *)
 	let tname = match t.tsub with None -> t.tname | Some n -> n in


### PR DESCRIPTION
Closes https://github.com/vshaxe/vshaxe/issues/668

in this `call(new |)` case after typing space we trigger `display/completion` request with completion list, but then `display/signatureHelp` request overwrites completion cache with this unexpected `raise_fields`:
```ocaml
Called from DisplayException.raise_fields in file "src/context/display/displayException.ml", line 17, characters 39-53
Called from Typeload.load_type_def in file "src/typing/typeload.ml", line 199, characters 2-110
Called from Typeload.load_instance' in file "src/typing/typeload.ml", line 406, characters 11-43
Called from Typeload.load_instance in file "src/typing/typeload.ml", line 440, characters 10-48
Called from TyperDisplay.handle_signature_display in file "src/typing/typerDisplay.ml", line 313, characters 45-104
Called from TyperDisplay.handle_display in file "src/typing/typerDisplay.ml", line 623, characters 2-37
```

It seems like in signature mode there should be no `raise_fields`? Let me know if i'm missing some logic there.