### PR TITLE
[tests] Use msys2 to run lua on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -566,6 +566,17 @@ jobs:
           choco install wget
           wget --version
 
+      - uses: msys2/setup-msys2@v2
+        if: matrix.target == 'lua'
+        id: msys2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-pcre2
+
       - name: Setup haxelib
         shell: pwsh
         run: |
@@ -582,6 +593,8 @@ jobs:
         run: haxe RunCi.hxml -D include_legacy
         working-directory: ${{github.workspace}}/tests
         timeout-minutes: 20
+        env:
+          MSYS2_LOCATION: ${{ matrix.target == 'lua' && steps.msys2.outputs.msys2-location || '' }}
 
 
   mac-build-universal:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -576,6 +576,7 @@ jobs:
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-openssl
             mingw-w64-ucrt-x86_64-pcre2
+            mingw-w64-ucrt-x86_64-libuv
 
       - name: Setup haxelib
         shell: pwsh

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -83,7 +83,7 @@ class Lua {
 			Sys.println('Lua Version: $lv');
 
 			final targetFlags = if (systemName == "Windows") ["--target", "vs"] else [];
-			runCommand("hererocks", [envpath, lv, "-r@418d2ab34891b130cc317df32f65f978640febcf", "-i"].concat(targetFlags));
+			runCommand("hererocks", [envpath, lv, "-r@v3.13.0", "-i"].concat(targetFlags));
 			trace('path: ' + Sys.getEnv("PATH"));
 
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -82,7 +82,7 @@ class Lua {
 			Sys.println('--------------------');
 			Sys.println('Lua Version: $lv');
 
-			final targetFlags = if (systemName == "Windows") ["--target", "vs"] else [];
+			final targetFlags = if (systemName == "Windows") ["--target", if (useWindowsVcpkg) "vs" else "mingw"] else [];
 			runCommand("hererocks", [envpath, lv, "-r@v3.13.0", "-i"].concat(targetFlags));
 			trace('path: ' + Sys.getEnv("PATH"));
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -56,16 +56,9 @@ class Lua {
 	static function installLib(lib : String, version : String, ?server :String){
 		if (!commandSucceed("luarocks", ["show", lib, version])) {
 			final args = ["install", lib, version];
-			if (systemName == "Mac") {
-				final opensslPath = commandResult("brew", ["--prefix", "openssl"]);
-				args.push('OPENSSL_DIR=${opensslPath.stdout.trim()}');
-				final pcrePath = commandResult("brew", ["--prefix", "pcre2"]);
-				args.push('PCRE2_DIR=${pcrePath.stdout.trim()}');
-			} else if (systemName == "Windows" && useWindowsVcpkg) {
+			if (systemName == "Windows" && useWindowsVcpkg) {
 				args.push('OPENSSL_DIR=C:\\Program Files\\OpenSSL');
 				args.push('OPENSSL_LIBDIR=C:\\Program Files\\OpenSSL\\lib\\VC\\x64\\MD');
-				final dir = Path.join([vcpkgRoot, "installed\\x64-windows-release"]);
-				args.push('PCRE2_DIR=$dir');
 			}
             if (server != null){
                 final server_arg = '--server=$server';
@@ -96,9 +89,16 @@ class Lua {
 
 			runCommand("lua",["-v"]);
 
-			if (systemName == "Windows" && useWindowsVcpkg) {
-				// required for luv build, default is very old
-				runCommand("luarocks", ["config", "cmake_generator", "Visual Studio 17 2022"]);
+			if (systemName == "Windows") {
+				if (useWindowsVcpkg) {
+					// required for luv build, default is very old
+					runCommand("luarocks", ["config", "cmake_generator", "Visual Studio 17 2022"]);
+					runCommand("luarocks", ["config", "external_deps_dirs[0]", Path.join([Sys.getEnv("VCPKG_INSTALLATION_ROOT"), 'installed/x64-windows-release'])]);
+				} else {
+					runCommand("luarocks", ["config", "external_deps_dirs[0]", Path.join([msys2Path, "ucrt64"])]);
+				}
+			} else if (systemName == "Mac") {
+				runCommand("luarocks", ["config", "external_deps_dirs[0]", commandResult("brew", ["--prefix"]).stdout.trim()]);
 			}
 
 			runCommand("luarocks", ["config", "--lua-incdir"]);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -8,6 +8,9 @@ using StringTools;
 class Lua {
 	static final miscLuaDir = getMiscSubDir('lua');
 
+	static var useWindowsVcpkg = false;
+	static var msys2Path = Sys.getEnv("MSYS2_LOCATION") ?? "C:\\msys64";
+
 	static public function getLuaDependencies(){
 		switch (systemName){
 			case "Linux":
@@ -22,8 +25,29 @@ class Lua {
 				runCommand("brew", ["install", "openssl"]);
 				runCommand("brew", ["install", "pipx"]);
 			case "Windows":
-				runCommand("vcpkg", ["install", "pcre2:x64-windows-release"]);
-				addToPATH(Path.join([Sys.getEnv("VCPKG_INSTALLATION_ROOT"), 'installed/x64-windows-release/bin']));
+				if (sys.FileSystem.exists(msys2Path)) {
+					addToPATH('$msys2Path\\usr\\bin');
+					addToPATH('$msys2Path\\ucrt64\\bin');
+					runCommand(
+						"pacman",
+						[
+							"--noconfirm",
+							"-S",
+							"--needed",
+							"--overwrite",
+							"mingw-w64-ucrt-x86_64-gcc",
+							"mingw-w64-ucrt-x86_64-openssl",
+							"mingw-w64-ucrt-x86_64-pcre2"
+						]
+					);
+				} else if(Sys.getEnv("VCPKG_INSTALLATION_ROOT") != null) {
+					useWindowsVcpkg = true;
+					runCommand("vcpkg", ["install", "pcre2:x64-windows-release"]);
+					addToPATH(Path.join([Sys.getEnv("VCPKG_INSTALLATION_ROOT"), 'installed/x64-windows-release/bin']));
+				} else {
+					failMsg("Running on windows requires msys2 or vcpkg environment");
+				}
+
 		}
 		runCommand("pipx", ["ensurepath"]);
 		runCommand("pipx", ["install", "hererocks"]);
@@ -37,16 +61,11 @@ class Lua {
 				args.push('OPENSSL_DIR=${opensslPath.stdout.trim()}');
 				final pcrePath = commandResult("brew", ["--prefix", "pcre2"]);
 				args.push('PCRE2_DIR=${pcrePath.stdout.trim()}');
-			} else if (systemName == "Windows") {
+			} else if (systemName == "Windows" && useWindowsVcpkg) {
 				args.push('OPENSSL_DIR=C:\\Program Files\\OpenSSL');
 				args.push('OPENSSL_LIBDIR=C:\\Program Files\\OpenSSL\\lib\\VC\\x64\\MD');
-				final vcpkgRoot = Sys.getEnv("VCPKG_INSTALLATION_ROOT");
-				if (vcpkgRoot == null) {
-					System.failMsg("VCPKG_INSTALLATION_ROOT missing, lua dependencies may fail to install");
-				} else {
-					final dir = Path.join([vcpkgRoot, "installed\\x64-windows-release"]);
-					args.push('PCRE2_DIR=$dir');
-				}
+				final dir = Path.join([vcpkgRoot, "installed\\x64-windows-release"]);
+				args.push('PCRE2_DIR=$dir');
 			}
             if (server != null){
                 final server_arg = '--server=$server';
@@ -77,7 +96,7 @@ class Lua {
 
 			runCommand("lua",["-v"]);
 
-			if (systemName == "Windows") {
+			if (systemName == "Windows" && useWindowsVcpkg) {
 				// required for luv build, default is very old
 				runCommand("luarocks", ["config", "cmake_generator", "Visual Studio 17 2022"]);
 			}
@@ -91,10 +110,10 @@ class Lua {
 			// Note: don't use a user config
 			// attemptCommand("luarocks", ["config", "--user-config"]);
 
+			installLib("luasocket", "3.0rc1-2");
 			installLib("luasec", "1.3.2-1");
 
 			installLib("lrexlib-pcre2", "2.9.1-1");
-			installLib("luasocket", "3.0rc1-2");
 
 			//Install bit32 for lua 5.1 and 5.4
 			if (lv == "-l5.1" || lv == "-l5.4")

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -117,7 +117,7 @@ class Lua {
 
 			//Install bit32 for lua 5.1 and 5.4
 			if (lv == "-l5.1" || lv == "-l5.4")
-				installLib("bit32", "5.3.5.1-1");
+				installLib("https://raw.githubusercontent.com/lunarmodules/lua-compat-5.3/refs/heads/master/rockspecs/bit32-scm-1.rockspec", "");
 
 			installLib("luv", "1.50.0-1");
 			installLib("luautf8", "0.1.6-1");

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -110,7 +110,7 @@ class Lua {
 			// Note: don't use a user config
 			// attemptCommand("luarocks", ["config", "--user-config"]);
 
-			installLib("luasocket", "3.0rc1-2");
+			installLib("luasocket", "3.1.0-1");
 			installLib("luasec", "1.3.2-1");
 
 			installLib("lrexlib-pcre2", "2.9.1-1");

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -14,7 +14,7 @@ class Lua {
 	static public function getLuaDependencies(){
 		switch (systemName){
 			case "Linux":
-				Linux.requireAptPackages(["libpcre2-dev", "libssl-dev", "libreadline-dev", "pipx"]);
+				Linux.requireAptPackages(["libpcre2-dev", "libssl-dev", "libuv1-dev", "libreadline-dev", "pipx"]);
 			case "Mac":
 				if (commandSucceed("python3", ["-V"]))
 					infoMsg('python3 has already been installed.');
@@ -23,6 +23,7 @@ class Lua {
 
 				attemptCommand("brew", ["install", "pcre2"]);
 				runCommand("brew", ["install", "openssl"]);
+				runCommand("brew", ["install", "libuv"]);
 				runCommand("brew", ["install", "pipx"]);
 			case "Windows":
 				if (sys.FileSystem.exists(msys2Path)) {
@@ -37,12 +38,14 @@ class Lua {
 							"--overwrite",
 							"mingw-w64-ucrt-x86_64-gcc",
 							"mingw-w64-ucrt-x86_64-openssl",
-							"mingw-w64-ucrt-x86_64-pcre2"
+							"mingw-w64-ucrt-x86_64-pcre2",
+							"mingw-w64-ucrt-x86_64-libuv"
 						]
 					);
 				} else if(Sys.getEnv("VCPKG_INSTALLATION_ROOT") != null) {
 					useWindowsVcpkg = true;
 					runCommand("vcpkg", ["install", "pcre2:x64-windows-release"]);
+					runCommand("vcpkg", ["install", "libuv:x64-windows-release"]);
 					addToPATH(Path.join([Sys.getEnv("VCPKG_INSTALLATION_ROOT"), 'installed/x64-windows-release/bin']));
 				} else {
 					failMsg("Running on windows requires msys2 or vcpkg environment");
@@ -56,6 +59,7 @@ class Lua {
 	static function installLib(lib : String, version : String, ?server :String){
 		if (!commandSucceed("luarocks", ["show", lib, version])) {
 			final args = ["install", lib, version];
+			args.push('WITH_SHARED_LIBUV=ON');
 			if (systemName == "Windows" && useWindowsVcpkg) {
 				args.push('OPENSSL_DIR=C:\\Program Files\\OpenSSL');
 				args.push('OPENSSL_LIBDIR=C:\\Program Files\\OpenSSL\\lib\\VC\\x64\\MD');
@@ -119,7 +123,7 @@ class Lua {
 			if (lv == "-l5.1" || lv == "-l5.4")
 				installLib("https://raw.githubusercontent.com/lunarmodules/lua-compat-5.3/refs/heads/master/rockspecs/bit32-scm-1.rockspec", "");
 
-			installLib("luv", "1.50.0-1");
+			installLib("https://raw.githubusercontent.com/tobil4sk/lua-luv/refs/heads/feature/rockspec-shared-libuv/luv-scm-0.rockspec", "");
 			installLib("luautf8", "0.1.6-1");
 
 			installLib("https://raw.githubusercontent.com/HaxeFoundation/hx-lua-simdjson/master/hx-lua-simdjson-scm-1.rockspec", "");


### PR DESCRIPTION
The msys2/mingw environment seems to install and build faster than the vcpkg/msvc environment, so it should save some time in ci.

I've also made it so that the system libuv is used which avoids recompiling it for every lua installation.

Links to some upstream issues related to workarounds in this PR:
- https://github.com/lunarmodules/lua-compat-5.3/issues/73. We have to install bit32 from github for now.
- https://github.com/luvit/luv/pull/794. We have to use a forked rockspec that supports passing `WITH_SHARED_LIBUV=ON`.
- https://github.com/libuv/libuv/pull/5021. libuv crashes on unicode 0x10FFFF, which we use [in our tests](https://github.com/HaxeFoundation/haxe/blob/32042c412a62bd949f7e0ffdb90e4e06711c3521/tests/sys/src/UnicodeSequences.hx#L27). We now avoid this by using a non-debug build (from msys2).