### PR TITLE
[cpp] Un-dynamic zip implementation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -667,7 +667,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ~/hxcache
+      # HXCPP_COMPILE_CACHE: ~/hxcache
       ARCH: 64
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -667,7 +667,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows64
       TEST: ${{matrix.target}}
-      # HXCPP_COMPILE_CACHE: ~/hxcache
+      HXCPP_COMPILE_CACHE: ~/hxcache
       ARCH: 64
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,7 +218,7 @@ jobs:
     env:
       PLATFORM: linux64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
+      HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PLATFORM: linux64
-      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
+      HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
     steps:
       - uses: actions/checkout@main
         with:
@@ -465,7 +465,7 @@ jobs:
     env:
       PLATFORM: linux-arm64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
+      HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
@@ -667,7 +667,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
+      HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
       ARCH: 64
     strategy:
       fail-fast: false
@@ -801,7 +801,7 @@ jobs:
     env:
       PLATFORM: mac-universal
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
+      HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,7 +369,7 @@ jobs:
           haxelib git hxtemplo https://github.com/Simn/hxtemplo.git
           haxelib git hxargs https://github.com/Simn/hxargs.git
           haxelib git markdown https://github.com/dpeek/haxe-markdown.git
-          haxelib git hxcpp https://github.com/Aidan63/hxcpp.git typed-zip
+          haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git
           cd $(haxelib libpath hxcpp)/tools/hxcpp
           haxe compile.hxml
           cd -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -369,7 +369,7 @@ jobs:
           haxelib git hxtemplo https://github.com/Simn/hxtemplo.git
           haxelib git hxargs https://github.com/Simn/hxargs.git
           haxelib git markdown https://github.com/dpeek/haxe-markdown.git
-          haxelib git hxcpp https://github.com/HaxeFoundation/hxcpp.git
+          haxelib git hxcpp https://github.com/Aidan63/hxcpp.git typed-zip
           cd $(haxelib libpath hxcpp)/tools/hxcpp
           haxe compile.hxml
           cd -

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,7 +218,7 @@ jobs:
     env:
       PLATFORM: linux64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ~/hxcache
+      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
@@ -304,7 +304,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PLATFORM: linux64
-      HXCPP_COMPILE_CACHE: ~/hxcache
+      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
     steps:
       - uses: actions/checkout@main
         with:
@@ -465,7 +465,7 @@ jobs:
     env:
       PLATFORM: linux-arm64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ~/hxcache
+      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
@@ -667,7 +667,7 @@ jobs:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       PLATFORM: windows64
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ~/hxcache
+      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
       ARCH: 64
     strategy:
       fail-fast: false
@@ -801,7 +801,7 @@ jobs:
     env:
       PLATFORM: mac-universal
       TEST: ${{matrix.target}}
