### PR TITLE
Fix error range for Not_enough_arguments

### DIFF
--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -319,6 +319,8 @@ type field_access = {
 	fa_inline : bool;
 	(* The position of the field access expression in syntax. *)
 	fa_pos    : pos;
+	(* The position of the field name accessed on `fa_on`. *)
+	fa_field_pos : pos option;
 }
 
 type static_extension_access = {

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -126,7 +126,8 @@ let unify_call_args ctx el args r callp ?(call_field_p=callp) inline force_inlin
 					die "" __LOC__
 			end
 		| [],(_,false,_) :: _ ->
-			call_error (Not_enough_arguments args) call_field_p
+			let tail_p = { callp with pmin = call_field_p.pmin } in
+			call_error (Not_enough_arguments args) tail_p
 		| [],(name,true,t) :: args ->
 			if not ctx.allow_transform then begin
 				ignore(loop [] args);

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -7,7 +7,7 @@ open Error
 open FieldAccess
 open FieldCallCandidate
 
-let unify_call_args ctx el args r callp inline force_inline in_overload =
+let unify_call_args ctx el args r callp ?(call_field_p=callp) inline force_inline in_overload =
 	let call_error err p = raise_error_msg (Call_error err) p in
 
 	let arg_error e name opt =
@@ -126,7 +126,7 @@ let unify_call_args ctx el args r callp inline force_inline in_overload =
 					die "" __LOC__
 			end
 		| [],(_,false,_) :: _ ->
-			call_error (Not_enough_arguments args) callp
+			call_error (Not_enough_arguments args) call_field_p
 		| [],(name,true,t) :: args ->
 			if not ctx.allow_transform then begin
 				ignore(loop [] args);
@@ -296,7 +296,7 @@ let unify_field_call ctx fa el_typed el p inline =
 			let args_typed,args = unify_typed_args ctx tmap args el_typed p in
 			let el =
 				try
-					unify_call_args ctx el args ret p inline is_forced_inline in_overload
+					unify_call_args ctx el args ret ?call_field_p:fa.fa_field_pos p inline is_forced_inline in_overload
 				with DisplayException.DisplayException de ->
 					raise_augmented_display_exception cf de;
 			in

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -553,8 +553,14 @@ object(self)
 				t_dynamic
 			else if ctx.f.untyped then
 				mk_mono()
-			else
-				raise_typing_error (s_type (print_context()) e.etype ^ " cannot be called") e.epos
+			else (
+				let pos = match e.eexpr with
+					| TField(_,(FAnon cf | FInstance (_,_,cf) | FStatic (_,cf) | FClosure (_,cf))) ->
+						patch_string_pos e.epos cf.cf_name
+					| _ -> e.epos
+				in
+				raise_typing_error (s_type (print_context()) e.etype ^ " cannot be called") pos
+			)
 			in
 			mk (TCall (e,el)) t p
 		in

--- a/src/typing/fieldAccess.ml
+++ b/src/typing/fieldAccess.ml
@@ -22,12 +22,13 @@ type 'a accessor_resolution =
 	(* Accessor resolution was attempted on a non-property. *)
 	| AccessorInvalid
 
-let create e cf fh inline p = {
+let create e cf fh inline ?field_pos p = {
 	fa_on     = e;
 	fa_field  = cf;
 	fa_host   = fh;
 	fa_inline = inline;
 	fa_pos    = p;
+	fa_field_pos = field_pos;
 }
 
 (* Creates the `tfield_access` corresponding to this field access, using the provided field. *)
@@ -140,7 +141,7 @@ let find_accessor_for_field host cf t mode = match cf.cf_kind with
 (* Resolves the accessor on the field access, using the provided `mode`. *)
 let resolve_accessor fa mode =
 	let forward cf_acc new_host =
-		create fa.fa_on cf_acc new_host fa.fa_inline fa.fa_pos
+		create fa.fa_on cf_acc new_host fa.fa_inline fa.fa_pos ?field_pos:fa.fa_field_pos
 	in
 	match find_accessor_for_field fa.fa_host fa.fa_field fa.fa_on.etype mode with
 	| AccessorFound(cf_acc,new_host) ->

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -284,7 +284,7 @@ let class_field ctx c tl name p =
 (* Resolves field [i] on typed expression [e] using the given [mode]. *)
 (* Note: if mode = MCall, with_type (if known) refers to the return type *)
 let type_field cfg ctx e i p mode (with_type : WithType.t) =
-	let pfield = if e.epos = p then p else { p with pmin = p.pmax - (String.length i) } in
+	let pfield = if e.epos = p then p else patch_string_pos p i in
 	let is_set = match mode with MSet _ -> true | _ -> false in
 	let field_access e f fmode = field_access ctx mode f fmode e pfield in
 	let class_field_with_access e c tl =

--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -110,7 +110,7 @@ let field_access ctx mode f fh e pfield =
 	let is_set = match mode with MSet _ -> true | _ -> false in
 	check_no_closure_meta ctx f fh mode pfield;
 	let bypass_accessor () = if ctx.e.bypass_accessor > 0 then (ctx.e.bypass_accessor <- ctx.e.bypass_accessor - 1; true) else false in
-	let make_access inline = FieldAccess.create e f fh (inline && ctx.allow_inline) pfull in
+	let make_access inline = FieldAccess.create e f fh (inline && ctx.allow_inline) pfull ~field_pos:pfield in
 	match f.cf_kind with
 	| Method m ->
 		let normal () = AKField(make_access false) in

--- a/tests/misc/projects/Issue10707/Main.hx
+++ b/tests/misc/projects/Issue10707/Main.hx
@@ -1,0 +1,6 @@
+function main() {
+	final word = ["a", "b", "c"].map(char -> {
+		// some long function
+		return char;
+	}).join();
+}

--- a/tests/misc/projects/Issue10707/Main.hx
+++ b/tests/misc/projects/Issue10707/Main.hx
@@ -3,4 +3,6 @@ function main() {
 		// some long function
 		return char;
 	}).join();
+
+	final word = ["foo"].join("").length();
 }

