### PR TITLE
[null-safety] Check structures and better errors

### DIFF
--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -24,12 +24,18 @@ type scope_type =
 	(* A closure which gets executed along the "normal" program flow without being delayed or stored somewhere *)
 	| STImmediateClosure
 
-type safety_unify_error =
-	| NullSafetyError
+type unificator_ctx =
+	| None
+	| Field of string
+	| Arg of int * int
+	| Return
 
-exception Safety_error of safety_unify_error
+exception Safety_unify_error of t * t * unificator_ctx
 
-let safety_error () : unit = raise (Safety_error NullSafetyError)
+(**
+	Shadow Type.error to avoid raising unification errors, which should not be raised from null-safety checks
+*)
+let safety_error a b (ctx : unificator_ctx) : unit = raise (Safety_unify_error (a, b, ctx))
 
 type safety_mode =
 	| SMOff
@@ -222,16 +228,24 @@ class unificator =
 			Check if it's possible to pass a value of type `a` to a place where a value of type `b` is expected.
 			Raises `Safety_error` exception if it's not.
 		*)
-		method unify a b =
+		method unify ?(uctx: unificator_ctx = None) a b =
 			if a == b then
 				()
 			else
 				match a, b with
+					(* if b (to_type) is nullable anon, we still need to check fields nullability *)
+					| TAbstract ({ a_path = ([],"Null") },[TAnon a_anon ]),
+						TAbstract ({ a_path = ([],"Null") },[TAnon b_anon ])
+					| TAnon a_anon, TAbstract ({ a_path = ([],"Null") },[TAnon b_anon ]) ->
+						self#unify_anon_to_anon a_anon b_anon
+					| TInst (a_cls, a_params), TAbstract ({ a_path = ([],"Null") },[TAnon b_anon ]) ->
+						self#unify_class_to_anon a_cls a_params b_anon
+
 					(* if `b` is nullable, no more checks needed *)
 					| _, TAbstract ({ a_path = ([],"Null") },[t]) ->
 						()
 					| TAbstract ({ a_path = ([],"Null") },[t]), _ when not (is_nullable_type b) ->
-						safety_error()
+						safety_error a b uctx
 					| TInst (_, a_params), TInst(_, b_params) when (List.length a_params) = (List.length b_params) ->
 						List.iter2 self#unify a_params b_params
 					| TAnon a_anon, TAnon b_anon ->
@@ -285,7 +299,8 @@ class unificator =
 					in
 					match a_field with
 						| None -> ()
-						| Some a_field -> self#unify a_field.cf_type b_field.cf_type
+						| Some a_field ->
+							self#unify a_field.cf_type b_field.cf_type ~uctx: (Field name)
 				)
 				b.a_fields
 
@@ -300,7 +315,7 @@ class unificator =
 						| None -> ()
 						| Some a_field ->
 							let a_type = apply_params a.cl_params a_params a_field.cf_type in
-							self#unify a_type b_field.cf_type
+							self#unify a_type b_field.cf_type ~uctx: (Field name)
 				)
 				b.a_fields
 
@@ -308,17 +323,18 @@ class unificator =
 			(* check return type *)
 			(match b_result with
 				| TAbstract ({ a_path = ([], "Void") }, []) -> ()
-				| _ -> self#unify a_result b_result;
+				| _ -> self#unify a_result b_result ~uctx: Return;
 			);
+			let a_args_len = List.length a_args in
 			(* check arguments *)
-			let rec traverse a_args b_args =
+			let rec traverse i a_args b_args =
 				match a_args, b_args with
 					| [], _ | _, [] -> ()
 					| (_, _, a_arg) :: a_rest, (_, _, b_arg) :: b_rest ->
-						self#unify b_arg a_arg;
-						traverse a_rest b_rest
+						self#unify b_arg a_arg ~uctx: (Arg (i + 1, a_args_len));
+						traverse (i + 1) a_rest b_rest
 			in
