### PR TITLE
Check mono structs against abstract `from`

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -221,8 +221,23 @@ module Monomorph = struct
 				| None -> f()
 			) tl
 		| CStructural(fields,is_open) ->
-			let t2 = mk_anon ~fields (ref Closed) in
-			(!unify_ref) (default_unification_context()) t t2
+			let anon_t = mk_anon ~fields (ref Closed) in
+			let uctx = default_unification_context() in
+			begin match t with
+				| TAbstract(ab, tl) when ab.a_from <> [] ->
+					let check_via_from constraint_type =
+						List.exists (fun from_type ->
+							try
+								(!unify_ref) uctx constraint_type from_type;
+								true
+							with Unify_error _ -> false
+						) ab.a_from
+					in
+					if (check_via_from t) then ()
+					else (!unify_ref) uctx t anon_t
+				| _ ->
+					(!unify_ref) uctx t anon_t
+			end
 		| CMixed l ->
 			List.iter (fun constr -> check_down_constraints constr t) l
 

--- a/std/js/Boot.hx
+++ b/std/js/Boot.hx
@@ -107,13 +107,13 @@ class Boot {
 					}
 					var tostr;
 					try {
-						tostr = untyped o.toString;
+						tostr = untyped (o : {toString: () -> String}).toString;
 					} catch (e:Dynamic) {
 						// strange error on IE
 						return "???";
 					}
 					if (tostr != null && tostr != js.Syntax.code("Object.toString") && js.Syntax.typeof(tostr) == "function") {
-						var s2 = o.toString();
+						var s2 = (o : {toString: () -> String}).toString();
 						if (s2 != "[object Object]")
 							return s2;
 					}

--- a/tests/unit/src/unit/issues/Issue11068.hx
+++ b/tests/unit/src/unit/issues/Issue11068.hx
@@ -1,0 +1,12 @@
+package unit.issues;
+
+class Issue11068 extends Test {
+	function test() {
+		final data:Dynamic = ({} : Dynamic);
+		data.id = 0;
+		use(data);
+		utest.Assert.pass();
+	}
+
+	static function use(v:Any) {}
+}


### PR DESCRIPTION
I'm probably missing something obvious and this should be done at different level of unification...

See https://github.com/HaxeFoundation/haxe/issues/11068

js `function __string_rec(o, s:String)` change there to prevent generation of recursive haxe `toString`, since this `mono.toString` is detected now somehow even in untyped code. Better way to fix this is to just mark `o` arg as `o:Dynamic`, but then `Int64.toString()` will be always keeped by DCE because of this:
https://github.com/HaxeFoundation/haxe/blob/e1f66520b7b26d1b7d4f5b344cc6b5c324bf1d26/std/haxe/Int64.hx#L503-L511
I'm not sure generating `Int64.toString` on dynamic access is better than just do `@:ifFeature(haxe.Int64)`, idk what case it covers.
Current `ifFeature` was added recently https://github.com/HaxeFoundation/haxe/commit/118414ff774159a9112b91ac5feda955d3844694#diff-62cacf31488f8335508254a0bf62e024a1e1b0ae5e396e051c9fa37b5b75a218R506