### PR TITLE
[display] Add ?wait:Bool param to server/readClassPaths

### DIFF
--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -332,10 +332,16 @@ let handler =
 			]);
 		);
 		"server/readClassPaths", (fun hctx ->
+			let wait = hctx.jsonrpc#get_opt_param (fun () -> hctx.jsonrpc#get_bool_param "wait") false in
 			hctx.com.callbacks#add_after_init_macros (fun () ->
 				let cc = hctx.display#get_cs#get_context (Define.get_signature hctx.com.defines) in
 				cc#set_initialized true;
 				DisplayToplevel.read_class_paths hctx.com ["init"];
+				if wait then
+					hctx.display#get_cs#run_tasks true (fun task -> match task#get_id with
+						| "explore" :: _ -> true
+						| _ -> false
+					);
 				let files = hctx.display#get_cs#get_files in
 				hctx.send_result (jobject [
 					"files", jint (List.length files)

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -332,7 +332,7 @@ let handler =
 			]);
 		);
 		"server/readClassPaths", (fun hctx ->
-			let wait = hctx.jsonrpc#get_opt_param (fun () -> hctx.jsonrpc#get_bool_param "wait") false in
+			let wait = hctx.jsonrpc#has_params && hctx.jsonrpc#get_opt_param (fun () -> hctx.jsonrpc#get_bool_param "wait") false in
 			hctx.com.callbacks#add_after_init_macros (fun () ->
 				let cc = hctx.display#get_cs#get_context (Define.get_signature hctx.com.defines) in
 				cc#set_initialized true;

--- a/src/core/json/jsonrpc_handler.ml
+++ b/src/core/json/jsonrpc_handler.ml
@@ -14,6 +14,7 @@ class jsonrpc_handler (id,name,params) = object(self)
 
 	method get_id = id
 	method get_method_name = method_name
+	method has_params = match params with JNull -> false | _ -> true
 
 	method raise_haxe_json_error : 'a . haxe_json_error -> 'a = function
 		| MissingField(name,on) -> raise_custom id 1 (Printf.sprintf "Missing param \"%s\" on \"%s\"" name on)

--- a/std/haxe/display/Server.hx
+++ b/std/haxe/display/Server.hx
@@ -31,7 +31,7 @@ class ServerMethods {
 	/**
 		This request is sent from the client to Haxe to explore the class paths. This effectively creates a cache for toplevel completion.
 	**/
-	static inline var ReadClassPaths = new HaxeRequestMethod<NoData, Response<{?files:Int}>>("server/readClassPaths");
+	static inline var ReadClassPaths = new HaxeRequestMethod<ReadClassPathsParams, Response<{?files:Int}>>("server/readClassPaths");
 
 	static inline var Configure = new HaxeRequestMethod<ConfigureParams, Response<NoData>>("server/configure");
 	static inline var Invalidate = new HaxeRequestMethod<FileParams, Response<NoData>>("server/invalidate");
@@ -45,6 +45,12 @@ class ServerMethods {
 	static inline var Type = new HaxeRequestMethod<TypeParams, Response<JsonModuleType<Any>>>("server/type");
 	static inline var Files = new HaxeRequestMethod<ContextParams, Response<Array<JsonServerFile>>>("server/files");
 	static inline var ModuleCreated = new HaxeRequestMethod<FileParams, Response<NoData>>("server/moduleCreated");
+}
+
+/* ReadClassPaths */
+typedef ReadClassPathsParams = {
+	/** Explore classpaths during the request instead of delaying it to a server task **/
+	var ?wait:Bool;
 }
 
 /* Configure */

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -369,7 +369,7 @@ class ServerTests extends TestCase {
 
 	function testSyntaxCache() {
 		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
-		runHaxeJson(["-cp", "."], ServerMethods.ReadClassPaths, null);
+		runHaxeJson(["-cp", "."], ServerMethods.ReadClassPaths, {wait: true});
 		vfs.putContent("Empty.hx", "");
 		runHaxeJson([], ServerMethods.ModuleCreated, {file: new FsPath("Empty.hx")});
 		vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
@@ -401,7 +401,7 @@ class ServerTests extends TestCase {
 	function testSyntaxCache2() {
 		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
 		var args = ["-cp", ".", "--interp"];
-		runHaxeJson(args, ServerMethods.ReadClassPaths, null);
+		runHaxeJson(args, ServerMethods.ReadClassPaths, {wait: true});
 		vfs.putContent("Empty.hx", getTemplate("Empty.hx"));
 		runHaxeJson([] /* No args here because file watchers don't generally know */, ServerMethods.ModuleCreated, {file: new FsPath("Empty.hx")});
 		runHaxeJson(args, DisplayMethods.Completion, {file: new FsPath("HelloWorld.hx"), offset: 75, wasAutoTriggered: false});

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -367,6 +367,18 @@ class ServerTests extends TestCase {
 		});
 	}
 
+	function testReadClassPaths() {
+		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
+		runHaxeJson(["-cp", "."], ServerMethods.ReadClassPaths, null);
+		assertSuccess();
+	}
+
+	function testReadClassPaths2() {
+		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
+		runHaxeJson(["-cp", "."], ServerMethods.ReadClassPaths, {wait: true});
+		assertSuccess();
+	}
+
 	function testSyntaxCache() {
 		vfs.putContent("HelloWorld.hx", getTemplate("HelloWorld.hx"));
 		runHaxeJson(["-cp", "."], ServerMethods.ReadClassPaths, {wait: true});

--- a/tests/server/src/cases/display/issues/Issue8644.hx
+++ b/tests/server/src/cases/display/issues/Issue8644.hx
@@ -6,7 +6,7 @@ class Issue8644 extends DisplayTestCase {
 	function test(_) {
 		vfs.putContent("HelloJvm.hx", getTemplate("HelloJvm.hx"));
 		var args = ["-cp", ".", "--interp"];
-		runHaxeJson(args, ServerMethods.ReadClassPaths, null);
+		runHaxeJson(args, ServerMethods.ReadClassPaths, {wait: true});
 		runHaxeJson(args, DisplayMethods.Completion, {file: new FsPath("HelloJvm.hx"), offset: 55, wasAutoTriggered: false});
 		var completion = parseCompletion();
 		assertHasNoCompletion(completion, module -> switch (module.kind) {

--- a/tests/server/src/cases/display/issues/Issue9082.hx
+++ b/tests/server/src/cases/display/issues/Issue9082.hx
@@ -11,7 +11,7 @@ class Issue9082 extends DisplayTestCase {
 		vfs.putContent("AThing.hx", "class AThing {}");
 		vfs.putContent("ThingB.hx", "class ThingB {}");
 		runHaxeJson(args, Methods.Initialize, {maxCompletionItems: 2});
-		runHaxeJson(args, ServerMethods.ReadClassPaths, null);
+		runHaxeJson(args, ServerMethods.ReadClassPaths, {wait: true});
 
 		var markers = Markers.parse("class C extends Thing{-1-}");
 		vfs.putContent("C.hx", markers.source);

--- a/tests/server/src/cases/issues/Issue8004.hx
+++ b/tests/server/src/cases/issues/Issue8004.hx
@@ -20,7 +20,7 @@ class Issue8004 extends TestCase {
 		var args = output == null ? ["-main", "Empty", target] : ["-main", "Empty", '-$target', 'bin/$output', "--no-output"];
 
 		runHaxe(args);
-		runHaxeJson(args, ServerMethods.ReadClassPaths, null);
+		runHaxeJson(args, ServerMethods.ReadClassPaths, {wait: true});
 		runHaxe(args.concat(["--display", "?@0@workspace-symbols@uint"]));
 
 		var result:Array<SymbolReply> = Json.parse(lastResult.stderr);


### PR DESCRIPTION
Problem: `server/readClassPaths` is executed as a compilation server task, meaning in our tests a race condition can make it happen after the next request, making it fail.