### PR TITLE
[cpp] Managed extern for typed mutex and condition

### DIFF
--- a/std/cpp/_std/sys/thread/Condition.hx
+++ b/std/cpp/_std/sys/thread/Condition.hx
@@ -1,33 +1,47 @@
 package sys.thread;
 
+@:include("hx/thread/ConditionVariable.hpp")
+@:cpp.ManagedType({ namespace : [ "hx", "thread" ], flags : [ StandardNaming ] })
+private extern class ConditionVariable {
+	function new():Void;
+
+	public function acquire():Void;
+	public function tryAcquire():Bool;
+	public function release():Void;
+	public function wait():Void;
+	public function signal():Void;
+	public function broadcast():Void;
+}
+
 @:coreApi
 class Condition {
-	var c:Dynamic;
+	final c:ConditionVariable;
+
 	public function new():Void {
-		c = untyped __global__.__hxcpp_condition_create();
+		c = new ConditionVariable();
 	}
 
 	public function acquire():Void {
-		untyped __global__.__hxcpp_condition_acquire(c);
+		c.acquire();
 	}
 
 	public function tryAcquire():Bool {
-		return untyped __global__.__hxcpp_condition_try_acquire(c);
+		return c.tryAcquire();
 	}
 
 	public function release():Void {
-		untyped __global__.__hxcpp_condition_release(c);
+		c.release();
 	}
 
 	public function wait():Void {
-		untyped __global__.__hxcpp_condition_wait(c);
+		c.wait();
 	}
 
 	public function signal():Void {
-		untyped __global__.__hxcpp_condition_signal(c);
+		c.signal();
 	}
 
 	public function broadcast():Void {
-		untyped __global__.__hxcpp_condition_broadcast(c);
+		c.broadcast();
 	}
 }

--- a/std/cpp/_std/sys/thread/Mutex.hx
+++ b/std/cpp/_std/sys/thread/Mutex.hx
@@ -22,23 +22,33 @@
 
 package sys.thread;
 
+@:include("hx/thread/RecursiveMutex.hpp")
+@:cpp.ManagedType({ namespace : [ "hx", "thread" ], flags : [ StandardNaming ] })
+private extern class RecursiveMutex {
+	function new():Void;
+
+	function acquire():Void;
+	function tryAcquire():Bool;
+	function release():Void;
+}
+
 @:coreApi
 class Mutex {
-	var m:Dynamic;
+	final m:RecursiveMutex;
 
 	public function new() {
-		m = untyped __global__.__hxcpp_mutex_create();
+		m = new RecursiveMutex();
 	}
 
 	public function acquire():Void {
-		untyped __global__.__hxcpp_mutex_acquire(m);
+		m.acquire();
 	}
 
 	public function tryAcquire():Bool {
-		return untyped __global__.__hxcpp_mutex_try(m);
+		return m.tryAcquire();
 	}
 
 	public function release():Void {
-		untyped __global__.__hxcpp_mutex_release(m);
+		m.release();
 	}
 }

