### PR TITLE
[cpp] Mark overridden scriptable methods

### DIFF
--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -1012,20 +1012,20 @@ let generate_managed_class base_ctx tcpp_class =
     if List.length tcpp_class.tcl_functions > 0 || List.length tcpp_class.tcl_static_functions > 0 then (
 
       let dump_script is_static f acc =
-        if not f.tcf_is_overriding && f.tcf_name <> "toString" then (* toString implicitly overrides hx::Object::toString *)
-          let signature = generate_script_function is_static f ("__s_" ^ f.tcf_field.cf_name) f.tcf_name in
-          let superCall = if is_static then "0" else "__s_" ^ f.tcf_field.cf_name ^ "<true>" in
-          let named =
-            Printf.sprintf
-              "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", %s HXCPP_CPPIA_SUPER_ARG(%s))"
-              f.tcf_field.cf_name
-              f.tcf_field.cf_name
-              signature
-              (if is_static then "true" else "false")
-              superCall in
+        let signature = generate_script_function is_static f ("__s_" ^ f.tcf_field.cf_name) f.tcf_name in
+        let superCall = if is_static then "0" else "__s_" ^ f.tcf_field.cf_name ^ "<true>" in
+        let named =
+          Printf.sprintf
+            "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", %s HXCPP_CPPIA_SUPER_ARG(%s), %s)"
+            f.tcf_field.cf_name
+            f.tcf_field.cf_name
+            signature
+            (if is_static then "true" else "false")
+            superCall
+            (* toString implicitly overrides hx::Object::toString *)
+            (if f.tcf_is_overriding || f.tcf_name = "toString" then "true" else "false") in
 
-          named :: acc
-        else acc
+        named :: acc
       in
 
       let sigs =
@@ -1036,7 +1036,7 @@ let generate_managed_class base_ctx tcpp_class =
       in
 
       output_cpp "#ifndef HXCPP_CPPIA_SUPER_ARG\n";
-      output_cpp "#define HXCPP_CPPIA_SUPER_ARG(x)\n";
+      output_cpp "#define HXCPP_CPPIA_SUPER_ARG(x) ,0\n";
       output_cpp "#endif\n";
       Printf.sprintf "static ::hx::ScriptNamedFunction __scriptableFunctions[] = {\n%s\n};\n\n" sigs |> output_cpp)
     else

--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -1016,7 +1016,7 @@ let generate_managed_class base_ctx tcpp_class =
         let superCall = if is_static then "0" else "__s_" ^ f.tcf_field.cf_name ^ "<true>" in
         let named =
           Printf.sprintf
-            "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", %s HXCPP_CPPIA_SUPER_ARG(%s), %s)"
+            "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", %s, %s, %s)"
             f.tcf_field.cf_name
             f.tcf_field.cf_name
             signature
@@ -1029,15 +1029,12 @@ let generate_managed_class base_ctx tcpp_class =
       in
 
       let sigs =
-        [ "\t::hx::ScriptNamedFunction(0,0,0 HXCPP_CPPIA_SUPER_ARG(0) )" ]
+        [ "\t::hx::ScriptNamedFunction(0,0,0)" ]
         |> List.fold_right (dump_script false) tcpp_class.tcl_functions
         |> List.fold_right (dump_script true) tcpp_class.tcl_static_functions
         |> String.concat ",\n"
       in
 
-      output_cpp "#ifndef HXCPP_CPPIA_SUPER_ARG\n";
-      output_cpp "#define HXCPP_CPPIA_SUPER_ARG(x) ,0\n";
-      output_cpp "#endif\n";
       Printf.sprintf "static ::hx::ScriptNamedFunction __scriptableFunctions[] = {\n%s\n};\n\n" sigs |> output_cpp)
     else
       output_cpp "static ::hx::ScriptNamedFunction *__scriptableFunctions = 0;\n");

--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -1029,7 +1029,7 @@ let generate_managed_class base_ctx tcpp_class =
       in
 
       let sigs =
-        [ "\t::hx::ScriptNamedFunction(0,0,0)" ]
+        [ "\t::hx::ScriptNamedFunction()" ]
         |> List.fold_right (dump_script false) tcpp_class.tcl_functions
         |> List.fold_right (dump_script true) tcpp_class.tcl_static_functions
         |> String.concat ",\n"