-			traverse a_args b_args
+			traverse 0 a_args b_args
 	end
 
 (**
@@ -341,11 +357,6 @@ let rec unfold_null t =
 		| TLazy f -> unfold_null (lazy_type f)
 		| TType (t,tl) -> unfold_null (apply_typedef t tl)
 		| _ -> t
-
-(**
-	Shadow Type.error to avoid raising unification errors, which should not be raised from null-safety checks
-*)
-let safety_error () : unit = raise (Safety_error NullSafetyError)
 
 let accessed_field_name access =
 	match access with
@@ -1138,32 +1149,35 @@ class expr_checker mode immediate_execution report =
 					false
 				else begin
 					let expr_type = unfold_null expr.etype in
-					let errors = ref [] in
-					self#check_anon_to_anon
-						(fun field_name expr_field_type to_field_type ->
-							errors := Invalid_field_type field_name :: !errors;
-							errors := Cannot_unify(expr_field_type, to_field_type) :: !errors
-						)
-						expr_type to_type;
-
-					if !errors <> [] then begin
-						self#error_unify (List.rev !errors) p;
-						(* returning `true` because error is already logged in the line above *)
+					try
+						new unificator#unify expr_type to_type;
 						true
-					end
-					else begin
-						try
-							new unificator#unify expr_type to_type;
+					with
+						| Safety_unify_error (expr_type, to_type, ctx) ->
+							let errors = match ctx with
+								| None ->
+									[Cannot_unify(expr_type, to_type)]
+								| Field field ->
+									[
+										Invalid_field_type field;
+										Cannot_unify(expr_type, to_type)
+									]
+								| Arg (i, total) ->
+									[
+										Invalid_function_argument (i, total);
+										Cannot_unify(expr_type, to_type)
+									]
+								| Return ->
+									[
+										Invalid_return_type;
+										Cannot_unify(expr_type, to_type)
+									]
+							in
+							self#error_unify errors p;
+							(* returning `true` because error is already logged in the line above *)
 							true
-						with
-							| Safety_error _ ->
-								let errors = [Cannot_unify(expr_type, to_type)] in
-								self#error_unify errors p;
-								(* returning `true` because error is already logged in the line above *)
-								true
-							| e ->
-								fail ~msg:"Null safety unification failure" expr.epos __POS__
-					end
+						| e ->
+							fail ~msg:"Null safety unification failure" expr.epos __POS__
 				end
 			in
 			let check_anon_fields fields to_type =
@@ -1189,30 +1203,6 @@ class expr_checker mode immediate_execution report =
 							| _ -> try_unify expr to_type
 					)
 				| _, _ -> try_unify expr to_type
-
-		method check_anon_to_anon report_error expr_type to_type =
-			let check_field anon name to_field =
-				try
-					let expr_field = PMap.find name anon.a_fields in
-					(* let field_path = if path = "" then name else path ^ "." ^ name in *)
-
-					if is_nullable_type expr_field.cf_type && not (is_nullable_type to_field.cf_type) then
-						report_error name expr_field.cf_type to_field.cf_type;
-
-					self#check_anon_to_anon report_error expr_field.cf_type to_field.cf_type
-				with Not_found -> ()
-			in
-			match unfold_null expr_type, unfold_null to_type with
-				| TAnon anon, TAnon to_anon ->
-					PMap.iter
-						(fun name to_field -> check_field anon name to_field)
-					to_anon.a_fields
-				| TAnon anon, TInst (cl, _) ->
-					PMap.iter
-						(fun name to_field -> check_field anon name to_field)
-					cl.cl_fields
-				| _ -> ()
-
 
 		(**
 			Should be called for the root expressions of a method or for then initialization expressions of fields.
@@ -1589,7 +1579,7 @@ class class_checker cls immediate_execution report (main_expr : texpr option) =
 	object (self)
 			val is_safe_class = (safety_enabled cls_meta)
 			val mutable checker = new expr_checker SMLoose immediate_execution report
-			val mutable mode = None
+			val mutable mode : safety_mode option = None
 		(**
 			Entry point for checking a class
 		*)

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1174,7 +1174,7 @@ class expr_checker mode immediate_execution report =
 						if not (self#can_pass_expr field_expr field_to_type.cf_type field_pos) then
 							self#error "Cannot assign nullable value here." [field_pos];
 						acc && true
-					with Not_found -> false) true fields
+					with Not_found -> true) true fields
 			in
 			match expr.eexpr, to_type with
 				| TLocal v, _ when contains_unsafe_meta v.v_meta -> true

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -1,6 +1,7 @@
 open Globals
 open Ast
 open Type
