### PR TITLE
Defer EntryPoint inclusion until after DCE

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -350,7 +350,7 @@ let finalize_typing ctx tctx =
 
 let filter ctx tctx ectx before_destruction =
 	Timer.time ctx.timer_ctx ["filters"] (fun () ->
-		run_or_diagnose ctx (fun () -> Filters.run tctx ectx ctx.com.main.main_expr before_destruction)
+		run_or_diagnose ctx (fun () -> Filters.run tctx ectx before_destruction)
 	) ()
 
 let compile ctx actx callbacks =

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -218,7 +218,7 @@ let destruction_on_com scom com types =
 	(* These aren't actually safe. The logic works fine regardless, we just can't parallelize this at the moment. *)
 	SafeCom.run_type_filters_safe scom filters types
 
-let destruction (com : Common.context) scom ectx detail_times main rename_locals_config all_types all_types_array =
+let destruction (com : Common.context) scom ectx detail_times rename_locals_config all_types all_types_array =
 	let all_types = Parallel.run_in_new_pool scom.timer_ctx (fun pool ->
 		with_timer scom.timer_ctx detail_times "type 2" None (fun () ->
 			SafeCom.run_with_scom com scom (fun () ->
@@ -238,10 +238,13 @@ let destruction (com : Common.context) scom ectx detail_times main rename_locals
 			in
 			let std_paths = com.class_paths#get_std_paths in
 			let mscom = Option.map of_com (com.get_macros()) in
+			let main = com.main.main_expr in
 			let types = Dce.run pool scom mscom main dce_mode std_paths all_types in
 			types
 		) in
 		Common.enter_stage com CDceDone;
+
+		Finalization.maybe_add_entrypoint com;
 
 		(* This has to run after DCE, or otherwise its condition always holds. *)
 		begin match ectx with
@@ -469,7 +472,7 @@ let run_safe_filters ectx com (scom : SafeCom.t) all_types_array new_types_array
 	Parallel.ParallelArray.iter pool (SafeCom.run_expression_filters_safe scom detail_times filters_after_analyzer) new_types_array;
 	Dump.maybe_generate_dump com AfterSanitizing
 
-let run com ectx main before_destruction =
+let run com ectx before_destruction =
 	let scom = SafeCom.of_com com in
 	let detail_times = Timer.level_from_define com.defines Define.FilterTimes in
 	let new_types = List.filter (fun t ->
@@ -537,4 +540,4 @@ let run com ectx main before_destruction =
 		com.callbacks#run com.error_ext com.callbacks#get_after_save;
 	);
 	before_destruction();
-	destruction com scom ectx detail_times main rename_locals_config com.types all_types_array
+	destruction com scom ectx detail_times rename_locals_config com.types all_types_array

--- a/src/typing/finalization.ml
+++ b/src/typing/finalization.ml
@@ -14,6 +14,24 @@ let maybe_load_main tctx = match tctx.com.main.main_path with
 	| None ->
 		None
 
+let maybe_add_entrypoint com =
+	begin match com.main.main_expr with
+	| None ->
+		()
+	| Some main ->
+		try
+			let path = (["haxe"],"EntryPoint") in
+			let method_name = "run" in
+			let et = List.find (fun t -> t_path t = path) com.types in
+			let ec = (match et with TClassDecl c -> c | _ -> die "" __LOC__) in
+			let ef = PMap.find method_name ec.cl_statics in
+			let et = Texpr.Builder.make_typeexpr et null_pos in
+			let e = mk (TCall (mk (TField (et,FStatic (ec,ef))) ef.cf_type null_pos,[])) com.basic.tvoid null_pos in
+			let e = mk (TBlock [main;e]) com.basic.tvoid main.epos in
+			com.main.main_expr <- Some e
+		with Not_found ->
+			()
+	end
 
 let get_main ctx main_module types =
 	match main_module with
@@ -53,26 +71,6 @@ let get_main ctx main_module types =
 		if not (Meta.has Meta.Keep f.cf_meta) then f.cf_meta <- (Dce.mk_keep_meta f.cf_pos) :: f.cf_meta;
 		let emain = type_module_type ctx (TClassDecl c) null_pos in
 		let main = mk (TCall (mk (TField (emain,fmode)) ft null_pos,[])) r null_pos in
-		let call_static path method_name =
-			let et = List.find (fun t -> t_path t = path) types in
-			let ec = (match et with TClassDecl c -> c | _ -> die "" __LOC__) in
-			let ef = PMap.find method_name ec.cl_statics in
-			let et = Texpr.Builder.make_typeexpr et null_pos in
-			mk (TCall (mk (TField (et,FStatic (ec,ef))) ef.cf_type null_pos,[])) ctx.t.tvoid null_pos
-		in
-		(* add haxe.EntryPoint.run() call *)
-		let add_entry_point_run main =
-			try
-				[main; call_static (["haxe"],"EntryPoint") "run"]
-			with Not_found ->
-				[main]
-		in
-		let main =
-			let exprs = add_entry_point_run main in
-			match exprs with
-			| [e] -> e
-			| _ -> mk (TBlock exprs) ctx.t.tvoid p
-		in
 		Some main,Some (Path.UniqueKey.lazy_path main_module.m_extra.m_file)
 
 let finalize ctx =

--- a/std/haxe/EntryPoint.hx
+++ b/std/haxe/EntryPoint.hx
@@ -6,7 +6,8 @@ package haxe;
 **/
 class EntryPoint {
 
-	@:keep public static function run() @:privateAccess {
+	@:ifFeature("haxe.EventLoop.*")
+	public static function run() @:privateAccess {
 		#if js
 			var nextTick = haxe.EventLoop.main.getNextTick();
 			inline function setTimeoutNextTick() {


### PR DESCRIPTION
I can't find any other references to `EntryPoint` in std, so the `@:ifFeature("haxe.EventLoop.*)` should be sufficient.

Funnily enough, the API doc on `EntryPoint` even says:

```
If `haxe.MainLoop` is kept from DCE, then we will insert an `haxe.EntryPoint.run()` call just at then end of `main()`.
```

That's just not how it was actually implemented.

Edit: Forgot to mention, I checked that a `haxe.Timer.delay(() -> trace("Hello World"), 1000)` still works as expected. It keeps `EventLoop` via `Timer.new`, and that then keeps `EntryPoint`.