--- a/src/generators/cpp/gen/cppGenInterfaceImplementation.ml
+++ b/src/generators/cpp/gen/cppGenInterfaceImplementation.ml
@@ -230,7 +230,7 @@ let generate_managed_interface base_ctx tcpp_interface =
           s |> output_cpp;
       in
       List.iter dump_func sig_and_funcs;
-      output_cpp "\t::hx::ScriptNamedFunction(0,0,0) };\n");
+      output_cpp "\t::hx::ScriptNamedFunction() };\n");
 
     let mapper f = Printf.sprintf "\t%s&%s::%s" (cpp_tfun_signature true f.iff_args f.iff_return) script_name f.iff_name in
     let strings =

--- a/src/generators/cpp/gen/cppGenInterfaceImplementation.ml
+++ b/src/generators/cpp/gen/cppGenInterfaceImplementation.ml
@@ -221,19 +221,16 @@ let generate_managed_interface base_ctx tcpp_interface =
     | _ ->
       let sig_and_funcs = List.map generate_script_function all_functions in
 
-      output_cpp "#ifndef HXCPP_CPPIA_SUPER_ARG\n";
-      output_cpp "#define HXCPP_CPPIA_SUPER_ARG(x)\n";
-      output_cpp "#endif\n";
       output_cpp "static ::hx::ScriptNamedFunction __scriptableFunctions[] = {\n";
       let dump_func (s, func) =
         Printf.sprintf
-          "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", false HXCPP_CPPIA_SUPER_ARG(0)),\n"
+          "\t::hx::ScriptNamedFunction(\"%s\", __s_%s, \"%s\", false),\n"
           func.iff_field.cf_name
           func.iff_field.cf_name
           s |> output_cpp;
       in
       List.iter dump_func sig_and_funcs;
-      output_cpp "\t::hx::ScriptNamedFunction(0,0,0 HXCPP_CPPIA_SUPER_ARG(0) ) };\n");
+      output_cpp "\t::hx::ScriptNamedFunction(0,0,0) };\n");
 
     let mapper f = Printf.sprintf "\t%s&%s::%s" (cpp_tfun_signature true f.iff_args f.iff_return) script_name f.iff_name in
     let strings =

--- a/tests/unit/src/scripthost/Issue12413.hx
+++ b/tests/unit/src/scripthost/Issue12413.hx
@@ -1,0 +1,17 @@
+package scripthost;
+
+#if cpp
+@:keep class HostParent12413 {
+	public function new() {}
+
+	public function methodA() {
+		return "HostParent";
+	}
+}
+
+@:keep class HostChild12413 extends HostParent12413 {
+	override function methodA() {
+		return super.methodA() + ", HostChild";
+	}
+}
+#end

--- a/tests/unit/src/unit/issues/Issue12413.hx
+++ b/tests/unit/src/unit/issues/Issue12413.hx
@@ -1,0 +1,20 @@
+package unit.issues;
+
+import scripthost.Issue12413;
+
+class Issue12413 extends Test {
+	#if cppia
+	public function test() {
+		var child:ScriptChild = new ScriptChild();
+		eq('HostParent, HostChild, ScriptChild', child.methodA());
+	}
+	#end
+}
+
+#if cppia
+private class ScriptChild extends HostChild12413 {
+	override function methodA() {
+		return super.methodA() + ", ScriptChild";
+	}
+}
+#end


### PR DESCRIPTION
#12375 and #12377 reintroduced a bug with super.method calls: https://github.com/HaxeFoundation/hxcpp/issues/1150

This provides an alternative solution to the original issues: #12374 #12376 (and I suppose #5502), by marking methods as overrides so that the cppia runtime can ignore them when constructing the vtable, but still access them for resolving super.method calls (as done in #11773). This requires support from the hxcpp side: https://github.com/HaxeFoundation/hxcpp/pull/1273.

This solves the issue while preserving the fix from #11773. I have added a test here for https://github.com/HaxeFoundation/hxcpp/issues/1150 to avoid further regressions.

See also: https://github.com/HaxeFoundation/haxe/issues/12376#issuecomment-3585980070