### PR TITLE
Inherit user var names when aliasing

### DIFF
--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -598,17 +598,6 @@ module Printer = struct
 	let s_tvar_extra ve =
 		Printf.sprintf "Some(%s, %s)" (s_type_params "" ve.v_params) (s_opt (s_expr_ast true "" s_type) ve.v_expr)
 
-	let s_tvar v =
-		s_record_fields "" [
-			"v_id",string_of_int v.v_id;
-			"v_name",v.v_name;
-			"v_type",s_type v.v_type;
-			"v_capture",string_of_bool (has_var_flag v VCaptured);
-			"v_extra",s_opt s_tvar_extra v.v_extra;
-			"v_meta",s_metadata v.v_meta;
-			"v_pos",s_pos v.v_pos;
-		]
-
 	let s_tvar_kind v_kind = match v_kind with
 		| VUser tvar_origin -> "VUser(" ^ (match tvar_origin with
 			| TVOLocalVariable -> "TVOLocalVariable"
@@ -622,6 +611,18 @@ module Printer = struct
 		| VInlinedConstructorVariable sl -> "VInlinedConstructorVariable" ^ "(" ^ (String.concat ", " sl) ^ ")"
 		| VExtractorVariable -> "VExtractorVariable"
 		| VAbstractThis -> "VAbstractThis"
+
+	let s_tvar v =
+		s_record_fields "" [
+			"v_id",string_of_int v.v_id;
+			"v_name",v.v_name;
+			"v_type",s_type v.v_type;
+			"v_kind",s_tvar_kind v.v_kind;
+			"v_capture",string_of_bool (has_var_flag v VCaptured);
+			"v_extra",s_opt s_tvar_extra v.v_extra;
+			"v_meta",s_metadata v.v_meta;
+			"v_pos",s_pos v.v_pos;
+		]
 
 	let s_module_kind = function
 		| MCode -> "MCode"

--- a/src/optimization/analyzer.ml
+++ b/src/optimization/analyzer.ml
@@ -631,6 +631,7 @@ module CopyPropagationImpl = struct
 							| [bb'] when in_scope bb bb' -> ()
 							| _ -> leave()
 						end;
+						maybe_inherit_var_name v' v;
 						commit bb {e with eexpr = TLocal v'}
 					| This t ->
 						if not (type_change_ok actx.com t v.v_type) then leave();

--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -150,6 +150,16 @@ let is_unbound_call_that_might_have_side_effects s el = match s,el with
 	| "__js__",[{eexpr = TConst (TString s)}] when Str.string_match r s 0 -> false
 	| _ -> true
 
+let maybe_inherit_var_name v v_alias =
+	if v.v_name <> v_alias.v_name then match v_alias.v_kind,v.v_kind with
+	| VUser _,VUser _ ->
+		()
+	| VUser _,_ ->
+		(* If we go from a user variable to something else, we probably want to inherit the name. *)
+		v.v_name <- v_alias.v_name
+	| _ ->
+		()
+
 let type_change_ok com t1 t2 =
 	if t1 == t2 then
 		true

--- a/src/optimization/analyzerTexprTransformer.ml
+++ b/src/optimization/analyzerTexprTransformer.ml
@@ -758,6 +758,7 @@ and func ctx i =
 		| TVar(v,eo) ->
 			let eo = Option.map loop eo in
 			let v' = get_var_origin ctx.graph v in
+			maybe_inherit_var_name v' v;
 			{e with eexpr = TVar(v',eo)}
 		| TBinop(OpAssign,e1,({eexpr = TBinop(op,e2,e3)} as e4)) when target_handles_assign_ops ctx.com e3 ->
 			let e1 = loop e1 in


### PR DESCRIPTION
This detects cases in the analyzer where we alias a user variable to a non-user variable and then makes the latter inherit the name of the former. In unit.js I'm seeing quite a few renames of `_g` to something more meaningful, which should always be good.

This doesn't yet fix the original problem case that @yuxiaomao gave me, so there's more work to be done.