### PR TITLE
Check Void values in optimized `trace`

### DIFF
--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -1650,6 +1650,7 @@ and type_call_builtin ctx e el mode with_type p =
 		let infos = mk_infos ctx p params in
 		if (platform ctx.com Js || platform ctx.com Python) && el = [] && has_dce ctx.com then
 			let e = type_expr ctx e WithType.value in
+			if ExtType.is_void (follow e.etype) then raise_typing_error "Cannot use Void as value" e.epos;
 			let infos = type_expr ctx infos WithType.value in
 			let e = match follow e.etype with
 				| TAbstract({a_impl = Some c},_) when PMap.mem "toString" c.cl_statics ->

--- a/tests/misc/projects/Issue8127/Main.hx
+++ b/tests/misc/projects/Issue8127/Main.hx
@@ -1,0 +1,5 @@
+function main() {
+	trace(name());
+}
+
+inline function name():Void {}

--- a/tests/misc/projects/Issue8127/compile-fail.hxml
+++ b/tests/misc/projects/Issue8127/compile-fail.hxml
@@ -1,0 +1,2 @@
+-main Main
+--js bin/main.js

--- a/tests/misc/projects/Issue8127/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8127/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:2: characters 8-14 : Cannot use Void as value


### PR DESCRIPTION
Void as value was allowed when `trace` is generated as basic `console.log`, like when there is no `--dce no`. I think this needs less hacky way to enable it instead of `haxe.Log.trace = haxe.Log.trace;` in `--dce full`, but anyway.
Closes https://github.com/HaxeFoundation/haxe/issues/8127