### PR TITLE
Null coalescing null value fix

### DIFF
--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -405,7 +405,9 @@ let rec process_condition mode condition (is_nullable_expr:texpr->bool) callback
 			| TBinop (OpBoolAnd, left_expr, right_expr) when not positive ->
 				List.iter
 					(fun e ->
-						let _, not_nulls = process_condition mode left_expr is_nullable_expr callback in
+						let _, not_nulls =
+							process_condition mode left_expr is_nullable_expr callback
+						in
 						List.iter (add true) not_nulls
 					)
 					[left_expr; right_expr]
@@ -834,7 +836,9 @@ class local_safety (mode:safety_mode) =
 				| TWhile (condition, body, DoWhile) ->
 					let original_safe_locals = self#get_safe_locals_copy in
 					condition_callback condition;
-					let (_, not_nulls) = process_condition mode condition is_nullable_expr (fun _ -> ()) in
+					let (_, not_nulls) =
+						process_condition mode condition is_nullable_expr (fun _ -> ())
+					in
 					body_callback
 						(fun () ->
 							List.iter
@@ -850,7 +854,9 @@ class local_safety (mode:safety_mode) =
 						body
 				| TWhile (condition, body, NormalWhile) ->
 					condition_callback condition;
-					let (nulls, not_nulls) = process_condition mode condition is_nullable_expr (fun _ -> ()) in
+					let (nulls, not_nulls) =
+						process_condition mode condition is_nullable_expr (fun _ -> ())
+					in
 					let original_safe = self#get_safe_locals_copy in
 					(** execute `body` with known not-null variables *)
 					List.iter self#get_current_scope#add_to_safety not_nulls;
@@ -1105,10 +1111,6 @@ class expr_checker mode immediate_execution report =
 					let is_nullable = traverse exprs in
 					local_safety#scope_closed;
 					is_nullable
-					(* (match exprs with
-						| [] -> false
-						| _ -> self#is_nullable_expr (List.hd (List.rev exprs))
-					) *)
 				| TIf _ ->
 					let nullable = ref false in
 					let check body = nullable := !nullable || self#is_nullable_expr body in

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1764,7 +1764,7 @@ and type_expr ?(mode=MGet) ctx (e,p) (with_type:WithType.t) =
 			| TAbstract({a_path = [],"Null"},[t]) -> tmin
 			| _ -> follow_without_type tmin
 		in
-		let e1_null_t = if is_nullable e1.etype then e1.etype else ctx.t.tnull e1.etype in
+		let e1_null_t = ctx.t.tnull e1.etype in
 		let var_name = match WithType.get_expected_name with_type with
 			| None
 			(* TODO: why does this happen? *)

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -315,14 +315,89 @@ class TestStrict {
 	static function ternary_nullableElse_assignToNotNullableValue_shouldFail() {
 		var v:Null<String> = null;
 		var a:String;
-		shouldFail((true ? 'hello' : v).length);
+		shouldFail((false ? 'hello' : v).length);
 	}
 
 	static function inlineCallWithNullArg_shouldFail() {
 		inline function check(value: Int): Int {
+			value++;
 			return value;
 		}
 		shouldFail(check((null : Null<Int>)));
+		var foo:Null<Int> = null;
+		shouldFail(check(foo));
+		final v:Int = shouldFail(check(foo));
+	}
+
+	static function fancyInlineCallWithNullArg_shouldFail() {
+		inline function check(value: Int): Int {
+			badInit = cast value;
+			return value;
+		}
+		shouldFail(check((null : Null<Int>)));
+		var foo:Null<Int> = null;
+		// different error range for some fancy reason
+		#if (js_es >= 6)
+		shouldFail(final v:Int = check(foo));
+		#else
+		final v:Int = shouldFail(check(foo));
+		#end
+		// don't know how to detect fancy inline yet
+		// shouldFail(check(foo));
+	}
+
+
+	static var anyNotNull:Any = "";
+
+	static function inlineCallWithNullArg2_shouldFail() {
+		anyNotNull = shouldFail(pathRelativeToRoot(null));
+	}
+
+	static inline function pathRelativeToRoot(uri:String):String {
+		return eatNotNulls(uri);
+	}
+
+	static function eatNotNulls(s:String):String {
+		return s;
+	}
+
+	static function nullCoal_onNull_shouldPass():Void {
+		var a:String = null ?? "";
+		var b = null ?? "";
+		var c:String = b;
+	}
+
+	static function constants_shouldPass():Void {
+		// var a:String = null == null ? "" : null;
+		// var b:Int = true ? 0 : null;
+		// var c:Int = (false) ? null : 0;
+	}
+
+	static function constants_shouldFail():Void {
+		shouldFail(var a:String = null == null ? null : "");
+		shouldFail(var b:Int = false ? 0 : null);
+		shouldFail(var c:Int = true ? null : 0);
+	}
+
+	static function nullCoal_onNullField_shouldPass():Void {
+		final object:{field:Null<String>} = {field: null};
+		final notOk:String = (Std.random(0) == 0 ? object.field : object.field) ?? "";
+	}
+
+	static function nullCoal_returnNull_shouldPass(?foo:String):Null<String> {
+		final name = foo ?? cast return null;
+		final name2 = foo ?? return null;
+		var s:String = name;
+		var s2:String = name2;
+		return s;
+	}
+
+	function objIterationAfterNullCheck_shouldPass(result:{?leaks:Array<String>}):Void {
+		if (result.leaks != null) {
+			for (leak in result.leaks) {
+				final v:String = leak;
+			}
+		}
 	}
 
 	static function ternary_returnedFromInlinedFunction_shouldPass() {
@@ -549,6 +624,12 @@ class TestStrict {
 		}
 		//function execution will continue only if `b` is not null
 		var s:String = b;
+	}
+
+	static function checkAgainstNull_deadEndTernary_shouldPass():Void {
+		var nullable:Null<Int> = null;
+		var a:Int = nullable == null ? return : nullable;
+		var b:Int = nullable;
 	}
 
 	static function checkAgainstNull_deadEndOfLoop_shouldPassAfterCheckedBlock(?a:String, ?b:String) {
@@ -1163,13 +1244,13 @@ abstract NullFloat(Null<Float>) from Null<Float> to Null<Float> {
 }
 
 class BinopFlow {
-	function ifAndTrue_shoudPass(?a:Int):Void {
+	function ifAndTrue_shouldPass(?a:Int):Void {
 		if (a == null) return;
 		if (a == 2 && true) {}
 		a++;
 	}
 
-	function ifOrTrue_shoudPass(?a:Int):Void {
+	function ifOrTrue_shouldPass(?a:Int):Void {
 		if (a == null) return;
 		if (a == null || true) {}
 		a++;

--- a/tests/nullsafety/src/cases/TestStrictThreaded.hx
+++ b/tests/nullsafety/src/cases/TestStrictThreaded.hx
@@ -8,4 +8,14 @@ class TestStrictThreaded {
 			shouldFail(var notNullable:String = o.field);
 		}
 	}
+
+	function objIterationAfterNullCheck_shouldFail(result:{?leaks:Array<String>}):Void {
+		if (result.leaks != null) {
+			shouldFail(shouldFail(
+				for (leak in result.leaks) {
+					final v:String = leak;
+				}
+			));
+		}
+	}
 }


### PR DESCRIPTION
Actual fix in typer.ml, i think temp var should be typed as `Null<T>` since it looks like this for null safety filter:
```haxe
var notOk = @:mergeBlock {
	var notOk = { // :String = null gives error
		null2;
	};
	if (notOk != null) notOk else {
		"";
	};
};
```

I also added more tests while testing vshaxe and did minor formatting changes.

I also made `constants_shouldPass` test work locally, but not sure if this analysis really useful, it's a bit annoying to traverse around `0 == MY_CONST ? always_true : null`, when condition operands should be extracted from parentheses.

Closes https://github.com/HaxeFoundation/haxe/issues/12445