--- a/tests/threads/src/cases/TestCondition.hx
+++ b/tests/threads/src/cases/TestCondition.hx
@@ -29,17 +29,14 @@ class TestCondition extends utest.Test {
 	function testGCDuringWait() {
 		final cond = new Condition();
 
-		var threadRunning = false;
+		cond.acquire();
 		Thread.create(() -> {
-			threadRunning = true;
 			cond.acquire();
 			cond.wait();
 			cond.release();
 		});
+		cond.release();
 
-		while (!threadRunning) {
-			Sys.sleep(0.001);
-		}
 		#if cpp
 		cpp.vm.Gc.run(true);
 		#elseif hl

--- a/tests/threads/src/cases/TestCondition.hx
+++ b/tests/threads/src/cases/TestCondition.hx
@@ -1,5 +1,6 @@
 package cases;
 
+import utest.Assert;
 import sys.thread.Condition;
 import sys.thread.Thread;
 
@@ -14,6 +15,45 @@ class TestCondition extends utest.Test {
 		});
 		cond.wait();
 		cond.release();
+		Assert.pass();
+	}
+
+	function testTryAcquire() {
+		final cond = new Condition();
+		Assert.isTrue(cond.tryAcquire());
+		// I would prefer to specify it to be not recursive...
+		// Assert.isFalse(cond.tryAcquire());
+		cond.release();
+	}
+
+	function testGCDuringWait() {
+		final cond = new Condition();
+
+		var threadRunning = false;
+		Thread.create(() -> {
+			threadRunning = true;
+			cond.acquire();
+			cond.wait();
+			cond.release();
+		});
+
+		while (!threadRunning) {
+			Sys.sleep(0.001);
+		}
+		#if cpp
+		cpp.vm.Gc.run(true);
+		#elseif hl
+		hl.Gc.major();
+		#elseif interp
+		eval.vm.Gc.full_major();
+		#elseif neko
+		neko.vm.Gc.run(true);
+		#end
+
+		cond.acquire();
+		cond.signal();
+		cond.release();
+
 		utest.Assert.pass();
 	}
 }

--- a/tests/threads/src/cases/TestCondition.hx
+++ b/tests/threads/src/cases/TestCondition.hx
@@ -32,10 +32,12 @@ class TestCondition extends utest.Test {
 		cond.acquire();
 		Thread.create(() -> {
 			cond.acquire();
+			cond.signal();
 			cond.wait();
 			cond.release();
 		});
-		cond.release();
+		// wait for signal from thread
+		cond.wait();
 
 		#if cpp
 		cpp.vm.Gc.run(true);
@@ -47,7 +49,6 @@ class TestCondition extends utest.Test {
 		neko.vm.Gc.run(true);
 		#end
 
-		cond.acquire();
 		cond.signal();
 		cond.release();
 

--- a/tests/threads/src/cases/TestEvents.hx
+++ b/tests/threads/src/cases/TestEvents.hx
@@ -9,22 +9,22 @@ class TestEvents extends utest.Test {
 		var e3 = null;
 		var e2 = null;
 		var e1 = null;
-		e2 = events.repeat(() -> {
+		e2 = events.addTimer(() -> {
 			checks.push(2);
-			events.cancel(e1);
-			events.cancel(e2);
-			events.cancel(e3);
-		}, 20);
-		e1 = events.repeat(() -> checks.push(1), 10);
-		e3 = events.repeat(() -> checks.push(3), 30);
+			e1.stop();
+			e2.stop();
+			e3.stop();
+		}, 20 / 1000);
+		e1 = events.addTimer(() -> checks.push(1), 10 / 1000);
+		e3 = events.addTimer(() -> checks.push(3), 30 / 1000);
 		Sys.sleep(0.1);
 
 		var checker = null;
-		checker = events.repeat(() -> {
+		checker = events.addTimer(() -> {
 			same([1, 2], checks);
 			async.done();
-			events.cancel(checker);
-		}, 100);
+			checker.stop();
+		}, 100 / 1000);
 	}
 
 	function testRun(async:Async) {
@@ -52,14 +52,14 @@ class TestEvents extends utest.Test {
 		function test(thread:Thread, done:()->Void) {
 			var timesExecuted = 0;
 			var eventHandler = null;
-			eventHandler = thread.events.repeat(() -> {
+			eventHandler = thread.events.addTimer(() -> {
 				++timesExecuted;
 				isTrue(thread == Thread.current());
 				if(timesExecuted >= 3) {
-					thread.events.cancel(eventHandler);
+					eventHandler.stop();
 					done();
 				}
-			}, 50);
+			}, 50 / 1000);
 		}
 
 		var mainThread = Thread.current();


### PR DESCRIPTION
These changes aren't strictly needed, but now that I've exposed the implementation on the hxcpp side we can get rid of the untyped.

CI will fail until this is merged https://github.com/HaxeFoundation/hxcpp/pull/1298/

This has just made me realise the hxcpp impl has a timeout wait which isn't exposed to haxe.