### PR TITLE
make handles_assign_ops for cpp always true

### DIFF
--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -109,7 +109,7 @@ let target_handles_unops com = match com.platform with
 let target_handles_assign_ops com e2 = match com.platform with
 	| Php -> not (has_side_effect e2)
 	| Lua -> false
-	| Cpp when not (Define.defined com.defines Define.Cppia) -> false
+	| Cpp when not (Define.defined com.defines Define.Cppia) -> not (has_side_effect e2)
 	| _ -> true
 
 let target_handles_side_effect_order com = match com.platform with

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -109,7 +109,7 @@ let target_handles_unops com = match com.platform with
 let target_handles_assign_ops com e2 = match com.platform with
 	| Php -> not (has_side_effect e2)
 	| Lua -> false
-	| Cpp when not (Define.defined com.defines Define.Cppia) -> false
+	(* | Cpp when not (Define.defined com.defines Define.Cppia) -> false *)
 	| _ -> true
 
 let target_handles_side_effect_order com = match com.platform with

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -109,7 +109,7 @@ let target_handles_unops com = match com.platform with
 let target_handles_assign_ops com e2 = match com.platform with
 	| Php -> not (has_side_effect e2)
 	| Lua -> false
-	(* | Cpp when not (Define.defined com.defines Define.Cppia) -> false *)
+	| Cpp when not (Define.defined com.defines Define.Cppia) -> false
 	| _ -> true
 
 let target_handles_side_effect_order com = match com.platform with


### PR DESCRIPTION
Previously ``+=`` would not be handled by the analyzer.
This issue/fix was found by @Apprentice-Alchemist but I decided to make a PR before it gets forgotten😅 

Given:
```hx
class Float2 {
    public var x:Float = 0.0;
    public var y:Float = 0.0;

    public function new(_x:Float, _y:Float) {
        x = _x;
        y = _y;
    }

    public function toString():String {
        return 'Float2($x, $y)';
    }
}

class Test {
    static var v:Float2;

    static function main() {
        v = new Float2(10.0, 20.0);

        trace(v.toString());
        doSomething();
        trace(v.toString());
    }

    static function doSomething():Void {
        v.x += 30.0;
        v.y *= 2.0;
    }
}
```

It would generate 

```cpp
void Test_obj::doSomething(){
                HX_STACKFRAME(&_hx_pos_df13cafffbed243f_26_doSomething)
                HXLINE(  27)         ::Float2 fh = ::Test_obj::v;
                HXDLIN(  27)        fh->x = (fh->x + ((Float)30.0));
                HXLINE(  28)         ::Float2 fh1 = ::Test_obj::v;
                HXDLIN(  28)        fh1->y = (fh1->y * ((Float)2.0));
}
```

While with this change, or by doing ``v.x = v.x + 30.0`` instead of ``v.x += 30.0`` it would generate:
```cpp
void Test_obj::doSomething(){
                HX_STACKFRAME(&_hx_pos_df13cafffbed243f_26_doSomething)
                HXDLIN(  27)        ::Test_obj::v->x = (::Test_obj::v->x + ((Float)30.0));
                HXDLIN(  28)        ::Test_obj::v->y = (::Test_obj::v->y * ((Float)2.0));
}
```

I believe this change is rather crucial as without this change there is a difference in behaviour regarding ``x += y`` and ``x = x + y`` when using ``cpp.Struct<T>`` (or any type with copy semantics...)

You can follow the conversation inside the Haxe discord server [here](https://discord.com/channels/162395145352904705/162395145352904705/1429487413691944960)