### PR TITLE
[lua] Fix function extracted from typedef anon to local (#10055)

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -865,6 +865,14 @@ and gen_expr ?(local=true) ctx e = begin
                         spr ctx "_hx_staticToInstance(";
                         gen_expr ctx e1;
                         spr ctx ")";
+                    | TField(_, FAnon f) when is_function_type f.cf_type ->
+                        (* Unwrap function from anon object when storing in local variable.
+                           Anon functions are wrapped with function(_,...) return f(...) end to work with colon syntax.
+                           Local variables are called with dot syntax, so we need to add a dummy self argument. *)
+                        add_feature ctx "use._hx_anonToField";
+                        spr ctx "_hx_anonToField(";
+                        gen_value ctx e;
+                        spr ctx ")";
                     | _ -> gen_value ctx e);
         end
     | TNew (c,_,el) ->

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -150,6 +150,17 @@ class TestLua extends Test {
 		eq(result, "completed");
 	}
 
+	// Issue #10055: Function extracted from typedef anon object to local should be unwrapped
+	function testFunctionExtractedFromTypedefAnon() {
+		var result:String = null;
+		Issue10055Helper.take({
+			callback: function(arg:String) {
+				result = arg;
+			}
+		});
+		eq(result, "test");
+	}
+
 	// Issue #12192: Closure inside try-catch inside loop should not inherit loop context
 	function testClosureBreakInTryCatchLoop() {
 		// Test 1: Closure with try-catch inside loop should not generate pcall_break check
@@ -256,6 +267,21 @@ class Issue7738Helper {
 	public static function process(args:Issue7738Args) {
 		if (args.onComplete != null) {
 			args.onComplete();
+		}
+	}
+}
+
+// Issue #10055
+typedef Issue10055Params = {
+	?callback:(String)->Void
+}
+
+class Issue10055Helper {
+	public static function take(p:Issue10055Params) {
+		// Extract to local variable - this should unwrap the anon function
+		var cb = p.callback;
+		if (cb != null) {
+			cb("test");
 		}
 	}
 }


### PR DESCRIPTION
Here's another "wrapped/anonymous/function shenanigan" foot gun.  This covers one of the last spots it was popping up.  

When a function is read from an anonymous object field (FAnon) and stored in a local variable, it was still wrapped with the self-discarding wrapper `function(_,...) return f(...) end`. This wrapper is needed for colon-syntax calls but breaks when the local is called with dot syntax.

Apply `_hx_anonToField` unwrapping when assigning a function from an FAnon field to a local variable, similar to how Var field assignments are handled.