### PR TITLE
Revive -D cdebug

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -315,7 +315,7 @@ let do_type ctx mctx actx display_file_dot_path =
 			if com.display.dms_kind <> DMNone then DisplayTexpr.check_display_file tctx cs;
 			List.iter (fun cpath ->
 				ignore(tctx.Typecore.g.Typecore.do_load_module tctx cpath null_pos);
-				Typecore.flush_pass tctx.g PBuildClass "actx.classes"
+				Typecore.flush_pass tctx PBuildClass "actx.classes"
 			) (List.rev actx.classes);
 			Finalization.finalize tctx;
 		);

--- a/src/context/display/displayEmitter.ml
+++ b/src/context/display/displayEmitter.ml
@@ -169,7 +169,7 @@ let check_display_metadata ctx meta =
 		List.iter (fun e ->
 			if display_position#enclosed_in (pos e) then begin
 				let e = preprocess_expr ctx.com e in
-				delay ctx.g PTypeField (fun _ -> ignore(type_expr ctx e WithType.value));
+				delay ctx PTypeField (fun _ -> ignore(type_expr ctx e WithType.value));
 			end
 		) args
 	) meta

--- a/src/context/display/displayTexpr.ml
+++ b/src/context/display/displayTexpr.ml
@@ -64,7 +64,7 @@ let actually_check_display_field ctx c cff p =
 	let fctx = TypeloadFields.create_field_context ctx cctx cff true display_modifier in
 	let cf = TypeloadFields.create_class_field cctx cff in
 	TypeloadFields.init_field (ctx,cctx,fctx) cff cf;
-	flush_pass ctx.g PTypeField ("check_display_field",(fst c.cl_path @ [snd c.cl_path;fst cff.cff_name]));
+	flush_pass ctx PTypeField ("check_display_field",(fst c.cl_path @ [snd c.cl_path;fst cff.cff_name]));
 	ignore(follow cf.cf_type)
 
 let check_display_field ctx sc c cf =
@@ -174,7 +174,7 @@ let check_display_file ctx cs =
 			let m = try
 				ctx.com.module_lut#find path
 			with Not_found ->
-				begin match !TypeloadCacheHook.type_module_hook ctx.com (delay ctx.g) path null_pos with
+				begin match !TypeloadCacheHook.type_module_hook ctx.com (delay ctx) path null_pos with
 				| NoModule | BadModule _ -> raise Not_found
 				| BinaryModule mc ->
 					let api = (new TypeloadModule.hxb_reader_api_typeload ctx.com ctx.g TypeloadModule.load_module' p :> HxbReaderApi.hxb_reader_api) in

--- a/src/context/display/importHandling.ml
+++ b/src/context/display/importHandling.ml
@@ -297,4 +297,4 @@ let init_using ctx path p =
 		ctx.m.import_resolution#add (module_type_resolution mt None p)
 	) (List.rev types);
 	(* delay the using since we need to resolve typedefs *)
-	delay_late ctx.g PConnectField (fun () -> ctx.m.module_using <- filter_classes types @ ctx.m.module_using)
+	delay_late ctx PConnectField (fun () -> ctx.m.module_using <- filter_classes types @ ctx.m.module_using)

--- a/src/context/display/syntaxExplorer.ml
+++ b/src/context/display/syntaxExplorer.ml
@@ -177,7 +177,7 @@ let explore_uncached_modules tctx cs symbols =
 				begin try
 					let m = tctx.g.do_load_module tctx (cfile.c_package,module_name) null_pos in
 					(* We have to flush immediately so we catch exceptions from weird modules *)
-					Typecore.flush_pass tctx.g PFinal ("final",cfile.c_package @ [module_name]);
+					Typecore.flush_pass tctx PFinal ("final",cfile.c_package @ [module_name]);
 					m :: acc
 				with _ ->
 					acc

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -456,27 +456,34 @@ let is_gen_local v = match v.v_kind with
 	| _ ->
 		false
 
-let delay g (p : typer_pass) f =
+let delay' g (p : typer_pass) f =
 	let p = Obj.magic p in
 	let tasks = g.delayed.(p) in
 	tasks.tasks <- f :: tasks.tasks;
 	if p < g.delayed_min_index then
 		g.delayed_min_index <- p
 
-let delay_late g (p : typer_pass) f =
+let delay ctx (p : typer_pass) f =
+	delay' ctx.g p f
+
+let delay_late' g (p : typer_pass) f =
 	let p = Obj.magic p in
 	let tasks = g.delayed.(p) in
 	tasks.tasks <- tasks.tasks @ [f];
 	if p < g.delayed_min_index then
 		g.delayed_min_index <- p
 
+let delay_late ctx (p : typer_pass) f =
+	delay_late' ctx.g p f
+
 let delay_if_mono g p t f = match follow t with
 	| TMono _ ->
-		delay g p f
+		delay' g p f
 	| _ ->
 		f()
 
-let rec flush_pass g (p : typer_pass) where =
+let rec flush_pass ctx (p : typer_pass) where =
+	let g = ctx.g in
 	let rec loop i =
 		if i > (Obj.magic p) then
 			()
