### PR TITLE
[hl] Allow remove uv dependencies in EventLoop

### DIFF
--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -93,7 +93,7 @@ class EventLoop {
 	**/
 	public var thread : sys.thread.Thread;
 	#end
-	#if hl
+	#if (hl && !hl_no_libuv)
 	var uvLoop : hl.uv.Loop;
 	var inUV : Bool;
 	#end
@@ -105,7 +105,7 @@ class EventLoop {
 		#end
 	}
 
-	#if hl
+	#if (hl && !hl_no_libuv)
 	function getUVLoop() {
 		if( uvLoop == null ) {
 			if( this == main )
@@ -127,7 +127,7 @@ class EventLoop {
 		It is already automatically called for threads loops.
 	**/
 	public function dispose() {
-		#if hl
+		#if (hl && !hl_no_libuv)
 		if( uvLoop != null && uvLoop.close() != 0 ) Sys.println("Some async handlers have not been closed");
 		#end
 	}
@@ -140,7 +140,7 @@ class EventLoop {
 		checkThread();
 		while( hasEvents(true) || promiseCount > 0 || (this == main && hasRunningThreads()) ) {
 			var time = getNextTick();
-			#if hl
+			#if (hl && !hl_no_libuv)
 			// disable wait if we have our uvloop alive
 			if( uvLoop != null && time > 0 && uvLoop.alive() > 0 )
 				time = -1;
@@ -217,7 +217,7 @@ class EventLoop {
 	public function loopOnce( threadCheck = true ) {
 		if( threadCheck )
 			checkThread();
-		#if hl
+		#if (hl && !hl_no_libuv)
 		if( inUV ) throw "You cannot callback EventLoop.loop() while in uv event callback";
 		#end
 
@@ -227,7 +227,7 @@ class EventLoop {
 		inLoop = true;
 		unlock();
 
-		#if hl
+		#if (hl && !hl_no_libuv)
 		if( uvLoop != null ) {
 			inUV = true;
 			uvLoop.run(NoWait);
@@ -449,7 +449,7 @@ class EventLoop {
 		If blocking is set to true, only check if it has remaining blocking events.
 	**/
 	public function hasEvents( blocking : Bool = true ) {
-		#if hl
+		#if (hl && !hl_no_libuv)
 		if( uvLoop != null && uvLoop.alive() > 0 )
 			return true;
 		#end

--- a/std/hl/uv/Fs.hx
+++ b/std/hl/uv/Fs.hx
@@ -27,6 +27,7 @@
 	var Change = 2;
 }
 
+#if !hl_no_libuv
 @:hlNative("uv")
 class Fs extends Handle {
 	public function new(?loop : Loop, path : String, onContentChanged : Event -> Void) {
@@ -49,3 +50,4 @@ class Fs extends Handle {
 		return false;
 	}
 }
+#end

--- a/std/hl/uv/Handle.hx
+++ b/std/hl/uv/Handle.hx
@@ -22,6 +22,7 @@
 
 package hl.uv;
 
+#if !hl_no_libuv
 @:hlNative("uv")
 class Handle {
 	public var handle:HandleData;
@@ -38,3 +39,4 @@ class Handle {
 
 	static function close_handle(h:HandleData, callb:Void->Void):Void {}
 }
+#end

--- a/std/hl/uv/HandleData.hx
+++ b/std/hl/uv/HandleData.hx
@@ -22,4 +22,6 @@
 
 package hl.uv;
 
+#if !hl_no_libuv
 typedef HandleData = hl.Abstract<"uv_handle">;
+#end

--- a/std/hl/uv/Loop.hx
+++ b/std/hl/uv/Loop.hx
@@ -22,6 +22,7 @@
 
 package hl.uv;
 
+#if !hl_no_libuv
 enum abstract LoopRunMode(Int) {
 	var Default = 0;
 	var Once = 1;
@@ -67,3 +68,4 @@ abstract Loop(hl.Abstract<"uv_loop">) {
 	#end
 
 }
+#end

--- a/std/hl/uv/SSLStream.hx
+++ b/std/hl/uv/SSLStream.hx
@@ -22,6 +22,7 @@
 
 package hl.uv;
 
+#if !hl_no_libuv
 class SSLStream extends Stream {
 
 	var sub : Stream;
@@ -156,3 +157,4 @@ class SSLStream extends Stream {
 	}
 
 }
+#end

--- a/std/hl/uv/Stream.hx
+++ b/std/hl/uv/Stream.hx
@@ -22,6 +22,7 @@
 
 package hl.uv;
 
+#if !hl_no_libuv
 @:hlNative("uv")
 class Stream extends Handle {
 	public function write(bytes:haxe.io.Bytes, ?onWrite:Bool->Void, pos = 0, len = -1) {
@@ -68,3 +69,4 @@ class Stream extends Handle {
 		return false;
 	}
 }
+#end

--- a/std/hl/uv/Tcp.hx
+++ b/std/hl/uv/Tcp.hx
@@ -22,6 +22,7 @@
 
 package hl.uv;
 
+#if !hl_no_libuv
 @:hlNative("uv")
 class Tcp extends Stream {
 	public function new(?loop:Loop) {
@@ -70,3 +71,4 @@ class Tcp extends Stream {
 
 	static function tcp_nodelay_wrap(h:HandleData, b:Bool):Void {}
 }
+#end


### PR DESCRIPTION
Since
- https://github.com/HaxeFoundation/haxe/commit/a7c1a5368ab4d548bb5fffe148406b854fd4de15

libuv becomes a hard dependencies of hashlink if we use EventLoop. This cause problem on cosole, and needs some flag to disable/enable it.

Nicolas suggested `-D hl_no_libuv`