### PR TITLE
[lua] Fix multi-return field call generating incorrect variable name

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -527,6 +527,15 @@ and gen_call ctx e el =
          spr ctx ")(";
          concat ctx "," (gen_argument ctx) (e::el);
          spr ctx ")";
+     | TField ({eexpr = TLocal v}, f), el when Meta.has Meta.MultiReturn v.v_meta ->
+         (* Call to a field of a multi-return local - the field is actually just a local variable *)
+         let (_, args, _) = Meta.get (Meta.Custom ":lua_mr_id") v.v_meta in
+         (match args with
+          | [(EConst(String(id,_)), _)] ->
+              spr ctx (id ^ "_" ^ (ident v.v_name) ^ "_" ^ (field_name f));
+              gen_paren_arguments ctx el;
+          | _ ->
+              Globals.die "" __LOC__);
      | TField (field_owner, (FInstance(_,_,f) | FAnon(f))), el when Meta.has Meta.SelfCall f.cf_meta ->
          (* @:selfCall methods - call the object directly *)
          gen_value ctx field_owner;

--- a/tests/unit/src/unit/issues/Issue10921.hx
+++ b/tests/unit/src/unit/issues/Issue10921.hx
@@ -1,0 +1,41 @@
+package unit.issues;
+
+class Issue10921 extends Test {
+	#if lua
+	function test() {
+		// Test that calling a function field of a multi-return local variable
+		// generates the correct variable name (e.g., _hx_1_p_next instead of p.next)
+		var t:lua.Table<Int, String> = untyped __lua__("{[1] = 'a', [2] = 'b', [3] = 'c'}");
+		var result = findNext(t, function(s) return s == "b");
+		eq(result, "b");
+
+		// Also test with pairs
+		var result2 = findFirst(t, function(s) return s == "c");
+		eq(result2, "c");
+	}
+
+	static function findNext<T>(table:lua.Table<Int, T>, fn:T->Bool):Null<T> {
+		final p = lua.Lua.ipairs(table);
+		function loop(nextP:lua.Lua.NextResult<Int, T>) {
+			return if (fn(nextP.value))
+				nextP.value
+			else
+				loop(p.next(p.table, nextP.index));
+		}
+		return loop(p.next(p.table, p.index));
+	}
+
+	static function findFirst<K, V>(table:lua.Table<K, V>, fn:V->Bool):Null<V> {
+		final p = lua.Lua.pairs(table);
+		function loop(nextP:lua.Lua.NextResult<K, V>) {
+			if (nextP.index == null)
+				return null;
+			return if (fn(nextP.value))
+				nextP.value
+			else
+				loop(p.next(p.table, nextP.index));
+		}
+		return loop(p.next(p.table, p.index));
+	}
+	#end
+}


### PR DESCRIPTION
## Summary
- Fixes #10921
- When calling a function field of a multi-return local variable (e.g., `p.next(...)` where `p = Lua.ipairs(table)`), the generated code was incorrectly using `p.next(...)` instead of the destructured variable name `_hx_1_p_next(...)`
- Added a pattern match case in `gen_call` to handle calls to fields of multi-return locals

## Test plan
- Added regression test in `tests/unit/src/unit/issues/Issue10921.hx`
- All Lua tests pass (11536 assertions)