### PR TITLE
[lua] Add iterator() and keyValueIterator() to Table

### DIFF
--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -84,7 +84,6 @@
 	js : add new WebGLPolygonMode extension (#12026)
 	js : add js.lib.NativeStringTools (#12127)
 	lua : add lua.Syntax extern for typed raw Lua code injection (#12520)
-	lua : add iterator() and keyValueIterator() to lua.Table (#12531)
 	php : add externs for some POSIX functions (#11769)
 	macro : delay typer creation to after init macros (#11323)
 	macro : added Context.resolveComplexType

--- a/extra/CHANGES.txt
+++ b/extra/CHANGES.txt
@@ -84,6 +84,7 @@
 	js : add new WebGLPolygonMode extension (#12026)
 	js : add js.lib.NativeStringTools (#12127)
 	lua : add lua.Syntax extern for typed raw Lua code injection (#12520)
+	lua : add iterator() and keyValueIterator() to lua.Table (#12531)
 	php : add externs for some POSIX functions (#11769)
 	macro : delay typer creation to after init macros (#11323)
 	macro : added Context.resolveComplexType

--- a/std/lua/Table.hx
+++ b/std/lua/Table.hx
@@ -85,6 +85,42 @@ extern class Table<A, B> implements ArrayAccess<B> implements Dynamic<B> {
 		return Boot.defArray(PairTools.copy(tbl), length);
     }
 
+	/**
+		Returns an iterator over the values in the table.
+		Enables `for (v in table)` syntax.
+	**/
+	inline function iterator():Iterator<B> {
+		var tbl:Table<A, B> = this;
+		var cur:A = Lua.next(tbl, null).index;
+		return {
+			hasNext: function() return cur != null,
+			next: function() {
+				var key = cur;
+				var val = tbl[untyped key];
+				cur = Lua.next(tbl, key).index;
+				return val;
+			}
+		};
+	}
+
+	/**
+		Returns an iterator over the key-value pairs in the table.
+		Enables `for (k => v in table)` syntax.
+	**/
+	inline function keyValueIterator():KeyValueIterator<A, B> {
+		var tbl:Table<A, B> = this;
+		var cur:A = Lua.next(tbl, null).index;
+		return {
+			hasNext: function() return cur != null,
+			next: function() {
+				var key = cur;
+				var val = tbl[untyped key];
+				cur = Lua.next(tbl, key).index;
+				return {key: key, value: val};
+			}
+		};
+	}
+
 	@:overload(function<A, B>(table:Table<A, B>):Void {})
 	static function concat<A, B>(table:Table<A, B>, ?sep:String, ?i:Int, ?j:Int):String;
 

--- a/tests/unit/src/unit/issues/Issue12530.hx
+++ b/tests/unit/src/unit/issues/Issue12530.hx
@@ -1,0 +1,55 @@
+package unit.issues;
+
+#if lua
+import utest.Assert;
+
+class Issue12530 extends unit.Test {
+	// Table.iterator() and Table.keyValueIterator() for native for-loop syntax
+	function testTableValueIterator() {
+		var tbl:lua.Table<String, Int> = lua.Table.create();
+		untyped tbl["a"] = 1;
+		untyped tbl["b"] = 2;
+		untyped tbl["c"] = 3;
+
+		// Test value iterator: for (v in table)
+		var sum = 0;
+		for (v in tbl) {
+			sum += v;
+		}
+		eq(sum, 6);
+	}
+
+	function testTableKeyValueIterator() {
+		var tbl:lua.Table<String, Int> = lua.Table.create();
+		untyped tbl["a"] = 1;
+		untyped tbl["b"] = 2;
+		untyped tbl["c"] = 3;
+
+		// Test key-value iterator: for (k => v in table)
+		var keys:Array<String> = [];
+		var values:Array<Int> = [];
+		for (k => v in tbl) {
+			keys.push(k);
+			values.push(v);
+		}
+		eq(keys.length, 3);
+		eq(values.length, 3);
+		// Order is undefined, so check that all values are present
+		Assert.isTrue(keys.contains("a"));
+		Assert.isTrue(keys.contains("b"));
+		Assert.isTrue(keys.contains("c"));
+		Assert.isTrue(values.contains(1));
+		Assert.isTrue(values.contains(2));
+		Assert.isTrue(values.contains(3));
+	}
+
+	function testTableEmptyIteration() {
+		var empty:lua.Table<String, Int> = lua.Table.create();
+		var emptyCount = 0;
+		for (v in empty) {
+			emptyCount++;
+		}
+		eq(emptyCount, 0);
+	}
+}
+#end

--- a/tests/unit/src/unit/issues/Issue12530.hx
+++ b/tests/unit/src/unit/issues/Issue12530.hx
@@ -1,9 +1,7 @@
 package unit.issues;
 
-#if lua
-import utest.Assert;
-
 class Issue12530 extends unit.Test {
+#if lua
 	// Table.iterator() and Table.keyValueIterator() for native for-loop syntax
 	function testTableValueIterator() {
 		var tbl:lua.Table<String, Int> = lua.Table.create();
@@ -35,12 +33,12 @@ class Issue12530 extends unit.Test {
 		eq(keys.length, 3);
 		eq(values.length, 3);
 		// Order is undefined, so check that all values are present
-		Assert.isTrue(keys.contains("a"));
-		Assert.isTrue(keys.contains("b"));
-		Assert.isTrue(keys.contains("c"));
-		Assert.isTrue(values.contains(1));
-		Assert.isTrue(values.contains(2));
-		Assert.isTrue(values.contains(3));
+		t(keys.contains("a"));
+		t(keys.contains("b"));
+		t(keys.contains("c"));
+		t(values.contains(1));
+		t(values.contains(2));
+		t(values.contains(3));
 	}
 
 	function testTableEmptyIteration() {
@@ -51,5 +49,5 @@ class Issue12530 extends unit.Test {
 		}
 		eq(emptyCount, 0);
 	}
-}
 #end
+}


### PR DESCRIPTION
## Summary

Adds `iterator()` and `keyValueIterator()` methods to `lua.Table`, enabling native Haxe for-loop syntax:

```haxe
var t:Table<String, Int> = Table.create();
t["a"] = 1;
t["b"] = 2;

// Value iteration
for (v in t) {
    trace(v);  // 1, 2
}

// Key-value iteration  
for (k => v in t) {
    trace('$k: $v');  // a: 1, b: 2
}
```

## Motivation

Previously, iterating over Lua tables required using `PairTools`:
- `PairTools.pairsIterator(table)` - verbose wrapper
- `PairTools.pairsEach(table, callback)` - can't use `break`/`return`

This change makes tables feel like first-class Haxe collections.

## Implementation

Uses `Lua.next()` directly (same pattern as `StringMap.keys()`). Order is undefined per Lua semantics.

Fixes #12530

Related: #6131, PR #6132 (original 2017 request that resulted in `PairTools.pairsIterator`)