### PR TITLE
[ci] Use intel runner for x86 hl mac tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -797,7 +797,6 @@ jobs:
 
   mac-test:
     needs: mac-build-universal
-    runs-on: macos-latest
     env:
       PLATFORM: mac-universal
       HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
@@ -805,15 +804,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, cpp, jvm, php, python, lua, flash, neko]
+        target: [macro, js, hl, cpp, jvm, php, python, lua, flash, neko]
+        arch: [arm64]
         include:
         - target: hl
           arch: arm64
           runci-args: --skip-hl-jit
         - target: hl
           arch: x86_64
-          haxe-invoke: arch -x86_64
+          runner: macos-15-intel
 
+    runs-on: ${{ matrix.runner || 'macos-latest' }}
     steps:
       - uses: actions/checkout@main
         with:
@@ -868,7 +869,7 @@ jobs:
         run: |
           # disable invalid Unicode filenames on APFS
           echo "" > sys/compile-fs.hxml
-          ${{ matrix.haxe-invoke }} haxe -D include_legacy --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
+          haxe -D include_legacy --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
         working-directory: ${{github.workspace}}/tests
         timeout-minutes: 60
 

--- a/extra/github-actions/test-mac.yml
+++ b/extra/github-actions/test-mac.yml
@@ -24,6 +24,6 @@
   run: |
     # disable invalid Unicode filenames on APFS
     echo "" > sys/compile-fs.hxml
-    ${{ matrix.haxe-invoke }} haxe -D include_legacy --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
+    haxe -D include_legacy --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
   working-directory: ${{github.workspace}}/tests
   timeout-minutes: 60

--- a/extra/github-actions/workflows/main.yml
+++ b/extra/github-actions/workflows/main.yml
@@ -450,7 +450,6 @@ jobs:
 
   mac-test:
     needs: mac-build-universal
-    runs-on: macos-latest
     env:
       PLATFORM: mac-universal
       HXCPP_COMPILE_CACHE: ${{ github.workspace }}/hxcache
@@ -458,15 +457,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [macro, js, cpp, jvm, php, python, lua, flash, neko]
+        target: [macro, js, hl, cpp, jvm, php, python, lua, flash, neko]
+        arch: [arm64]
         include:
         - target: hl
           arch: arm64
           runci-args: --skip-hl-jit
         - target: hl
           arch: x86_64
-          haxe-invoke: arch -x86_64
+          runner: macos-15-intel
 
+    runs-on: ${{ matrix.runner || 'macos-latest' }}
     steps:
       - uses: actions/checkout@main
         with:


### PR DESCRIPTION
Github is providing this runner for now, so we can use it to run the hl mac x86 tests. Hopefully this will be more reliable than emulating x86, so let's see if this will address #12465.