### PR TITLE
[tests] Use hxb to speed up eval unicode tests

### DIFF
--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -27,7 +27,8 @@ class Macro {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "eval/resolution"]);
 
 		changeDirectory(sysDir);
-		runSysTest("haxe", ["compile-macro.hxml"].concat(args));
+		runCommand("haxe", args.concat(["--each", "compile-eval-hxb.hxml"]));
+		runSysTest("haxe", ["--hxb-lib", "bin/eval/sys.hxb", "--run", "Main"]);
 
 		switch Sys.systemName() {
 			case 'Linux':

--- a/tests/sys/compile-eval-hxb.hxml
+++ b/tests/sys/compile-eval-hxb.hxml
@@ -1,0 +1,22 @@
+compile-each.hxml
+Main
+--interp
+--hxb bin/eval/sys.hxb
+
+--next
+compile-each.hxml
+TestArguments
+--interp
+--hxb bin/eval/TestArguments.hxb
+
+--next
+compile-each.hxml
+ExitCode
+--interp
+--hxb bin/eval/ExitCode.hxb
+
+--next
+compile-each.hxml
+UtilityProcess
+--interp
+--hxb bin/eval/UtilityProcess.hxb

--- a/tests/sys/compile-macro.hxml
+++ b/tests/sys/compile-macro.hxml
@@ -1,3 +1,0 @@
-compile-each.hxml
---main Main
---interp

--- a/tests/sys/compile.hxml
+++ b/tests/sys/compile.hxml
@@ -1,5 +1,4 @@
 # This is not run by CIs, just for convenience when testing manually.
-# Note that compile-macro.hxml is not included.
 
 --next compile-neko.hxml
 --next compile-python.hxml
@@ -9,3 +8,4 @@
 --next compile-hl.hxml
 --next compile-js.hxml
 --next compile-lua.hxml
+--next compile-eval-hxb.hxml

--- a/tests/sys/gen_test_res.py
+++ b/tests/sys/gen_test_res.py
@@ -88,7 +88,7 @@ for data in all_filenames:
         ("../../bin/neko/UtilityProcess.n", "bin-neko"),
         ("../../bin/php/UtilityProcess/index.php", "bin-php"),
         ("../../bin/python/UtilityProcess.py", "bin-py"),
-        ("../../src/UtilityProcess.hx", "bin-eval"),
+        ("../../bin/eval/UtilityProcess.hxb", "bin-eval"),
         ("../../bin/js/UtilityProcess.js", "bin-js")
     ]:
         os.symlink(target, os.path.join(TESTDIR, data, name), target_is_directory=False)

--- a/tests/sys/run.hxml
+++ b/tests/sys/run.hxml
@@ -18,7 +18,7 @@ compile.hxml
 --cmd echo Hl     && export EXISTS=1 && hl bin/hl/sys.hl
 --cmd echo Js     && export EXISTS=1 && node bin/js/sys.js
 --cmd echo Lua    && export EXISTS=1 && lua bin/sys.lua
---cmd echo Macro  && export EXISTS=1 && haxe compile-macro.hxml
+--cmd echo Eval   && export EXISTS=1 && haxe --hxb-lib bin/eval/sys.hxb --run Main
 
 # Windows
 # --next
@@ -30,4 +30,4 @@ compile.hxml
 # --cmd echo Hl     && set EXISTS=1 && hl bin/hl/sys.hl
 # --cmd echo Js     && set EXISTS=1 && node bin/js/sys.js
 # --cmd echo Lua    && set EXISTS=1 && lua bin/lua/sys.lua
-# --cmd echo Macro  && set EXISTS=1 && haxe compile-macro.hxml
+# --cmd echo Eval   && set EXISTS=1 && haxe --hxb-lib bin/eval/sys.hxb --run Main