+open Error
 
 type safety_message = {
 	sm_msg : string;
@@ -1078,6 +1079,12 @@ class expr_checker mode immediate_execution report =
 				in
 				add_error report msg (get_first_valid_pos positions)
 			end
+
+		method error_unify (trace:unify_error list) p =
+			if not is_pretending then begin
+				let msg = (BetterErrors.better_error_message trace) in
+				add_error report msg p
+			end
 		(**
 			Check if `e` is nullable even if the type is reported not-nullable.
 			Haxe type system lies sometimes.
@@ -1131,16 +1138,32 @@ class expr_checker mode immediate_execution report =
 					false
 				else begin
 					let expr_type = unfold_null expr.etype in
-					try
-						new unificator#unify expr_type to_type;
+					let errors = ref [] in
+					self#check_anon_to_anon
+						(fun field_name expr_field_type to_field_type ->
+							errors := Invalid_field_type field_name :: !errors;
+							errors := Cannot_unify(expr_field_type, to_field_type) :: !errors
+						)
+						expr_type to_type;
+
+					if !errors <> [] then begin
+						self#error_unify (List.rev !errors) p;
+						(* returning `true` because error is already logged in the line above *)
 						true
-					with
-						| Safety_error err ->
-							self#error ("Cannot unify " ^ (str_type expr_type) ^ " with " ^ (str_type to_type)) [p; expr.epos];
-							(* returning `true` because error is already logged in the line above *)
+					end
+					else begin
+						try
+							new unificator#unify expr_type to_type;
 							true
-						| e ->
-							fail ~msg:"Null safety unification failure" expr.epos __POS__
+						with
+							| Safety_error _ ->
+								let errors = [Cannot_unify(expr_type, to_type)] in
+								self#error_unify errors p;
+								(* returning `true` because error is already logged in the line above *)
+								true
+							| e ->
+								fail ~msg:"Null safety unification failure" expr.epos __POS__
+					end
 				end
 			in
 			let check_anon_fields fields to_type =
@@ -1166,6 +1189,31 @@ class expr_checker mode immediate_execution report =
 							| _ -> try_unify expr to_type
 					)
 				| _, _ -> try_unify expr to_type
+
+		method check_anon_to_anon report_error expr_type to_type =
+			let check_field anon name to_field =
+				try
+					let expr_field = PMap.find name anon.a_fields in
+					(* let field_path = if path = "" then name else path ^ "." ^ name in *)
+
+					if is_nullable_type expr_field.cf_type && not (is_nullable_type to_field.cf_type) then
+						report_error name expr_field.cf_type to_field.cf_type;
+
+					self#check_anon_to_anon report_error expr_field.cf_type to_field.cf_type
+				with Not_found -> ()
+			in
+			match unfold_null expr_type, unfold_null to_type with
+				| TAnon anon, TAnon to_anon ->
+					PMap.iter
+						(fun name to_field -> check_field anon name to_field)
+					to_anon.a_fields
+				| TAnon anon, TInst (cl, _) ->
+					PMap.iter
+						(fun name to_field -> check_field anon name to_field)
+					cl.cl_fields
+				| _ -> ()
+
+
 		(**
 			Should be called for the root expressions of a method or for then initialization expressions of fields.
 		*)

--- a/src/typing/nullSafety.ml
+++ b/src/typing/nullSafety.ml
@@ -24,18 +24,14 @@ type scope_type =
 	(* A closure which gets executed along the "normal" program flow without being delayed or stored somewhere *)
 	| STImmediateClosure
 
-type unificator_ctx =
-	| None
-	| Field of string
-	| Arg of int * int
-	| Return
+type access_kind = BetterErrors.access_kind
 
-exception Safety_unify_error of t * t * unificator_ctx
+exception Safety_unify_error of t * t * access_kind
 
 (**
 	Shadow Type.error to avoid raising unification errors, which should not be raised from null-safety checks
 *)
-let safety_error a b (ctx : unificator_ctx) : unit = raise (Safety_unify_error (a, b, ctx))
+let safety_error a b (ctx : access_kind) : unit = raise (Safety_unify_error (a, b, ctx))
 
 type safety_mode =
 	| SMOff
@@ -228,7 +224,7 @@ class unificator =
 			Check if it's possible to pass a value of type `a` to a place where a value of type `b` is expected.
 			Raises `Safety_error` exception if it's not.
 		*)
