### PR TITLE
[hl] restrict GUID to >= 1.16.0

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -4199,7 +4199,7 @@ let create_context com =
 					Some (get_class "ArrayBytes_hl_I64");
 			aguid =
 				if Gctx.raw_defined com "hl_legacy32"
-					|| hl_ver <> "" && compare_version hl_ver "1.13.0" < 0
+					|| hl_ver <> "" && compare_version hl_ver "1.16.0" < 0
 				then
 					None
 				else

--- a/src/generators/hlcode.ml
+++ b/src/generators/hlcode.ml
@@ -454,6 +454,7 @@ let gather_types (code:code) =
 		(match t with
 		| HObj { psuper = Some p } -> get_type (HObj p)
 		| HStruct { psuper = Some p } -> get_type (HStruct p)
+		| HNull t | HRef t -> get_type t
 		| _ -> ());
 		if PMap.mem t !types then () else
 		let index = DynArray.length arr in
@@ -465,8 +466,6 @@ let gather_types (code:code) =
 			get_type ret
 		| HObj p | HStruct p ->
 			Array.iter (fun (_,n,t) -> get_type t) p.pfields
-		| HNull t | HRef t ->
-			get_type t
 		| HVirtual v ->
 			Array.iter (fun (_,_,t) -> get_type t) v.vfields
 		| HEnum e ->
@@ -474,7 +473,7 @@ let gather_types (code:code) =
 		| _ ->
 			()
 	in
-	List.iter (fun t -> get_type t) [HVoid; HUI8; HUI16; HI32; HI64; HGUID; HF32; HF64; HBool; HType; HDyn]; (* make sure all basic types get lower indexes *)
+	List.iter (fun t -> get_type t) [HVoid; HUI8; HUI16; HI32; HI64; HF32; HF64; HBool; HType; HDyn]; (* make sure all basic types get lower indexes *)
 	Array.iter (fun g -> get_type g) code.globals;
 	Array.iter (fun (_,_,t,_) -> get_type t) code.natives;
 	Array.iter (fun f ->

--- a/std/hl/Api.hx
+++ b/std/hl/Api.hx
@@ -52,14 +52,12 @@ extern class Api {
 	#if (hl_ver >= version("1.13.0"))
 	@:hlNative("?std", "sys_has_debugger") static function hasDebugger() : Bool;
 	#end
-	#if (hl_ver >= version("1.15.0"))
+	#if (hl_ver >= version("1.16.0"))
+	#if !hl_legacy32
 	@:hlNative("?std", "register_guid_name") private static function _registerGUIDName( guid : hl.I64, bytes : hl.Bytes ) : Void;
 	static inline function registerGUIDName( guid : GUID, name : Null<String> ) {
 		_registerGUIDName(guid, @:privateAccess name?.bytes);
 	}
-	#end
-	#if (hl_ver >= version("1.16.0"))
-	#if !hl_legacy32
 	@:hlNative("?std", "sys_timestamp_ms") static function timestampMs():haxe.Int64;
 	#end
 	@:hlNative("?std", "sys_resolve_type") static function resolveTypeDyn( t : hl.Type, gt : hl.Type ) : Dynamic;

--- a/std/hl/GUID.hx
+++ b/std/hl/GUID.hx
@@ -22,6 +22,7 @@
 
 package hl;
 
+#if (hl_ver >= version("1.16.0") && !hl_legacy32)
 @:coreType @:notNull @:runtimeValue abstract GUID to I64 from I64 {
 	// Same as `Std.string`, but copied here to prevent Std.string(const TInt) optimization on GUID
 	public function toString() {
@@ -30,11 +31,10 @@ package hl;
 		return @:privateAccess String.__alloc__(bytes, len);
 	}
 
-	#if (hl_ver >= version("1.12.0") && !hl_legacy32)
 	@:op(a==b) function eq(v:GUID) : Bool;
 	@:op(a>=b) function gte(v:GUID) : Bool;
 	@:op(a<=b) function lte(v:GUID) : Bool;
 	@:op(a>b) function gt(v:GUID) : Bool;
 	@:op(a<b) function lt(v:GUID) : Bool;
-	#end
 }
+#end

--- a/std/hl/types/ArrayBase.hx
+++ b/std/hl/types/ArrayBase.hx
@@ -165,7 +165,9 @@ class ArrayBase extends ArrayAccess {
 		a.size = length;
 		return a;
 	}
+	#end
 
+	#if (hl_ver >= version("1.16.0") && !hl_legacy32)
 	public static function allocGUID(bytes:BytesAccess<GUID>, length:Int) @:privateAccess {
 		var a:ArrayBytes.ArrayGUID = untyped $new(ArrayBytes.ArrayGUID);
 		a.length = length;

--- a/std/hl/types/ArrayBytes.hx
+++ b/std/hl/types/ArrayBytes.hx
@@ -148,12 +148,16 @@ class BytesIterator<T> extends ArrayIterator<T> {
 		var tid = Type.get((cast null : T));
 		if (tid == Type.get(0))
 			(bytes : Bytes).sortI32(0, length, cast f);
-		else if( tid == Type.get((0:hl.I64)) || tid == Type.get((0:hl.GUID)) ) {
+		else if( tid == Type.get((0:hl.I64)) ) {
 			#if (hl_ver >= version("1.16.0") && !hl_legacy32)
 			(bytes : Bytes).sortI64(0, length, cast f);
 			#else
 			throw "Array sort I64 requires -D hl-ver=1.16.0";
 			#end
+		#if (hl_ver >= version("1.16.0") && !hl_legacy32)
+		} else if( tid == Type.get((0:hl.GUID)) ) {
+			(bytes : Bytes).sortI64(0, length, cast f);
+		#end
 		} else
 			(bytes : Bytes).sortF64(0, length, cast f);
 	}
@@ -372,5 +376,7 @@ typedef ArrayF32 = ArrayBytes<F32>;
 typedef ArrayF64 = ArrayBytes<Float>;
 #if (hl_ver >= version("1.13.0") && !hl_legacy32)
 typedef ArrayI64 = ArrayBytes<I64>;
+#end
+#if (hl_ver >= version("1.16.0") && !hl_legacy32)
 typedef ArrayGUID = ArrayBytes<GUID>;
 #end

--- a/std/hl/types/ArrayDyn.hx
+++ b/std/hl/types/ArrayDyn.hx
@@ -239,6 +239,8 @@ class ArrayDyn extends ArrayAccess {
 			allowReinterpret = false;
 			return arr;
 		}
+		#end
+		#if (hl_ver >= version("1.16.0") && !hl_legacy32)
 		if (t == Type.get((null : ArrayBytes.ArrayGUID))) {
 			var a:BytesAccess<GUID> = null;
 			a = new Bytes(array.length << a.sizeBits);


### PR DESCRIPTION
`HGUID` is a Hashlink VM core type which only exists since 1.15.0 and is really functional only with 1.16.0.

My previous implementations on GUID make haxe generate HGUID type even the target hashlink VM version is lower. It cause runtime error invalid type (HGUID) / invalid opcode (OSetMem HGUID) on hashlink 1.15.0.
- https://github.com/HaxeFoundation/haxe/pull/12418
- https://github.com/HaxeFoundation/haxe/pull/12440

This PR fix it by restrict GUID usage with `hl_ver >= 1.16.0 && !hl_legacy32`