### PR TITLE
[tests] Fix misc issues in cpp tests

### DIFF
--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -46,25 +46,14 @@ class Cpp {
 	static public function run(args:Array<String>, testCompiled:Bool, testCppia:Bool) {
 		getCppDependencies();
 
-		final archFlag = switch systemName {
-			case 'Windows':
-				'HXCPP_M32';
-			case 'Linux' if(Linux.arch == Arm64):
-				'HXCPP_LINUX_ARM64';
-			case 'Mac' if(commandResult('arch', []).stdout == "arm64"):
-				'HXCPP_ARM64';
-			case _:
-				'HXCPP_M64';
-		}
-
 		if (testCompiled) {
 			runCommand("rm", ["-rf", "cpp"]);
-			runCommand("haxe", ["compile-cpp.hxml", "-D", archFlag].concat(args));
+			runCommand("haxe", ["compile-cpp.hxml"].concat(args));
 			runCpp("bin/cpp/TestMain-debug", []);
 		}
 
 		if (testCppia) {
-			runCommand("haxe", ["compile-cppia-host.hxml", "-D", archFlag].concat(args));
+			runCommand("haxe", ["compile-cppia-host.hxml"].concat(args));
 			runCommand("haxe", ["compile-cppia.hxml"].concat(args));
 			runCpp("bin/cppia/Host-debug", ["bin/unit.cppia"]);
 
@@ -75,11 +64,11 @@ class Cpp {
 		Display.maybeRunDisplayTests(Cpp);
 
 		changeDirectory(sysDir);
-		runCommand("haxe", ["-D", archFlag, "--each", "compile-cpp.hxml"].concat(args));
+		runCommand("haxe", ["--each", "compile-cpp.hxml"].concat(args));
 		runSysTest(FileSystem.fullPath("bin/cpp/Main-debug"));
 
 		changeDirectory(threadsDir);
-		runCommand("haxe", ["-D", archFlag, "build.hxml", "-cpp", "export/cpp"]);
+		runCommand("haxe", ["build.hxml", "-cpp", "export/cpp"]);
 		runCpp("export/cpp/Main");
 
 		changeDirectory(getMiscSubDir("eventLoop"));
@@ -89,7 +78,7 @@ class Cpp {
 
 		if (Sys.systemName() == "Mac") {
 			changeDirectory(getMiscSubDir("cppObjc"));
-			runCommand("haxe", ["-D", archFlag, "build.hxml"]);
+			runCommand("haxe", ["build.hxml"]);
 			runCpp("bin/TestObjc-debug");
 		}
 

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -64,25 +64,25 @@ class Cpp {
 		Display.maybeRunDisplayTests(Cpp);
 
 		changeDirectory(sysDir);
-		runCommand("haxe", ["--each", "compile-cpp.hxml"].concat(args));
+		runCommand("haxe", args.concat(["--each", "compile-cpp.hxml"]));
 		runSysTest(FileSystem.fullPath("bin/cpp/Main-debug"));
 
 		changeDirectory(threadsDir);
-		runCommand("haxe", ["build.hxml", "-cpp", "export/cpp"]);
+		runCommand("haxe", ["build.hxml", "-cpp", "export/cpp"].concat(args));
 		runCpp("export/cpp/Main");
 
 		changeDirectory(getMiscSubDir("eventLoop"));
-		runCommand("haxe", ["build-cpp.hxml"]);
+		runCommand("haxe", ["build-cpp.hxml"].concat(args));
 		// TODO: check output like misc tests do
 		runCpp("cpp/Main");
 
 		if (Sys.systemName() == "Mac") {
 			changeDirectory(getMiscSubDir("cppObjc"));
-			runCommand("haxe", ["build.hxml"]);
+			runCommand("haxe", ["build.hxml"].concat(args));
 			runCpp("bin/TestObjc-debug");
 		}
 
 		changeDirectory(miscCppDir);
-		runCommand("haxe", ["run.hxml"]);
+		runCommand("haxe", ["run.hxml"].concat(args));
 	}
 }

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -46,8 +46,6 @@ class Cpp {
 	static public function run(args:Array<String>, testCompiled:Bool, testCppia:Bool) {
 		getCppDependencies();
 
-		final isLinuxArm64 = systemName == 'Linux' && Linux.arch == Arm64;
-
 		final archFlag = switch systemName {
 			case 'Windows':
 				'HXCPP_M32';
@@ -70,7 +68,7 @@ class Cpp {
 			runCommand("haxe", ["compile-cppia.hxml"].concat(args));
 			runCpp("bin/cppia/Host-debug", ["bin/unit.cppia"]);
 
-			if (!isLinuxArm64) // FIXME
+			if (!(systemName == 'Linux' && Linux.arch == Arm64)) // FIXME
 				runCpp("bin/cppia/Host-debug", ["bin/unit.cppia", "-jit"]);
 		}
 
@@ -80,11 +78,9 @@ class Cpp {
 		runCommand("haxe", ["-D", archFlag, "--each", "compile-cpp.hxml"].concat(args));
 		runSysTest(FileSystem.fullPath("bin/cpp/Main-debug"));
 
-		if (!isLinuxArm64) { // FIXME
-			changeDirectory(threadsDir);
-			runCommand("haxe", ["-D", archFlag, "build.hxml", "-cpp", "export/cpp"]);
-			runCpp("export/cpp/Main");
-		}
+		changeDirectory(threadsDir);
+		runCommand("haxe", ["-D", archFlag, "build.hxml", "-cpp", "export/cpp"]);
+		runCpp("export/cpp/Main");
 
 		changeDirectory(getMiscSubDir("eventLoop"));
 		runCommand("haxe", ["build-cpp.hxml"]);

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -64,25 +64,25 @@ class Cpp {
 		Display.maybeRunDisplayTests(Cpp);
 
 		changeDirectory(sysDir);
-		runCommand("haxe", args.concat(["--each", "compile-cpp.hxml"]));
+		runCommand("haxe", ["--each", "compile-cpp.hxml"].concat(args));
 		runSysTest(FileSystem.fullPath("bin/cpp/Main-debug"));
 
 		changeDirectory(threadsDir);
-		runCommand("haxe", ["build.hxml", "-cpp", "export/cpp"].concat(args));
+		runCommand("haxe", ["build.hxml", "-cpp", "export/cpp"]);
 		runCpp("export/cpp/Main");
 
 		changeDirectory(getMiscSubDir("eventLoop"));
-		runCommand("haxe", ["build-cpp.hxml"].concat(args));
+		runCommand("haxe", ["build-cpp.hxml"]);
 		// TODO: check output like misc tests do
 		runCpp("cpp/Main");
 
 		if (Sys.systemName() == "Mac") {
 			changeDirectory(getMiscSubDir("cppObjc"));
-			runCommand("haxe", ["build.hxml"].concat(args));
+			runCommand("haxe", ["build.hxml"]);
 			runCpp("bin/TestObjc-debug");
 		}
 
 		changeDirectory(miscCppDir);
-		runCommand("haxe", ["run.hxml"].concat(args));
+		runCommand("haxe", ["run.hxml"]);
 	}
 }


### PR DESCRIPTION
- Enable cpp thread tests on linux arm64. These were disabled when the linux arm64 tests were running on an emulator, but they seem stable now that they are running on an actual arm64 machine.
- Use default architecture for cpp tests, including 64 bit x86 for windows.
- Allow changing architecture for all cpp test builds, e.g. by running `haxe --run RunCi cpp -D HXCPP_M32`.