-		method unify ?(uctx: unificator_ctx = None) a b =
+		method unify ?(acc_kind: access_kind = Root) a b =
 			if a == b then
 				()
 			else
@@ -245,7 +241,7 @@ class unificator =
 					| _, TAbstract ({ a_path = ([],"Null") },[t]) ->
 						()
 					| TAbstract ({ a_path = ([],"Null") },[t]), _ when not (is_nullable_type b) ->
-						safety_error a b uctx
+						safety_error a b acc_kind
 					| TInst (_, a_params), TInst(_, b_params) when (List.length a_params) = (List.length b_params) ->
 						List.iter2 self#unify a_params b_params
 					| TAnon a_anon, TAnon b_anon ->
@@ -300,7 +296,7 @@ class unificator =
 					match a_field with
 						| None -> ()
 						| Some a_field ->
-							self#unify a_field.cf_type b_field.cf_type ~uctx: (Field name)
+							self#unify a_field.cf_type b_field.cf_type ~acc_kind: (Field name)
 				)
 				b.a_fields
 
@@ -315,7 +311,7 @@ class unificator =
 						| None -> ()
 						| Some a_field ->
 							let a_type = apply_params a.cl_params a_params a_field.cf_type in
-							self#unify a_type b_field.cf_type ~uctx: (Field name)
+							self#unify a_type b_field.cf_type ~acc_kind: (Field name)
 				)
 				b.a_fields
 
@@ -323,7 +319,7 @@ class unificator =
 			(* check return type *)
 			(match b_result with
 				| TAbstract ({ a_path = ([], "Void") }, []) -> ()
-				| _ -> self#unify a_result b_result ~uctx: Return;
+				| _ -> self#unify a_result b_result ~acc_kind: FunctionReturn;
 			);
 			let a_args_len = List.length a_args in
 			(* check arguments *)
@@ -331,7 +327,7 @@ class unificator =
 				match a_args, b_args with
 					| [], _ | _, [] -> ()
 					| (_, _, a_arg) :: a_rest, (_, _, b_arg) :: b_rest ->
-						self#unify b_arg a_arg ~uctx: (Arg (i + 1, a_args_len));
+						self#unify b_arg a_arg ~acc_kind: (FunctionArgument (i + 1, a_args_len));
 						traverse (i + 1) a_rest b_rest
 			in
 			traverse 0 a_args b_args
@@ -1155,23 +1151,23 @@ class expr_checker mode immediate_execution report =
 					with
 						| Safety_unify_error (expr_type, to_type, ctx) ->
 							let errors = match ctx with
-								| None ->
-									[Cannot_unify(expr_type, to_type)]
 								| Field field ->
 									[
 										Invalid_field_type field;
 										Cannot_unify(expr_type, to_type)
 									]
-								| Arg (i, total) ->
+								| FunctionArgument (i, total) ->
 									[
 										Invalid_function_argument (i, total);
 										Cannot_unify(expr_type, to_type)
 									]
-								| Return ->
+								| FunctionReturn ->
 									[
 										Invalid_return_type;
 										Cannot_unify(expr_type, to_type)
 									]
+								| _ ->
+									[Cannot_unify(expr_type, to_type)]
 							in
 							self#error_unify errors p;
 							(* returning `true` because error is already logged in the line above *)