--- a/tests/misc/projects/Issue10707/compile-fail.hxml
+++ b/tests/misc/projects/Issue10707/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/projects/Issue10707/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10707/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:5: characters 5-9 : Not enough arguments, expected sep:String
+Main.hx:5: characters 5-11 : Not enough arguments, expected sep:String

--- a/tests/misc/projects/Issue10707/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10707/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:5: characters 5-9 : Not enough arguments, expected sep:String

--- a/tests/misc/projects/Issue10707/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue10707/compile-fail.hxml.stderr
@@ -1,1 +1,2 @@
 Main.hx:5: characters 5-11 : Not enough arguments, expected sep:String
+Main.hx:7: characters 32-38 : Int cannot be called

--- a/tests/misc/projects/Issue3802/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue3802/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:3: characters 3-7 : Not enough arguments, expected i:Int, s:String
+Main.hx:3: characters 3-9 : Not enough arguments, expected i:Int, s:String

--- a/tests/misc/projects/Issue3802/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue3802/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:3: characters 3-9 : Not enough arguments, expected i:Int, s:String
+Main.hx:3: characters 3-7 : Not enough arguments, expected i:Int, s:String

--- a/tests/misc/projects/Issue5940/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue5940/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
 Main.hx:3: characters 21-24 : Cannot access non-static abstract field statically
-Main.hx:3: characters 15-24 : Not enough arguments, expected this:Int
+Main.hx:3: characters 21-24 : Not enough arguments, expected this:Int


### PR DESCRIPTION
I also tried to subtract `fa.fa_on.epos` from full `call_pos`, but then there is also a dot in `foo.bar`, that will be highlighted in errors.

Is there can be some better solution, like extracting this call "field/name" from TField tree expression or like that?

Closes https://github.com/HaxeFoundation/haxe/issues/10707