@@ -486,7 +493,7 @@ let rec flush_pass g (p : typer_pass) where =
 			| f :: l ->
 				tasks.tasks <- l;
 				f();
-				flush_pass g p where
+				flush_pass ctx p where
 			| [] ->
 				(* Done with this pass (for now), update min index to next one *)
 				let i = i + 1 in
@@ -500,6 +507,11 @@ let make_pass ctx f = f
 
 let enter_field_typing_pass g info =
 	flush_pass g PConnectField info
+
+let make_lazy' g t_proc f where =
+	let r = make_unforced_lazy t_proc f where in
+	delay' g PForce (fun () -> ignore(lazy_type r));
+	r
 
 let make_lazy ctx t_proc f where =
 	let r = make_unforced_lazy t_proc f where in

--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -850,9 +850,9 @@ let pending_passes ctx =
 	| [] -> ""
 	| l -> " ??PENDING[" ^ String.concat ";" (List.map (fun (_,(i,_),_) -> i) l) ^ "]"
 
-let display_error com ?(depth=0) msg p =
+let display_error com ?(sub:macro_error list = []) msg p =
 	debug com [] ("ERROR " ^ msg);
-	display_error com ~depth msg p
+	display_error com ~sub msg p
 
 let display_error_ext com err =
 	debug com [] ("ERROR " ^ (error_msg err.err_message));
@@ -879,7 +879,7 @@ let make_pass ?inf ctx f =
 		t
 	)
 
-let rec flush_pass ctx p where =
+let (*rec*) flush_pass ctx p where =
 	let rec loop() =
 		match ctx.g.debug_delayed with
 		| (p2,l) :: rest when p2 <= p ->

--- a/src/typing/finalization.ml
+++ b/src/typing/finalization.ml
@@ -76,7 +76,7 @@ let get_main ctx main_module types =
 		Some main,Some (Path.UniqueKey.lazy_path main_module.m_extra.m_file)
 
 let finalize ctx =
-	flush_pass ctx.g PFinal ("final",[]);
+	flush_pass ctx PFinal ("final",[]);
 	match ctx.com.callbacks#get_after_typing with
 		| [] ->
 			()
@@ -88,7 +88,7 @@ let finalize ctx =
 					()
 				| new_types ->
 					List.iter (fun f -> f new_types) fl;
-					flush_pass ctx.g PFinal ("final",[]);
+					flush_pass ctx PFinal ("final",[]);
 					loop all_types
 			in
 			loop []

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -99,7 +99,7 @@ object(self)
 					v.v_meta <- (Meta.This,[],null_pos) :: v.v_meta;
 					loop ((v,None) :: acc) false syntax typed
 				| ((_,pn),opt,m,_,_) :: syntax,(name,eo,t) :: typed ->
