### PR TITLE
EventLoop: fix null access .stop in run

### DIFF
--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -40,7 +40,7 @@ class Event {
 	}
 
 	/**
-		Stop this event from repeating.
+		Start the event with the given callback function.
 	**/
 	public function start( callb : Void -> Void ) {
 		this.callb = callb;
@@ -203,8 +203,8 @@ class EventLoop {
 		Add a function to be run once at next loop of the event loop.
 	**/
 	public function run( callb : Void -> Void, priority = 0 ) : Event {
-		var e : Event = null;
-		e = add(function() { e.stop(); callb(); }, priority);
+		var e : Event = new Event(this,priority);
+		e.start(function() { e.stop(); callb(); });
 		return e;
 	}
 


### PR DESCRIPTION
`tests/threads/src/cases/TestEvents.hx` sometimes (https://github.com/HaxeFoundation/haxe/actions/runs/19028366571/job/54336911408#step:9:1388) fail with

```
Uncaught exception: Null access .stop
Called from haxe.EventLoop.~run.1(haxe/EventLoop.hx:207)
Called from haxe.EventLoop.loopOnce(haxe/EventLoop.hx:148)
Called from haxe.EventLoop.loop(haxe/EventLoop.hx:103)
Called from haxe.$EntryPoint.run(haxe/EntryPoint.hx:52)
Called from .init(?:1)
```