### PR TITLE
Add @:fromNull for abstracts over basic type

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -344,6 +344,12 @@
 		"links": ["https://haxe.org/manual/types-abstract-implicit-casts.html"]
 	},
 	{
+		"name": "FromNull",
+		"metadata": ":fromNull",
+		"doc": "Allows implicit use of `null` as underlying value; static targets will convert it to the default value. For abstracts over basic types only.",
+		"targets": ["TAbstract"]
+	},
+	{
 		"name": "FunctionalInterface",
 		"metadata": ":functionalInterface",
 		"doc": "Mark an interface as a functional interface",

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -90,11 +90,6 @@
 		"parent": "WTyper"
 	},
 	{
-		"name": "WStaticPlatformBasicTypeNull",
-		"doc": "Warns when the compiler replaces `null` with the default value for a basic type on static platforms.",
-		"parent": "WTyper"
-	},
-	{
 		"name": "WClosureCompare",
 		"doc": "Closures are being compared, which might be undefined",
 		"parent": "WTyper"

--- a/src-json/warning.json
+++ b/src-json/warning.json
@@ -90,6 +90,11 @@
 		"parent": "WTyper"
 	},
 	{
+		"name": "WStaticPlatformBasicTypeNull",
+		"doc": "Warns when the compiler replaces `null` with the default value for a basic type on static platforms.",
+		"parent": "WTyper"
+	},
+	{
 		"name": "WClosureCompare",
 		"doc": "Closures are being compared, which might be undefined",
 		"parent": "WTyper"

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -439,7 +439,7 @@ let run_safe_filters ectx com (scom : SafeCom.t) all_types_array new_types_array
 	] in
 
 	let filters_after_analyzer = [
-		"sanitize",(fun scom e -> Sanitize.sanitize scom.SafeCom.platform_config e);
+		"sanitize",(fun scom e -> Sanitize.sanitize scom e);
 		"add_final_return",(fun _ -> if scom.platform_config.pf_add_final_return then AddFinalReturn.add_final_return else (fun e -> e));
 		"RenameVars",(match scom.platform with
 			| Eval -> (fun _ e -> e)

--- a/src/filters/safe/addFieldInits.ml
+++ b/src/filters/safe/addFieldInits.ml
@@ -54,7 +54,7 @@ let add_field_inits cl_path locals scom t =
 			| Some e ->
 				(* This seems a bit expensive, but hopefully constructor expressions aren't that massive. *)
 				let e = RenameVars.run cl_path locals e in
-				let e = Sanitize.sanitize scom.platform_config e in
+				let e = Sanitize.sanitize scom e in
 				let e = if scom.platform_config.pf_add_final_return then AddFinalReturn.add_final_return e else e in
 				cf.cf_expr <- Some e
 			| _ ->

--- a/src/filters/safe/sanitize.ml
+++ b/src/filters/safe/sanitize.ml
@@ -77,7 +77,7 @@ let sanitize_expr config e =
 				(* TODO: this should use get_underlying_type, but we do not have access to Codegen here.  *)
 				| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> loop (apply_params a.a_params tl a.a_this)
 				| _ ->
-					if config != Common.default_config then (* This is atrocious *)
+					if config != Common.default_config then (* This is atrocious; see #12105 *)
 						Error.raise_typing_error ("On static platforms, null can't be used as basic type " ^ s_type (print_context()) e.etype) e.epos
 			in
 			loop e.etype

--- a/src/filters/safe/sanitize.ml
+++ b/src/filters/safe/sanitize.ml
@@ -80,8 +80,7 @@ let sanitize_expr scom e =
 				| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> loop (apply_params a.a_params tl a.a_this)
 				| _ when scom.platform == Cross -> e
 				| _ ->
-					SafeCom.add_warning scom WStaticPlatformBasicTypeNull (Printf.sprintf "On static platforms, `null` can't be used as basic type `%s`; using platform default value instead" (s_type (print_context()) e.etype)) e.epos;
-					{ e with eexpr = TCast (e, Some (module_type_of_type t)) }
+					Error.raise_typing_error ("On static platforms, null can't be used as basic type " ^ s_type (print_context()) e.etype) e.epos
 			in
 			loop e.etype
 		end else e

--- a/src/filters/safe/sanitize.ml
+++ b/src/filters/safe/sanitize.ml
@@ -75,7 +75,7 @@ let sanitize_expr scom e =
 				| TMono _ -> e (* in these cases the null will cast to default value *)
 				| TFun _ -> e (* this is a bit a particular case, maybe flash-specific actually *)
 				| TAbstract(a,tl) when (Meta.has Meta.FromNull a.a_meta) ->
-					{ e with eexpr = TCast (e, Some (module_type_of_type t)) }
+					{ e with eexpr = TCast (e, None) }
 				(* TODO: this should use get_underlying_type, but we do not have access to Codegen here.  *)
 				| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> loop (apply_params a.a_params tl a.a_this)
 				| _ when scom.platform == Cross -> e

--- a/src/filters/safe/sanitize.ml
+++ b/src/filters/safe/sanitize.ml
@@ -72,17 +72,19 @@ let sanitize_expr scom e =
 	| TConst TNull ->
 		if scom.SafeCom.platform_config.pf_static && not (is_nullable e.etype) then begin
 			let rec loop t = match follow t with
-				| TMono _ -> () (* in these cases the null will cast to default value *)
-				| TFun _ -> () (* this is a bit a particular case, maybe flash-specific actually *)
+				| TMono _ -> e (* in these cases the null will cast to default value *)
+				| TFun _ -> e (* this is a bit a particular case, maybe flash-specific actually *)
+				| TAbstract(a,tl) when (Meta.has Meta.FromNull a.a_meta) ->
+					{ e with eexpr = TCast (e, Some (module_type_of_type t)) }
 				(* TODO: this should use get_underlying_type, but we do not have access to Codegen here.  *)
 				| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> loop (apply_params a.a_params tl a.a_this)
-				| _ when scom.platform == Cross -> ()
+				| _ when scom.platform == Cross -> e
 				| _ ->
-					SafeCom.add_warning scom WStaticPlatformBasicTypeNull (Printf.sprintf "On static platforms, `null` can't be used as basic type `%s`; using platform default value instead" (s_type (print_context()) e.etype)) e.epos
+					SafeCom.add_warning scom WStaticPlatformBasicTypeNull (Printf.sprintf "On static platforms, `null` can't be used as basic type `%s`; using platform default value instead" (s_type (print_context()) e.etype)) e.epos;
+					{ e with eexpr = TCast (e, Some (module_type_of_type t)) }
 			in
 			loop e.etype
-		end;
-		e
+		end else e
 	| TBinop (op,e1,e2) ->
 		let swap op1 op2 =
 			let p1, left1 = standard_precedence op1 in

--- a/src/filters/safe/sanitize.ml
+++ b/src/filters/safe/sanitize.ml
@@ -42,7 +42,7 @@ let rec need_parent e =
 	| TCast _ | TThrow _ | TReturn _ | TTry _ | TSwitch _ | TIf _ | TWhile _ | TBinop _ | TContinue | TBreak
 	| TBlock _ | TVar _ | TFunction _ | TUnop _ -> true
 
-let sanitize_expr config e =
+let sanitize_expr scom e =
 	let parent e =
 		match e.eexpr with
 		| TParenthesis _ -> e
@@ -70,15 +70,15 @@ let sanitize_expr config e =
 	in
 	match e.eexpr with
 	| TConst TNull ->
-		if config.PlatformConfig.pf_static && not (is_nullable e.etype) then begin
+		if scom.SafeCom.platform_config.pf_static && not (is_nullable e.etype) then begin
 			let rec loop t = match follow t with
 				| TMono _ -> () (* in these cases the null will cast to default value *)
 				| TFun _ -> () (* this is a bit a particular case, maybe flash-specific actually *)
 				(* TODO: this should use get_underlying_type, but we do not have access to Codegen here.  *)
 				| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) -> loop (apply_params a.a_params tl a.a_this)
+				| _ when scom.platform == Cross -> ()
 				| _ ->
-					if config != Common.default_config then (* This is atrocious; see #12105 *)
-						Error.raise_typing_error ("On static platforms, null can't be used as basic type " ^ s_type (print_context()) e.etype) e.epos
+					SafeCom.add_warning scom WStaticPlatformBasicTypeNull (Printf.sprintf "On static platforms, `null` can't be used as basic type `%s`; using platform default value instead" (s_type (print_context()) e.etype)) e.epos
 			in
 			loop e.etype
 		end;
@@ -194,5 +194,5 @@ let reduce_expr com e =
 	| _ ->
 		e
 
-let rec sanitize config e =
-	sanitize_expr config (reduce_expr config (Type.map_expr (sanitize config) e))
+let rec sanitize scom e =
+	sanitize_expr scom (reduce_expr scom.SafeCom.platform_config (Type.map_expr (sanitize scom) e))

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -1717,7 +1717,7 @@ and eval_expr ctx e =
 			0 (* first reg *)
 		| TNull ->
 			let r = alloc_tmp ctx (to_type ctx e.etype) in
-			op ctx (ONull r);
+			set_default ctx r;
 			r)
 	| TVar (v,e) ->
 		(match e with

--- a/src/optimization/optimizer.ml
+++ b/src/optimization/optimizer.ml
@@ -132,7 +132,7 @@ let reduce_control_flow scom e = match e.eexpr with
 let rec reduce_loop (scom : SafeCom.t) stack e =
 	let e = Type.map_expr (reduce_loop scom stack) e in
 	let reduce_expr = Sanitize.reduce_expr in
-	Sanitize.sanitize_expr scom.platform_config (match e.eexpr with
+	Sanitize.sanitize_expr scom (match e.eexpr with
 	| TCall(e1,el) ->
 		begin match Texpr.skip e1 with
 			| { eexpr = TFunction func } as ef ->

--- a/tests/unit/src/unit/issues/Issue12415.hx
+++ b/tests/unit/src/unit/issues/Issue12415.hx
@@ -8,5 +8,6 @@ class Issue12415 extends Test {
 		eq(true, value == null);
 		eq(false, value != null);
 		eq(true, value.isNull());
+		eq(true, haxe.Int64.isZero((null:Issue12415Abstract)));
 	}
 }

--- a/tests/unit/src/unit/issues/Issue12415.hx
+++ b/tests/unit/src/unit/issues/Issue12415.hx
@@ -8,8 +8,13 @@ class Issue12415 extends Test {
 		eq(true, value == null);
 		eq(false, value != null);
 		eq(true, value.isNull());
+
 		#if static
+		eq(true, (cast value) == 0);
+
+		#if !flash
 		eq(true, haxe.Int64.isZero((null:Issue12415Abstract)));
+		#end
 		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue12415.hx
+++ b/tests/unit/src/unit/issues/Issue12415.hx
@@ -5,7 +5,6 @@ using unit.issues.misc.Issue12415Abstract;
 class Issue12415 extends Test {
 	function test() {
 		var value:Issue12415Abstract = null;
-		eq(#if static haxe.Int64.ofInt(0) #else null #end, value);
 		eq(true, value == null);
 		eq(false, value != null);
 		eq(true, value.isNull());

--- a/tests/unit/src/unit/issues/Issue12415.hx
+++ b/tests/unit/src/unit/issues/Issue12415.hx
@@ -8,6 +8,8 @@ class Issue12415 extends Test {
 		eq(true, value == null);
 		eq(false, value != null);
 		eq(true, value.isNull());
+		#if static
 		eq(true, haxe.Int64.isZero((null:Issue12415Abstract)));
+		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue12415.hx
+++ b/tests/unit/src/unit/issues/Issue12415.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+using unit.issues.misc.Issue12415Abstract;
+
+class Issue12415 extends Test {
+	function test() {
+		var value:Issue12415Abstract = null;
+		eq(#if static haxe.Int64.ofInt(0) #else null #end, value);
+		eq(true, value == null);
+		eq(false, value != null);
+		eq(true, value.isNull());
+	}
+}

--- a/tests/unit/src/unit/issues/misc/Issue12415Abstract.hx
+++ b/tests/unit/src/unit/issues/misc/Issue12415Abstract.hx
@@ -1,0 +1,11 @@
+package unit.issues.misc;
+
+import haxe.Int64;
+
+@:fromNull
+abstract Issue12415Abstract(Int64) from Int64 to Int64 {
+	public inline function isNull() {
+		#if !static if (this == null) return true; #end
+		return haxe.Int64.isZero(this);
+	}
+}

--- a/tests/unit/src/unit/issues/misc/Issue12415Abstract.hx
+++ b/tests/unit/src/unit/issues/misc/Issue12415Abstract.hx
@@ -5,7 +5,7 @@ import haxe.Int64;
 @:fromNull
 abstract Issue12415Abstract(Int64) from Int64 to Int64 {
 	public inline function isNull() {
-		#if !static if (this == null) return true; #end
+		if (abstract == null) return true;
 		return haxe.Int64.isZero(this);
 	}
 }


### PR DESCRIPTION
History is a bit of a mess, but I kept the warning in there to extract it as another PR, if that's something we consider. We will squash all of this anyway.

Allows this:

```haxe
class Test {
	static function main() {
		var value:GuidInt = null;
		trace(value); // 0
		trace(value == null); // true
		trace(value != null); // false
		trace(value.isNull()); // true
	}
}

@:fromNull
abstract GuidInt(haxe.Int64) from haxe.Int64 to haxe.Int64 {
	public inline function isNull() {
		#if !static if (this == null) return true; #end
		return haxe.Int64.isZero(this);
	}
}
```

See #12415