### PR TITLE
[lua] Fix string length being null with invalid utf-8

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -735,7 +735,7 @@ and gen_expr ?(local=true) ctx e = begin
         ) else (
             spr ctx "__lua_lib_luautf8_Utf8.len(";
             gen_value ctx e;
-            spr ctx ")";
+            spr ctx ", nil, nil, true)";
         )
     | TField (e, ef) when is_possible_string_field e (field_name ef)  ->
         add_feature ctx "use._hx_wrap_if_string_field";

--- a/std/lua/lib/luautf8/Utf8.hx
+++ b/std/lua/lib/luautf8/Utf8.hx
@@ -9,10 +9,12 @@ package lua.lib.luautf8;
 @:luaRequire('lua-utf8')
 extern class Utf8 {
 	/**
-		Receives a string and returns its length. The empty string `""` has
-		length `0`. Embedded zeros are counted, so `"a\000bc\000"` has length `5`.
+		Returns the number of UTF-8 characters in string s that start between
+		positions i and j (both inclusive). The default for i is 1 and for j is -1.
+		If it finds any invalid byte sequence, returns fail plus the position of
+		the first invalid byte.
 	**/
-	static function len(str:String):Int;
+	static function len(str:String, ?start:Int, ?end:Int, ?lax:Bool):Int;
 
 	/**
 		Receives zero or more integers. Returns a string with length equal to the

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -89,17 +89,13 @@ class Lua {
 			installLib("https://raw.githubusercontent.com/HaxeFoundation/hx-lua-simdjson/master/hx-lua-simdjson-scm-1.rockspec", "");
 
 			changeDirectory(unitDir);
-			final luaDefine = if (lv.startsWith("-l")) {
-				lv.replace("-l", "lua").replace(".", "_");
-			} else lv.replace("-j", "luajit").replace(".", "_");
-			final luaVer = ["-D", luaDefine];
-			runCommand("haxe", ["compile-lua.hxml"].concat(args).concat(luaVer));
+			runCommand("haxe", ["compile-lua.hxml"].concat(args));
 			runCommand("lua", ["bin/unit.lua"]);
 
 			Display.maybeRunDisplayTests(Lua);
 
 			changeDirectory(sysDir);
-			runCommand("haxe", ["compile-lua.hxml"].concat(args).concat(luaVer));
+			runCommand("haxe", ["compile-lua.hxml"].concat(args));
 			runSysTest("lua", ["bin/lua/sys.lua"]);
 
 			changeDirectory(getMiscSubDir("luaDeadCode", "stringReflection"));

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -79,17 +79,12 @@ class Lua {
 			installLib("lrexlib-pcre2", "2.9.1-1");
 			installLib("luasocket", "3.0rc1-2");
 
-			//Install bit32 for lua 5.1
-			if (lv == "-l5.1")
-				installLib("bit32", "5.2.2-1");
+			//Install bit32 for lua 5.1 and 5.4
+			if (lv == "-l5.1" || lv == "-l5.4")
+				installLib("bit32", "5.3.5.1-1");
 
 			installLib("luv", "1.50.0-1");
-			if (lv == "-l5.4") {
-				installLib("bit32", "5.3.5.1-1");
-				installLib("luautf8", "0.1.5-2");
-			} else {
-				installLib("luautf8", "0.1.1-1");
-			}
+			installLib("luautf8", "0.2.0-1");
 
 			installLib("https://raw.githubusercontent.com/HaxeFoundation/hx-lua-simdjson/master/hx-lua-simdjson-scm-1.rockspec", "");
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -84,7 +84,7 @@ class Lua {
 				installLib("bit32", "5.3.5.1-1");
 
 			installLib("luv", "1.50.0-1");
-			installLib("luautf8", "0.2.0-1");
+			installLib("luautf8", "0.1.6-1");
 
 			installLib("https://raw.githubusercontent.com/HaxeFoundation/hx-lua-simdjson/master/hx-lua-simdjson-scm-1.rockspec", "");
 

--- a/tests/unit/src/unit/TestResource.hx
+++ b/tests/unit/src/unit/TestResource.hx
@@ -18,8 +18,7 @@ class TestResource extends Test {
 		#if (neko || php || eval)
 		// allow binary strings
 		eq(haxe.Resource.getBytes("re/s?!%[]))(\"'1.bin").sub(0, 9).toHex(), "48656c6c6f2c204927");
-		// updated luautf8.len returns nil for data with invalid sequences
-		#elseif !lua5_4
+		#else
 		// cut until first \0
 		eq(haxe.Resource.getString("re/s?!%[]))(\"'1.bin").substr(0, 2), "He");
 		#end


### PR DESCRIPTION
lua-utf8 versions 0.1.3 and above are strict by default, so we need to pass lax=true to avoid the returned length being null. Older versions are lax by default and will simply ignore the extra argument.

The lax argument was added in 0.1.2: https://github.com/starwing/luautf8/commit/6405900538bf4a969c4bd854bacca92248b72a3d

However, the strict behaviour only started being default in 0.1.3: https://github.com/starwing/luautf8/commit/b382abe35809f24df25faf52d91e6f95bfc82816

Fixes #11088.

Workaround was added in #11069.