### PR TITLE
[lua] Fix function callbacks passed via anonymous objects (#10089)

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1342,7 +1342,7 @@ and gen_tbinop ctx op e1 e2 =
               gen_value ctx e1;
               spr ctx " = ";
               gen_value ctx e3;
-          | TField(e3, (FClosure _ | FAnon _)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) when is_function_type e2.etype ->
+          | TField(e3, (FClosure _ | FAnon _)), TField(e4, (FClosure _ | FStatic _)) when is_function_type e2.etype ->
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);
               add_feature ctx "use._hx_funcToField";
@@ -1356,11 +1356,21 @@ and gen_tbinop ctx op e1 e2 =
               spr ctx "_hx_funcToField(";
               gen_value ctx e2;
               spr ctx ")";
-          | TField(e3, (FInstance _ as ci)), TField(e4, (FClosure _ | FStatic _ | FAnon _)) when is_function_type e2.etype && not (is_dot_access e3 ci) ->
+          | TField(e3, (FInstance _ as ci)), TField(e4, (FClosure _ | FStatic _)) when is_function_type e2.etype && not (is_dot_access e3 ci) ->
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);
               add_feature ctx "use._hx_funcToField";
               spr ctx "_hx_funcToField(";
+              gen_value ctx e2;
+              spr ctx ")";
+          | TField(e3, (FInstance(_, _, icf) as ci)), TField(e4, FAnon _) when is_function_type e2.etype && (match icf.cf_kind with Var _ -> true | _ -> false) && is_dot_access e3 ci ->
+              (* Unwrap function from anon object when storing in Var field.
+                 Anon functions are wrapped with function(_,...) return f(...) end to work with colon syntax.
+                 Var fields are called with dot syntax, so we need to add a dummy self argument. *)
+              gen_value ctx e1;
+              print ctx " %s " (Ast.s_binop op);
+              add_feature ctx "use._hx_anonToField";
+              spr ctx "_hx_anonToField(";
               gen_value ctx e2;
               spr ctx ")";
           | TField(e3, (FInstance _ as ci)), TLocal t when ((is_function_type t.v_type) && (not (is_dot_access e3 ci))) ->
@@ -2119,7 +2129,7 @@ let generate com =
     List.iter (generate_type_forward ctx) com.types; newline ctx;
 
     (* Generate some dummy placeholders for utility libs that may be required*)
-    println ctx "local _hx_bind, _hx_bit, _hx_staticToInstance, _hx_funcToField, _hx_maxn, _hx_print, _hx_apply_self, _hx_box_mr, _hx_bit_clamp, _hx_table, _hx_bit_raw";
+    println ctx "local _hx_bind, _hx_bit, _hx_staticToInstance, _hx_funcToField, _hx_anonToField, _hx_maxn, _hx_print, _hx_apply_self, _hx_box_mr, _hx_bit_clamp, _hx_table, _hx_bit_raw";
     println ctx "local _hx_pcall_default = {};";
     println ctx "local _hx_pcall_break = {};";
 
@@ -2163,6 +2173,10 @@ let generate com =
 
     if has_feature ctx "use._hx_funcToField" then begin
         print_file (find_file "lua/_lua/_hx_func_to_field.lua");
+    end;
+
+    if has_feature ctx "use._hx_anonToField" then begin
+        print_file (find_file "lua/_lua/_hx_anon_to_field.lua");
     end;
 
     if has_feature ctx "Math.random" then begin

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -1153,9 +1153,9 @@ and gen_anon_value ctx e =
         ctx.in_loop <- snd old;
         ctx.separator <- true
     | _ when (is_function_type e.etype) && not (is_const_null e) ->
-        spr ctx "function(_,...) return ";
+        spr ctx "function(_,...) return (";
         gen_value ctx e;
-        spr ctx "(...) end";
+        spr ctx ")(...) end";
     | _->
         gen_value ctx e
 
@@ -1367,6 +1367,15 @@ and gen_tbinop ctx op e1 e2 =
               (* Unwrap function from anon object when storing in Var field.
                  Anon functions are wrapped with function(_,...) return f(...) end to work with colon syntax.
                  Var fields are called with dot syntax, so we need to add a dummy self argument. *)
