### PR TITLE
[ci] Enable hl tests on linux arm64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -464,16 +464,18 @@ jobs:
     runs-on: ubuntu-22.04-arm
     env:
       PLATFORM: linux-arm64
-      TEST: ${{matrix.target}}
       HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, cpp, jvm, php, python, lua, neko]
+        target: [macro, js, hl, cpp, jvm, php, python, lua, neko]
         include:
           - target: lua
             APT_PACKAGES: ncurses-dev
+          - target: hl
+            APT_PACKAGES: cmake ninja-build libturbojpeg-dev
+            runci-args: --skip-hl-jit
     steps:
       - uses: actions/checkout@main
         with:
@@ -532,7 +534,7 @@ jobs:
           sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Test
-        run: haxe RunCi.hxml -D include_legacy
+        run: haxe -D include_legacy --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
         working-directory: ${{github.workspace}}/tests
         timeout-minutes: 20
 

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -310,16 +310,18 @@ jobs:
     runs-on: ubuntu-22.04-arm
     env:
       PLATFORM: linux-arm64
-      TEST: ${{matrix.target}}
       HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
       HAXE_STD_PATH: /usr/local/share/haxe/std
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, cpp, jvm, php, python, lua, neko]
+        target: [macro, js, hl, cpp, jvm, php, python, lua, neko]
         include:
           - target: lua
             APT_PACKAGES: ncurses-dev
+          - target: hl
+            APT_PACKAGES: cmake ninja-build libturbojpeg-dev
+            runci-args: --skip-hl-jit
     steps:
       - uses: actions/checkout@main
         with:
@@ -360,7 +362,7 @@ jobs:
           sudo apt install -qqy ${{matrix.APT_PACKAGES}}
 
       - name: Test
-        run: haxe RunCi.hxml -D include_legacy
+        run: haxe -D include_legacy --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
         working-directory: ${{github.workspace}}/tests
         timeout-minutes: 20
 


### PR DESCRIPTION
They are currently failing due to a hashlink bug, see: https://github.com/HaxeFoundation/hashlink/pull/856