### PR TITLE
[ci] Update setup-ocaml on windows

### DIFF
--- a/.github/actions/setup-ocaml-windows/action.yml
+++ b/.github/actions/setup-ocaml-windows/action.yml
@@ -3,8 +3,7 @@ runs:
   using: composite
   steps:
   - name: Setup ocaml
-  # Lock to 3.2.19 to work around an issue with 32-bit libraries getting installed
-    uses: ocaml/setup-ocaml@3d85bf33a66e089149cd1e9c75da7b9cb6d9d3a7
+    uses: ocaml/setup-ocaml@v3
     with:
       ocaml-compiler: ${{ env.OCAML_VERSION }}
       opam-local-packages: |

--- a/.github/actions/setup-ocaml-windows/action.yml
+++ b/.github/actions/setup-ocaml-windows/action.yml
@@ -34,3 +34,6 @@ runs:
         $env:PATH="${env:CYG_ROOT}\bin;${env:CYG_ROOT}\usr\x86_64-w64-mingw32\bin;${env:PATH}"
         opam install haxe --deps-only
         opam list
+    env:
+      # Work around default resolver installing 32-bit libraries
+      OPAMEXTERNALSOLVER: builtin-mccs+glpk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
           opam exec -- make -s -f Makefile.win -j"$env:NUMBER_OF_PROCESSORS" haxe
           opam exec -- make -s -f Makefile.win haxelib
           opam exec -- make -f Makefile.win echo_package_files package_bin package_installer_win package_choco
-          cygcheck ./haxe.exe
-          cygcheck ./haxelib.exe
+          opam exec -- cygcheck ./haxe.exe
+          opam exec -- cygcheck ./haxelib.exe
           ls ./out
 
       - name: Upload artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       PLATFORM: windows64
       ARCH: 64
       MINGW_ARCH: x86_64
-      CYG_ROOT: D:\cygwin
+      CYG_ROOT: C:\cygwin
     steps:
       - uses: actions/checkout@main
         with:


### PR DESCRIPTION
This should solve #12200, in case that ever occurs again.

Due to #12203, we had to lock the `setup-ocaml` version (#12201). However, we can replace that workaround by specifying an [environment variable](https://github.com/ocaml/setup-ocaml/pull/974#issuecomment-2823275778) to force the old dependency resolver (`builtin-mccs+glpk`) which avoids the bug with the new one (`builtin-0install`). The problem occurs because the new resolver installs both i686 and x86_64 mingw packages and we rely on cygcheck to copy dlls into the package, which does not discriminate architectures. I've also opened an upstream issue: https://github.com/ocaml/opam/issues/6843. 