### PR TITLE
Add README for unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ This repository is about the Haxe compiler itself and the Haxe standard library.
 * Something on api.haxe.org: For content this is probably the right repository. If it's about the representation, try <https://github.com/HaxeFoundation/dox/issues> instead.
 * Something else on haxe.org: <https://github.com/HaxeFoundation/haxe.org/issues>
 
+## Adding tests
+
+When fixing a bug, please add a regression test. See [tests/unit/README.md](tests/unit/README.md) for guidelines.
+
 ## Other remarks:
 
 - Sometimes people try to be particularly helpful by not only including broken parts in their code, but also "similar" code which is working. More often than not this is more distracting than helpful. If you want to highlight something like this, consider adding the working code commented out.

--- a/README.md
+++ b/README.md
@@ -96,4 +96,8 @@ Haxe            | Neko  | SWF   | Python | HL   | PHP  | Lua |
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more. Thank you!
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on filing issues.
+
+For running and writing tests, see [tests/unit/README.md](tests/unit/README.md).
+
+Thank you!

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,50 @@
+# Unit Tests
+
+## Adding Regression Tests for Bug Fixes
+
+When fixing a bug, add a regression test in `src/unit/issues/`:
+
+```
+tests/unit/src/unit/issues/Issue12345.hx
+```
+
+This pattern:
+- Avoids merge conflicts (each issue gets its own file)
+- Makes it clear which issue each test covers
+- Automatically runs with the test suite
+
+### Example
+
+```haxe
+package unit.issues;
+
+class Issue12345 extends Test {
+    // Use #if for target-specific tests
+    #if lua
+    function test() {
+        // Test that would fail without the fix
+        eq(actualValue, expectedValue);
+    }
+    #end
+}
+```
+
+## Test File Locations
+
+| Location | Purpose |
+|----------|---------|
+| `src/unit/issues/IssueXXXXX.hx` | Per-issue regression tests |
+| `src/unit/Test*.hx` | General feature/target tests |
+| `src/unit/spec/` | Specification tests |
+
+## Running Tests
+
+```bash
+# Compile for a target (e.g., Lua)
+haxe --cwd tests/unit compile-lua.hxml
+
+# Run
+lua bin/unit.lua
+```
+
+See `compile-*.hxml` files for other targets.


### PR DESCRIPTION
## Summary
Documents the preferred pattern for adding regression tests.

## Motivation
When multiple PRs add tests to the same file (e.g., `TestLua.hx`), merge conflicts are common. The `issues/IssueXXXXX.hx` pattern already exists but isn't documented.

## Changes
Adds `tests/unit/README.md` explaining:
- Use `issues/IssueXXXXX.hx` for per-issue regression tests (avoids conflicts)
- Use `#if target` for target-specific tests
- Test file location summary
- How to run tests