### PR TITLE
[tests] Flush stderr after running command

### DIFF
--- a/tests/runci/System.hx
+++ b/tests/runci/System.hx
@@ -79,6 +79,8 @@ class System {
 		final exitCode = Sys.command(cmd, args);
 		final dt = Math.round(Timer.stamp() - t);
 
+		Sys.stderr().flush();
+
 		final msg = 'Command exited with $exitCode in ${dt}s: $displayed';
 		if (exitCode != 0)
 			failMsg(msg);


### PR DESCRIPTION
This makes it easier to understand warnings/errors in test output. There have been many cases in the past where we get failures and irrelevant logs are pasted because test runs used to dump all stderr at the end.