### PR TITLE
[lua] Fix @:selfCall on methods

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -510,6 +510,10 @@ and gen_call ctx e el =
          spr ctx ")(";
          concat ctx "," (gen_argument ctx) (e::el);
          spr ctx ")";
+     | TField (field_owner, (FInstance(_,_,f) | FAnon(f))), el when Meta.has Meta.SelfCall f.cf_meta ->
+         (* @:selfCall methods - call the object directly *)
+         gen_value ctx field_owner;
+         gen_paren_arguments ctx el;
      | TField (field_owner, ((FInstance _ | FAnon _ | FDynamic _) as ef)), el ->
          let s = (field_name ef) in
          if Hashtbl.mem kwds s || not (valid_lua_ident s) then begin

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -108,6 +108,13 @@ class TestLua extends Test {
 		Assert.notEquals(lua.Lua.getmetatable(cast a), lua.Lua.getmetatable(cast b));
 		Assert.notEquals(lua.Lua.getmetatable(cast aChild), lua.Lua.getmetatable(cast b));
 	}
+
+	function testSelfCallMethod() {
+		// Create a callable object using Lua metatables
+		final callable:SelfCallable = untyped __lua__("setmetatable({value = 10}, {__call = function(self, x) return self.value + x end})");
+		// @:selfCall method should generate callable(5) instead of callable:call(5)
+		eq(callable.call(5), 15);
+	}
 }
 
 @:multiReturn extern class Multi {
@@ -132,4 +139,9 @@ class TLB { private var foo: String; public function new() { this.foo = "B"; } }
 typedef Issue11842Slot = {
 	var data:Int;
 	var func:(Int) -> Int;
+}
+
+// Issue #9369
+extern class SelfCallable {
+	@:selfCall function call(x:Int):Int;
 }


### PR DESCRIPTION
## Summary
- Fixes #9369: `@:selfCall` on a method is now respected in Lua target
- When a method has `@:selfCall`, calling it generates `obj(args)` instead of `obj:method(args)`
- This matches the existing behavior for constructors with `@:selfCall`

## Changes
- Added pattern in `gen_call` to check for `@:selfCall` metadata on instance/anon fields
- Added test case using Lua metatables with `__call` to verify correct code generation

## Test plan
- [x] Existing Lua tests pass (11,521 assertions)
- [x] New test verifies `@:selfCall` method generates correct callable syntax