--- a/tests/sys/src/ExitCode.hx
+++ b/tests/sys/src/ExitCode.hx
@@ -8,7 +8,7 @@ import haxe.io.*;
 class ExitCode {
 	static public var bin:String =
 	#if interp
-		"bin/interp/ExitCode";
+		"bin/eval/ExitCode.hxb";
 	#elseif neko
 		"bin/neko/ExitCode.n";
 	#elseif hl

--- a/tests/sys/src/TestArguments.hx
+++ b/tests/sys/src/TestArguments.hx
@@ -68,7 +68,7 @@ class TestArguments extends utest.Test {
 
 	static public var bin:String =
 	#if interp
-		"TestArguments.hx";
+		"bin/eval/TestArguments.hxb";
 	#elseif neko
 		"bin/neko/TestArguments.n";
 	#elseif hl

--- a/tests/sys/src/TestCommandBase.hx
+++ b/tests/sys/src/TestCommandBase.hx
@@ -18,7 +18,7 @@ class TestCommandBase extends utest.Test {
 
 		var exitCode =
 			#if (macro || interp)
-				run("haxe", ["compile-each.hxml", "--run", "TestArguments"].concat(args));
+				run("haxe", ["--hxb-lib", bin, "--run", "TestArguments"].concat(args));
 			#elseif cpp
 				run(bin, args);
 			#elseif java
@@ -108,7 +108,7 @@ class TestCommandBase extends utest.Test {
 			var args = [Std.string(code)];
 			var exitCode =
 				#if (macro || interp)
-					run("haxe", ["compile-each.hxml", "--run", "ExitCode"].concat(args));
+					run("haxe", ["--hxb-lib", bin, "--run", "ExitCode"].concat(args));
 				#elseif cpp
 					run(bin, args);
 				#elseif java

--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -273,19 +273,19 @@ class TestUnicode extends utest.Test {
 	function testIPC() {
 		// stdin.readLine
 		UnicodeSequences.normalBoth(str -> {
-				assertUEquals(runUtility(["stdin.readLine"], {stdin: str + endLine}).stdout, str + endLine);
+				assertUEquals(runUtility(["stdin.readLine"], str + endLine).stdout, str + endLine);
 			});
 
 		// stdin.readString
 		UnicodeSequences.normalBoth(str -> {
 				var byteLength = Bytes.ofString(str).length;
-				assertUEquals(runUtility(["stdin.readString", '${byteLength}'], {stdin: '$str'}).stdout, str + endLine);
+				assertUEquals(runUtility(["stdin.readString", '${byteLength}'], '$str').stdout, str + endLine);
 			});
 
 		// stdin.readUntil
 		UnicodeSequences.normalBoth(str -> {
 				// make sure the 0x70 byte is not part of the test string
-				assertUEquals(runUtility(["stdin.readUntil", "0x70"], {stdin: str + "\x70" + str + "\x70"}).stdout, str + endLine);
+				assertUEquals(runUtility(["stdin.readUntil", "0x70"], str + "\x70" + str + "\x70").stdout, str + endLine);
 			});
 
 		UnicodeSequences.normalBothIndexed((str, i, nfc) -> {

--- a/tests/sys/src/UtilityProcess.hx
+++ b/tests/sys/src/UtilityProcess.hx
@@ -27,7 +27,7 @@ class UtilityProcess {
 #elseif python
 		Path.join(["bin", "python"]);
 #elseif eval
-		Path.join(["src"]);
+		Path.join(["bin", "eval"]);
 #elseif js
 		Path.join(["bin", "js"]);
 #else
@@ -57,25 +57,22 @@ class UtilityProcess {
 #elseif python
 		"UtilityProcess.py";
 #elseif eval
-		"UtilityProcess.hx";
+		"UtilityProcess.hxb";
 #elseif js
 		"UtilityProcess.js";
 #else
 		null;
 #end
 
-	public static function runUtility(args:Array<String>, ?options:{?stdin:String, ?execPath:String, ?execName:String}):{
+	public static function runUtility(args:Array<String>, ?stdin:String):{
 		exitCode:Int,
 		stdout:String,
 		stderr:String
 	} {
-		if (options == null) options = {};
-		if (options.execPath == null) options.execPath = BIN_PATH;
-		if (options.execName == null) options.execName = BIN_NAME;
-		var execFull = Path.join([options.execPath, options.execName]);
+		var execFull = Path.join([BIN_PATH, BIN_NAME]);
 		var proc =
 		#if (macro || interp)
-		new Process("haxe", ["compile-each.hxml", "-p", options.execPath, "--run", options.execName].concat(args));
+		new Process("haxe", ["--hxb-lib", execFull, "--run", Path.withoutExtension(BIN_NAME)].concat(args));
 		#elseif cpp
 		new Process(execFull, args);
 		#elseif java
@@ -97,8 +94,8 @@ class UtilityProcess {
 		#else
 		null;
 		#end
-		if (options.stdin != null) {
-			proc.stdin.writeString(options.stdin);
+		if (stdin != null) {
+			proc.stdin.writeString(stdin);
 			proc.stdin.flush();
 		}
 		var exitCode = proc.exitCode();
@@ -117,14 +114,11 @@ class UtilityProcess {
 
 		Returns the exit code of the command.
 	 **/
-	public static function runUtilityAsCommand(args:Array<String>, ?options:{?stdin:String, ?execPath:String, ?execName:String}):Int {
-		if (options == null) options = {};
-		if (options.execPath == null) options.execPath = BIN_PATH;
-		if (options.execName == null) options.execName = BIN_NAME;
-		final execFull = Path.join([options.execPath, options.execName]);
+	public static function runUtilityAsCommand(args:Array<String>):Int {
+		final execFull = Path.join([BIN_PATH, BIN_NAME]);
 		final exitCode =
 		#if (macro || interp)
-		Sys.command("haxe", ["compile-each.hxml", "-p", options.execPath, "--run", options.execName].concat(args));
+		Sys.command("haxe", ["--hxb-lib", execFull, "--run", BIN_NAME.substr(0, -4)].concat(args));
 		#elseif cpp
 		Sys.command(execFull, args);
 		#elseif java


### PR DESCRIPTION
See: #8380.

They are slow because they run a bunch of smaller haxe programs, and on eval that means re-parsing, re-typing, etc. for every execution. By using hxb, I was able to get the time for testIPC from 4 mins 48 secs down to 14 secs.

I've still not enabled it by default locally as it's over half of the total sys test runtime (8 secs off vs 22 secs on), but maybe that's acceptable now?