### PR TITLE
Add haxe 5 enum constructor change to changelog

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -13,6 +13,7 @@
 
 	Breaking changes:
 
+	all : don't prioritize enum constructors over classes (#9197)
 	all : rework module resolution (#11168)
 	all : don't infer string on concat (#11318)
 	all : delay typer creation to after init macros (#11323)


### PR DESCRIPTION
This is technically part of #11168 so not sure if it should be put as part of that instead, but either way it would be good to explicitly mention this change in the changelog.