### PR TITLE
[lua] Stub EReg for -D lua-vanilla mode

### DIFF
--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -25,53 +25,21 @@
 // Vanilla Lua mode - EReg requires lrexlib-pcre2 which is not available
 @:coreApi
 class EReg {
-	public function new(r:String, opt:String):Void {
-		throw new haxe.exceptions.NotImplementedException("EReg requires the lrexlib-pcre2 library. Use -D lua-vanilla=false or install lrexlib-pcre2.");
-	}
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("EReg requires lrexlib-pcre2");
 
-	public function match(s:String):Bool {
-		return false;
-	}
-
-	public function matched(n:Int):String {
-		return null;
-	}
-
-	public function matchedLeft():String {
-		return null;
-	}
-
-	public function matchedRight():String {
-		return null;
-	}
-
-	public function matchedPos():{pos:Int, len:Int} {
-		return null;
-	}
-
-	public function matchedNum():Int {
-		return 0;
-	}
-
-	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
-		return false;
-	}
-
-	public function split(s:String):Array<String> {
-		return null;
-	}
-
-	public function replace(s:String, by:String):String {
-		return null;
-	}
-
-	public function map(s:String, f:EReg->String):String {
-		return null;
-	}
-
-	public static function escape(s:String):String {
-		return null;
-	}
+	public function new(r:String, opt:String):Void notImplemented();
+	public function match(s:String):Bool return notImplemented();
+	public function matched(n:Int):String return notImplemented();
+	public function matchedLeft():String return notImplemented();
+	public function matchedRight():String return notImplemented();
+	public function matchedPos():{pos:Int, len:Int} return notImplemented();
+	public function matchedNum():Int return notImplemented();
+	public function matchSub(s:String, pos:Int, len:Int = -1):Bool return notImplemented();
+	public function split(s:String):Array<String> return notImplemented();
+	public function replace(s:String, by:String):String return notImplemented();
+	public function map(s:String, f:EReg->String):String return notImplemented();
+	public static function escape(s:String):String return notImplemented();
 }
 
 #else

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -26,7 +26,7 @@
 @:coreApi
 class EReg {
 	static inline function notImplemented():Dynamic
-		throw new haxe.exceptions.NotImplementedException("EReg requires lrexlib-pcre2");
+		throw new haxe.exceptions.NotImplementedException("EReg cannot be used with -D lua-vanilla because it requires lrexlib-pcre2");
 
 	public function new(r:String, opt:String):Void notImplemented();
 	public function match(s:String):Bool return notImplemented();

--- a/std/lua/_std/EReg.hx
+++ b/std/lua/_std/EReg.hx
@@ -20,6 +20,62 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#if lua_vanilla
+
+// Vanilla Lua mode - EReg requires lrexlib-pcre2 which is not available
+@:coreApi
+class EReg {
+	public function new(r:String, opt:String):Void {
+		throw new haxe.exceptions.NotImplementedException("EReg requires the lrexlib-pcre2 library. Use -D lua-vanilla=false or install lrexlib-pcre2.");
+	}
+
+	public function match(s:String):Bool {
+		return false;
+	}
+
+	public function matched(n:Int):String {
+		return null;
+	}
+
+	public function matchedLeft():String {
+		return null;
+	}
+
+	public function matchedRight():String {
+		return null;
+	}
+
+	public function matchedPos():{pos:Int, len:Int} {
+		return null;
+	}
+
+	public function matchedNum():Int {
+		return 0;
+	}
+
+	public function matchSub(s:String, pos:Int, len:Int = -1):Bool {
+		return false;
+	}
+
+	public function split(s:String):Array<String> {
+		return null;
+	}
+
+	public function replace(s:String, by:String):String {
+		return null;
+	}
+
+	public function map(s:String, f:EReg->String):String {
+		return null;
+	}
+
+	public static function escape(s:String):String {
+		return null;
+	}
+}
+
+#else
+
 import lua.Table;
 import lua.Lib;
 import lua.lib.lrexlib.Rex;
@@ -220,3 +276,5 @@ class EReg {
 		}
 	}
 }
