### PR TITLE
[cpp] Marshal String Encodings

### DIFF
--- a/src/generators/cpp/cppRetyper.ml
+++ b/src/generators/cpp/cppRetyper.ml
@@ -118,6 +118,7 @@ and cpp_type_from_path stack path params value_type_handler default =
   | ([], "Single"), _ -> TCppScalar "float"
   | ([ "cpp" ], "Char"), _ -> TCppScalar "char"
   | ([ "cpp" ], "Char16"), _ -> TCppScalar "char16_t"
+  | ([ "cpp" ], "Char32"), _ -> TCppScalar "char32_t"
   | ([ "cpp" ], "Object"), _ -> TCppObjectPtr
   | ([ "cpp" ], "Float32"), _ -> TCppScalar "float"
   | ([ "cpp" ], "Float64"), _ -> TCppScalar "double"

--- a/src/generators/cpp/cppTypeUtils.ml
+++ b/src/generators/cpp/cppTypeUtils.ml
@@ -52,6 +52,7 @@ let is_internal_class = function
    | [ "cpp" ], "UInt8"
    | [ "cpp" ], "Char"
    | [ "cpp" ], "Char16"
+   | [ "cpp" ], "Char32"
    | [ "cpp" ], "Int16"
    | [ "cpp" ], "UInt16"
    | [ "cpp" ], "Int32"
@@ -155,6 +156,7 @@ let is_numeric t =
    | TAbstract({ a_path = ([], "Single") }, [])
    | TAbstract({ a_path = (["cpp"], "Char") }, [])
    | TAbstract({ a_path = (["cpp"], "Char16") }, [])
+   | TAbstract({ a_path = (["cpp"], "Char32") }, [])
    | TAbstract({ a_path = (["cpp"], "Float32") }, [])
    | TAbstract({ a_path = (["cpp"], "Float64") }, [])
    | TAbstract({ a_path = (["cpp"], "Int8") }, [])

--- a/std/cpp/Char32.hx
+++ b/std/cpp/Char32.hx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package cpp;
+
+@:coreType @:notNull @:runtimeValue abstract Char32 from Int to Int {}