+              gen_value ctx e1;
+              print ctx " %s " (Ast.s_binop op);
+              add_feature ctx "use._hx_anonToField";
+              spr ctx "_hx_anonToField(";
+              gen_value ctx e2;
+              spr ctx ")";
+          | TField(e3, (FInstance(_, _, icf) as ci)), TField(e4, FDynamic _) when is_function_type icf.cf_type && (match icf.cf_kind with Var _ -> true | _ -> false) && is_dot_access e3 ci ->
+              (* Unwrap function from dynamic object when storing in function-typed Var field.
+                 Dynamic fields may contain wrapped functions from anon objects. *)
               gen_value ctx e1;
               print ctx " %s " (Ast.s_binop op);
               add_feature ctx "use._hx_anonToField";

--- a/std/lua/_lua/_hx_anon_to_field.lua
+++ b/std/lua/_lua/_hx_anon_to_field.lua
@@ -1,0 +1,9 @@
+_hx_anonToField = function(f)
+  if type(f) == 'function' then
+    return function(...)
+      return f(nil, ...)
+    end
+  else
+    return f
+  end
+end

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -126,6 +126,29 @@ class TestLua extends Test {
 		callable.invoke();
 		eq(result, "Argument String");
 	}
+
+	// Issue #11901: Function from Dynamic object stored in class Var field
+	function testFunctionFromDynamicObject() {
+		var a = new Issue11901Test({
+			test: function(k:Dynamic, v:Dynamic) {
+				return Std.string(k) + "," + Std.string(v);
+			}
+		});
+		eq(a.func("a", 1), "a,1");
+		eq(a.call("b", 2), "b,2");
+	}
+
+	// Issue #7738: Nested function in typedef-based anonymous object
+	function testNestedFunctionInTypedef() {
+		var result:String = null;
+		Issue7738Helper.process({
+			time: 1000,
+			onComplete: function() {
+				result = "completed";
+			}
+		});
+		eq(result, "completed");
+	}
 }
 
 @:multiReturn extern class Multi {
@@ -169,5 +192,30 @@ class Issue10089Callable {
 	}
 	public function invoke() {
 		callback("Argument String");
+	}
+}
+
+// Issue #11901
+class Issue11901Test {
+	public var func:(Dynamic, Dynamic) -> String;
+	public function new(obj:Dynamic) {
+		this.func = obj.test;
+	}
+	public function call(k:Dynamic, v:Dynamic):String {
+		return func(k, v);
+	}
+}
+
+// Issue #7738
+typedef Issue7738Args = {
+	?time:Int,
+	?onComplete:Void->Void
+}
+
+class Issue7738Helper {
+	public static function process(args:Issue7738Args) {
+		if (args.onComplete != null) {
+			args.onComplete();
+		}
 	}
 }

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -115,6 +115,17 @@ class TestLua extends Test {
 		// @:selfCall method should generate callable(5) instead of callable:call(5)
 		eq(callable.call(5), 15);
 	}
+
+	// Issue #10089: Function callbacks passed via anonymous objects should work correctly
+	function testFunctionCallbackInAnonObject() {
+		var result:String = null;
+		var callback = function(arg:String) {
+			result = arg;
+		};
+		var callable = new Issue10089Callable({callback: callback});
+		callable.invoke();
+		eq(result, "Argument String");
+	}
 }
 
 @:multiReturn extern class Multi {
@@ -124,7 +135,7 @@ class TestLua extends Test {
 
 class MultiCall {
 	public static function doit() : Dynamic {
-		return untyped __lua__("1,'hi'");	
+		return untyped __lua__("1,'hi'");
 	}
 	public static function acceptMr(m:Multi){
 		return lua.Lua.type(m) == "table";
@@ -144,4 +155,19 @@ typedef Issue11842Slot = {
 // Issue #9369
 extern class SelfCallable {
 	@:selfCall function call(x:Int):Int;
+}
+
+// Issue #10089
+typedef Issue10089CallableParams = {
+	var callback:String->Void;
+}
+
+class Issue10089Callable {
+	var callback:String->Void;
+	public function new(params:Issue10089CallableParams) {
+		callback = params.callback;
+	}
+	public function invoke() {
+		callback("Argument String");
+	}
 }


### PR DESCRIPTION
Here's another loaded footgun I left in there.

Functions in anonymous objects are wrapped to work with colon syntax. When assigned to class Var fields (called with dot syntax), this caused argument shifting. So, I need to properly unpack those on the other side. Added another tiny _hx_anonToField helper to unwrap these functions.