+
+#end

--- a/std/lua/_std/Sys.hx
+++ b/std/lua/_std/Sys.hx
@@ -20,6 +20,44 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#if lua_vanilla
+
+import lua.Boot;
+import lua.Io;
+import lua.Lua;
+import sys.io.FileInput;
+import sys.io.FileOutput;
+
+@:coreApi
+class Sys {
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("Sys cannot be used with -D lua-vanilla because it requires luv");
+
+	public static inline function print(v:Dynamic):Void lua.Lib.print(v);
+	public static inline function println(v:Dynamic):Void lua.Lib.println(v);
+	public static inline function args():Array<String> return lua.Table.toArray(lua.PairTools.copy(Lua.arg));
+	public static function command(cmd:String, ?args:Array<String>):Int return notImplemented();
+	public static inline function cpuTime():Float return lua.Os.clock();
+	public static inline function exit(code:Int):Void lua.Os.exit(code);
+	public static inline function getChar(echo:Bool):Int return lua.Io.read().charCodeAt(0);
+	public static function systemName():String return lua.Boot.systemName();
+	public static function environment():Map<String, String> return notImplemented();
+	@:deprecated("Use programPath instead") public static function executablePath():String return notImplemented();
+	public static inline function programPath():String return haxe.io.Path.join([getCwd(), Lua.arg[0]]);
+	public static function getCwd():String return notImplemented();
+	public static function setCwd(s:String):Void notImplemented();
+	public static function getEnv(s:String):Null<String> return notImplemented();
+	public static function putEnv(s:String, v:Null<String>):Void notImplemented();
+	public static inline function setTimeLocale(loc:String):Bool return lua.Os.setlocale(loc) != null;
+	public static function sleep(seconds:Float):Void notImplemented();
+	public static inline function stderr():haxe.io.Output return @:privateAccess new FileOutput(Io.stderr);
+	public static inline function stdin():haxe.io.Input return @:privateAccess new FileInput(Io.stdin);
+	public static inline function stdout():haxe.io.Output return @:privateAccess new FileOutput(Io.stdout);
+	public static function time():Float return notImplemented();
+}
+
+#else
+
 import lua.Boot;
 import lua.Io;
 import lua.Lua;
@@ -126,3 +164,5 @@ class Sys {
 		return stamp.seconds + (stamp.microseconds / 1000000);
 	}
 }
+
+#end

--- a/std/lua/_std/haxe/iterators/StringIterator.hx
+++ b/std/lua/_std/haxe/iterators/StringIterator.hx
@@ -21,6 +21,20 @@
  */
 
 package haxe.iterators;
+
+#if lua_vanilla
+
+class StringIterator {
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("StringIterator cannot be used with -D lua-vanilla because it requires lua-utf8");
+
+	public inline function new(s:String) notImplemented();
+	public inline function hasNext():Bool return notImplemented();
+	public inline function next():Int return notImplemented();
+}
+
+#else
+
 import lua.lib.luautf8.Utf8;
 
 class StringIterator {
@@ -48,3 +62,5 @@ class StringIterator {
         return ret;
     }
 }
+
+#end

--- a/std/lua/_std/sys/FileSystem.hx
+++ b/std/lua/_std/sys/FileSystem.hx
@@ -22,6 +22,26 @@
 
 package sys;
 
+#if lua_vanilla
+
+class FileSystem {
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("FileSystem cannot be used with -D lua-vanilla because it requires luv");
+
+	public static function exists(path:String):Bool return notImplemented();
+	public static function rename(path:String, newPath:String):Void notImplemented();
+	public static function stat(path:String):FileStat return notImplemented();
+	public static function fullPath(relPath:String):String return notImplemented();
+	public static function absolutePath(relPath:String):String return notImplemented();
+	public static function deleteFile(path:String):Void notImplemented();
+	public static function readDirectory(path:String):Array<String> return notImplemented();
+	public static function isDirectory(path:String):Bool return notImplemented();
+	public static function deleteDirectory(path:String):Void notImplemented();
+	public static function createDirectory(path:String):Void notImplemented();
+}
+
+#else
+
 import lua.Io;
 import haxe.io.Path;
 import lua.lib.luv.fs.FileSystem as LFileSystem;
