### PR TITLE
Reject abstract operator overloads if nullability doesn't match

### DIFF
--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -479,12 +479,19 @@ let find_abstract_binop_overload ctx op e1 e2 a c tl left is_assign_op p =
 						let monos,t1,t2,tret = map_arguments() in
 						let make e1 e2 = make op_cf cf e1 e2 tret in
 						let t1 = if is_impl then Abstract.follow_with_abstracts t1 else t1 in
+						let check_nullable e t =
+							if is_nullable e.etype <> is_nullable t then raise (Unify_error [])
+							in
 						let e1,e2 = if left || not left && swapped then begin
-							Type.type_eq EqStrict (if is_impl then Abstract.follow_with_abstracts e1.etype else e1.etype) t1;
-							e1,AbstractCast.cast_or_unify_raise ctx t2 e2 p
+							Type.type_eq EqDoNotFollowNull (if is_impl then Abstract.follow_with_abstracts e1.etype else e1.etype) t1;
+							let e2 = AbstractCast.cast_or_unify_raise ctx t2 e2 p in
+							check_nullable e2 t2;
+							e1,e2
 						end else begin
-							Type.type_eq EqStrict e2.etype t2;
-							AbstractCast.cast_or_unify_raise ctx t1 e1 p,e2
+							Type.type_eq EqDoNotFollowNull e2.etype t2;
+							let e1 = AbstractCast.cast_or_unify_raise ctx t1 e1 p in
+							check_nullable e1 t1;
+							e1,e2
 						end in
 						let check_null e t = if is_eq_op then match e.eexpr with
 							| TConst TNull when not (is_explicit_null t) -> raise (Unify_error [])

--- a/src/typing/operators.ml
+++ b/src/typing/operators.ml
@@ -480,20 +480,20 @@ let find_abstract_binop_overload ctx op e1 e2 a c tl left is_assign_op p =
 						let make e1 e2 = make op_cf cf e1 e2 tret in
 						let t1 = if is_impl then Abstract.follow_with_abstracts t1 else t1 in
 						let check_nullable e t =
-							if is_nullable e.etype <> is_nullable t then raise (Unify_error [])
-							in
+							if is_nullable e.etype <> is_nullable t then raise (Unify_error []);
+						in
 						let e1,e2 = if left || not left && swapped then begin
 							Type.type_eq EqDoNotFollowNull (if is_impl then Abstract.follow_with_abstracts e1.etype else e1.etype) t1;
 							let e2 = AbstractCast.cast_or_unify_raise ctx t2 e2 p in
-							check_nullable e2 t2;
+							if is_eq_op then check_nullable e2 t2;
 							e1,e2
 						end else begin
 							Type.type_eq EqDoNotFollowNull e2.etype t2;
 							let e1 = AbstractCast.cast_or_unify_raise ctx t1 e1 p in
-							check_nullable e1 t1;
+							if is_eq_op then check_nullable e1 t1;
 							e1,e2
 						end in
-						let check_null e t = if is_eq_op then match e.eexpr with
+						let check_null e t = match e.eexpr with
 							| TConst TNull when not (is_explicit_null t) -> raise (Unify_error [])
 							| _ -> ()
 						in

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -28,9 +28,6 @@ using haxe.Int64;
 	A cross-platform signed 64-bit integer.
 	Int64 instances can be created from two 32-bit words using `Int64.make()`.
 **/
-#if flash
-@:notNull
-#end
 @:transitive
 abstract Int64(__Int64) from __Int64 to __Int64 {
 	private inline function new(x:__Int64)
@@ -480,7 +477,7 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return x;
 		#end
 	}
