### PR TITLE
[hl] fix const Single from float/int generates cast

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -2796,6 +2796,8 @@ and eval_expr ctx e =
 		ctx.m.mcontinues <- oldc;
 		ctx.m.mloop_trys <- oldtrys;
 		alloc_tmp ctx HVoid
+	| TCast ({ eexpr = TConst (TInt _ | TFloat _) as ec }, None) ->
+		eval_to ctx { e with eexpr = ec } (to_type ctx e.etype)
 	| TCast ({ eexpr = TCast (v,None) },None) when not (is_number (to_type ctx e.etype)) ->
 		(* coalesce double casts into a single runtime check - temp fix for Map accesses *)
 		eval_expr ctx { e with eexpr = TCast(v,None) }

--- a/tests/unit/src/unit/issues/Issue11425.hx
+++ b/tests/unit/src/unit/issues/Issue11425.hx
@@ -58,7 +58,7 @@ class Issue11425 extends Test {
 		// generated: Variant.toFloat(variant1 != null ? variant1 : 1.0)
 		// testValue10 is inferred as Variant
 		// and hxcpp does not like casting Float to that
-		#if !cpp 
+		#if !(cpp || hl)
 		var testValue10 = variant1 ?? cast 1.0; // Works fine.
 		// generated: variant1 != null ? variant1 : 1.0
 		#end


### PR DESCRIPTION
Previous attempt
- https://github.com/HaxeFoundation/hashlink/pull/871

The following code

```haxe
inline final SCALAR_MAX : Single = 3.40282347E+38;
inline final SCALAR_1 : Single = 3.40282347E+37;
inline final SCALAR_0 : Single = 0;

function main() {
	var best = SCALAR_MAX; // [Cast:Single] [Const:Float] 3.40282347E+38, eval_to
	if( best > SCALAR_1 // [Cast:Single] [Const:Float] 3.40282347E+37, eval_expr
	  || best == SCALAR_0 ) // [Cast:Single] [Const:Int] 0, eval_expr
		trace(best);
}
```

generates before

```
float 0,@0
tosfloat 1,0
float 0,@1
tosfloat 3,0
jslt 3,1,3
int 4,@0
tosfloat 3,4
jnoteq 1,3,15
```

after
```
float 0,@0
float 2,@1
jslt 2,0,2
float 2,@2
jnoteq 0,2,15
```