### PR TITLE
[lua] Add lua.Syntax extern for typed raw Lua code injection

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -83,6 +83,7 @@
 	js : clean up ES5 implementation of StringMap.keys() (#11895)
 	js : add new WebGLPolygonMode extension (#12026)
 	js : add js.lib.NativeStringTools (#12127)
+	lua : add lua.Syntax extern for typed raw Lua code injection (#12520)
 	php : add externs for some POSIX functions (#11769)
 	macro : delay typer creation to after init macros (#11323)
 	macro : added Context.resolveComplexType

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -427,6 +427,18 @@ and gen_call ctx e el =
          spr ctx ",";
          gen_argument ctx args;
          spr ctx ")";
+     | TField (_, FStatic( { cl_path = (["lua"],"Syntax") }, { cf_name = "code" })), code :: args ->
+         (match code.eexpr with
+          | TConst (TString s) ->
+              Codegen.interpolate_code ctx.com.error s args (spr ctx) (gen_expr ctx) code.epos
+          | _ ->
+              raise_typing_error "The code argument for lua.Syntax.code must be a string constant" code.epos)
+     | TField (_, FStatic( { cl_path = (["lua"],"Syntax") }, { cf_name = "plainCode" })), [code] ->
+         (match code.eexpr with
+          | TConst (TString s) ->
+              spr ctx (String.concat "\n" (ExtString.String.nsplit s "\r\n"))
+          | _ ->
+              raise_typing_error "The code argument for lua.Syntax.plainCode must be a string constant" code.epos)
      | TCall (x,_) , el when (match x.eexpr with TIdent "__lua__" -> false | _ -> true) ->
          gen_paren ctx [e];
          gen_paren_arguments ctx el;

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -164,7 +164,7 @@ class Boot {
 				// Shift all numeric keys by -1 to convert from 1-indexed to 0-indexed.
 				// Cannot use table.remove as it doesn't work correctly for sparse tables.
 				var result:Table<Int, T> = Table.create();
-				Syntax.code("for k, v in pairs({0}) do if type(k) == 'number' then {1}[k - 1] = v end end", tab, result);
+				Syntax.code("for k, v in {0}({1}) do if {2}(k) == 'number' then {3}[k - 1] = v end end", Lua.pairs, tab, Lua.type, result);
 				return untyped _hx_tab_array(result, length);
 			} else {
 				return [];
@@ -296,9 +296,9 @@ class Boot {
 				return "Windows";
 			}
 
-			var popen_status:Bool = false;
-			var popen_result:lua.FileHandle = null;
-			Syntax.code("popen_status, popen_result = pcall(_G.io.popen, '')");
+			var result = Lua.pcall(Io.popen, "");
+			var popen_status = result.status;
+			var popen_result:lua.FileHandle = result.value;
 			if (popen_status) {
 				popen_result.close();
 				os = lua.Io.popen('uname -s', 'r').read('*l').toLowerCase();

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -39,7 +39,7 @@ class Boot {
 
 	public static var platformBigEndian = NativeStringTools.byte(NativeStringTools.dump(function() {}), 7) > 0;
 
-	static var hiddenFields:Table<String, Bool> = untyped __lua__("{__id__=true, hx__closures=true, super=true, prototype=true, __fields__=true, __ifields__=true, __class__=true, __properties__=true}");
+	static var hiddenFields:Table<String, Bool> = Syntax.code("{__id__=true, hx__closures=true, super=true, prototype=true, __fields__=true, __ifields__=true, __class__=true, __properties__=true}");
 
 	static function __unhtml(s:String)
 		return s.split("&").join("&amp;").split("<").join("&lt;").split(">").join("&gt;");
@@ -298,7 +298,7 @@ class Boot {
 
 			var popen_status:Bool = false;
 			var popen_result:lua.FileHandle = null;
-			untyped __lua__("popen_status, popen_result = pcall(_G.io.popen, '')");
+			Syntax.code("popen_status, popen_result = pcall(_G.io.popen, '')");
 			if (popen_status) {
 				popen_result.close();
 				os = lua.Io.popen('uname -s', 'r').read('*l').toLowerCase();

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -297,9 +297,8 @@ class Boot {
 			}
 
 			var result = Lua.pcall(Io.popen, "");
-			var popen_status = result.status;
 			var popen_result:lua.FileHandle = result.value;
-			if (popen_status) {
+			if (result.status) {
 				popen_result.close();
 				os = lua.Io.popen('uname -s', 'r').read('*l').toLowerCase();
 			} else {

--- a/std/lua/Boot.hx
+++ b/std/lua/Boot.hx
@@ -164,7 +164,7 @@ class Boot {
 				// Shift all numeric keys by -1 to convert from 1-indexed to 0-indexed.
 				// Cannot use table.remove as it doesn't work correctly for sparse tables.
 				var result:Table<Int, T> = Table.create();
-				untyped __lua__("for k, v in pairs(tab) do if type(k) == 'number' then result[k - 1] = v end end");
+				Syntax.code("for k, v in pairs({0}) do if type(k) == 'number' then {1}[k - 1] = v end end", tab, result);
 				return untyped _hx_tab_array(result, length);
 			} else {
 				return [];

--- a/std/lua/PairTools.hx
+++ b/std/lua/PairTools.hx
@@ -27,33 +27,33 @@ package lua;
 **/
 class PairTools {
 	public static function ipairsEach<T>(table:Table<Dynamic, T>, func:Int->T->Void):Void {
-		untyped __lua__("for i,v in _G.ipairs(table) do func(i,v) end");
+		Syntax.code("for i,v in _G.ipairs(table) do func(i,v) end");
 	}
 
 	public static function pairsEach<A, B>(table:Table<A, B>, func:A->B->Void):Void {
-		untyped __lua__("for k,v in _G.pairs(table) do func(k,v) end");
+		Syntax.code("for k,v in _G.pairs(table) do func(k,v) end");
 	}
 
 	public static function ipairsMap<A, B>(table:Table<Dynamic, A>, func:Int->A->B):Table<Int, B> {
 		var ret:Table<Int, B> = Table.create();
-		untyped __lua__("for i,v in _G.ipairs(table) do ret[i] = func(i,v) end");
+		Syntax.code("for i,v in _G.ipairs(table) do ret[i] = func(i,v) end");
 		return ret;
 	}
 
 	public static function pairsMap<A, B, C>(table:Table<A, B>, func:A->B->C->C):Table<A, C> {
 		var ret:Table<A, C> = Table.create();
-		untyped __lua__("for k,v in _G.pairs(table) do ret[k] = func(k,v) end");
+		Syntax.code("for k,v in _G.pairs(table) do ret[k] = func(k,v) end");
 		return ret;
 	}
 
 	public static function ipairsFold<A, B>(table:Table<Int, A>, func:Int->A->B->B, seed:B):B {
-		untyped __lua__("for i,v in _G.ipairs(table) do seed = func(i,v,seed) end");
-		return untyped __lua__("seed");
+		Syntax.code("for i,v in _G.ipairs(table) do seed = func(i,v,seed) end");
+		return Syntax.code("seed");
 	}
 
 	public static function pairsFold<A, B, C>(table:Table<A, B>, func:A->B->C->C, seed:C):C {
-		untyped __lua__("for k,v in _G.pairs(table) do seed = func(k,v,seed) end");
-		return untyped __lua__("seed");
+		Syntax.code("for k,v in _G.pairs(table) do seed = func(k,v,seed) end");
+		return Syntax.code("seed");
 	}
 
 	public static function ipairsConcat<T>(table1:Table<Int, T>, table2:Table<Int, T>) {
@@ -77,16 +77,16 @@ class PairTools {
 	}
 
 	public static function ipairsExist<T>(table:Table<Int, T>, func:Int->T->Bool) {
-		untyped __lua__("for k,v in _G.ipairs(table) do if func(k,v) then return true end end");
+		Syntax.code("for k,v in _G.ipairs(table) do if func(k,v) then return true end end");
 	}
 
 	public static function pairsExist<A, B>(table:Table<A, B>, func:A->B->Bool) {
-		untyped __lua__("for k,v in _G.pairs(table) do if func(k,v) then return true end end");
+		Syntax.code("for k,v in _G.pairs(table) do if func(k,v) then return true end end");
 	}
 
 	public static function copy<A, B>(table1:Table<A, B>):Table<A, B> {
 		var ret:Table<A, B> = Table.create();
-		untyped __lua__("for k,v in _G.pairs(table1) do ret[k] = v end");
+		Syntax.code("for k,v in _G.pairs(table1) do ret[k] = v end");
 		return ret;
 	}
 

--- a/std/lua/PairTools.hx
+++ b/std/lua/PairTools.hx
@@ -27,31 +27,31 @@ package lua;
 **/
 class PairTools {
 	public static function ipairsEach<T>(table:Table<Dynamic, T>, func:Int->T->Void):Void {
-		Syntax.code("for i,v in {0}({1}) do {2}(i,v) end", Lua.ipairs, table, func);
+		Syntax.code("for i,v in {0}({1}) do ({2})(i,v) end", Lua.ipairs, table, func);
 	}
 
 	public static function pairsEach<A, B>(table:Table<A, B>, func:A->B->Void):Void {
-		Syntax.code("for k,v in {0}({1}) do {2}(k,v) end", Lua.pairs, table, func);
+		Syntax.code("for k,v in {0}({1}) do ({2})(k,v) end", Lua.pairs, table, func);
 	}
 
 	public static function ipairsMap<A, B>(table:Table<Dynamic, A>, func:Int->A->B):Table<Int, B> {
 		var ret:Table<Int, B> = Table.create();
-		Syntax.code("for i,v in {0}({1}) do {2}[i] = {3}(i,v) end", Lua.ipairs, table, ret, func);
+		Syntax.code("for i,v in {0}({1}) do {2}[i] = ({3})(i,v) end", Lua.ipairs, table, ret, func);
 		return ret;
 	}
 
 	public static function pairsMap<A, B, C>(table:Table<A, B>, func:A->B->C->C):Table<A, C> {
 		var ret:Table<A, C> = Table.create();
-		Syntax.code("for k,v in {0}({1}) do {2}[k] = {3}(k,v) end", Lua.pairs, table, ret, func);
+		Syntax.code("for k,v in {0}({1}) do {2}[k] = ({3})(k,v) end", Lua.pairs, table, ret, func);
 		return ret;
 	}
 
 	public static function ipairsFold<A, B>(table:Table<Int, A>, func:Int->A->B->B, seed:B):B {
-		return Syntax.code("(function() local s = {0}; for i,v in {1}({2}) do s = {3}(i,v,s) end; return s end)()", seed, Lua.ipairs, table, func);
+		return Syntax.code("(function() local s = {0}; for i,v in {1}({2}) do s = ({3})(i,v,s) end; return s end)()", seed, Lua.ipairs, table, func);
 	}
 
 	public static function pairsFold<A, B, C>(table:Table<A, B>, func:A->B->C->C, seed:C):C {
-		return Syntax.code("(function() local s = {0}; for k,v in {1}({2}) do s = {3}(k,v,s) end; return s end)()", seed, Lua.pairs, table, func);
+		return Syntax.code("(function() local s = {0}; for k,v in {1}({2}) do s = ({3})(k,v,s) end; return s end)()", seed, Lua.pairs, table, func);
 	}
 
 	public static function ipairsConcat<T>(table1:Table<Int, T>, table2:Table<Int, T>) {
@@ -75,11 +75,11 @@ class PairTools {
 	}
 
 	public static function ipairsExist<T>(table:Table<Int, T>, func:Int->T->Bool) {
-		Syntax.code("for k,v in {0}({1}) do if {2}(k,v) then return true end end", Lua.ipairs, table, func);
+		Syntax.code("for k,v in {0}({1}) do if ({2})(k,v) then return true end end", Lua.ipairs, table, func);
 	}
 
 	public static function pairsExist<A, B>(table:Table<A, B>, func:A->B->Bool) {
-		Syntax.code("for k,v in {0}({1}) do if {2}(k,v) then return true end end", Lua.pairs, table, func);
+		Syntax.code("for k,v in {0}({1}) do if ({2})(k,v) then return true end end", Lua.pairs, table, func);
 	}
 
 	public static function copy<A, B>(table1:Table<A, B>):Table<A, B> {

--- a/std/lua/PairTools.hx
+++ b/std/lua/PairTools.hx
@@ -27,33 +27,31 @@ package lua;
 **/
 class PairTools {
 	public static function ipairsEach<T>(table:Table<Dynamic, T>, func:Int->T->Void):Void {
-		Syntax.code("for i,v in _G.ipairs(table) do func(i,v) end");
+		Syntax.code("for i,v in _G.ipairs({0}) do {1}(i,v) end", table, func);
 	}
 
 	public static function pairsEach<A, B>(table:Table<A, B>, func:A->B->Void):Void {
-		Syntax.code("for k,v in _G.pairs(table) do func(k,v) end");
+		Syntax.code("for k,v in _G.pairs({0}) do {1}(k,v) end", table, func);
 	}
 
 	public static function ipairsMap<A, B>(table:Table<Dynamic, A>, func:Int->A->B):Table<Int, B> {
 		var ret:Table<Int, B> = Table.create();
-		Syntax.code("for i,v in _G.ipairs(table) do ret[i] = func(i,v) end");
+		Syntax.code("for i,v in _G.ipairs({0}) do {1}[i] = {2}(i,v) end", table, ret, func);
 		return ret;
 	}
 
 	public static function pairsMap<A, B, C>(table:Table<A, B>, func:A->B->C->C):Table<A, C> {
 		var ret:Table<A, C> = Table.create();
-		Syntax.code("for k,v in _G.pairs(table) do ret[k] = func(k,v) end");
+		Syntax.code("for k,v in _G.pairs({0}) do {1}[k] = {2}(k,v) end", table, ret, func);
 		return ret;
 	}
 
 	public static function ipairsFold<A, B>(table:Table<Int, A>, func:Int->A->B->B, seed:B):B {
-		Syntax.code("for i,v in _G.ipairs(table) do seed = func(i,v,seed) end");
-		return Syntax.code("seed");
+		return Syntax.code("(function() local s = {2}; for i,v in _G.ipairs({0}) do s = {1}(i,v,s) end; return s end)()", table, func, seed);
 	}
 
 	public static function pairsFold<A, B, C>(table:Table<A, B>, func:A->B->C->C, seed:C):C {
-		Syntax.code("for k,v in _G.pairs(table) do seed = func(k,v,seed) end");
-		return Syntax.code("seed");
+		return Syntax.code("(function() local s = {2}; for k,v in _G.pairs({0}) do s = {1}(k,v,s) end; return s end)()", table, func, seed);
 	}
 
 	public static function ipairsConcat<T>(table1:Table<Int, T>, table2:Table<Int, T>) {
@@ -77,16 +75,16 @@ class PairTools {
 	}
 
 	public static function ipairsExist<T>(table:Table<Int, T>, func:Int->T->Bool) {
-		Syntax.code("for k,v in _G.ipairs(table) do if func(k,v) then return true end end");
+		Syntax.code("for k,v in _G.ipairs({0}) do if {1}(k,v) then return true end end", table, func);
 	}
 
 	public static function pairsExist<A, B>(table:Table<A, B>, func:A->B->Bool) {
-		Syntax.code("for k,v in _G.pairs(table) do if func(k,v) then return true end end");
+		Syntax.code("for k,v in _G.pairs({0}) do if {1}(k,v) then return true end end", table, func);
 	}
 
 	public static function copy<A, B>(table1:Table<A, B>):Table<A, B> {
 		var ret:Table<A, B> = Table.create();
-		Syntax.code("for k,v in _G.pairs(table1) do ret[k] = v end");
+		Syntax.code("for k,v in _G.pairs({0}) do {1}[k] = v end", table1, ret);
 		return ret;
 	}
 

--- a/std/lua/PairTools.hx
+++ b/std/lua/PairTools.hx
@@ -27,31 +27,31 @@ package lua;
 **/
 class PairTools {
 	public static function ipairsEach<T>(table:Table<Dynamic, T>, func:Int->T->Void):Void {
-		Syntax.code("for i,v in _G.ipairs({0}) do {1}(i,v) end", table, func);
+		Syntax.code("for i,v in {0}({1}) do {2}(i,v) end", Lua.ipairs, table, func);
 	}
 
 	public static function pairsEach<A, B>(table:Table<A, B>, func:A->B->Void):Void {
-		Syntax.code("for k,v in _G.pairs({0}) do {1}(k,v) end", table, func);
+		Syntax.code("for k,v in {0}({1}) do {2}(k,v) end", Lua.pairs, table, func);
 	}
 
 	public static function ipairsMap<A, B>(table:Table<Dynamic, A>, func:Int->A->B):Table<Int, B> {
 		var ret:Table<Int, B> = Table.create();
-		Syntax.code("for i,v in _G.ipairs({0}) do {1}[i] = {2}(i,v) end", table, ret, func);
+		Syntax.code("for i,v in {0}({1}) do {2}[i] = {3}(i,v) end", Lua.ipairs, table, ret, func);
 		return ret;
 	}
 
 	public static function pairsMap<A, B, C>(table:Table<A, B>, func:A->B->C->C):Table<A, C> {
 		var ret:Table<A, C> = Table.create();
-		Syntax.code("for k,v in _G.pairs({0}) do {1}[k] = {2}(k,v) end", table, ret, func);
+		Syntax.code("for k,v in {0}({1}) do {2}[k] = {3}(k,v) end", Lua.pairs, table, ret, func);
 		return ret;
 	}
 
 	public static function ipairsFold<A, B>(table:Table<Int, A>, func:Int->A->B->B, seed:B):B {
-		return Syntax.code("(function() local s = {2}; for i,v in _G.ipairs({0}) do s = {1}(i,v,s) end; return s end)()", table, func, seed);
+		return Syntax.code("(function() local s = {0}; for i,v in {1}({2}) do s = {3}(i,v,s) end; return s end)()", seed, Lua.ipairs, table, func);
 	}
 
 	public static function pairsFold<A, B, C>(table:Table<A, B>, func:A->B->C->C, seed:C):C {
-		return Syntax.code("(function() local s = {2}; for k,v in _G.pairs({0}) do s = {1}(k,v,s) end; return s end)()", table, func, seed);
+		return Syntax.code("(function() local s = {0}; for k,v in {1}({2}) do s = {3}(k,v,s) end; return s end)()", seed, Lua.pairs, table, func);
 	}
 
 	public static function ipairsConcat<T>(table1:Table<Int, T>, table2:Table<Int, T>) {
@@ -75,16 +75,16 @@ class PairTools {
 	}
 
 	public static function ipairsExist<T>(table:Table<Int, T>, func:Int->T->Bool) {
-		Syntax.code("for k,v in _G.ipairs({0}) do if {1}(k,v) then return true end end", table, func);
+		Syntax.code("for k,v in {0}({1}) do if {2}(k,v) then return true end end", Lua.ipairs, table, func);
 	}
 
 	public static function pairsExist<A, B>(table:Table<A, B>, func:A->B->Bool) {
-		Syntax.code("for k,v in _G.pairs({0}) do if {1}(k,v) then return true end end", table, func);
+		Syntax.code("for k,v in {0}({1}) do if {2}(k,v) then return true end end", Lua.pairs, table, func);
 	}
 
 	public static function copy<A, B>(table1:Table<A, B>):Table<A, B> {
 		var ret:Table<A, B> = Table.create();
-		Syntax.code("for k,v in _G.pairs({0}) do {1}[k] = v end", table1, ret);
+		Syntax.code("for k,v in {0}({1}) do {2}[k] = v end", Lua.pairs, table1, ret);
 		return ret;
 	}
 

--- a/std/lua/Syntax.hx
+++ b/std/lua/Syntax.hx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package lua;
+
+import haxe.extern.Rest;
+
+/**
+	Generate Lua syntax not directly supported by Haxe.
+	Use only at low-level when specific target-specific code-generation is required.
+**/
+@:noClosure
+extern class Syntax {
+	/**
+		Inject `code` directly into generated source.
+
+		`code` must be a string constant.
+
+		Additional `args` are supported to provide code interpolation, for example:
+		```haxe
+		Syntax.code("print({0}, {1})", "hi", 42);
+		```
+		will generate
+		```lua
+		print("hi", 42)
+		```
+
+		Emits a compilation error if the count of `args` does not match the count of placeholders in `code`.
+	**/
+	static function code(code:String, args:Rest<Dynamic>):Dynamic;
+
+	/**
+		Inject `code` directly into generated source.
+		The same as `lua.Syntax.code` except this one does not provide code interpolation.
+	**/
+	static function plainCode(code:String):Dynamic;
+}

--- a/std/lua/_std/Math.hx
+++ b/std/lua/_std/Math.hx
@@ -40,10 +40,9 @@ class Math {
 
 	public static var NaN(get, null):Float;
 
-	// Note: this has to be an untyped literal, otherwise the compiler tries
-	// to unify it to an Int, which defeats useful numeric reflection behavior.
+	// Note: this has to produce NaN at runtime, not compile time.
 	static inline function get_NaN():Float
-		return untyped __lua__("(0/0)");
+		return lua.Syntax.code("(0/0)");
 
 	public static function isNaN(f:Float):Bool
 		return (f != f);

--- a/std/lua/_std/Math.hx
+++ b/std/lua/_std/Math.hx
@@ -40,9 +40,10 @@ class Math {
 
 	public static var NaN(get, null):Float;
 
-	// Note: this has to produce NaN at runtime, not compile time.
+	// Note: this has to be a raw literal, otherwise the compiler tries
+	// to unify it to an Int, which defeats useful numeric reflection behavior.
 	static inline function get_NaN():Float
-		return lua.Syntax.code("(0/0)");
+		return lua.Syntax.plainCode("(0/0)");
 
 	public static function isNaN(f:Float):Bool
 		return (f != f);

--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -157,7 +157,7 @@ import lua.TableTools;
 				b[k-1] = v
 				l = math.max(k,l)
 			end
-			return f(_hx_tab_array(b, l))
-		end");
+			return {0}(_hx_tab_array(b, l))
+		end", f);
 	}
 }

--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -149,7 +149,7 @@ import lua.TableTools;
 			- Recreate as dynamic array
 			- Return function called with this array
 		 */
-		return untyped __lua__("function(...)
+		return lua.Syntax.code("function(...)
 			local a = {...}
 			local b = {}
 			local l = 0

--- a/std/lua/_std/Std.hx
+++ b/std/lua/_std/Std.hx
@@ -59,7 +59,7 @@ import lua.NativeStringTools;
 		if (x == null)
 			return null;
 		untyped {
-			__lua__("local sign, numString = {0}", NativeStringTools.match(x, "^%s*([%-+]?)0[xX]([%da-fA-F]*)"));
+			lua.Syntax.code("local sign, numString = {0}", NativeStringTools.match(x, "^%s*([%-+]?)0[xX]([%da-fA-F]*)"));
 			if (numString != null)
 				return switch sign {
 					case '-': -lua.Lua.tonumber(numString, 16);

--- a/std/lua/_std/haxe/ds/IntMap.hx
+++ b/std/lua/_std/haxe/ds/IntMap.hx
@@ -114,8 +114,6 @@ class IntMap<T> implements haxe.Constraints.IMap<Int, T> {
 	}
 	
 	public function size():Int {
-		var s = 0;
-		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
-		return s;
+		return lua.Syntax.code("(function() local s = 0; for _ in pairs({0}) do s = s + 1 end; return s end)()", h);
 	}
 }

--- a/std/lua/_std/haxe/ds/ObjectMap.hx
+++ b/std/lua/_std/haxe/ds/ObjectMap.hx
@@ -119,8 +119,6 @@ class ObjectMap<A, B> implements haxe.Constraints.IMap<A, B> {
 	}
 	
 	public function size():Int {
-		var s = 0;
-		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
-		return s;
+		return lua.Syntax.code("(function() local s = 0; for _ in pairs({0}) do s = s + 1 end; return s end)()", h);
 	}
 }

--- a/std/lua/_std/haxe/ds/StringMap.hx
+++ b/std/lua/_std/haxe/ds/StringMap.hx
@@ -118,8 +118,6 @@ class StringMap<T> implements haxe.Constraints.IMap<String, T> {
 	}
 	
 	public function size():Int {
-		var s = 0;
-		untyped __lua__("for _ in pairs({0}) do s = s + 1 end", h);
-		return s;
+		return lua.Syntax.code("(function() local s = 0; for _ in pairs({0}) do s = s + 1 end; return s end)()", h);
 	}
 }

--- a/tests/unit/src/unit/TestLua.hx
+++ b/tests/unit/src/unit/TestLua.hx
@@ -193,6 +193,42 @@ class TestLua extends Test {
 		eq(10, count);
 	}
 
+	// PairTools inline: function literals must be bracketed in Syntax.code to avoid Lua syntax errors
+	function testPairToolsInlineCall() {
+		var t:lua.Table<Int, Int> = lua.Table.create();
+		t[1] = 10;
+		t[2] = 20;
+		t[3] = 30;
+
+		// inline ipairsEach with function literal
+		var sum = 0;
+		inline lua.PairTools.ipairsEach(t, function(_, v) {
+			sum += v;
+		});
+		eq(sum, 60);
+
+		// inline pairsEach with function literal
+		sum = 0;
+		inline lua.PairTools.pairsEach(t, function(_, v) {
+			sum += v;
+		});
+		eq(sum, 60);
+
+		// inline ipairsFold with function literal
+		var total:Int = inline lua.PairTools.ipairsFold(t, function(_, v, acc) {
+			return acc + v;
+		}, 0);
+		eq(total, 60);
+
+		// inline ipairsMap with function literal
+		var mapped = inline lua.PairTools.ipairsMap(t, function(_, v) {
+			return v * 2;
+		});
+		eq(mapped[1], 20);
+		eq(mapped[2], 40);
+		eq(mapped[3], 60);
+	}
+
 	// Issue #10252: BytesBuffer.addDouble should produce correct IEEE 754 bytes
 	function testBytesBufferAddDouble() {
 		// 9007199254740991 is 2^53 - 1, the max safe integer


### PR DESCRIPTION
## Summary

Implements `lua.Syntax.code` and `lua.Syntax.plainCode` similar to `js.Syntax` for the JavaScript target. This provides a typed interface for raw Lua code injection with interpolation support.

- **std/lua/Syntax.hx**: New extern class with `code()` and `plainCode()` methods
- **genlua.ml**: Add handling to process `lua.Syntax.code` calls using `Codegen.interpolate_code`
- **std lib updates**: Replace all `untyped __lua__(...)` calls with `lua.Syntax.code(...)`

This addresses @Simn's review comment on #12516 suggesting a typed alternative to `untyped __lua__`.

## Test plan

- [x] All Lua unit tests pass (11534 assertions)
- [x] Verified generated code is correct for interpolated values