### PR TITLE
[CI] avoid PHP 8.5 for now

### DIFF
--- a/tests/runci/targets/Php.hx
+++ b/tests/runci/targets/Php.hx
@@ -59,6 +59,7 @@ class Php {
 				Linux.requireAptPackages(["php-cli", "php-mbstring", "php-sqlite3"]);
 			case "Mac":
 				runNetworkCommand("brew", ["install", "php@8.4"]);
+				runCommand("brew", ["link", "--overwrite", "--force", "php@8.4"]);
 			case "Windows":
 				runNetworkCommand("cinst", ["php", "-version", "7.1.8", "-y"]);
 			case _:

--- a/tests/runci/targets/Php.hx
+++ b/tests/runci/targets/Php.hx
@@ -58,7 +58,7 @@ class Php {
 			case "Linux":
 				Linux.requireAptPackages(["php-cli", "php-mbstring", "php-sqlite3"]);
 			case "Mac":
-				runNetworkCommand("brew", ["install", "php"]);
+				runNetworkCommand("brew", ["install", "php@8.4"]);
 			case "Windows":
 				runNetworkCommand("cinst", ["php", "-version", "7.1.8", "-y"]);
 			case _:


### PR DESCRIPTION
Mac CI started failing earlier today because mac runner now uses PHP 8.5 and it doesn't like Haxe generated code..

Dodging for now, as I don't even have PHP 8.5 on my computer yet >_>