-	
+
 	static var IMPL = ___Int64;
 }
 

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -995,7 +995,7 @@ class TestStrict {
 	static function issue8122_abstractOnTopOfNullable() {
 		var x:NullFloat = null;
 		var y:Float = x.val();
-		x += x;
+		x += y;
 	}
 
 	static function issue9649_nullCheckedAbstractShouldUnify_shouldPass() {

--- a/tests/unit/src/unit/issues/Issue12444.hx
+++ b/tests/unit/src/unit/issues/Issue12444.hx
@@ -34,26 +34,6 @@ private abstract NotInt64(Int) {
 	@:op(A != B) public static function neqYesYes(a:Null<NotInt64>, b:Null<NotInt64>):String {
 		return "neqYesYes";
 	}
-
-	@:commutative @:op(A + B) public static function plusNoNo(a:NotInt64, b:Int):String {
-		return "plusNoNo";
-	}
-
-	@:commutative @:op(A + B) public static function plusYesNo(a:Null<NotInt64>, b:Int):String {
-		return "plusYesNo";
-	}
-
-	@:commutative @:op(A + B) public static function plusNoYes(a:NotInt64, b:Null<Int>):String {
-		return "plusNoYes";
-	}
-
-	@:commutative @:op(A + B) public static function plusYesYes(a:Null<NotInt64>, b:Null<Int>):String {
-		return "plusYesYes";
-	}
-
-	public inline function get() {
-		return this;
-	}
 }
 
 class Issue12444 extends Test {
@@ -72,14 +52,5 @@ class Issue12444 extends Test {
 		eq("neqYesNo", nullable != notNullable);
 		eq("neqNoYes", notNullable != nullable);
 		eq("neqNoNo", notNullable != notNullable);
-		// + with @:commutative
-		eq("plusYesYes", nullable + nullableInt);
-		eq("plusYesYes", nullableInt + nullable);
-		eq("plusYesNo", nullable + notNullableInt);
-		eq("plusYesNo", notNullableInt + nullable);
-		eq("plusNoYes", notNullable + nullableInt);
-		eq("plusNoYes", nullableInt + notNullable);
-		eq("plusNoNo", notNullable + notNullableInt);
-		eq("plusNoNo", notNullableInt + notNullable);
 	}
 }

--- a/tests/unit/src/unit/issues/Issue12444.hx
+++ b/tests/unit/src/unit/issues/Issue12444.hx
@@ -1,0 +1,85 @@
+package unit.issues;
+
+@:notNull
+@:fromNull
+private abstract NotInt64(Int) {
+	@:op(A == B) public static function eqNoNo(a:NotInt64, b:NotInt64):String {
+		return "eqNoNo";
+	}
+
+	@:op(A == B) public static function eqYesNo(a:Null<NotInt64>, b:NotInt64):String {
+		return "eqYesNo";
+	}
+
+	@:op(A == B) public static function eqNoYes(a:NotInt64, b:Null<NotInt64>):String {
+		return "eqNoYes";
+	}
+
+	@:op(A == B) public static function eqYesYes(a:Null<NotInt64>, b:Null<NotInt64>):String {
+		return "eqYesYes";
+	}
+
+	@:op(A != B) public static function neqNoNo(a:NotInt64, b:NotInt64):String {
+		return "neqNoNo";
+	}
+
+	@:op(A != B) public static function neqYesNo(a:Null<NotInt64>, b:NotInt64):String {
+		return "neqYesNo";
+	}
+
+	@:op(A != B) public static function neqNoYes(a:NotInt64, b:Null<NotInt64>):String {
+		return "neqNoYes";
+	}
+
+	@:op(A != B) public static function neqYesYes(a:Null<NotInt64>, b:Null<NotInt64>):String {
+		return "neqYesYes";
+	}
+
+	@:commutative @:op(A + B) public static function plusNoNo(a:NotInt64, b:Int):String {
+		return "plusNoNo";
+	}
+
+	@:commutative @:op(A + B) public static function plusYesNo(a:Null<NotInt64>, b:Int):String {
+		return "plusYesNo";
+	}
+
+	@:commutative @:op(A + B) public static function plusNoYes(a:NotInt64, b:Null<Int>):String {
+		return "plusNoYes";
+	}
+
+	@:commutative @:op(A + B) public static function plusYesYes(a:Null<NotInt64>, b:Null<Int>):String {
+		return "plusYesYes";
+	}
+
+	public inline function get() {
+		return this;
+	}
+}
+
+class Issue12444 extends Test {
+	function test() {
+		var nullable:Null<NotInt64> = null;
+		var notNullable:NotInt64 = null;
+		var nullableInt:Null<Int> = null;
+		var notNullableInt:Int = 0;
+		// ==
+		eq("eqYesYes", nullable == nullable);
+		eq("eqYesNo", nullable == notNullable);
+		eq("eqNoYes", notNullable == nullable);
+		eq("eqNoNo", notNullable == notNullable);
+		// !=
+		eq("neqYesYes", nullable != nullable);
+		eq("neqYesNo", nullable != notNullable);
+		eq("neqNoYes", notNullable != nullable);
+		eq("neqNoNo", notNullable != notNullable);
+		// + with @:commutative
+		eq("plusYesYes", nullable + nullableInt);
+		eq("plusYesYes", nullableInt + nullable);
+		eq("plusYesNo", nullable + notNullableInt);
+		eq("plusYesNo", notNullableInt + nullable);
+		eq("plusNoYes", notNullable + nullableInt);
+		eq("plusNoYes", nullableInt + notNullable);
+		eq("plusNoNo", notNullable + notNullableInt);
+		eq("plusNoNo", notNullableInt + notNullable);
+	}
+}


### PR DESCRIPTION
The idea here is to resolve abstract operator overloads only if the nullability of the expression type matches the nullability of the argument.

Not ready yet, I just need an issue number for tests.