### PR TITLE
[hl] Fix hl.Int64 issue with -D hl_legacy32

### DIFF
--- a/std/hl/Api.hx
+++ b/std/hl/Api.hx
@@ -59,7 +59,9 @@ extern class Api {
 	}
 	#end
 	#if (hl_ver >= version("1.16.0"))
+	#if !hl_legacy32
 	@:hlNative("?std", "sys_timestamp_ms") static function timestampMs():haxe.Int64;
+	#end
 	@:hlNative("?std", "sys_resolve_type") static function resolveTypeDyn( t : hl.Type, gt : hl.Type ) : Dynamic;
 	@:hlNative("?std", "sys_load_plugin") private static function _loadPlugin( file : hl.Bytes ) : Bool;
 	static inline function loadPlugin( file : String ) : Bool { return _loadPlugin(@:privateAccess file.bytes); }

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -149,7 +149,7 @@ class BytesIterator<T> extends ArrayIterator<T> {
 		if (tid == Type.get(0))
 			(bytes : Bytes).sortI32(0, length, cast f);
 		else if( tid == Type.get((0:hl.I64)) ) {
-			#if (hl_ver >= version("1.16.0"))
+			#if (hl_ver >= version("1.16.0") && !hl_legacy32)
 			(bytes : Bytes).sortI64(0, length, cast f);
 			#else
 			throw "Array sort I64 requires -D hl-ver=1.16.0";

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -37,7 +37,7 @@ class RunCi {
 			infoMsg('test $test');
 			try {
 				changeDirectory(unitDir);
-				haxelibInstallGit("ncannasse", "utest", "dec118f248649b20abb6148d0e9960ef93556fda", "--always");
+				haxelibInstallGit("haxe-utest", "utest", "8e99ed92b7376f1979f967ad7a729bdde47dae8f", "--always");
 
 				var args = switch (ci) {
 					case null:

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -37,7 +37,7 @@ class RunCi {
 			infoMsg('test $test');
 			try {
 				changeDirectory(unitDir);
-				haxelibInstallGit("haxe-utest", "utest", "8e99ed92b7376f1979f967ad7a729bdde47dae8f", "--always");
+				haxelibInstallGit("haxe-utest", "utest", "--always");
 
 				var args = switch (ci) {
 					case null:


### PR DESCRIPTION
and restore the use of `haxe-utest`.

I don't know how to test it with haxe CI, the error is only in runtime. I just found hashlink's 32 bit CI fail on timeout even with HelloWorld, so I start to try on my machine.

I think we'll drop totally 32 bit one day, but probably not today.