### PR TITLE
[cpp] Root API

### DIFF
--- a/std/cpp/marshal/RootHandle.hx
+++ b/std/cpp/marshal/RootHandle.hx
@@ -1,0 +1,36 @@
+package cpp.marshal;
+
+/**
+ * An object which has been rooted will not be collected by the GC even if it has no other references.
+ * Rooted objects can also be used to safely pass managed objects into unmanaged code.
+ */
+@:semantics(value)
+@:cpp.ValueType({ namespace : [ "cpp", "marshal" ] })
+extern class RootHandle {
+	/**
+	 * Root the provided object and return a handle representing it.
+	 */
+	public static function create(obj:Dynamic):RootHandle;
+
+	/**
+	 * Reinterpret the provided `void*` as a rooted object.
+	 * If `ptr` is not a rooted object the behaviour is undefined.
+	 */
+	public static function fromVoidPointer(ptr:cpp.Pointer<cpp.Void>):RootHandle;
+
+	/**
+	 * Unroot the object represented by this handle.
+	 * If there are no other references to the object it will be eligible for collection by the GC.
+	 */
+	function close():Void;
+
+	/**
+	 * Return the object represented by this handle.
+	 */
+	function getObject():Dynamic;
+
+	/**
+	 * Returns the rooted object reinterpreted as a `void*`.
+	 */
+	function toVoidPointer():cpp.Pointer<cpp.Void>;
+}


### PR DESCRIPTION
Expose the existing hxcpp rooting api in a haxe friendly way, eliminating the need to use untyped or cpp glue code to root and pass haxe objects into void pointers.

Using this the SDL coro example doesn't need the untyped, e.g. SdlDispatcher.dispatch

```haxe
public function dispatch(obj:IScheduleObject) {
	final event = new Event();
	event.type = id;
	event.user.data1 = RootHandle.create(obj).toVoidPointer();

	SDL.pushEvent(event);
}
```

Event dispatching in the loop.

```haxe
final root = RootHandle.fromVoidPointer(event.user.data1);

final obj : IScheduleObject = root.getObject();

root.close();

obj.onSchedule();
```

https://github.com/HaxeFoundation/hxcpp/pull/1292