### PR TITLE
[cpp] sizeof and alignof magic functions

### DIFF
--- a/src/generators/cpp/cppAstTools.ml
+++ b/src/generators/cpp/cppAstTools.ml
@@ -527,22 +527,21 @@ and get_extern_value_type_boxed value_type =
 
   Printf.sprintf "::cpp::marshal::Boxed< %s%s >" p suffix, Printf.sprintf "::cpp::marshal::Boxed_obj< %s%s >" p suffix
 
-and get_native_marshalled_type value_type =
-  let marshal_type_parameter_to_string pos tcpp =
-    match tcpp with
-    | TCppMarshalNativeType ((Pointer _) as value_type, _) -> get_native_marshalled_type value_type ^ "*"
-    | TCppMarshalNativeType (value_type, _) -> get_native_marshalled_type value_type
-    | TCppScalar _
-    | TCppPointer _
-    | TCppRawPointer _
-    | TCppStar _
-    | TCppVoidStar
-    | TCppStruct _ ->
-      tcpp_to_string_suffix "" tcpp
-    | _ ->
-      cpp_abort InvalidMarshallingTypeParameter pos
-  in
+and marshal_type_parameter_to_string pos tcpp =
+  match tcpp with
+  | TCppMarshalNativeType ((Pointer _) as value_type, _) -> get_native_marshalled_type value_type ^ "*"
+  | TCppMarshalNativeType (value_type, _) -> get_native_marshalled_type value_type
+  | TCppScalar _
+  | TCppPointer _
+  | TCppRawPointer _
+  | TCppStar _
+  | TCppVoidStar
+  | TCppStruct _ ->
+    tcpp_to_string_suffix "" tcpp
+  | _ ->
+    cpp_abort InvalidMarshallingTypeParameter pos
 
+and get_native_marshalled_type value_type =
   match value_type with
   | ValueClass (cls, params) ->
     build_type cls.cl_path cls.cl_pos params cls.cl_meta Meta.CppValueType (marshal_type_parameter_to_string cls.cl_pos) |> fst

--- a/src/generators/cpp/cppError.ml
+++ b/src/generators/cpp/cppError.ml
@@ -14,6 +14,7 @@ type cppError =
     | UnresolvedTypeParameter of string
     | PromotedStackOnlyValueType
     | HeapAllocationOfValueType
+    | InvalidIntrinsicUse
 
 let cpp_abort error pos =
     let print = Printf.sprintf "CPP%0*i: %s" 4 in
@@ -32,6 +33,7 @@ let cpp_abort error pos =
         | UnresolvedTypeParameter s -> print 10 (Printf.sprintf "Unable to resolve parameter %s, consider adding a type hint" s)
         | PromotedStackOnlyValueType -> print 11 "Marshalling value type with the StackOnly flag cannot be promoted to the heap"
         | HeapAllocationOfValueType -> print 12 "Value type cannot be allocated directly to a pointer"
+        | InvalidIntrinsicUse -> print 13 "Intrinsic functions can only be directly called"
     in
 
     abort str pos

--- a/src/generators/cpp/cppRetyper.ml
+++ b/src/generators/cpp/cppRetyper.ml
@@ -588,6 +588,11 @@ let expression ctx request_type function_args function_type expression_tree forI
           let retyper_ctx, cppType = retype retyper_ctx return_type e in
           (retyper_ctx, cppType.cppexpr, cppType.cpptype)
 
+      | TField (obj, FStatic ({ cl_path = (["cpp";"marshal"],"Intrinsics") }, { cf_kind = Method _ })) ->
+        cpp_abort InvalidIntrinsicUse expr.epos
+
+      (* Marshal type functions, need to be able to resolve type parameters to a concrete type, hance the special handling *)
+        
       | TField (_, FClosure (Some (cls, _), _)) when is_marshalling_native_value_class cls || is_marshalling_native_pointer cls ->
         cpp_abort NativeMarshallingFunctionClosures expr.epos
       | TField (obj, FInstance (cls, params, ({ cf_type = (TFun _) } as member))) when is_marshalling_native_value_class cls || is_marshalling_native_pointer cls ->
@@ -851,6 +856,16 @@ let expression ctx request_type function_args function_type expression_tree forI
               else (retyper_ctx, CppDynamicField (obj, fieldName), TCppVariant)
           | FEnum (enum, enum_field) ->
             (retyper_ctx, CppEnumField (enum, enum_field), TCppEnum enum))
+            
+      (* magic intrinsic functions *)
+
+      | TCall ({ epos; etype = TFun ([ (_, _, TAbstract (_, [ t ])) ], r); eexpr = TField (obj, FStatic ({ cl_path = (["cpp";"marshal"],"Intrinsics") }, { cf_name = ("sizeof" | "alignof") as name })) }, _) ->
+        let return = cpp_type_of r in
+        let arg    = cpp_type_of t |> marshal_type_parameter_to_string expr.epos in
+        let str    = Printf.sprintf "%s(%s)" name arg in
+
+        (retyper_ctx, CppCode (str, []), return)
+
       | TCall ({ eexpr = TIdent "__cpp__" }, arg_list) ->
         let retyper_ctx, cppExpr =
           match arg_list with

--- a/std/cpp/marshal/Intrinsics.hx
+++ b/std/cpp/marshal/Intrinsics.hx
@@ -1,0 +1,6 @@
+package cpp.marshal;
+
+extern class Intrinsics {
+	@:pure public static function sizeof<T>(obj:Class<T>):cpp.SizeT;
+	@:pure public static function alignof<T>(obj:Class<T>):cpp.SizeT;
+}


### PR DESCRIPTION
Magic compiler functions which generate `sizeof` and `alignof` in the output C++. This has the same restrictions that type parameters have with marshing types, i.e. the type must be an unmanaged one.

```haxe
@:semantics(value)
@:cpp.ValueType
extern class Foo {}

function main() {
    final buffer = haxe.io.Bytes.alloc(cpp.marshal.Intrinsics.sizeof(Foo) * 10); // Space for 10 Foo classes.
}
```