@@ -123,3 +143,5 @@ class FileSystem {
 		}
 	}
 }
+
+#end

--- a/std/lua/_std/sys/io/Process.hx
+++ b/std/lua/_std/sys/io/Process.hx
@@ -22,6 +22,26 @@
 
 package sys.io;
 
+#if lua_vanilla
+
+@:coreApi
+class Process {
+	public var stdout(default, null):haxe.io.Input;
+	public var stderr(default, null):haxe.io.Input;
+	public var stdin(default, null):haxe.io.Output;
+
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("Process cannot be used with -D lua-vanilla because it requires luv");
+
+	public function new(cmd:String, ?args:Array<String>, ?detached:Bool) notImplemented();
+	public function getPid():Int return notImplemented();
+	public function close():Void notImplemented();
+	public function exitCode(block:Bool = true):Null<Int> return notImplemented();
+	public function kill():Void notImplemented();
+}
+
+#else
+
 import lua.Io;
 import lua.lib.luv.Pipe;
 import lua.lib.luv.Signal;
@@ -226,3 +246,5 @@ private class ProcessOutput extends haxe.io.Output {
 		b.close();
 	}
 }
+
+#end

--- a/std/lua/_std/sys/net/Socket.hx
+++ b/std/lua/_std/sys/net/Socket.hx
@@ -22,6 +22,36 @@
 
 package sys.net;
 
+#if lua_vanilla
+
+class Socket {
+	public var input(default, null):haxe.io.Input;
+	public var output(default, null):haxe.io.Output;
+
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("Socket cannot be used with -D lua-vanilla because it requires luasocket");
+
+	public function new():Void notImplemented();
+	public function close():Void notImplemented();
+	public function read():String return notImplemented();
+	public function write(content:String):Void notImplemented();
+	public function connect(host:Host, port:Int):Void notImplemented();
+	public function listen(connections:Int):Void notImplemented();
+	public function shutdown(read:Bool, write:Bool):Void notImplemented();
+	public function bind(host:Host, port:Int):Void notImplemented();
+	public function accept():Socket return notImplemented();
+	public function peer():{host:Host, port:Int} return notImplemented();
+	public function host():{host:Host, port:Int} return notImplemented();
+	public function setTimeout(timeout:Float):Void notImplemented();
+	public function waitForRead():Void notImplemented();
+	public function setBlocking(b:Bool):Void notImplemented();
+	public function setFastSend(b:Bool):Void notImplemented();
+	public static function select(read:Array<Socket>, write:Array<Socket>, others:Array<Socket>,
+			?timeout:Float):{read:Array<Socket>, write:Array<Socket>, others:Array<Socket>} return notImplemented();
+}
+
+#else
+
 import lua.lib.luasocket.Socket as LuaSocket;
 import lua.lib.luasocket.socket.*;
 import lua.*;
@@ -160,3 +190,5 @@ class Socket {
 		return {read: read_arr, write: write_arr, others: []};
 	}
 }
+
+#end

--- a/std/lua/_std/sys/net/SocketInput.hx
+++ b/std/lua/_std/sys/net/SocketInput.hx
@@ -19,8 +19,21 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
- 
+
 package sys.net;
+
+#if lua_vanilla
+
+class SocketInput extends haxe.io.Input {
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("SocketInput cannot be used with -D lua-vanilla because it requires luasocket");
+
+	public function new(tcp:Dynamic) notImplemented();
+	override public function readByte():Int return notImplemented();
+	override public function readBytes(s:haxe.io.Bytes, pos:Int, len:Int):Int return notImplemented();
+}
+
+#else
 
 import lua.lib.luasocket.socket.TcpClient;
 import lua.*;
@@ -67,3 +80,5 @@ class SocketInput extends haxe.io.Input {
 	}
 
 }