--- a/std/cpp/_std/haxe/io/Bytes.hx
+++ b/std/cpp/_std/haxe/io/Bytes.hx
@@ -253,7 +253,7 @@ class Bytes {
 			return s.asCharView().asBytesView().toBytes();
 		} else {
 			final count = Utf8.getByteCount(s);
-			final bytes = Bytes.alloc(count.toInt());
+			final bytes = Bytes.alloc(Int64.toInt(count));
 
 			if (Utf8.encode(s, bytes.asView()) != count) {
 				throw new haxe.Exception('Failed to encode string to UTF8');

--- a/std/cpp/_std/haxe/io/Bytes.hx
+++ b/std/cpp/_std/haxe/io/Bytes.hx
@@ -24,6 +24,8 @@ package haxe.io;
 
 import cpp.NativeArray;
 import cpp.marshal.View;
+import cpp.encoding.Utf8;
+import cpp.encoding.Ascii;
 import haxe.iterators.StringIterator;
 
 using cpp.marshal.Marshal;
@@ -192,9 +194,7 @@ class Bytes {
 		interpreted with the given `encoding` (UTF-8 by default).
 	**/
 	public function getString(pos:Int, len:Int, ?encoding:Encoding):String {
-		final chars : View<cpp.Char> = this.asView().reinterpret();
-
-		return chars.slice(pos, len).toString();
+		return Utf8.decode(this.asView().slice(pos, len));
 	}
 
 	@:deprecated("readString is deprecated, use getString instead")
@@ -249,9 +249,18 @@ class Bytes {
 	**/
 	@:pure
 	public static function ofString(s:String, ?encoding:Encoding):Bytes {
-		final chars = s.toCharView();
+		if (Ascii.isEncoded(s)) {
+			return s.asCharView().asBytesView().toBytes();
+		} else {
+			final count = Utf8.getByteCount(s);
+			final bytes = Bytes.alloc(count.toInt());
 
-		return chars.slice(0, chars.length - 1).asBytesView().toBytes();
+			if (Utf8.encode(s, bytes.asView()) != count) {
+				throw new haxe.Exception('Failed to encode string to UTF8');
+			} else {
+				return bytes;
+			}
+		}
 	}
 
 	/**

--- a/std/cpp/encoding/Ascii.hx
+++ b/std/cpp/encoding/Ascii.hx
@@ -1,0 +1,15 @@
+package cpp.encoding;
+
+import cpp.UInt8;
+import cpp.Int64;
+import cpp.marshal.View;
+
+@:semantics(value)
+@:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
+extern class Ascii {
+    static function isEncoded(string:String):Bool;
+
+    static function encode(string:String, buffer:View<UInt8>):Int64;
+
+    static function decode(buffer:View<UInt8>):String;
+}

--- a/std/cpp/encoding/Ascii.hx
+++ b/std/cpp/encoding/Ascii.hx
@@ -4,8 +4,6 @@ import cpp.UInt8;
 import cpp.Int64;
 import cpp.marshal.View;
 
-@:buildXml('<include name="${HXCPP}/src/cpp/encoding/Build.xml" />')
-@:include('cpp/encoding/Ascii.hpp')
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Ascii {

--- a/std/cpp/encoding/Ascii.hx
+++ b/std/cpp/encoding/Ascii.hx
@@ -7,9 +7,25 @@ import cpp.marshal.View;
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Ascii {
+    /**
+     * Returns if the provided string is ascii encoded.
+     */
     static function isEncoded(string:String):Bool;
 
+    /**
+     * Encodes all characters in the string to ascii bytes.
+     *
+     * If the string cannot be encoded to ASCII an exception is thrown.
+     * If the provided buffer is too small to fit the encoded data an exception is thrown and no data is written.
+     *
+     * @param string String to encode.
+     * @param buffer Buffer bytes will be written into.
+     * @return Number of bytes written into the buffer.
+     */
     static function encode(string:String, buffer:View<UInt8>):Int64;
 
+    /**
+     * Decodes all the bytes in the buffer into a string. An empty string is returned if the buffer is empty.
+     */
     static function decode(buffer:View<UInt8>):String;
 }

--- a/std/cpp/encoding/Ascii.hx
+++ b/std/cpp/encoding/Ascii.hx
@@ -4,6 +4,8 @@ import cpp.UInt8;
 import cpp.Int64;
 import cpp.marshal.View;
 
+@:buildXml('<include name="${HXCPP}/src/cpp/encoding/Build.xml" />')
+@:include('cpp/encoding/Ascii.hpp')
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Ascii {

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -1,0 +1,22 @@
+package cpp.encoding;
+
+import cpp.UInt8;
+import cpp.Int64;
+import cpp.Char32;
+import cpp.marshal.View;
+import haxe.extern.AsVar;
+
+@:semantics(value)
+@:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
+extern class Utf16 {
+    static function isEncoded(string:String):Bool;
+
+    static overload function getByteCount(codepoint:Char32):Int64;
+    static overload function getByteCount(string:String):Int64;
+
+    static overload function encode(string:String, buffer:View<UInt8>):Int64;
+    static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int64;
+
+    static overload function decode(buffer:View<UInt8>):String;
+    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int64;
+}

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -1,9 +1,9 @@
 package cpp.encoding;
 
 import cpp.UInt8;
-import cpp.Int64;
 import cpp.Char32;
 import cpp.marshal.View;
+import haxe.Int64;
 import haxe.extern.AsVar;
 
 @:semantics(value)
@@ -13,6 +13,9 @@ extern class Utf16 {
 
     static overload function getByteCount(codepoint:Char32):Int64;
     static overload function getByteCount(string:String):Int64;
+
+    static overload function getCharCount(codepoint:Char32):Int64;
+    static overload function getCharCount(string:String):Int64;
 
     static overload function encode(string:String, buffer:View<UInt8>):Int64;
     static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int64;

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -2,6 +2,7 @@ package cpp.encoding;
 
 import cpp.UInt8;
 import cpp.Char32;
+import cpp.Reference;
 import cpp.marshal.View;
 import haxe.Int64;
 import haxe.extern.AsVar;
@@ -69,5 +70,5 @@ extern class Utf16 {
      * @param codepoint The decoded codepoint is written to this variable.
      * @return Number of bytes read to decode the codepoint.
      */
-    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int;
+    static overload function decode(buffer:View<UInt8>, codepoint:Reference<Char32>):Int;
 }

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -60,7 +60,7 @@ extern class Utf16 {
     /**
      * Decodes all bytes in the buffer into a string. An empty string is returned if the buffer is empty.
      */
-    static overload function decode(buffer:View<UInt8>):String;
+    static function decode(buffer:View<UInt8>):String;
 
     /**
      * Decodes a UTF-16 encoded codepoint from the buffer. Characters are read in machine specific endianness.
@@ -70,5 +70,5 @@ extern class Utf16 {
      * @param codepoint The decoded codepoint is written to this variable.
      * @return Number of bytes read to decode the codepoint.
      */
-    static overload function decode(buffer:View<UInt8>, codepoint:Reference<Char32>):Int;
+    static function codepoint(buffer:View<UInt8>):Char32;
 }

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -9,17 +9,65 @@ import haxe.extern.AsVar;
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Utf16 {
+    /**
+     * Returns if the provided string is UTF-16 encoded.
+     */
     static function isEncoded(string:String):Bool;
 
-    static overload function getByteCount(codepoint:Char32):Int64;
+    /**
+     * Calculates the number of bytes needed to encode the given codepoint.
+     */
+    static overload function getByteCount(codepoint:Char32):Int;
+
+    /**
+     * Calculates the number of bytes needed to encode the given string.
+     */
     static overload function getByteCount(string:String):Int64;
 
-    static overload function getCharCount(codepoint:Char32):Int64;
+    /**
+     * Calculates the number of characters needed to encode the given codepoint.
+     */
+    static overload function getCharCount(codepoint:Char32):Int;
+
+    /**
+     * Calculates the number of characters needed to encode the given string.
+     */
     static overload function getCharCount(string:String):Int64;
 
+    /**
+     * Encodes all characters in the string to UTF-16 bytes. Endianness of the characters are machine specific.
+     *
+     * If the provided buffer is too small to fit the encoded data an exception is thrown and no data is written.
+     *
+     * @param string String to encode.
+     * @param buffer Buffer bytes will be witten into.
+     * @return Number of bytes written into the buffer.
+     */
     static overload function encode(string:String, buffer:View<UInt8>):Int64;
-    static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int64;
 
+    /**
+     * Encodes the given codepoint to UTF-16 bytes. Endianness of the characters are machine specific.
+     *
+     * If the provided buffer is too small to fit the encoded data an exception is thrown and no data is written.
+     *
+     * @param codepoint Unicode codepoint to encode.
+     * @param buffer Buffer bytes will be written into.
+     * @return Number of bytes written into the buffer.
+     */
+    static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int;
+
+    /**
+     * Decodes all bytes in the buffer into a string. An empty string is returned if the buffer is empty.
+     */
     static overload function decode(buffer:View<UInt8>):String;
-    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int64;
+
+    /**
+     * Decodes a UTF-16 encoded codepoint from the buffer. Characters are read in machine specific endianness.
+     *
+     * If the provided buffer is too small for the codepoint an exception is raised.
+     *
+     * @param codepoint The decoded codepoint is written to this variable.
+     * @return Number of bytes read to decode the codepoint.
+     */
+    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int;
 }

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -7,6 +7,8 @@ import cpp.marshal.View;
 import haxe.Int64;
 import haxe.extern.AsVar;
 
+@:buildXml('<include name="${HXCPP}/src/cpp/encoding/Build.xml" />')
+@:include('cpp/encoding/Utf16.hpp')
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Utf16 {

--- a/std/cpp/encoding/Utf16.hx
+++ b/std/cpp/encoding/Utf16.hx
@@ -7,8 +7,6 @@ import cpp.marshal.View;
 import haxe.Int64;
 import haxe.extern.AsVar;
 
-@:buildXml('<include name="${HXCPP}/src/cpp/encoding/Build.xml" />')
-@:include('cpp/encoding/Utf16.hpp')
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Utf16 {

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -1,0 +1,20 @@
+package cpp.encoding;
+
+import cpp.UInt8;
+import cpp.Int64;
+import cpp.Char32;
+import cpp.marshal.View;
+import haxe.extern.AsVar;
+
+@:semantics(value)
+@:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
+extern class Utf8 {
+    static overload function getByteCount(codepoint:Char32):Int64;
+    static overload function getByteCount(string:String):Int64;
+
+    static overload function encode(string:String, buffer:View<UInt8>):Int64;
+    static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int64;
+
+    static overload function decode(buffer:View<UInt8>):String;
+    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int64;
+}

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -7,8 +7,6 @@ import cpp.marshal.View;
 import haxe.Int64;
 import haxe.extern.AsVar;
 
-@:buildXml('<include name="${HXCPP}/src/cpp/encoding/Build.xml" />')
-@:include('cpp/encoding/Utf8.hpp')
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Utf8 {

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -1,9 +1,9 @@
 package cpp.encoding;
 
 import cpp.UInt8;
-import cpp.Int64;
 import cpp.Char32;
 import cpp.marshal.View;
+import haxe.Int64;
 import haxe.extern.AsVar;
 
 @:semantics(value)
@@ -11,6 +11,9 @@ import haxe.extern.AsVar;
 extern class Utf8 {
     static overload function getByteCount(codepoint:Char32):Int64;
     static overload function getByteCount(string:String):Int64;
+
+    static overload function getCharCount(codepoint:Char32):Int64;
+    static overload function getCharCount(string:String):Int64;
 
     static overload function encode(string:String, buffer:View<UInt8>):Int64;
     static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int64;

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -9,15 +9,60 @@ import haxe.extern.AsVar;
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Utf8 {
-    static overload function getByteCount(codepoint:Char32):Int64;
+    /**
+     * Calculates the number of bytes needed to encode the given codepoint.
+     */
+    static overload function getByteCount(codepoint:Char32):Int;
+
+    /**
+     * Calculates the number of bytes needed to encode the given string.
+     */
     static overload function getByteCount(string:String):Int64;
 
-    static overload function getCharCount(codepoint:Char32):Int64;
+    /**
+     * Calculates the number of characters needed to encode the given codepoint.
+     */
+    static overload function getCharCount(codepoint:Char32):Int;
+
+    /**
+     * Calculates the number of characters needed to encode the given string.
+     */
     static overload function getCharCount(string:String):Int64;
 
+    /**
+     * Encodes all characters in the string to UTF-8 bytes.
+     *
+     * If the provided buffer is too small to fit the encoded data an exception is thrown and no data is written.
+     *
+     * @param string String to encode.
+     * @param buffer Buffer bytes will be witten into.
+     * @return Number of bytes written into the buffer.
+     */
     static overload function encode(string:String, buffer:View<UInt8>):Int64;
-    static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int64;
 
+    /**
+     * Encodes the given codepoint to UTF-8 bytes.
+     *
+     * If the provided buffer is too small to fit the encoded data an exception is thrown and no data is written.
+     *
+     * @param codepoint Unicode codepoint to encode.
+     * @param buffer Buffer bytes will be written into.
+     * @return Number of bytes written into the buffer.
+     */
+    static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int;
+
+    /**
+     * Decodes all bytes in the buffer into a string. An empty string is returned if the buffer is empty.
+     */
     static overload function decode(buffer:View<UInt8>):String;
-    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int64;
+
+    /**
+     * Decodes a UTF-8 encoded codepoint from the buffer.
+     *
+     * If the provided buffer is too small for the codepoint an exception is raised.
+     *
+     * @param codepoint The decoded codepoint is written to this variable.
+     * @return Number of bytes read to decode the codepoint.
+     */
+    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int;
 }

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -2,6 +2,7 @@ package cpp.encoding;
 
 import cpp.UInt8;
 import cpp.Char32;
+import cpp.Reference;
 import cpp.marshal.View;
 import haxe.Int64;
 import haxe.extern.AsVar;
@@ -64,5 +65,5 @@ extern class Utf8 {
      * @param codepoint The decoded codepoint is written to this variable.
      * @return Number of bytes read to decode the codepoint.
      */
-    static overload function decode(buffer:View<UInt8>, codepoint:AsVar<Char32>):Int;
+    static overload function decode(buffer:View<UInt8>, codepoint:Reference<Char32>):Int;
 }

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -55,7 +55,7 @@ extern class Utf8 {
     /**
      * Decodes all bytes in the buffer into a string. An empty string is returned if the buffer is empty.
      */
-    static overload function decode(buffer:View<UInt8>):String;
+    static function decode(buffer:View<UInt8>):String;
 
     /**
      * Decodes a UTF-8 encoded codepoint from the buffer.
@@ -65,5 +65,5 @@ extern class Utf8 {
      * @param codepoint The decoded codepoint is written to this variable.
      * @return Number of bytes read to decode the codepoint.
      */
-    static overload function decode(buffer:View<UInt8>, codepoint:Reference<Char32>):Int;
+    static function codepoint(buffer:View<UInt8>):Char32;
 }

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -7,6 +7,8 @@ import cpp.marshal.View;
 import haxe.Int64;
 import haxe.extern.AsVar;
 
+@:buildXml('<include name="${HXCPP}/src/cpp/encoding/Build.xml" />')
+@:include('cpp/encoding/Utf8.hpp')
 @:semantics(value)
 @:cpp.PointerType({ namespace : [ "cpp", "encoding" ] })
 extern class Utf8 {

--- a/std/cpp/marshal/Marshal.hx
+++ b/std/cpp/marshal/Marshal.hx
@@ -18,58 +18,18 @@ import cpp.Pointer;
 @:cpp.ValueType({ namespace : [ 'cpp', 'marshal' ] })
 final extern class Marshal {
 	/**
-	 * Returns a view to UTF8 encoded characters of the given string. The characters in the view will be null terminated.
-	 * 
-	 * Depending on the internal incoding of `s` this function may allocate GC bytes.
+	 * Returns a view to ASCII encoded characters of the given string. If the internal encoding of the string is not ASCII an exception is raised.
 	 * 
 	 * @param s String to return the view of.
 	 */
-	static overload function toCharView(s:String):View<Char>;
+	static overload function asCharView(s:String):View<Char>;
 
 	/**
-	 * Fills `buffer` with `s` encoded as UTF8 characters. The characters in the view will be null terminated.
-	 * 
-	 * @param s The string to encode into the buffer.
-	 * @param buffer The view to write into.
-	 * @returns The number of characters written into `buffer`.
-	 *
-	 * @throws InvalidViewLength If `buffer` does not have enough space.
-	 */
-	static overload function toCharView(s:String, buffer:View<Char>):Int;
-
-	/**
-	 * Returns a view to UTF16 encoded characters of the given string. The characters in the view will be null terminated.
-	 * 
-	 * Depending on the internal incoding of `s` this function may allocate GC bytes.
+	 * Returns a view to UTF16 encoded characters of the given string. If the internal encoding of the string is not UTF16 an exception is raised.
 	 * 
 	 * @param s String to return the view of.
 	 */
-	static overload function toWideCharView(s:String):View<Char16>;
-
-	/**
-	 * Fills `buffer` with `s` encoded as UTF16 characters. The characters in the view will be null terminated.
-	 * 
-	 * @param s The string to encode into the buffer.
-	 * @param buffer The view to write into.
-	 * @returns The number of characters written into `buffer`.
-	 *
-	 * @throws InvalidViewLength If `buffer` does not have enough space.
-	 */
-	static overload function toWideCharView(s:String, buffer:View<Char16>):Int;
-
-	/**
-	 * Allocates a string from the provided utf8 characters.
-	 *
-	 * @param buffer Buffer to characters, does not need to be null terminated.
-	 */
-	static overload function toString(buffer:View<Char>):String;
-
-	/**
-	 * Allocates a string from the provided utf16 characters.
-	 *
-	 * @param buffer Buffer to characters, does not need to be null terminated.
-	 */
-	static overload function toString(buffer:View<Char16>):String;
+	static overload function asWideCharView(s:String):View<Char16>;
 
 	static function read<T>(view:View<UInt8>):T;
 

--- a/std/cpp/marshal/View.hx
+++ b/std/cpp/marshal/View.hx
@@ -1,6 +1,5 @@
 package cpp.marshal;
 
-import cpp.SizeT;
 import haxe.Int64;
 import haxe.ds.Vector;
 import haxe.exceptions.ArgumentException;
@@ -8,10 +7,10 @@ import haxe.exceptions.ArgumentException;
 @:semantics(value)
 @:cpp.ValueType({ namespace:['cpp', 'marshal'], flags: [ StackOnly ] })
 extern final class View<T> implements ArrayAccess<T> {
-    final length : SizeT;
+    final length : Int64;
 	final ptr : Pointer<T>;
 
-	function new(ptr:Pointer<T>, length:SizeT):Void;
+	function new(ptr:Pointer<T>, length:Int64):Void;
 
 	/**
 	 * Attempts to copy the data from the current view to the destination view.

--- a/std/cpp/marshal/View.hx
+++ b/std/cpp/marshal/View.hx
@@ -21,14 +21,10 @@ extern final class View<T> implements ArrayAccess<T> {
 
 	/**
 	 * Copies the the from the current view to the destination view.
+	 * If the destination is smaller than the current view this function raises an exception and no data is written to the destination.
 	 * @param destination Target of the copy operation
-	 * @throws ArgumentException If the destination is smaller than the current view.
 	 */
-	inline function copyTo(destination:View<T>) {
-		if (tryCopyTo(destination) == false) {
-			throw new ArgumentException("destination", "Not enough space in the destination view");
-		}
-	}
+	function copyTo(destination:View<T>):Void;
 
 	/**
 	 * Sets all items in the current view to their default value.
@@ -64,5 +60,12 @@ extern final class View<T> implements ArrayAccess<T> {
 	 */
 	function reinterpret<K>():View<K>;
 
-	function compare(rhs:View<T>):Int;
+	/**
+	 * Returns 0 if the contents of the two views are identical.
+	 * 
+	 * Returns a negative value if the length of this view is less than the length of other, or a positive value if the length of this view is greater than the length of other.
+	 *
+	 * In case of equal lengths, returns a negative value if the first different value in other is greater than the corresponding value in this view. Otherwise, returns a positive value.
+	 */
+	function compare(other:View<T>):Int;
 }

--- a/std/cpp/marshal/ViewExtensions.hx
+++ b/std/cpp/marshal/ViewExtensions.hx
@@ -4,6 +4,7 @@ import cpp.Pointer;
 import cpp.Star;
 import cpp.RawPointer;
 import cpp.Char;
+import cpp.Char16;
 import cpp.UInt8;
 import cpp.NativeString;
 import haxe.io.Bytes;
@@ -75,6 +76,11 @@ final class ViewExtensions {
 		return source.reinterpret();
 	}
 
+	/**
+	 * Allocates a new `Array` instance and copies `source` into it.
+	 *
+	 * @throws ArgumentException If `source` represents a region of bytes greater than the max Int32 value.
+	 */
 	@:unreflective @:generic public static function toArray<T>(source:View<T>):Array<T> {
 		if (source.length > 2147483647) {
 			throw new ArgumentException("source");
@@ -88,6 +94,11 @@ final class ViewExtensions {
 		return output;
 	}
 
+	/**
+	 * Allocates a new `haxe.ds.Vector` instance and copies `source` into it.
+	 *
+	 * @throws ArgumentException If `source` represents a region of bytes greater than the max Int32 value.
+	 */
 	@:unreflective @:generic public static function toVector<T>(source:View<T>):Vector<T> {
 		if (source.length > 2147483647) {
 			throw new ArgumentException("source");
@@ -101,6 +112,11 @@ final class ViewExtensions {
 		return output;
 	}
 
+	/**
+	 * Allocates a new `haxe.io.Bytes` instance and copies `source` into it.
+	 *
+	 * @throws ArgumentException If `source` represents a region of bytes greater than the max Int32 value.
+	 */
 	@:unreflective @:generic public static function toBytes<T>(source:View<T>):Bytes {
 		final bytes = asBytesView(source);
 		
@@ -114,5 +130,47 @@ final class ViewExtensions {
 		bytes.copyTo(destination);
 
 		return output;
+	}
+
+	/**
+	 * Reads UTF-8 characters from the view up to the first null character and decodes them into a string.
+	 */
+	public static inline overload extern function szToString(source:View<Char>):String {
+		final bytes = asBytesView(source);
+
+        var count     = 0i64;
+        var codepoint = (0 : cpp.Char32);
+        while (bytes.isEmpty() == false) {
+            final read = cpp.encoding.Utf8.decode(bytes.slice(count), codepoint);
+
+            if (0 == codepoint) {
+                break;
+            } else {
+                count += read;
+            }
+        }
+
+        return cpp.encoding.Utf8.decode(bytes.slice(0, count));
+	}
+
+	/**
+	 * Reads UTF-16 characters from the view up to the first null character and decodes them into a string.
+	 */
+	public static inline overload extern function szToString(source:View<Char16>):String {
+		final bytes = asBytesView(source);
+
+        var count     = 0i64;
+        var codepoint = (0 : cpp.Char32);
+        while (bytes.isEmpty() == false) {
+            final read = cpp.encoding.Utf16.decode(bytes.slice(count), codepoint);
+
+            if (0 == codepoint) {
+                break;
+            } else {
+                count += read;
+            }
+        }
+
+        return cpp.encoding.Utf16.decode(bytes.slice(0, count));
 	}
 }

--- a/std/cpp/marshal/ViewExtensions.hx
+++ b/std/cpp/marshal/ViewExtensions.hx
@@ -19,7 +19,7 @@ import haxe.extern.AsVar;
 import haxe.exceptions.ArgumentException;
 
 final class ViewExtensions {
-	public static inline overload extern function asView<T>(source:Pointer<T>, length:Int):View<T> {
+	public static inline overload extern function asView<T>(source:Pointer<T>, length:Int64):View<T> {
 		return new View(source, length);
 	}
 
@@ -80,7 +80,7 @@ final class ViewExtensions {
 			throw new ArgumentException("source");
 		}
 
-		final output      = cpp.NativeArray.create(source.length);
+		final output      = cpp.NativeArray.create(cast source.length);
 		final destination = asView(output);
 
 		source.copyTo(destination);
@@ -93,7 +93,7 @@ final class ViewExtensions {
 			throw new ArgumentException("source");
 		}
 
-		final output      = new Vector(source.length);
+		final output      = new Vector(cast source.length);
 		final destination = asView(output);
 
 		source.copyTo(destination);
@@ -108,7 +108,7 @@ final class ViewExtensions {
 			throw new ArgumentException("source");
 		}
 
-		final output      = Bytes.alloc(bytes.length);
+		final output      = Bytes.alloc(cast bytes.length);
 		final destination = ViewExtensions.asView(output);
 
 		bytes.copyTo(destination);

--- a/std/cpp/marshal/ViewExtensions.hx
+++ b/std/cpp/marshal/ViewExtensions.hx
@@ -136,11 +136,11 @@ final class ViewExtensions {
 	 * Reads UTF-8 characters from the view up to the first null character and decodes them into a string.
 	 */
 	public static inline overload extern function szToString(source:View<Char>):String {
-		final bytes = asBytesView(source);
+        final bytes = asBytesView(source);
 
         var count     = 0i64;
-        var codepoint = (0 : cpp.Char32);
-        while (bytes.isEmpty() == false) {
+		var codepoint = (0 : cpp.Char32);
+        while (count < bytes.length) {
             final read = cpp.encoding.Utf8.decode(bytes.slice(count), codepoint);
 
             if (0 == codepoint) {
@@ -157,11 +157,11 @@ final class ViewExtensions {
 	 * Reads UTF-16 characters from the view up to the first null character and decodes them into a string.
 	 */
 	public static inline overload extern function szToString(source:View<Char16>):String {
-		final bytes = asBytesView(source);
+        final bytes = asBytesView(source);
 
         var count     = 0i64;
-        var codepoint = (0 : cpp.Char32);
-        while (bytes.isEmpty() == false) {
+		var codepoint = (0 : cpp.Char32);
+        while (count < bytes.length) {
             final read = cpp.encoding.Utf16.decode(bytes.slice(count), codepoint);
 
             if (0 == codepoint) {

--- a/std/cpp/marshal/ViewExtensions.hx
+++ b/std/cpp/marshal/ViewExtensions.hx
@@ -23,14 +23,6 @@ final class ViewExtensions {
 		return new View(source, length);
 	}
 
-	public static inline overload extern function asView<T>(source:Star<T>, length:Int):View<T> {
-		return new View(Pointer.fromStar(source), length);
-	}
-
-	public static inline overload extern function asView<T>(source:RawPointer<T>, length:Int):View<T> {
-		return new View(Pointer.fromRaw(source), length);
-	}
-
 	public static inline overload extern function asView<T>(source:Array<T>):View<T> {
 		return new View(Pointer.ofArray(source), source.length);
 	}

--- a/std/cpp/marshal/ViewExtensions.hx
+++ b/std/cpp/marshal/ViewExtensions.hx
@@ -138,15 +138,14 @@ final class ViewExtensions {
 	public static inline overload extern function szToString(source:View<Char>):String {
         final bytes = asBytesView(source);
 
-        var count     = 0i64;
-		var codepoint = (0 : cpp.Char32);
+        var count = 0i64;
         while (count < bytes.length) {
-            final read = cpp.encoding.Utf8.decode(bytes.slice(count), codepoint);
-
+			final codepoint = cpp.encoding.Utf8.codepoint(bytes.slice(count));
+			
             if (0 == codepoint) {
                 break;
             } else {
-                count += read;
+                count += cpp.encoding.Utf8.getByteCount(codepoint);
             }
         }
 
@@ -159,15 +158,14 @@ final class ViewExtensions {
 	public static inline overload extern function szToString(source:View<Char16>):String {
         final bytes = asBytesView(source);
 
-        var count     = 0i64;
-		var codepoint = (0 : cpp.Char32);
+        var count = 0i64;
         while (count < bytes.length) {
-            final read = cpp.encoding.Utf16.decode(bytes.slice(count), codepoint);
-
+			final codepoint = cpp.encoding.Utf16.codepoint(bytes.slice(count));
+			
             if (0 == codepoint) {
                 break;
             } else {
-                count += read;
+                count += cpp.encoding.Utf16.getByteCount(codepoint);
             }
         }
 

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -27,7 +27,7 @@ class Cpp {
 			final path = getHaxelibPath("hxcpp");
 			infoMsg('hxcpp has already been installed in $path.');
 		} catch(e:Dynamic) {
-			haxelibInstallGit("HaxeFoundation", "hxcpp", true);
+			haxelibInstallGit("Aidan63", "hxcpp", "cpp_encoding", true);
 			final oldDir = Sys.getCwd();
 			changeDirectory(getHaxelibPath("hxcpp") + "tools/hxcpp/");
 			runCommand("haxe", ["-D", "source-header=''", "compile.hxml"]);

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -27,7 +27,7 @@ class Cpp {
 			final path = getHaxelibPath("hxcpp");
 			infoMsg('hxcpp has already been installed in $path.');
 		} catch(e:Dynamic) {
-			haxelibInstallGit("Aidan63", "hxcpp", "cpp_encoding", true);
+			haxelibInstallGit("HaxeFoundation", "hxcpp", true);
 			final oldDir = Sys.getCwd();
 			changeDirectory(getHaxelibPath("hxcpp") + "tools/hxcpp/");
 			runCommand("haxe", ["-D", "source-header=''", "compile.hxml"]);


### PR DESCRIPTION
I was thinking about using the new cpp marshalling stuff to make a better `StringBuf` implementation but realised that the string marshalling stuff I added was only really usable in terms of null terminated c string interop, not general string to encoded bytes usage.

So this makes it a bit more flexible. New extern types `cpp.encoding.Ascii`, `cpp.encoding.Utf8, and `cpp.encoding.Utf16` have been added to deal with conversions between the various internal string encodings hxcpp uses. Most of this functionality already existed in hxcpp, so it's just making it usable from the haxe side.

hxcpp side : https://github.com/HaxeFoundation/hxcpp/pull/1283