--- a/tests/misc/projects/Issue10147/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10147/compile-fail.hxml.stderr
@@ -1,4 +1,8 @@
 Main.hx:11: characters 33-37 : Null safety: Cannot assign nullable value here.
-Main.hx:14: characters 3-32 : Null safety: Cannot unify { text : Null<String> } with HasAString
-Main.hx:17: characters 3-35 : Null safety: Cannot unify { text : Null<String> } with { text : String }
+Main.hx:14: characters 3-32 : Null safety: error: Null<String> should be String
+Main.hx:14: characters 3-32 : ... have: { text: Null<...> }
+Main.hx:14: characters 3-32 : ... want: { text: String }
+Main.hx:17: characters 3-35 : Null safety: error: Null<String> should be String
+Main.hx:17: characters 3-35 : ... have: { text: Null<...> }
+Main.hx:17: characters 3-35 : ... want: { text: String }
 Main.hx:20: characters 30-38 : Null safety: Cannot use nullable value of Null<String> as an item in Array<String>

--- a/tests/misc/projects/Issue10147/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10147/compile-fail.hxml.stderr
@@ -1,8 +1,8 @@
 Main.hx:11: characters 33-37 : Null safety: Cannot assign nullable value here.
 Main.hx:14: characters 3-32 : Null safety: error: Null<String> should be String
-Main.hx:14: characters 3-32 : ... have: { text: Null<...> }
+Main.hx:14: characters 3-32 : ... have: { text: Null<String> }
 Main.hx:14: characters 3-32 : ... want: { text: String }
 Main.hx:17: characters 3-35 : Null safety: error: Null<String> should be String
-Main.hx:17: characters 3-35 : ... have: { text: Null<...> }
+Main.hx:17: characters 3-35 : ... have: { text: Null<String> }
 Main.hx:17: characters 3-35 : ... want: { text: String }
 Main.hx:20: characters 30-38 : Null safety: Cannot use nullable value of Null<String> as an item in Array<String>

--- a/tests/misc/projects/Issue7855/Main.hx
+++ b/tests/misc/projects/Issue7855/Main.hx
@@ -1,0 +1,35 @@
+typedef Struct = {
+	final foo:Null<Int>;
+}
+
+typedef Struct2 = {
+	final foo:Int;
+}
+
+@:nullSafety
+class Main {
+	static var callback:(i:Int) -> Void = cast null;
+	static var nullableCallback:(i:Null<Int>) -> Void = cast null;
+
+	static var callback2:(v:Array<String>) -> Void = cast null;
+	static var nullableCallback2:(v:Null<Array<String>>) -> Void = cast null;
+
+	static var callback3:() -> Null<Struct> = cast null;
+	static var nullableCallback3:() -> Struct = cast null;
+
+	static function main() {
+		var a:{?a:{b:Null<Int>}} = cast null;
+		var b:{?a:{b:Int}} = cast null;
+		b = a;
+		final s:Struct = cast null;
+		addStruct2(s);
+
+		nullableCallback = callback;
+		// tests that short type is Null<Array<...>>, not full
+		nullableCallback2 = callback2;
+
+		nullableCallback3 = callback3;
+	}
+
+	static function addStruct2(s:Struct2) {}
+}

