### PR TITLE
Decouple EventLoop from Thread

### DIFF
--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -89,8 +89,10 @@ class EventLoop {
 	**/
 	public static var current(get,never) : EventLoop;
 
+	#if target.threaded
 	static var eventsTls:sys.thread.Tls<EventLoop>;
 	static var threadsToEventLoops:IntMap<EventLoop>;
+	#end
 
 	var events : Event;
 	var queue : Event;
@@ -468,6 +470,7 @@ class EventLoop {
 		#end
 	}
 
+	#if target.threaded
 
 	/**
 		Returns the instance of `EventLoop` associated with `thread`, or `null` if no such
@@ -476,6 +479,8 @@ class EventLoop {
 	static public function getThreadLoop(thread:sys.thread.Thread) {
 		return threadsToEventLoops.get(thread.id);
 	}
+
+	#end
 
 	static function get_current() {
 		#if target.threaded
@@ -491,6 +496,8 @@ class EventLoop {
 		if( main == null ) main = new EventLoop();
 		return main;
 	}
+
+	#if target.threaded
 
 	static function __init__() {
 		eventsTls = new sys.thread.Tls();
@@ -535,4 +542,6 @@ class EventLoop {
 			}
 		}
 	}
+
+	#end
 }

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -510,15 +510,15 @@ class EventLoop {
 		threadsToEventLoops.set(mainEvents.thread.id, mainEvents);
 
 		// Set up onJobStart
-		final onCreate = sys.thread.Thread.onJobStart;
+		final onJobStart = sys.thread.Thread.onJobStart;
 		sys.thread.Thread.onJobStart = function() {
 			final thread = sys.thread.Thread.current();
 			final events = new EventLoop();
 			events.thread = thread;
 			eventsTls.value = events;
 			threadsToEventLoops.set(thread.id, events);
-			if (onCreate != null) {
-				onCreate();
+			if (onJobStart != null) {
+				onJobStart();
 			}
 
 			// Set up onJobDone

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -517,8 +517,7 @@ class EventLoop {
 		threadsToEventLoopsMutex.release();
 
 		// Set up onJobStart
-		final onJobStart = sys.thread.Thread.onJobStart;
-		sys.thread.Thread.onJobStart = function() {
+		sys.thread.Thread.onJobStart(() -> {
 			final thread = sys.thread.Thread.current();
 			final events = new EventLoop();
 			events.thread = thread;
@@ -526,30 +525,19 @@ class EventLoop {
 			threadsToEventLoopsMutex.acquire();
 			threadsToEventLoops.set(thread.id, events);
 			threadsToEventLoopsMutex.release();
-			if (onJobStart != null) {
-				onJobStart();
-			}
 
 			// Set up onJobDone
-			final onJobDone = thread.onJobDone;
-			thread.onJobDone = function() {
+			thread.onJobDone(() -> {
 				events.loop();
-				if (onJobDone != null) {
-					onJobDone();
-				}
-			}
+			});
 
 			// Set up onExit
-			final onExit = thread.onExit;
-			thread.onExit = function() {
+			thread.onExit(() -> {
 				events.dispose();
 				mainEvents.wakeup();
 				eventsTls.value = null;
-				if (onExit != null) {
-					onExit();
-				}
-			}
-		}
+			});
+		});
 	}
 
 	#end

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -1,5 +1,6 @@
 package haxe;
 
+import haxe.ds.IntMap;
 import haxe.EntryPoint;
 
 class Event {
@@ -87,6 +88,9 @@ class EventLoop {
 		it is the same as `main`.
 	**/
 	public static var current(get,never) : EventLoop;
+
+	static var eventsTls:sys.thread.Tls<EventLoop>;
+	static var threadsToEventLoops:IntMap<EventLoop>;
 
 	var events : Event;
 	var queue : Event;
@@ -464,9 +468,18 @@ class EventLoop {
 		#end
 	}
 
+
+	/**
+		Returns the instance of `EventLoop` associated with `thread`, or `null` if no such
+		instance exists for the given thread.
+	**/
+	static public function getThreadLoop(thread:sys.thread.Thread) {
+		return threadsToEventLoops.get(thread.id);
+	}
+
 	static function get_current() {
 		#if target.threaded
-		var events = sys.thread.Thread.current().events;
+		var events = eventsTls.value;
 		if( events == null ) throw "The current thread doesn't have an event loop.";
 		return events;
 		#else
@@ -479,5 +492,47 @@ class EventLoop {
 		return main;
 	}
 
+	static function __init__() {
+		eventsTls = new sys.thread.Tls();
+		threadsToEventLoops = new IntMap();
 
+		// Set up main EventLoop
+		final mainEvents = main;
+		mainEvents.thread = sys.thread.Thread.main();
+		eventsTls.value = mainEvents;
+		threadsToEventLoops.set(mainEvents.thread.id, mainEvents);
+
+		// Set up onJobStart
+		final onCreate = sys.thread.Thread.onJobStart;
+		sys.thread.Thread.onJobStart = function() {
+			final thread = sys.thread.Thread.current();
+			final events = new EventLoop();
+			events.thread = thread;
+			eventsTls.value = events;
+			threadsToEventLoops.set(thread.id, events);
+			if (onCreate != null) {
+				onCreate();
+			}
+
+			// Set up onJobDone
+			final onJobDone = thread.onJobDone;
+			thread.onJobDone = function() {
+				events.loop();
+				if (onJobDone != null) {
+					onJobDone();
+				}
+			}
+
+			// Set up onExit
+			final onExit = thread.onExit;
+			thread.onExit = function() {
+				events.dispose();
+				mainEvents.wakeup();
+				eventsTls.value = null;
+				if (onExit != null) {
+					onExit();
+				}
+			}
+		}
+	}
 }

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -92,6 +92,7 @@ class EventLoop {
 	#if target.threaded
 	static var eventsTls:sys.thread.Tls<EventLoop>;
 	static var threadsToEventLoops:IntMap<EventLoop>;
+	static var threadsToEventLoopsMutex:sys.thread.Mutex;
 	#end
 
 	var events : Event;
@@ -477,7 +478,10 @@ class EventLoop {
 		instance exists for the given thread.
 	**/
 	static public function getThreadLoop(thread:sys.thread.Thread) {
-		return threadsToEventLoops.get(thread.id);
+		threadsToEventLoopsMutex.acquire();
+		final events = threadsToEventLoops.get(thread.id);
+		threadsToEventLoopsMutex.release();
+		return events;
 	}
 
 	#end
@@ -502,12 +506,15 @@ class EventLoop {
 	static function __init__() {
 		eventsTls = new sys.thread.Tls();
 		threadsToEventLoops = new IntMap();
+		threadsToEventLoopsMutex = new sys.thread.Mutex();
 
 		// Set up main EventLoop
 		final mainEvents = main;
 		mainEvents.thread = sys.thread.Thread.main();
 		eventsTls.value = mainEvents;
+		threadsToEventLoopsMutex.acquire(); // probably not necessary but let's play it safe
 		threadsToEventLoops.set(mainEvents.thread.id, mainEvents);
+		threadsToEventLoopsMutex.release();
 
 		// Set up onJobStart
 		final onJobStart = sys.thread.Thread.onJobStart;
@@ -516,7 +523,9 @@ class EventLoop {
 			final events = new EventLoop();
 			events.thread = thread;
 			eventsTls.value = events;
+			threadsToEventLoopsMutex.acquire();
 			threadsToEventLoops.set(thread.id, events);
+			threadsToEventLoopsMutex.release();
 			if (onJobStart != null) {
 				onJobStart();
 			}

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -32,18 +32,13 @@ class Thread {
 	static var mutex : Mutex;
 	static var mainThread : Thread;
 	static var idCounter : Int; // TODO: Should probably be an AtomicInt
-
-	/**
-		This function is called when a thread is about to start executing its job.
-
-		It is generally good practice to call any previously existing callback
-		from functions assigned to this.
-	**/
-	static public var onJobStart:Null<() -> Void>;
+	static var onJobStartCallback : Null<() -> Void>;
 
 	public final id : Int;
 	var impl : ThreadImpl;
 	var messages : Deque<Dynamic>;
+	var onExitCallback : Null<() -> Void>;
+	var onJobDoneCallback : Null<() -> Void>;
 
 	/**
 		Tells if we needs to wait for the thread to terminate before we stop the main loop (default:true).
@@ -147,7 +142,7 @@ class Thread {
 		threads.push(t);
 		mutex.release();
 		if ( onExit != null )
-			t.onExit = onExit;
+			t.onExitCallback = onExit;
 		if( onAbort != null )
 			t.onAbort = onAbort;
 		t.impl = ThreadImpl.create(function() {
@@ -159,17 +154,21 @@ class Thread {
 				#if hl
 				hl.Api.setErrorHandler(null);
 				#end
-				if (onJobStart != null) {
-					onJobStart();
+				if (onJobStartCallback != null) {
+					onJobStartCallback();
 				}
 				job();
-				t.onJobDone();
+				if (t.onJobDoneCallback != null) {
+					t.onJobDoneCallback();
+				}
 			} catch( e ) {
 				exception = e;
 			}
 			if( exception != null )
 				t.onAbort(exception);
-			t.onExit();
+			if (t.onExitCallback != null) {
+				t.onExitCallback();
+			}
 			t.dispose();
 		});
 		if( name != null ) t.name = name;
@@ -189,13 +188,32 @@ class Thread {
 	}
 
 	/**
-		This function is called once the thread has completed executing its job successfully.
-		It is not called if the thread has thrown an exception.
-
-		It is generally good practice to call any previously existing callback
-		from functions assigned to this.
+		Registers `f` to be called when a thread is about to start executing its job.
 	**/
-	public dynamic function onJobDone() {}
+	static public function onJobStart(f:() -> Void) {
+		final onJobStart = onJobStartCallback;
+		onJobStartCallback = function() {
+			f();
+			if (onJobStart != null) {
+				onJobStart();
+			}
+		}
+	}
+
+
+	/**
+		Registers `f` to be called once the thread has completed executing its job
+		successfully. It is not called if the thread has thrown an exception.
+	**/
+	public function onJobDone(f:() -> Void) {
+		final onJobDone = onJobDoneCallback;
+		onJobDoneCallback = function() {
+			f();
+			if (onJobDone != null) {
+				onJobDone();
+			}
+		}
+	}
 
 
 	/**
@@ -212,16 +230,21 @@ class Thread {
 	}
 
 	/**
-		This function is called when the thread is exiting. In the case of an exception, it is called
-		after `onAbort`.
+		Registers `f` to be called when the thread is exiting. In the case of an exception,
+		it is called after `onAbort`.
 
 		It is not guaranteed to be called if the thread is killed in a way that does not lead to
 		normal termination. Any callback assigned to this should not throw an exception.
-
-		It is generally good practice to call any previously existing callback
-		from functions assigned to this.
 	**/
-	public dynamic function onExit() {}
+	public function onExit(f:() -> Void) {
+		final onExit = onExitCallback;
+		onExitCallback = function() {
+			f();
+			if (onExit != null) {
+				onExit();
+			}
+		}
+	}
 
 	static function hasBlocking() {
 		// let's check if we have blocking threads running other that our calling thread

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -33,6 +33,11 @@ class Thread {
 	static var mainThread : Thread;
 	static var idCounter : Int; // TODO: Should probably be an AtomicInt
 
+	/**
+		This function is called when a thread is about to start executing its job.
+	**/
+	static public var onJobStart:Null<() -> Void>;
+
 	public final id : Int;
 	var impl : ThreadImpl;
 	var messages : Deque<Dynamic>;
@@ -177,11 +182,6 @@ class Thread {
 		mutex.release();
 		return tl;
 	}
-
-	/**
-		This function is called when a thread is about to start executing its job.
-	**/
-	static public dynamic function onJobStart() { }
 
 	/**
 		This function is called once the thread has completed executing its job successfully.

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -31,15 +31,11 @@ class Thread {
 	static var threads : Array<Thread>;
 	static var mutex : Mutex;
 	static var mainThread : Thread;
+	static var idCounter = 1; // TODO: Should probably be an AtomicInt
 
+	public final id : Int;
 	var impl : ThreadImpl;
 	var messages : Deque<Dynamic>;
-
-	/**
-		The events loop of this thread.
-		If this is a native thread, the events will be null.
-	**/
-	public var events(default,null) : Null<haxe.EventLoop>;
 
 	/**
 		Tells if we needs to wait for the thread to terminate before we stop the main loop (default:true).
@@ -58,6 +54,7 @@ class Thread {
 	public var isNative(default,null) : Bool;
 
 	function new(impl) {
+		this.id = idCounter++;
 		this.impl = impl;
 		if( impl != null ) this.name = ThreadImpl.getName(impl);
 	}
@@ -92,7 +89,6 @@ class Thread {
 		threads.remove(this);
 		mutex.release();
 		currentTLS.value = null;
-		events.dispose();
 	}
 
 	public static function readMessage( blocking : Bool ) : Null<Dynamic> {
@@ -140,8 +136,6 @@ class Thread {
 	public static function create(?name:String, job:()->Void, ?onExit:() -> Void, ?onAbort:haxe.Exception -> Void):Thread {
 		mutex.acquire();
 		var t = new Thread(null);
-		t.events = new haxe.EventLoop();
-		t.events.thread = t;
 		threads.push(t);
 		mutex.release();
 		if ( onExit != null )
@@ -157,8 +151,9 @@ class Thread {
 				#if hl
 				hl.Api.setErrorHandler(null);
 				#end
+				onJobStart();
 				job();
-				t.events.loop();
+				t.onJobDone();
 			} catch( e ) {
 				exception = e;
 			}
@@ -166,7 +161,6 @@ class Thread {
 				t.onAbort(exception);
 			t.onExit();
 			t.dispose();
-			@:privateAccess main().events.wakeup();
 		});
 		if( name != null ) t.name = name;
 		return t;
@@ -183,6 +177,18 @@ class Thread {
 		mutex.release();
 		return tl;
 	}
+
+	/**
+		This function is called when a thread is about to start executing its job.
+	**/
+	static public dynamic function onJobStart() { }
+
+	/**
+		This function is called once the thread has completed executing its job successfully.
+		It is not called if the thread has thrown an exception.
+	**/
+	public dynamic function onJobDone() {}
+
 
 	/**
 		This function is called when an uncaught exception aborted a thread.
@@ -220,8 +226,6 @@ class Thread {
 		mutex = new Mutex();
 		mainThread = new Thread(ThreadImpl.current());
 		mainThread.name = "Main";
-		mainThread.events = haxe.EventLoop.main;
-		mainThread.events.thread = mainThread;
 		threads = [mainThread];
 		currentTLS = new Tls();
 		currentTLS.value = mainThread;

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -31,7 +31,7 @@ class Thread {
 	static var threads : Array<Thread>;
 	static var mutex : Mutex;
 	static var mainThread : Thread;
-	static var idCounter = 1; // TODO: Should probably be an AtomicInt
+	static var idCounter : Int; // TODO: Should probably be an AtomicInt
 
 	public final id : Int;
 	var impl : ThreadImpl;
@@ -224,6 +224,7 @@ class Thread {
 
 	static function __init__() {
 		mutex = new Mutex();
+		idCounter = 1;
 		mainThread = new Thread(ThreadImpl.current());
 		mainThread.name = "Main";
 		threads = [mainThread];

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -35,6 +35,9 @@ class Thread {
 
 	/**
 		This function is called when a thread is about to start executing its job.
+
+		It is generally good practice to call any previously existing callback
+		from functions assigned to this.
 	**/
 	static public var onJobStart:Null<() -> Void>;
 
@@ -188,6 +191,9 @@ class Thread {
 	/**
 		This function is called once the thread has completed executing its job successfully.
 		It is not called if the thread has thrown an exception.
+
+		It is generally good practice to call any previously existing callback
+		from functions assigned to this.
 	**/
 	public dynamic function onJobDone() {}
 
@@ -195,6 +201,9 @@ class Thread {
 	/**
 		This function is called when an uncaught exception aborted a thread.
 		The error will be printed to stdout but this function can be redefined.
+
+		It is generally good practice to call any previously existing callback
+		from functions assigned to this.
 	**/
 	public dynamic function onAbort(e:haxe.Exception) {
 		var name = this.name;
@@ -207,7 +216,10 @@ class Thread {
 		after `onAbort`.
 
 		It is not guaranteed to be called if the thread is killed in a way that does not lead to
-		normal termination.
+		normal termination. Any callback assigned to this should not throw an exception.
+
+		It is generally good practice to call any previously existing callback
+		from functions assigned to this.
 	**/
 	public dynamic function onExit() {}
 

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -156,7 +156,9 @@ class Thread {
 				#if hl
 				hl.Api.setErrorHandler(null);
 				#end
-				onJobStart();
+				if (onJobStart != null) {
+					onJobStart();
+				}
 				job();
 				t.onJobDone();
 			} catch( e ) {

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -34,6 +34,13 @@ class Thread {
 	static var idCounter : Int; // TODO: Should probably be an AtomicInt
 	static var onJobStartCallback : Null<() -> Void>;
 
+	@:deprecated("Use haxe.EventLoop.getThreadLoop(thread) instead")
+	public var events(get, null):Null<haxe.EventLoop>;
+
+	inline function get_events() {
+		return haxe.EventLoop.getThreadLoop(this);
+	}
+
 	public final id : Int;
 	var impl : ThreadImpl;
 	var messages : Deque<Dynamic>;

--- a/tests/threads/src/cases/TestEvents.hx
+++ b/tests/threads/src/cases/TestEvents.hx
@@ -1,10 +1,12 @@
 package cases;
 
+import haxe.EventLoop;
+
 @:timeout(2000)
 class TestEvents extends utest.Test {
 
 	function testIssue10567_runEventsInOrderByTime(async:Async) {
-		var events = Thread.current().events;
+		var events = EventLoop.current;
 		var checks = [];
 		var e3 = null;
 		var e2 = null;
@@ -32,11 +34,11 @@ class TestEvents extends utest.Test {
 		Thread.create(() -> {
 			var childThread = Thread.current();
 			isTrue(mainThread != childThread);
-			mainThread.events.run(() -> {
+			EventLoop.getThreadLoop(mainThread).run(() -> {
 				isTrue(mainThread == Thread.current());
-				childThread.events.run(() -> {
+				EventLoop.getThreadLoop(childThread).run(() -> {
 					isTrue(childThread == Thread.current());
-					mainThread.events.run(() -> {
+					EventLoop.getThreadLoop(mainThread).run(() -> {
 						isTrue(mainThread == Thread.current());
 						async.done();
 					});
@@ -52,7 +54,7 @@ class TestEvents extends utest.Test {
 		function test(thread:Thread, done:()->Void) {
 			var timesExecuted = 0;
 			var eventHandler = null;
-			eventHandler = thread.events.addTimer(() -> {
+			eventHandler = EventLoop.getThreadLoop(thread).addTimer(() -> {
 				++timesExecuted;
 				isTrue(thread == Thread.current());
 				if(timesExecuted >= 3) {
@@ -69,7 +71,7 @@ class TestEvents extends utest.Test {
 			Thread.create(() -> {
 				var childThread = Thread.current();
 				isTrue(childThread != mainThread);
-				test(childThread, mainThread.events.run.bind(() -> async.done(),0));
+				test(childThread, EventLoop.getThreadLoop(mainThread).run.bind(() -> async.done(),0));
 			});
 		});
 	}

--- a/tests/threads/src/cases/TestMainLoop.hx
+++ b/tests/threads/src/cases/TestMainLoop.hx
@@ -1,6 +1,7 @@
 package cases;
 
 import haxe.MainLoop;
+import haxe.EventLoop;
 
 @:timeout(10000)
 @:depends(cases.TestEvents)
@@ -21,13 +22,13 @@ class TestMainLoop extends utest.Test {
 				async.done();
 			} else if(checkAttempts > 0) {
 				checkAttempts--;
-				mainThread.events.run(check);
+				EventLoop.getThreadLoop(mainThread).run(check);
 			} else {
 				fail();
 				async.done();
 			}
 		}
-		mainThread.events.run(check);
+		EventLoop.current.run(check);
 	}
 
 	function testNewAction_immediately(async:Async) {


### PR DESCRIPTION
* Adds `Thread.id` for unique integer IDs.
* Adds a new `Thread.onJobStart` ~~dynamic function~~ callback which is executed once a thread has been created, but before it runs its job.
* `EventLoop.__init__` hooks into that to manage its per-thread setup:
    * Create the per-thread instance of `EventLoop`, install it as a TLS and add it to a lookup map using `thread.id`.
    * Register `events.loop()` for the new `onJobDone` callback on threads.
    * Register its EventLoop-specific cleanup code on `onExit`.
* `Thread.current().events` is now `EventLoop.current`. Actually that was already a thing anyway, but now it uses the TLS instead of the explicit `events` on threads.
* `childThread.events` is now `EventLoop.getThreadLoop(childThread)` using the ID-based lookup.

This whole thing isn't very well tested, so it's possible that I've messed something up. And just as I write this, I see that C++ segfaults, so I've definitely messed something up.