-      HXCPP_COMPILE_CACHE: ~/hxcache
+      HXCPP_COMPILE_CACHE: ${{ runner.temp }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false

--- a/std/cpp/_std/haxe/zip/Compress.hx
+++ b/std/cpp/_std/haxe/zip/Compress.hx
@@ -19,53 +19,41 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package haxe.zip;
 
-@:coreApi @:buildXml('<include name="${HXCPP}/src/hx/libs/zlib/Build.xml" />')
-class Compress {
-	var s:Dynamic;
+import haxe.io.Bytes;
+using cpp.marshal.ViewExtensions;
 
-	public function new(level:Int):Void {
-		s = _deflate_init(level);
+@:coreApi class Compress {
+	private final impl : cpp.zip.Compress;
+
+	public function new(level:Int) {
+		impl = cpp.zip.Compress.create(level);
 	}
 
 	public function execute(src:haxe.io.Bytes, srcPos:Int, dst:haxe.io.Bytes, dstPos:Int):{done:Bool, read:Int, write:Int} {
-		return _deflate_buffer(s, src.getData(), srcPos, dst.getData(), dstPos);
+		final srcView = src.asView().slice(srcPos);
+		final dstView = dst.asView().slice(dstPos);
+		final result  = impl.execute(srcView, dstView);
+
+		return { write : result.write, read : result.read, done : result.done }
 	}
 
 	public function setFlushMode(f:FlushMode):Void {
-		_set_flush_mode(s, Std.string(f));
+		impl.setFlushMode(switch f {
+			case NO: cpp.zip.Flush.None;
+			case SYNC: cpp.zip.Flush.Sync;
+			case FULL: cpp.zip.Flush.Full;
+			case FINISH: cpp.zip.Flush.Finish;
+			case BLOCK: cpp.zip.Flush.Block;
+		});
 	}
 
 	public function close():Void {
-		_deflate_end(s);
+		impl.close();
 	}
 
 	public static function run(s:haxe.io.Bytes, level:Int):haxe.io.Bytes {
-		var c = new Compress(level);
-		c.setFlushMode(FlushMode.FINISH);
-		var out = haxe.io.Bytes.alloc(_deflate_bound(c.s, s.length));
-		var r = c.execute(s, 0, out, 0);
-		c.close();
-		if (!r.done || r.read != s.length)
-			throw "Compression failed";
-		return out.sub(0, r.write);
+		return Bytes.ofData(cpp.zip.Compress.run(s.asView(), level));
 	}
-
-	@:native("_hx_deflate_init")
-	extern static function _deflate_init(level:Int):Dynamic;
-
-	@:native("_hx_deflate_bound")
-	extern static function _deflate_bound(handle:Dynamic, length:Int):Int;
-
-	@:native("_hx_deflate_buffer")
-	extern static function _deflate_buffer(handle:Dynamic, src:haxe.io.BytesData, srcPos:Int, dest:haxe.io.BytesData,
-		destPos:Int):{done:Bool, read:Int, write:Int};
-
-	@:native("_hx_deflate_end")
-	extern static function _deflate_end(handle:Dynamic):Void;
-
-	@:native("_hx_zip_set_flush_mode")
-	extern static function _set_flush_mode(handle:Dynamic, flushMode:String):Void;
 }

--- a/std/cpp/zip/Compress.hx
+++ b/std/cpp/zip/Compress.hx
@@ -19,7 +19,20 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package cpp.zip;
 
-typedef Compress = haxe.zip.Compress;
+import haxe.io.BytesData;
+import cpp.marshal.View;
+import cpp.UInt8;
+
+@:buildXml('<include name="${HXCPP}/src/hx/zip/Build.xml" />')
+@:include('hx/zip/Compress.hpp')
+@:cpp.ManagedType({ namespace : [ 'hx', 'zip' ], flags : [ StandardNaming ] })
+extern final class Compress {
+	static function create(level:Int):Compress;
+	static function run(src:View<UInt8>, level:Int):BytesData;
+
+	function execute(src:View<UInt8>, dst:View<UInt8>):Result;
+	function setFlushMode(mode:Flush):Void;
+	function close():Void;
+}

--- a/std/cpp/zip/Flush.hx
+++ b/std/cpp/zip/Flush.hx
@@ -19,7 +19,15 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package cpp.zip;
 
-typedef Flush = haxe.zip.FlushMode;
+@:semantics(value)
+@:include('hx/zip/Zip.hpp')
+@:cpp.ValueType({ namespace : [ 'hx', 'zip' ] })
+extern enum abstract Flush(Int) {
+	var None;
+	var Sync;
+	var Full;
+	var Finish;
+	var Block;
+}

--- a/std/cpp/zip/Result.hx
+++ b/std/cpp/zip/Result.hx
@@ -19,41 +19,13 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-package haxe.zip;
+package cpp.zip;
 
-import haxe.io.Bytes;
-using cpp.marshal.ViewExtensions;
-
-@:coreApi class Uncompress {
-	private final impl : cpp.zip.Uncompress;
-
-	public function new(?windowBits:Int):Void {
-		impl = cpp.zip.Uncompress.create(windowBits ?? 15);
-	}
-
-	public function execute(src:haxe.io.Bytes, srcPos:Int, dst:haxe.io.Bytes, dstPos:Int):{done:Bool, read:Int, write:Int} {
-		final srcView = src.asView().slice(srcPos);
-		final dstView = dst.asView().slice(dstPos);
-		final result  = impl.execute(srcView, dstView);
-
-		return { write : result.write, read : result.read, done : result.done }
-	}
-
-	public function setFlushMode(f:FlushMode):Void {
-		impl.setFlushMode(switch f {
-			case NO: cpp.zip.Flush.None;
-			case SYNC: cpp.zip.Flush.Sync;
-			case FULL: cpp.zip.Flush.Full;
-			case FINISH: cpp.zip.Flush.Finish;
-			case BLOCK: cpp.zip.Flush.Block;
-		});
-	}
-
-	public function close():Void {
-		impl.close();
-	}
-
-	public static function run(src:haxe.io.Bytes, ?bufsize:Int):haxe.io.Bytes {
-		return Bytes.ofData(cpp.zip.Uncompress.run(src.asView(), bufsize ?? 1 << 16));
-	}
+@:semantics(value)
+@:cpp.ValueType({ namespace : [ 'hx', 'zip' ] })
+@:include('hx/zip/Zip.hpp')
+extern final class Result {
+	final done : Bool;
+	final read : Int;
+	final write : Int;
 }

--- a/std/cpp/zip/Uncompress.hx
+++ b/std/cpp/zip/Uncompress.hx
@@ -19,7 +19,20 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-
 package cpp.zip;
 
-typedef Uncompress = haxe.zip.Uncompress;
+import haxe.io.BytesData;
+import cpp.marshal.View;
+import cpp.UInt8;
+
+@:buildXml('<include name="${HXCPP}/src/hx/zip/Build.xml" />')
+@:include('hx/zip/Uncompress.hpp')
+@:cpp.ManagedType({ namespace : [ 'hx', 'zip' ], flags : [ StandardNaming ] })
+extern final class Uncompress {
+	static function create(windowSize:Int):Uncompress;
+	static function run(src:View<UInt8>, bufferSize:Int):BytesData;
+
+	function execute(src:View<UInt8>, dst:View<UInt8>):Result;
+	function setFlushMode(mode:Flush):Void;
+	function close():Void;
+}

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -27,7 +27,7 @@ class Cpp {
 			final path = getHaxelibPath("hxcpp");
 			infoMsg('hxcpp has already been installed in $path.');
 		} catch(e:Dynamic) {
-			haxelibInstallGit("HaxeFoundation", "hxcpp", true);
+			haxelibInstallGit("Aidan63", "hxcpp", "typed-zip", true);
 			final oldDir = Sys.getCwd();
 			changeDirectory(getHaxelibPath("hxcpp") + "tools/hxcpp/");
 			runCommand("haxe", ["-D", "source-header=''", "compile.hxml"]);

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -27,7 +27,7 @@ class Cpp {
 			final path = getHaxelibPath("hxcpp");
 			infoMsg('hxcpp has already been installed in $path.');
 		} catch(e:Dynamic) {
-			haxelibInstallGit("Aidan63", "hxcpp", "typed-zip", true);
+			haxelibInstallGit("HaxeFoundation", "hxcpp", true);
 			final oldDir = Sys.getCwd();
 			changeDirectory(getHaxelibPath("hxcpp") + "tools/hxcpp/");
 			runCommand("haxe", ["-D", "source-header=''", "compile.hxml"]);


### PR DESCRIPTION
I mentioned in the marshalling type PR that `cpp.ManagedType` externs could be used to un-dynamic much of the cpp std implementation, so here's an example of this using the zip api since it's relatively small.

The changes here are realtively small, mostly forwarding calls into a new typed extern which contains the hxcpp implementation. I'm using the new `View` type in the cpp signature to allow passing any data, not just haxe arrays, to the underlying implementation.

More info on the hxcpp side can be found in it's PR: https://github.com/HaxeFoundation/hxcpp/pull/1277

Again, I've changed the ci to use my fork just to show the tests, since this is a bit of a chicken and the egg problem.

Assuming this goes well slowly un-dynamicing the entire cpp std is something which can now be done.