### PR TITLE
Make parallelism opt-out again, …

### DIFF
--- a/src-json/define.json
+++ b/src-json/define.json
@@ -91,13 +91,13 @@
 		"name": "EnableParallelAbstractCast",
 		"define": "enable-parallel-abstract-cast",
 		"signatureNeutral": true,
-		"doc": "Enable experimental uses of parallelism in the compiler (abstract cast filter)."
+		"doc": "Enable experimental uses of parallelism in the abstract cast filter (can trigger memory leaks)."
 	},
 	{
 		"name": "EnableParallelAnalyzer",
 		"define": "enable-parallel-analyzer",
 		"signatureNeutral": true,
-		"doc": "Enable experimental uses of parallelism in the compiler (analyzer)."
+		"doc": "Enable experimental uses of parallelism in the analyzer (can trigger memory leaks)."
 	},
 	{
 		"name": "DisableUnicodeStrings",

--- a/src-json/define.json
+++ b/src-json/define.json
@@ -82,10 +82,22 @@
 		"doc": "Disable shortcuts used by hxb cache to speed up display requests."
 	},
 	{
-		"name": "EnableParallelism",
-		"define": "enable-parallelism",
+		"name": "DisableParallelism",
+		"define": "disable-parallelism",
 		"signatureNeutral": true,
-		"doc": "Enable experimental uses of parallelism in the compiler."
+		"doc": "Disable experimental uses of parallelism in the compiler."
+	},
+	{
+		"name": "EnableParallelAbstractCast",
+		"define": "enable-parallel-abstract-cast",
+		"signatureNeutral": true,
+		"doc": "Enable experimental uses of parallelism in the compiler (abstract cast filter)."
+	},
+	{
+		"name": "EnableParallelAnalyzer",
+		"define": "enable-parallel-analyzer",
+		"signatureNeutral": true,
+		"doc": "Enable experimental uses of parallelism in the compiler (analyzer)."
 	},
 	{
 		"name": "DisableUnicodeStrings",

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -270,7 +270,7 @@ module Setup = struct
 end
 
 let check_defines com =
-	if defined com Define.EnableParallelism then Parallel.enable := true;
+	if defined com Define.DisableParallelism then Parallel.enable := false;
 	PMap.iter (fun k v ->
 		try
 			let reason = Hashtbl.find Define.deprecation_lut k in

--- a/src/context/parallel.ml
+++ b/src/context/parallel.ml
@@ -1,4 +1,4 @@
-let enable = ref false
+let enable = ref true
 
 let run_parallel_for num_domains ?(chunk_size=0) length f =
 	if not !enable then begin

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -422,6 +422,8 @@ let run_safe_filters ectx com (scom : SafeCom.t) all_types_array new_types_array
 	let cv_wrapper_impl = com.Common.local_wrapper in
 	let filters_before_inlining = [
 		"handle_abstract_casts",AbstractCast.handle_abstract_casts;
+	] in
+	let filters_before_inlining_parallel = [
 		"local_statics",LocalStatic.run;
 		"fix_return_dynamic_from_void_function",SafeFilters.fix_return_dynamic_from_void_function;
 		"check_local_vars_init",CheckVarInit.check_local_vars_init;
@@ -447,14 +449,20 @@ let run_safe_filters ectx com (scom : SafeCom.t) all_types_array new_types_array
 		"mark_switch_break_loops",SafeFilters.mark_switch_break_loops;
 	] in
 
-	Parallel.ParallelArray.iter pool (SafeCom.run_expression_filters_safe scom detail_times filters_before_inlining) new_types_array;
+	begin
+		let pool = if Common.defined com Define.EnableParallelAbstractCast then pool else None in
+		Parallel.ParallelArray.iter pool (SafeCom.run_expression_filters_safe scom detail_times filters_before_inlining) new_types_array;
+	end;
+	Parallel.ParallelArray.iter pool (SafeCom.run_expression_filters_safe scom detail_times filters_before_inlining_parallel) new_types_array;
 	Dump.maybe_generate_dump com AfterCasting;
 
 	Parallel.ParallelArray.iter pool (SafeCom.run_expression_filters_safe scom detail_times filters_before_analyzer) new_types_array;
 	Dump.maybe_generate_dump com AfterInlining;
 
 	Common.enter_stage com CAnalyzerStart;
-	if scom.platform <> Cross then Analyzer.Run.run_on_types scom pool all_types_array new_types_array;
+	if scom.platform <> Cross then
+		let pool = if Common.defined com Define.EnableParallelAnalyzer then pool else None in
+		Analyzer.Run.run_on_types scom pool all_types_array new_types_array;
 	Dump.maybe_generate_dump com AfterAnalyzing;
 	Common.enter_stage com CAnalyzerDone;
 


### PR DESCRIPTION
… but opt-in for analyzer and abstract casts filter because those are the ones currently leaking when running in parallel..