### PR TITLE
[tests] Enable fullPath test on lua

### DIFF
--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -201,7 +201,6 @@ class TestUnicode extends utest.Test {
 		assertNormalEither(FileSystem.exists, 'test-res/b', 'expected exists == false');
 
 		// fullPath
-#if !lua // Lua disabled temporarily (#8215)
 		if (Sys.systemName() != "Windows") {
 			// symlinks behave strangely on Windows
 			pathBoth(path -> {
@@ -211,7 +210,6 @@ class TestUnicode extends utest.Test {
 						);
 				}, "test-res");
 		}
-#end
 
 		// isDirectory
 		assertNormalEither(FileSystem.isDirectory, 'test-res/a', 'expected isDirectory == true');


### PR DESCRIPTION
#8215 was fixed for lua in 020685773fc1ed4c1a59fbad46d7dfd554483ca5, but the tests weren't running properly back then so the test was never re-enabled.

Closes #8215.