### PR TITLE
[lua] Fix redundant _hx_funcToField for non-function fields

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1338,21 +1338,21 @@ and gen_tbinop ctx op e1 e2 =
               gen_value ctx e1;
               spr ctx " = ";
               gen_value ctx e3;
-          | TField(e3, (FClosure _ | FAnon _)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) ->
+          | TField(e3, (FClosure _ | FAnon _)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) when is_function_type e2.etype ->
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);
               add_feature ctx "use._hx_funcToField";
               spr ctx "_hx_funcToField(";
               gen_value ctx e2;
               spr ctx ")";
-          | TField(e3, (FInstance _ as lhs)), TField(e4, (FInstance _ as rhs)) when not (is_dot_access e3 lhs) && (is_dot_access e4 rhs) ->
+          | TField(e3, (FInstance _ as lhs)), TField(e4, (FInstance _ as rhs)) when is_function_type e2.etype && not (is_dot_access e3 lhs) && (is_dot_access e4 rhs) ->
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);
               add_feature ctx "use._hx_funcToField";
               spr ctx "_hx_funcToField(";
               gen_value ctx e2;
               spr ctx ")";
-          | TField(e3, (FInstance _ as ci)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) when not (is_dot_access e3 ci) ->
+          | TField(e3, (FInstance _ as ci)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) when is_function_type e2.etype && not (is_dot_access e3 ci) ->
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);
               add_feature ctx "use._hx_funcToField";

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -73,6 +73,20 @@ class TestLua extends Test {
 		eq(result, 99);
 	}
 
+	// Issue #11842: Non-function fields should not be wrapped with _hx_funcToField
+	function testNoFuncToFieldForNonFunctions() {
+		var a:Issue11842Slot = { data: 0, func: null };
+		var b:Issue11842Slot = { data: 42, func: function(x) return x * 2 };
+
+		// Non-function field assignment should work correctly
+		a.data = b.data;
+		eq(a.data, 42);
+
+		// Function field assignment should also work correctly
+		a.func = b.func;
+		eq(a.func(10), 20);
+	}
+
 	function testMetatablesAreShared() {
 
 		// New class instances get metatables assigned to them
@@ -113,3 +127,9 @@ class MultiCall {
 class TLA { private var foo: String; public function new() { this.foo = "A"; } }
 class TLAChild extends TLA { public function new() { super(); this.foo = "AChild"; } }
 class TLB { private var foo: String; public function new() { this.foo = "B"; } }
+
+// Issue #11842
+typedef Issue11842Slot = {
+	var data:Int;
+	var func:(Int) -> Int;
+}


### PR DESCRIPTION
Fixes #11842. The OpAssign patterns in genlua.ml were wrapping all field assignments between anonymous/closure types with _hx_funcToField, regardless of whether the field was actually a function type.

Added is_function_type checks to the three patterns that were missing them, matching the existing pattern for TLocal assignments.

