### PR TITLE
[hl/std] Fix compilation with hl_legacy32 / hl ver 1.12

### DIFF
--- a/std/haxe/ds/Int64Map.hx
+++ b/std/haxe/ds/Int64Map.hx
@@ -34,7 +34,7 @@ class Int64Map<T> implements haxe.Constraints.IMap<haxe.Int64, T> {
 	var m : Map<String,T>;
 
 	/**
-		Creates a new IntMap.
+		Creates a new Int64Map.
 	**/
 	public function new():Void {
 		m = new Map();

--- a/std/hl/_std/haxe/Int64.hx
+++ b/std/hl/_std/haxe/Int64.hx
@@ -312,7 +312,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	public static inline function toStr(x:Int64):String
 		return x.toString();
 
-	function toString():String {
+	public function toString():String {
 		var i:Int64 = cast this;
 		if (i == 0)
 			return "0";

--- a/std/hl/_std/haxe/ds/Int64Map.hx
+++ b/std/hl/_std/haxe/ds/Int64Map.hx
@@ -22,6 +22,8 @@
 
 package haxe.ds;
 
+#if (hl_ver >= version("1.13.0") && !hl_legacy32)
+
 @:coreApi
 class Int64Map<T> implements haxe.Constraints.IMap<haxe.Int64, T> {
 	var h:hl.types.Int64Map;
@@ -82,18 +84,82 @@ class Int64Map<T> implements haxe.Constraints.IMap<haxe.Int64, T> {
 	}
 
 	public function clear():Void {
-		#if (hl_ver >= version("1.11.0"))
 		@:privateAccess h.clear();
-		#else
-		h = new hl.types.Int64Map();
-		#end
 	}
 
 	public function size():Int {
-		#if (hl_ver >= version("1.12.0"))
 		return h.size();
-		#else
-		return h.keysArray().length;
-		#end
 	}
 }
+
+#else
+
+// Same as haxe.ds.Int64Map
+class Int64Map<T> implements haxe.Constraints.IMap<haxe.Int64, T> {
+	var m : Map<String,T>;
+
+	public function new():Void {
+		m = new Map();
+	}
+
+	public function set(key:Int64, value:T):Void {
+		m.set(key.toString(),value);
+	}
+
+	public function get(key:Int64):Null<T> {
+		return m.get(key.toString());
+	}
+
+	public function exists(key:Int64):Bool {
+		return m.exists(key.toString());
+	}
+
+	public function remove(key:Int64):Bool {
+		return m.remove(key.toString());
+	}
+
+	public function keys():Iterator<Int64> {
+		var it = m.keys();
+		return {
+			hasNext : () -> it.hasNext(),
+			next: () -> {
+				return haxe.Int64.parseString(it.next());
+			}
+		};
+	}
+
+	public function iterator():Iterator<T> {
+		return m.iterator();
+	}
+
+	public function keyValueIterator():KeyValueIterator<Int64, T> {
+		var it = m.keyValueIterator();
+		return {
+			hasNext : () -> it.hasNext(),
+			next : () -> {
+				var v = it.next();
+				return { key : haxe.Int64.parseString(v.key), value : v.value };
+			}
+		};
+	}
+
+	public function copy():Int64Map<T> {
+		var v = new Int64Map();
+		v.m = m.copy();
+		return v;
+	}
+
+	public function toString():String {
+		return m.toString();
+	}
+
+	public function clear():Void {
+		m.clear();
+	}
+
+	public function size():Int {
+		return m.size();
+	}
+}
+
+#end

--- a/std/hl/types/ArrayDyn.hx
+++ b/std/hl/types/ArrayDyn.hx
@@ -228,6 +228,7 @@ class ArrayDyn extends ArrayAccess {
 			allowReinterpret = false;
 			return arr;
 		}
+		#if (hl_ver >= version("1.13.0") && !hl_legacy32)
 		if (t == Type.get((null : ArrayBytes.ArrayI64))) {
 			var a:BytesAccess<I64> = null;
 			a = new Bytes(array.length << a.sizeBits);
@@ -238,6 +239,7 @@ class ArrayDyn extends ArrayAccess {
 			allowReinterpret = false;
 			return arr;
 		}
+		#end
 		return null;
 	}
 

--- a/tests/misc/hl/projects/Issue12401/Main.hx
+++ b/tests/misc/hl/projects/Issue12401/Main.hx
@@ -1,0 +1,7 @@
+class Main {
+	static function main() {
+		var m = new Map();
+		m.set("a", 0);
+		trace(m);
+	}
+}

--- a/tests/misc/hl/projects/Issue12401/compile.hxml
+++ b/tests/misc/hl/projects/Issue12401/compile.hxml
@@ -1,0 +1,3 @@
+--main Main
+-D hl_ver=1.12.0
+--hl out/main.hl


### PR DESCRIPTION
Hashlink's 32bit CI is currently failing with Int64Map, this PR suggests to use the default `haxe.ds.Int64Map` behavior as fallback.

To repro `haxe -main Main -D hl_legacy32 -hl test.hl` or `haxe -main Main -D hl_ver=1.12.0 -hl test.hl`

```haxe
// Main.hx
class Main {
	static function main() {
		var map = new Map();
		map.set("a", 10);
		trace(map.get("a"));
	}
}
```