--- a/tests/misc/projects/Issue7855/compile-fail.hxml
+++ b/tests/misc/projects/Issue7855/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue7855/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7855/compile-fail.hxml.stderr
@@ -1,0 +1,15 @@
+Main.hx:23: characters 3-8 : Null safety: error: Null<Int> should be Int
+Main.hx:23: characters 3-8 : ... have: { b: Null<Int> }
+Main.hx:23: characters 3-8 : ... want: { b: Int }
+Main.hx:25: characters 14-15 : Null safety: error: Null<Int> should be Int
+Main.hx:25: characters 14-15 : ... have: { foo: Null<Int> }
+Main.hx:25: characters 14-15 : ... want: { foo: Int }
+Main.hx:27: characters 3-30 : Null safety: error: Null<Int> should be Int
+Main.hx:27: characters 3-30 : ... have: (Int) -> ...
+Main.hx:27: characters 3-30 : ... want: (Null<Int>) -> ...
+Main.hx:29: characters 3-32 : Null safety: error: Null<Array<String>> should be Array<String>
+Main.hx:29: characters 3-32 : ... have: (Array<...>) -> ...
+Main.hx:29: characters 3-32 : ... want: (Null<Array<...>>) -> ...
+Main.hx:31: characters 3-32 : Null safety: error: Null<Struct> should be Struct
+Main.hx:31: characters 3-32 : ... have: (...) -> Null<Struct>
+Main.hx:31: characters 3-32 : ... want: (...) -> Struct

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -9,6 +9,10 @@ private enum DummyEnum {
 
 typedef TWrap<T> = T;
 
+class TestClassWithAnon {
+	public var a:Null<{b:Null<Int>}> = cast null;
+}
+
 abstract AWrap<T>(T) from T to T {
 	function abstracts_shouldBeChecked(?a:String) {
 		shouldFail(var s:String = a);
@@ -413,6 +417,14 @@ class TestStrict {
 		};
 		objOptField_shouldPass(shouldFail(foo));
 
+		var a:{?a:{b:Null<Int>}} = cast null;
+		var b:{?a:{b:Int}} = cast null;
+		shouldFail(b = a);
+
+		var t:TestClassWithAnon = cast null;
+		var t2:Null<{a:{b:Int}}> = cast null;
+		shouldFail(t2 = t);
+
 		var bar:{a:{b:Int}};
 		shouldFail(bar = foo);
 
@@ -422,7 +434,25 @@ class TestStrict {
 		shouldFail(passSafeClass(b));
 	}
 
+	static function objOptField_shouldPass(test:{?a:{b:Int}}):Void {
+		if (test.a == null) return;
+		final v:Int = test.a.b;
+	}
+
 	static function passSafeClass(obj:ObjWithField):Void {}
+
+	function assignNullableArgCallback_shouldFail():Void {
+		var cb = cb1;
+		shouldFail(cb = cb2);
+		var cb = cbs1;
+		shouldFail(cb = cbs2);
+	}
+
+	function cb1(a:Int, b:Null<Int>):Void {}
+	function cb2(a:Int, b:Int):Void {}
+
+	function cbs1(a:Int, b:Null<Int>):String return "";
+	function cbs2(a:Int, b:Int):Null<String> return "";
 
 	static function promise_then_nullableArg_shouldFail():Void {
 		showQuickPick(shouldFail((choice:Int) -> {}));
@@ -431,10 +461,6 @@ class TestStrict {
 
 	static function showQuickPick<T:Int>(callback:(choice:Null<T>) -> Void):Void {};
 
-	static function objOptField_shouldPass(test:{?a:{b:Int}}):Void {
-		if (test.a == null) return;
-		final v:Int = test.a.b;
-	}
 
 	static function objOptFieldNullable_shouldFail(test:{?a:{?b:Int}}):Void {
 		if (test.a == null) return;

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -441,6 +441,12 @@ class TestStrict {
 		shouldFail(final v:Int = test.a.b);
 	}
 
+	static function emptyObjTypeAssign_shouldPass():Void {
+		final other:{a:Int} = {a: 10};
+		final data:{} = other;
+		final anything:{} = {a: 10};
+	}
+
 	function objIterationAfterNullCheck_shouldPass(result:{?leaks:Array<String>}):Void {
 		if (result.leaks != null) {
 			for (leak in result.leaks) {

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -22,12 +22,22 @@ class Generic<T> {
 	}
 }
 
-typedef AnonAsClass = {
-	var ?optional:String;
+@:structInit
+class ClassWithNullableField {
+	public var field:Null<String> = null;
 }
 
-typedef AnonAsStruct = {
-	?optional:String
+@:structInit
+class ClassWithField {
+	public var field:String;
+}
+
+typedef ObjWithNullableField = {
+	?field:String
+}
+
+typedef ObjWithField = {
+	field:String
 }
 
 typedef AnonDefaultNever = {
@@ -390,6 +400,45 @@ class TestStrict {
 		var s:String = name;
 		var s2:String = name2;
 		return s;
+	}
+
+	static function call_objOptField_shouldFail():Void {
+		var a:{?a:Int} = {a: null};
+		shouldFail(var b:{a:Int} = a);
+
+		var foo:{a:{b:Null<Int>}} = {
+			a: {
+				b: null
+			}
+		};
+		objOptField_shouldPass(shouldFail(foo));
+
+		var bar:{a:{b:Int}};
+		shouldFail(bar = foo);
+
+		var a:ObjWithNullableField = {};
+		var b:ClassWithNullableField = {};
+		shouldFail(passSafeClass(a));
+		shouldFail(passSafeClass(b));
+	}
+
+	static function passSafeClass(obj:ObjWithField):Void {}
+
+	static function promise_then_nullableArg_shouldFail():Void {
+		showQuickPick(shouldFail((choice:Int) -> {}));
+		showQuickPick((choice:Null<Int>) -> {});
+	}
+
+	static function showQuickPick<T:Int>(callback:(choice:Null<T>) -> Void):Void {};
+
+	static function objOptField_shouldPass(test:{?a:{b:Int}}):Void {
+		if (test.a == null) return;
+		final v:Int = test.a.b;
+	}
+
+	static function objOptFieldNullable_shouldFail(test:{?a:{?b:Int}}):Void {
+		if (test.a == null) return;
+		shouldFail(final v:Int = test.a.b);
 	}
 
 	function objIterationAfterNullCheck_shouldPass(result:{?leaks:Array<String>}):Void {
@@ -821,10 +870,18 @@ class TestStrict {
 	}
 
 	static function anonymousObjects() {
-		var o:AnonAsClass = {};
-		shouldFail(var s:String = o.optional);
-		var o:AnonAsStruct = {};
-		shouldFail(var s:String = o.optional);
+		var nullableClass:ClassWithNullableField = {};
+		var basicClass:ClassWithField = {field: ""};
+		shouldFail(var s:String = nullableClass.field);
+		var nullableObj:ObjWithNullableField = {};
+		var basicObj:ObjWithField = {field: ""};
+		shouldFail(var s:String = nullableObj.field);
+
+		nullableObj = nullableClass;
+		nullableObj = basicClass;
+		basicObj = basicClass;
+		shouldFail(basicObj = nullableObj);
+		shouldFail(basicObj = nullableClass);
 	}
 
 	static function safetyInference_safeValueAssignedToNullable_shouldBecomeSafe(?a:String, ?b:String) {

--- a/tests/nullsafety/src/cases/TestStrict.hx
+++ b/tests/nullsafety/src/cases/TestStrict.hx
@@ -441,19 +441,6 @@ class TestStrict {
 
 	static function passSafeClass(obj:ObjWithField):Void {}
 
-	function assignNullableArgCallback_shouldFail():Void {
-		var cb = cb1;
-		shouldFail(cb = cb2);
-		var cb = cbs1;
-		shouldFail(cb = cbs2);
-	}
-
-	function cb1(a:Int, b:Null<Int>):Void {}
-	function cb2(a:Int, b:Int):Void {}
-
-	function cbs1(a:Int, b:Null<Int>):String return "";
-	function cbs2(a:Int, b:Int):Null<String> return "";
-
 	static function promise_then_nullableArg_shouldFail():Void {
 		showQuickPick(shouldFail((choice:Int) -> {}));
 		showQuickPick((choice:Null<Int>) -> {});


### PR DESCRIPTION
Found bug that `{?a:Int}` still can be passed to `{a:Int}` var.

Also added better errors usage, so instead of
```
Cannot unify { ?a : Null<Int> } with haxeLanguageServer.documents.OnTextDocumentChangeListener2
```
There's now:
```
Null safety: error: Null<Int> should be Int
have: { a: Null<Int> }
want: { a: Int }
```

Closes https://github.com/HaxeFoundation/haxe/issues/7855
Closes https://github.com/HaxeFoundation/haxe/issues/12454