+
+#end

--- a/std/lua/_std/sys/net/SocketOutput.hx
+++ b/std/lua/_std/sys/net/SocketOutput.hx
@@ -19,8 +19,21 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
- 
+
 package sys.net;
+
+#if lua_vanilla
+
+class SocketOutput extends haxe.io.Output {
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("SocketOutput cannot be used with -D lua-vanilla because it requires luasocket");
+
+	public function new(tcp:Dynamic) notImplemented();
+	override public function writeByte(c:Int):Void notImplemented();
+	override public function writeBytes(s:haxe.io.Bytes, pos:Int, len:Int):Int return notImplemented();
+}
+
+#else
 
 import lua.lib.luasocket.socket.TcpClient;
 import lua.*;
@@ -59,3 +72,5 @@ class SocketOutput extends haxe.io.Output {
 	}
 
 }
+
+#end

--- a/std/lua/_std/sys/ssl/Socket.hx
+++ b/std/lua/_std/sys/ssl/Socket.hx
@@ -20,19 +20,32 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
- package sys.ssl;
+package sys.ssl;
 
- import sys.net.Host;
- import sys.net.SocketInput;
- import sys.net.SocketOutput;
+#if lua_vanilla
 
- import lua.lib.luasocket.Socket as LuaSocket;
- import lua.lib.luasec.Ssl as LuaSecSsl;
- import lua.lib.luasec.SslTcpClient;
- 
- import haxe.io.Bytes;
- import haxe.io.Error;
- 
+class Socket extends sys.net.Socket {
+	static inline function notImplemented():Dynamic
+		throw new haxe.exceptions.NotImplementedException("sys.ssl.Socket cannot be used with -D lua-vanilla because it requires luasec");
+
+	public function handshake():Void notImplemented();
+	override public function connect(host:sys.net.Host, port:Int):Void notImplemented();
+	override public function close():Void notImplemented();
+}
+
+#else
+
+import sys.net.Host;
+import sys.net.SocketInput;
+import sys.net.SocketOutput;
+
+import lua.lib.luasocket.Socket as LuaSocket;
+import lua.lib.luasec.Ssl as LuaSecSsl;
+import lua.lib.luasec.SslTcpClient;
+
+import haxe.io.Bytes;
+import haxe.io.Error;
+
 class Socket extends sys.net.Socket { 
     var _sslSocket:SslTcpClient;
 
@@ -67,3 +80,5 @@ class Socket extends sys.net.Socket {
 		_sslSocket.close();
     }
 }
+
+#end


### PR DESCRIPTION
Note for simn, I'm gradually chipping away at some of the leftover issues from Lua.  And jotting down a few points where I hit some foot guns.  I'm using AI to help generate stub files and to write tests.  It's all things I wanted to do before but just couldn't find the motivation/time.  I can finish off the rest of the lua-vanilla issues, but wanted to give you a chance to see the basic intent before I added a bunch of stuff.

## Summary

- EReg now conditionally compiles: stub implementation for `-D lua-vanilla`, real implementation otherwise
- Stub throws `NotImplementedException` at runtime with a clear error message
- Partial fix for #12063 - removes the lrexlib-pcre2 dependency when using lua-vanilla

## Background

The `#error` directive approach in `_std` override files triggers eager file scanning, causing compilation failures even when the type isn't used. This PR uses conditional compilation with a runtime stub instead.

## Remaining work for #12063

Other modules still need the same treatment:
- `Sys.hx` (luv)
- `sys/FileSystem.hx` (luv)
- `sys/io/Process.hx` (luv)
- `sys/net/*.hx` (luasocket)
- `sys/ssl/Socket.hx` (luasec)
- `haxe/iterators/StringIterator.hx` (lua-utf8)

## Test plan

- [ ] Verify EReg compiles without lrexlib-pcre2 when using `-D lua-vanilla`
- [ ] Verify EReg throws NotImplementedException at runtime in vanilla mode
- [ ] Verify normal EReg functionality still works without `-D lua-vanilla`