-					delay ctx.g PTypeField (fun() -> self#check_rest (typed = []) eo opt t pn);
+					delay ctx PTypeField (fun() -> self#check_rest (typed = []) eo opt t pn);
 					if not is_extern then begin
 						Naming.check_local_variable_name ctx.com name TVOArgument pn;
 						if name <> "_" && List.exists (fun (v,_) -> v.v_name = name) acc then
@@ -125,7 +125,7 @@ object(self)
 			| syntax,(name,_,t) :: typed when is_abstract_this ->
 				loop false syntax typed
 			| ((_,pn),opt,m,_,_) :: syntax,(name,eo,t) :: typed ->
-				delay ctx.g PTypeField (fun() -> self#check_rest (typed = []) eo opt t pn);
+				delay ctx PTypeField (fun() -> self#check_rest (typed = []) eo opt t pn);
 				ignore(type_function_arg_value ctx t eo do_display);
 				loop false syntax typed
 			| [],[] ->

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -121,7 +121,7 @@ let generic_substitute_expr gctx e =
 	in
 	let rec build_expr e =
 		let e = match e.eexpr with
-		| TField(e1, (FInstance({cl_kind = KGeneric} as c,tl,cf) as fa_orig)) 
+		| TField(e1, (FInstance({cl_kind = KGeneric} as c,tl,cf) as fa_orig))
 		| TField(e1, (FClosure(Some ({cl_kind = KGeneric} as c, tl), cf) as fa_orig)) ->
 			let info = gctx.ctx.g.get_build_info gctx.ctx (TClassDecl c) gctx.p in
 			let t = info.build_apply (List.map (generic_substitute_type' gctx true) tl) in
@@ -351,7 +351,7 @@ let build_generic_class ctx c p tl =
 					| None ->
 						(* There can be cases like #11152 where cf_expr isn't ready yet. It should be safe to delay this to the end
 						   of the PTypeField pass. *)
-						delay_late ctx.g PTypeField (fun () -> match cf_old.cf_expr with
+						delay_late ctx PTypeField (fun () -> match cf_old.cf_expr with
 							| Some e ->
 								update_expr e
 							| None ->
@@ -369,7 +369,7 @@ let build_generic_class ctx c p tl =
 				t
 			in
 			let t = spawn_monomorph ctx p in
-			let r = make_lazy ctx.g t (fun () ->
+			let r = make_lazy ctx t (fun () ->
 				let t0 = f() in
 				unify_raise t0 t p;
 				link_dynamic t0 t;

--- a/src/typing/instanceBuilder.ml
+++ b/src/typing/instanceBuilder.ml
@@ -74,7 +74,7 @@ let get_build_info ctx mtype p =
 		if ctx.pass > PBuildClass then ignore(c.cl_build());
 		let build f s tl =
 			let t = spawn_monomorph ctx p in
-			let r = make_lazy ctx.g t (fun () ->
+			let r = make_lazy ctx t (fun () ->
 				let tf = f tl in
 				unify_raise tf t p;
 				link_dynamic t tf;

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -64,7 +64,7 @@ let macro_timer timer_ctx level s identifier f arg =
 let typing_timer ctx need_type f =
 	let t = Timer.start_timer ctx.com.timer_ctx ["typing"] in
 	let ctx = if need_type && ctx.pass < PTypeField then begin
-		enter_field_typing_pass ctx.g ("typing_timer",[]);
+		enter_field_typing_pass ctx ("typing_timer",[]);
 		TyperManager.clone_for_expr ctx ctx.e.curfun FunFunction
 	end else
 		ctx
@@ -567,7 +567,7 @@ let make_macro_api ctx mctx p =
 				List.iter (fun path ->
 					ImportHandling.init_using ctx path null_pos
 				) usings;
-				flush_pass ctx.g PConnectField ("with_imports",[] (* TODO: ? *));
+				flush_pass ctx PConnectField ("with_imports",[] (* TODO: ? *));
 				f()
 			in
 			let restore () =

--- a/src/typing/strictMeta.ml
+++ b/src/typing/strictMeta.ml
@@ -175,7 +175,7 @@ let get_strict_meta ctx meta params pos =
 			raise Exit
 	in
 	let t = Typeload.load_complex_type ctx false LoadNormal (ctype,pos) in
-	flush_pass ctx.g PBuildClass "get_strict_meta";
+	flush_pass ctx PBuildClass ("get_strict_meta",[]);
 	let texpr = type_expr ctx changed_expr NoValue in
 	let with_type_expr = (ECheckType( (EConst (Ident "null"), pos), (ctype,null_pos) ), pos) in
 	let extra = handle_fields ctx fields_to_check with_type_expr in

--- a/src/typing/typeload.ml
+++ b/src/typing/typeload.ml
@@ -385,7 +385,7 @@ let rec load_params ctx info params p =
 			let t = apply_params info.build_params params t in
 			maybe_build_instance ctx t ParamNormal p;
 		in
-		delay ctx.g PCheckConstraint (fun () ->
+		delay ctx PCheckConstraint (fun () ->
 			DynArray.iter (fun (t,c,p) ->
 				check_param_constraints ctx t map c p
 			) checks
@@ -467,7 +467,7 @@ and load_complex_type' ctx allow_display mode (t,p) =
 		) tl in
 		let tr = Monomorph.create() in
 		let t = TMono tr in
-		let r = make_lazy ctx.g t (fun () ->
+		let r = make_lazy ctx t (fun () ->
 			let ta = make_extension_type ctx tl in
 			Monomorph.bind tr ta;
 			ta
@@ -508,7 +508,7 @@ and load_complex_type' ctx allow_display mode (t,p) =
 			) tl in
 			let tr = Monomorph.create() in
 			let t = TMono tr in
-			let r = make_lazy ctx.g t (fun () ->
+			let r = make_lazy ctx t (fun () ->
 				Monomorph.bind tr (match il with
 					| [i] ->
 						mk_extension i
@@ -614,7 +614,7 @@ and load_complex_type' ctx allow_display mode (t,p) =
 		| None ->
 			()
 		| Some cf ->
-			delay ctx.g PBuildClass (fun () -> DisplayEmitter.display_field ctx (AnonymousStructure a) CFSMember cf cf.cf_name_pos);
+			delay ctx PBuildClass (fun () -> DisplayEmitter.display_field ctx (AnonymousStructure a) CFSMember cf cf.cf_name_pos);
 		end;
 		TAnon a
 	| CTFunction (args,r) ->
@@ -633,7 +633,7 @@ and load_complex_type ctx allow_display mode (t,pn) =
 		load_complex_type' ctx allow_display mode (t,pn)
 	with Error ({ err_message = Module_not_found(([],name)) } as err) ->
 		if Diagnostics.error_in_diagnostics_run ctx.com err.err_pos then begin
-			delay ctx.g PForce (fun () -> DisplayToplevel.handle_unresolved_identifier ctx name err.err_pos true);
+			delay ctx PForce (fun () -> DisplayToplevel.handle_unresolved_identifier ctx name err.err_pos true);
 			t_dynamic
 		end else
 			raise (Error err)
@@ -741,7 +741,7 @@ and type_type_params ctx host path tpl =
 			| None ->
 				()
 			| Some ct ->
-				let r = make_lazy ctx.g ttp.ttp_type (fun () ->
+				let r = make_lazy ctx ttp.ttp_type (fun () ->
 					let t = load_complex_type ctx true LoadNormal ct in
 					begin match host with
 						| TPHType ->
@@ -776,14 +776,14 @@ and type_type_params ctx host path tpl =
 					| TInst (c2,_) when ttp.ttp_class == c2 ->
 						raise_typing_error "Recursive constraint parameter is not allowed" (pos th)
 					| TInst ({ cl_kind = KTypeParameter ttp },_) ->
-						delay ctx.g PConnectField (fun () -> List.iter loop (get_constraints ttp))
+						delay ctx PConnectField (fun () -> List.iter loop (get_constraints ttp))
 					| _ ->
 						()
 				in
 				List.iter loop constr;
 				constr
 			) in
-			delay ctx.g PConnectField (fun () -> ignore (Lazy.force constraints));
+			delay ctx PConnectField (fun () -> ignore (Lazy.force constraints));
 			ttp.ttp_constraints <- Some constraints;
 	) param_pairs;
 	params
@@ -819,7 +819,7 @@ let load_core_class ctx c =
 		| _ -> c.cl_path
 	in
 	let t = load_type_def' ctx2 (fst c.cl_module.m_path) (snd c.cl_module.m_path) (snd tpath) null_pos in
-	flush_pass ctx2.g PFinal ("core_final",(fst c.cl_path @ [snd c.cl_path]));
+	flush_pass ctx2 PFinal ("core_final",(fst c.cl_path @ [snd c.cl_path]));
 	match t with
 	| TClassDecl ccore | TAbstractDecl {a_impl = Some ccore} ->
 		ccore

--- a/src/typing/typeloadCheck.ml
+++ b/src/typing/typeloadCheck.ml
@@ -328,7 +328,7 @@ let check_global_metadata ctx meta f_add mpath tpath so =
 		let add = ((field_mode && to_fields) || (not field_mode && to_types)) && (match_path recursive sl1 sl2) in
 		if add then f_add m
 	) ctx.com.global_metadata;
-	if ctx.m.is_display_file then delay ctx.g PCheckConstraint (fun () -> DisplayEmitter.check_display_metadata ctx meta)
+	if ctx.m.is_display_file then delay ctx PCheckConstraint (fun () -> DisplayEmitter.check_display_metadata ctx meta)
 
 module Inheritance = struct
 	let is_basic_class_path path = match path with
@@ -440,7 +440,7 @@ module Inheritance = struct
 		| _ ->
 		List.iter (fun (intf,params) ->
 			let missing = DynArray.create () in
-			check_interface ctx.com ctx.g missing c intf params;
+			check_interface ctx.com ctx missing c intf params;
 			if DynArray.length missing > 0 then begin
 				let l = DynArray.to_list missing in
 				let diag = {
@@ -538,7 +538,7 @@ module Inheritance = struct
 					   we do want to check them at SOME point. So we use this pending list which was maybe designed for this
 					   purpose. However, we STILL have to delay the check because at the time pending is handled, the class
 					   is not built yet. See issue #10847. *)
-					pending := (fun () -> delay ctx.g PConnectField check_interfaces_or_delay) :: !pending
+					pending := (fun () -> delay ctx PConnectField check_interfaces_or_delay) :: !pending
 				| _ when ctx.com.display.dms_full_typing ->
 					check_interfaces ctx c
 				| _ ->
@@ -551,7 +551,7 @@ module Inheritance = struct
 					if not (has_class_flag csup CInterface) then raise_typing_error (Printf.sprintf "Cannot extend by using a class (%s extends %s)" (s_type_path c.cl_path) (s_type_path csup.cl_path)) p;
 					c.cl_implements <- (csup,params) :: c.cl_implements;
 					if not !has_interf then begin
-						if not is_lib then delay ctx.g PConnectField check_interfaces_or_delay;
+						if not is_lib then delay ctx PConnectField check_interfaces_or_delay;
 						has_interf := true;
 					end
 				end else begin
@@ -573,7 +573,7 @@ module Inheritance = struct
 					if not (has_class_flag intf CInterface) then raise_typing_error "You can only implement an interface" p;
 					c.cl_implements <- (intf, params) :: c.cl_implements;
 					if not !has_interf && not is_lib && not (Meta.has (Meta.Custom "$do_not_check_interf") c.cl_meta) then begin
-						delay ctx.g PConnectField check_interfaces_or_delay;
+						delay ctx PConnectField check_interfaces_or_delay;
 						has_interf := true;
 					end;
 					(fun () ->

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -237,7 +237,7 @@ let ensure_struct_init_constructor ctx c ast_fields p =
 		cf.cf_meta <- [Meta.CompilerGenerated,[],null_pos; Meta.InheritDoc,[],null_pos];
 		cf.cf_kind <- Method MethNormal;
 		c.cl_constructor <- Some cf;
-		delay ctx.g PTypeField (fun() -> InheritDoc.build_class_field_doc ctx (Some c) cf)
+		delay ctx PTypeField (fun() -> InheritDoc.build_class_field_doc ctx (Some c) cf)
 
 let transform_abstract_field com this_t a_t a f =
 	let stat = List.mem_assoc AStatic f.cff_access in
@@ -420,7 +420,7 @@ let build_module_def ctx mt meta fvars fbuild =
 			let inherit_using (c,_) =
 				ti.mt_using <- ti.mt_using @ (t_infos (TClassDecl c)).mt_using
 			in
-			delay_late ctx.g PConnectField (fun () ->
+			delay_late ctx PConnectField (fun () ->
 				Option.may inherit_using csup;
 				List.iter inherit_using interfaces;
 			);
@@ -436,7 +436,7 @@ let build_module_def ctx mt meta fvars fbuild =
 					let path = List.rev (string_pos_list_of_expr_path_raise e) in
 					let types,filter_classes = ImportHandling.handle_using ctx path (pos e) in
 					(* Delay for #10107, but use delay_late to make sure base classes run before their children do. *)
-					delay_late ctx.g PConnectField (fun () ->
+					delay_late ctx PConnectField (fun () ->
 						ti.mt_using <- (filter_classes types) @ ti.mt_using
 					)
 				with Exit ->
@@ -666,7 +666,7 @@ module TypeBinding = struct
 		in
 		let force_macro display =
 			(* force macro system loading of this class in order to get completion *)
-			delay ctx.g PTypeField (fun() ->
+			delay ctx PTypeField (fun() ->
 				try
 					ignore(ctx.g.do_macro ctx MDisplay c.cl_path cf.cf_name [] p)
 				with
@@ -752,7 +752,7 @@ module TypeBinding = struct
 		let r = make_unforced_lazy t (fun () ->
 			(* type constant init fields (issue #1956) *)
 			if not ctx.g.return_partial_type || (match fst e with EConst _ -> true | _ -> false) then begin
-				enter_field_typing_pass ctx.g ("bind_var_expression",fst ctx.c.curclass.cl_path @ [snd ctx.c.curclass.cl_path;ctx.f.curfield.cf_name]);
+				enter_field_typing_pass ctx ("bind_var_expression",fst ctx.c.curclass.cl_path @ [snd ctx.c.curclass.cl_path;ctx.f.curfield.cf_name]);
 				if ctx.com.verbose then Common.log ctx.com ("Typing " ^ (if ctx.com.is_macro_context then "macro " else "") ^ s_type_path c.cl_path ^ "." ^ cf.cf_name);
 				let e = type_var_field ctx t e fctx.is_static fctx.is_display_field p in
 				let maybe_run_analyzer e = match e.eexpr with
@@ -938,7 +938,7 @@ let check_abstract (ctx,cctx,fctx) a c cf fd t ret p =
 		fctx.expr_presence_matters <- true;
 	end in
 	let handle_from () =
-		let r = make_lazy ctx.g t (fun () ->
+		let r = make_lazy ctx t (fun () ->
 			(* the return type of a from-function must be the abstract, not the underlying type *)
 			if not fctx.is_macro then (try type_eq EqStrict ret ta with Unify_error l -> raise_typing_error_ext (make_error (Unify l) p));
 			match t with
@@ -978,7 +978,7 @@ let check_abstract (ctx,cctx,fctx) a c cf fd t ret p =
 		let is_multitype_cast = Meta.has Meta.MultiType a.a_meta && not fctx.is_abstract_member in
 		if is_multitype_cast && not (Meta.has Meta.MultiType cf.cf_meta) then
 			cf.cf_meta <- (Meta.MultiType,[],null_pos) :: cf.cf_meta;
-		let r = make_lazy ctx.g t (fun () ->
+		let r = make_lazy ctx t (fun () ->
 			let args = if is_multitype_cast then begin
 				let ctor = match a.a_constructor with
 					| Some cf ->
@@ -1333,14 +1333,14 @@ let create_method (ctx,cctx,fctx) c f cf fd p =
 		TypeBinding.bind_method ctx cctx fctx fmode cf t args ret fd.f_expr function_mode (match fd.f_expr with Some e -> snd e | None -> f.cff_pos)
 	else begin
 		if fctx.is_display_field then begin
-			delay ctx.g PTypeField (fun () ->
+			delay ctx PTypeField (fun () ->
 				(* We never enter type_function so we're missing out on the argument processing there. Let's do it here. *)
 				let ctx = TyperManager.clone_for_expr ctx fmode function_mode in
 				ignore(args#for_expr ctx)
 			);
 			check_field_display ctx fctx c cf;
 		end else
-			delay ctx.g PTypeField (fun () ->
+			delay ctx PTypeField (fun () ->
 				let ctx = TyperManager.clone_for_expr ctx fmode function_mode in
 				args#verify_extern ctx
 			);
@@ -1396,7 +1396,7 @@ let create_property (ctx,cctx,fctx) c f cf (get,set,t,eo) p =
 			(* Now that we know there is a field, we have to delay the actual unification even further. The reason is that unification could resolve
 			   TLazy, which would then cause field typing before we're done with our PConnectField pass. This could cause interface fields to not
 			   be generated in time. *)
-			delay ctx.g PForce (fun () ->
+			delay ctx PForce (fun () ->
 				try
 					(match f2.cf_kind with
 						| Method MethMacro ->
@@ -1449,7 +1449,7 @@ let create_property (ctx,cctx,fctx) c f cf (get,set,t,eo) p =
 		with Not_found ->
 			()
 	in
-	let delay_check = delay ctx.g PConnectField in
+	let delay_check = delay ctx PConnectField in
 	let get = (match get with
 		| "null",_ -> AccNo
 		| "dynamic",_ -> AccCall
@@ -1457,12 +1457,12 @@ let create_property (ctx,cctx,fctx) c f cf (get,set,t,eo) p =
 		| "default",_ -> AccNormal
 		| "get",pget ->
 			let get = "get_" ^ name in
-			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pget then delay ctx.g PConnectField (fun () -> display_accessor get pget);
+			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pget then delay ctx PConnectField (fun () -> display_accessor get pget);
 			if not cctx.is_lib then delay_check (fun() -> check_method get t_get true);
 			AccCall
 		| "private get",pget ->
 			let get = "get_" ^ name in
-			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pget then delay ctx.g PConnectField (fun () -> display_accessor get pget);
+			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pget then delay ctx PConnectField (fun () -> display_accessor get pget);
 			if not cctx.is_lib then delay_check (fun() -> check_method get t_get true);
 			AccPrivateCall
 		| _,pget ->
@@ -1481,12 +1481,12 @@ let create_property (ctx,cctx,fctx) c f cf (get,set,t,eo) p =
 		| "default",_ -> AccNormal
 		| "set",pset ->
 			let set = "set_" ^ name in
-			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pset then delay ctx.g PConnectField (fun () -> display_accessor set pset);
+			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pset then delay ctx PConnectField (fun () -> display_accessor set pset);
 			if not cctx.is_lib then delay_check (fun() -> check_method set t_set false);
 			AccCall
 		| "private set",pset ->
 			let set = "set_" ^ name in
-			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pset then delay ctx.g PConnectField (fun () -> display_accessor set pset);
+			if fctx.is_display_field && DisplayPosition.display_position#enclosed_in pset then delay ctx PConnectField (fun () -> display_accessor set pset);
 			if not cctx.is_lib then delay_check (fun() -> check_method set t_set false);
 			AccPrivateCall
 		| _,pset ->
@@ -1558,7 +1558,7 @@ let init_field (ctx,cctx,fctx) f cf =
 	in
 	(if (fctx.is_static || fctx.is_macro && ctx.com.is_macro_context) then add_class_field_flag cf CfStatic);
 	if Meta.has Meta.InheritDoc cf.cf_meta then
-		delay ctx.g PTypeField (fun() -> InheritDoc.build_class_field_doc ctx (Some c) cf)
+		delay ctx PTypeField (fun() -> InheritDoc.build_class_field_doc ctx (Some c) cf)
 
 let check_overload ctx f fs is_extern_class =
 	try
@@ -1610,7 +1610,7 @@ let finalize_class cctx =
 	List.iter (fun (ctx,r) ->
 		(match r with
 		| None -> ()
-		| Some r -> delay ctx.g PTypeField (fun() -> ignore(lazy_type r)))
+		| Some r -> delay ctx PTypeField (fun() -> ignore(lazy_type r)))
 	) cctx.delayed_expr
 
 let check_functional_interface ctx c =
@@ -1632,13 +1632,13 @@ let init_class ctx_c cctx c p herits fields =
 	let com = ctx_c.com in
 	if cctx.is_class_debug then print_endline ("Created class context: " ^ dump_class_context cctx);
 	let fields = build_fields (ctx_c,cctx) c fields in
-	if cctx.is_core_api && com.display.dms_check_core_api then delay ctx_c.g PForce (fun() -> init_core_api ctx_c c);
+	if cctx.is_core_api && com.display.dms_check_core_api then delay ctx_c PForce (fun() -> init_core_api ctx_c c);
 	if not cctx.is_lib then begin
-		delay ctx_c.g PForce (fun() -> check_overloads ctx_c c);
+		delay ctx_c PForce (fun() -> check_overloads ctx_c c);
 		begin match c.cl_super with
 		| Some(csup,tl) ->
 			if (has_class_flag csup CAbstract) && not (has_class_flag c CAbstract) then
-				delay ctx_c.g PForce (fun () -> TypeloadCheck.Inheritance.check_abstract_class ctx_c c csup tl);
+				delay ctx_c PForce (fun () -> TypeloadCheck.Inheritance.check_abstract_class ctx_c c csup tl);
 		| None ->
 			()
 		end
@@ -1755,7 +1755,7 @@ let init_class ctx_c cctx c p herits fields =
 	end;
 	c.cl_ordered_statics <- List.rev c.cl_ordered_statics;
 	c.cl_ordered_fields <- List.rev c.cl_ordered_fields;
-	delay ctx_c.g PConnectField (fun () -> match follow c.cl_type with
+	delay ctx_c PConnectField (fun () -> match follow c.cl_type with
 		| TAnon an ->
 			an.a_fields <- c.cl_statics
 		| _ ->
@@ -1797,5 +1797,5 @@ let init_class ctx_c cctx c p herits fields =
 	end;
 	if not has_struct_init then
 		(* add_constructor does not deal with overloads correctly *)
-		if not com.config.pf_overload then delay_late ctx_c.g PConnectField (fun() -> TypeloadFunction.add_constructor ctx_c c cctx.force_constructor p);
+		if not com.config.pf_overload then delay_late ctx_c PConnectField (fun() -> TypeloadFunction.add_constructor ctx_c c cctx.force_constructor p);
 	finalize_class cctx

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -39,7 +39,7 @@ let type_function_params ctx fd host fname =
 let type_function ctx (args : function_arguments) ret e do_display p =
 	ctx.e.ret <- ret;
 	ctx.e.opened <- [];
-	enter_field_typing_pass ctx.g ("type_function",fst ctx.c.curclass.cl_path @ [snd ctx.c.curclass.cl_path;ctx.f.curfield.cf_name]);
+	enter_field_typing_pass ctx ("type_function",fst ctx.c.curclass.cl_path @ [snd ctx.c.curclass.cl_path;ctx.f.curfield.cf_name]);
 	args#bring_into_context ctx;
 	let e = match e with
 		| None ->
@@ -110,7 +110,7 @@ let type_function ctx (args : function_arguments) ret e do_display p =
 	let e = if ctx.e.curfun <> FunConstructor then
 		e
 	else begin
-		delay ctx.g PForce (fun () -> TypeloadCheck.check_final_vars ctx e);
+		delay ctx PForce (fun () -> TypeloadCheck.check_final_vars ctx e);
 		match has_super_constr() with
 		| Some (was_forced,t_super) ->
 			(try
@@ -201,7 +201,7 @@ let add_constructor ctx_c c force_constructor p =
 		cf.cf_params <- cfsup.cf_params;
 		cf.cf_meta <- List.filter (fun (m,_,_) -> m = Meta.CompilerGenerated) cfsup.cf_meta;
 		let t = spawn_monomorph ctx_c p in
-		let r = make_lazy ctx_c.g t (fun () ->
+		let r = make_lazy ctx_c t (fun () ->
 			let ctx = TyperManager.clone_for_field ctx_c cf cf.cf_params in
 			ignore (follow cfsup.cf_type); (* make sure it's typed *)
 			List.iter (fun cf -> ignore (follow cf.cf_type)) cf.cf_overloads;

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -160,7 +160,7 @@ module ModuleLevel = struct
 						t_meta = d.d_meta;
 					} in
 					(* failsafe in case the typedef is not initialized (see #3933) *)
-					delay ctx_m.g PBuildModule (fun () ->
+					delay ctx_m PBuildModule (fun () ->
 						match t.t_type with
 						| TMono r -> (match r.tm_type with None -> Monomorph.bind r com.basic.tvoid | _ -> ())
 						| _ -> ()
@@ -429,7 +429,7 @@ module TypeLevel = struct
 				with TypeloadCheck.Build_canceled state ->
 					c.cl_build <- make_pass ctx_c build;
 					let rebuild() =
-						delay_late ctx_c.g PBuildClass (fun() -> ignore(c.cl_build()));
+						delay_late ctx_c PBuildClass (fun() -> ignore(c.cl_build()));
 					in
 					(match state with
 					| Built -> die "" __LOC__
@@ -448,11 +448,11 @@ module TypeLevel = struct
 			build()
 		in
 		c.cl_build <- make_pass ctx_m build;
-		delay ctx_m.g PBuildClass (fun() -> ignore(c.cl_build()));
+		delay ctx_m PBuildClass (fun() -> ignore(c.cl_build()));
 		if Meta.has Meta.InheritDoc c.cl_meta then
-			delay ctx_m.g PConnectField (fun() -> InheritDoc.build_class_doc ctx_m c);
+			delay ctx_m PConnectField (fun() -> InheritDoc.build_class_doc ctx_m c);
 		if (ctx_m.com.platform = Jvm) && not (has_class_flag c CExtern) then
-			delay ctx_m.g PTypeField (fun () ->
+			delay ctx_m PTypeField (fun () ->
 				let metas = StrictMeta.check_strict_meta ctx_m c.cl_meta in
 				if metas <> [] then c.cl_meta <- metas @ c.cl_meta;
 				let rec run_field cf =
@@ -522,15 +522,15 @@ module TypeLevel = struct
 			incr index;
 			names := (fst c.ec_name) :: !names;
 			if Meta.has Meta.InheritDoc f.ef_meta then
-				delay ctx_en.g PConnectField (fun() -> InheritDoc.build_enum_field_doc ctx_en f);
+				delay ctx_en PConnectField (fun() -> InheritDoc.build_enum_field_doc ctx_en f);
 		) (!constructs);
 		e.e_names <- List.rev !names;
 		unify ctx_en (TType(enum_module_type e,[])) e.e_type p;
 		if !is_flat then e.e_meta <- (Meta.FlatEnum,[],null_pos) :: e.e_meta;
 		if Meta.has Meta.InheritDoc e.e_meta then
-			delay ctx_en.g PConnectField (fun() -> InheritDoc.build_enum_doc ctx_en e);
+			delay ctx_en PConnectField (fun() -> InheritDoc.build_enum_doc ctx_en e);
 		if (ctx_en.com.platform = Jvm) && not (has_enum_flag e EnExtern) then
-			delay ctx_en.g PTypeField (fun () ->
+			delay ctx_en PTypeField (fun () ->
 				let metas = StrictMeta.check_strict_meta ctx_en e.e_meta in
 				e.e_meta <- metas @ e.e_meta;
 				PMap.iter (fun _ ef ->
@@ -570,7 +570,7 @@ module TypeLevel = struct
 					| _ ->
 						()
 				in
-				let r = make_lazy ctx_td.g tt (fun () ->
+				let r = make_lazy ctx_td tt (fun () ->
 					check_rec tt;
 					tt
 				) "typedef_rec_check" in
@@ -604,7 +604,7 @@ module TypeLevel = struct
 			let t = load_complex_type ctx_a true LoadNormal t in
 			let t = if not (Meta.has Meta.CoreType a.a_meta) then begin
 				if !is_type then begin
-					let r = make_lazy ctx_a.g t (fun () ->
+					let r = make_lazy ctx_a t (fun () ->
 						(try (if from then Type.unify t a.a_this else Type.unify a.a_this t) with Unify_error _ -> raise_typing_error "You can only declare from/to with compatible types" pos);
 						t
 					) "constraint" in
@@ -625,7 +625,7 @@ module TypeLevel = struct
 				if a.a_impl = None then raise_typing_error "Abstracts with underlying type must have an implementation" a.a_pos;
 				if Meta.has Meta.CoreType a.a_meta then raise_typing_error "@:coreType abstracts cannot have an underlying type" p;
 				let at = load_complex_type ctx_a true LoadNormal t in
-				delay ctx_a.g PForce (fun () ->
+				delay ctx_a PForce (fun () ->
 					let rec loop stack t =
 						match follow t with
 						| TAbstract(a,_) when not (Meta.has Meta.CoreType a.a_meta) ->
@@ -652,7 +652,7 @@ module TypeLevel = struct
 				raise_typing_error "Abstract is missing underlying type declaration" a.a_pos
 		end;
 		if Meta.has Meta.InheritDoc a.a_meta then
-			delay ctx_a.g PConnectField (fun() -> InheritDoc.build_abstract_doc ctx_a a)
+			delay ctx_a PConnectField (fun() -> InheritDoc.build_abstract_doc ctx_a a)
 
 	(*
 		In this pass, we can access load and access other modules types, but we cannot follow them or access their structure
@@ -720,7 +720,7 @@ let type_types_into_module com g m tdecls p =
 	(* setup module types *)
 	List.iter (TypeLevel.init_module_type ctx_m) decls;
 	(* Make sure that we actually init the context at some point (issue #9012) *)
-	delay ctx_m.g PConnectField (fun () -> ctx_m.m.import_resolution#resolve_lazies);
+	delay ctx_m PConnectField (fun () -> ctx_m.m.import_resolution#resolve_lazies);
 	ctx_m
 
 (*
@@ -770,11 +770,11 @@ class hxb_reader_api_typeload
 			| Var _ ->
 				true
 			| Method _ ->
-				delay g PTypeField (fun () -> ignore(follow cf.cf_type));
+				delay' g PTypeField (fun () -> ignore(follow cf.cf_type));
 				false
 
 	method make_lazy_type t f =
-		TLazy (make_lazy g t f "typeload-api")
+		TLazy (make_lazy' g t f "typeload-api")
 end
 
 let rec load_hxb_module com g path p =
@@ -784,7 +784,7 @@ let rec load_hxb_module com g path p =
 			let reader = new HxbReader.hxb_reader path com.hxb_reader_stats (if Common.defined com Define.HxbTimes then Some com.timer_ctx else None) in
 			let read = reader#read api bytes in
 			let m = read EOT in
-			delay g PConnectField (fun () ->
+			delay' g PConnectField (fun () ->
 				ignore(read EOM);
 			);
 			m
@@ -814,7 +814,7 @@ and load_module' com g m p =
 		com.module_lut#find m
 	with Not_found ->
 		(* Check cache *)
-		match !TypeloadCacheHook.type_module_hook com (delay g) m p with
+		match !TypeloadCacheHook.type_module_hook com (delay' g) m p with
 		| GoodModule m ->
 			m
 		| BinaryModule _ ->
@@ -850,7 +850,7 @@ and load_module' com g m p =
 let load_module ?(origin:module_dep_origin = MDepFromTyping) ctx m p =
 	let m2 = load_module' ctx.com ctx.g m p in
 	add_dependency ~skip_postprocess:true ctx.m.curmod m2 origin;
-	if ctx.pass = PTypeField then flush_pass ctx.g PConnectField ("load_module",fst m @ [snd m]);
+	if ctx.pass = PTypeField then flush_pass ctx PConnectField ("load_module",fst m @ [snd m]);
 	m2
 
 ;;


### PR DESCRIPTION
This brings back the typer context to the pass functions in typecore.ml which was removed in #11548. While it's not required for normal operations, it turns out that we need it in order to show accurate debug information when using `-D cdebug`.

We probably still have to deal with the `delay'` in `load_module'`.