### PR TITLE
[lua] Fix Rest.of and Table.toArray for arrays with null values

### DIFF
--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -154,16 +154,18 @@ class Boot {
 
 
 	/**
-		Define an array from the given table
+		Define an array from the given table.
+		Converts from 1-indexed Lua table to 0-indexed Haxe array.
 	**/
 	public inline static function defArray<T>(tab:Table<Int, T>, ?length:Int):Array<T> {
 		if (length == null) {
 			length = TableTools.maxn(tab);
 			if (length > 0) {
-				var head = tab[1];
-				Table.remove(tab, 1);
-				tab[0] = head;
-				return untyped _hx_tab_array(tab, length);
+				// Shift all numeric keys by -1 to convert from 1-indexed to 0-indexed.
+				// Cannot use table.remove as it doesn't work correctly for sparse tables.
+				var result:Table<Int, T> = Table.create();
+				untyped __lua__("for k, v in pairs(tab) do if type(k) == 'number' then result[k - 1] = v end end");
+				return untyped _hx_tab_array(result, length);
 			} else {
 				return [];
 			}

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -194,6 +194,22 @@ class TestLua extends Test {
 	}
 
 
+	// Issue #10909: Rest.of should handle arrays with null values correctly
+	function testRestOfWithNulls() {
+		var arr:Array<Any> = [1, 2, 3, null, 5];
+		var r:haxe.Rest<Any> = haxe.Rest.of(arr);
+		eq(r.length, 5);
+		eq(r[0], 1);
+		eq(r[1], 2);
+		eq(r[2], 3);
+		eq(r[3], null);
+		eq(r[4], 5);
+		// Also verify toArray/toString work correctly
+		var backToArray = r.toArray();
+		eq(backToArray.length, 5);
+		eq(backToArray[4], 5);
+	}
+
 	// Issue #12192: Closure inside try-catch inside loop should not inherit loop context
 	function testClosureBreakInTryCatchLoop() {
 		// Test 1: Closure with try-catch inside loop should not generate pcall_break check


### PR DESCRIPTION
## Summary
- Fixes #10909: `Rest.of(array)` returns incorrect values when the array contains null

## Root Cause
`Boot.defArray` used `table.remove(tab, 1)` to shift from 1-indexed Lua tables to 0-indexed Haxe arrays. However, Lua's `table.remove` only shifts elements up to the first nil value - it doesn't work correctly for sparse tables.

Example: `{[1]=1, [2]=2, [3]=3, [5]=5}` (no key 4)
- After `table.remove(t, 1)`: `{[1]=2, [2]=3, [5]=5}` - key 5 is NOT shifted!
- Result when accessed 0-4: `1, 2, 3, nil, nil` instead of `1, 2, 3, nil, 5`

## Fix
Manually iterate with `pairs` and shift only numeric keys by -1.

## Test plan
- [x] Added regression test `testRestOfWithNulls` in TestLua.hx
- [x] All Lua tests pass (11543 assertions)