### PR TITLE
[lua] Fix multiReturn handling in static __init__ functions

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -2035,72 +2035,75 @@ let alloc_ctx com =
 
 let transform_multireturn ctx = function
     | TClassDecl c ->
+        let is_multireturn t =
+            match follow t with
+            | TInst (c, _) when Meta.has Meta.MultiReturn c.cl_meta -> true
+            | _ -> false
+        in
+        let rec loop e =
+            match e.eexpr with
+            (*
+                if we found a var declaration initialized by a multi-return call, mark it with @:multiReturn meta,
+                so it will later be generated as multiple locals unpacking the value
+            *)
+            | TVar (v, Some ({ eexpr = TCall _ } as ecall)) when is_multireturn v.v_type ->
+                v.v_meta <- (Meta.MultiReturn,[],v.v_pos) :: v.v_meta;
+                let ecall = Type.map_expr loop ecall in
+                { e with eexpr = TVar (v, Some ecall) }
+
+            (* if we found a field access for the multi-return call, generate select call *)
+            | TField ({ eexpr = TCall _ } as ecall, f) when is_multireturn ecall.etype ->
+                let ecall = Type.map_expr loop ecall in
+                mk_mr_select ctx.com.basic e ecall (field_name f)
+
+            (* if we found a multi-return call used as a value, box it *)
+            | TCall _ when is_multireturn e.etype ->
+                let e = Type.map_expr loop e in
+                mk_mr_box ctx e
+
+            (* Don't bother wrapping multireturn function results if we don't use the return values *)
+            | TBlock el ->
+                let el2 = List.map (fun x ->
+                    match x.eexpr with
+                    | TCall (e2, el) when is_multireturn x.etype ->
+                        mk (TCall (e2, List.map(fun x-> Type.map_expr loop x) el)) x.etype x.epos
+                    | _ -> loop x) el in
+                mk (TBlock el2) e.etype e.epos;
+
+
+                (* if we found a field access for a multi-return local - that's fine, because it'll be generated as a local var *)
+            | TField ({ eexpr = TLocal v}, _) when Meta.has Meta.MultiReturn v.v_meta ->
+                e
+            | TReturn Some(e2) ->
+                if is_multireturn e2.etype then
+                    raise_typing_error "You cannot return a multireturn type from a haxe function" e2.epos
+                else
+                    Type.map_expr loop e;
+            (*
+                if we found usage of local var we previously marked with @:multiReturn as a value itself,
+                remove the @:multiReturn meta and add "box me" meta so it'll be boxed on var initialization
+            *)
+            | TLocal v when Meta.has Meta.MultiReturn v.v_meta ->
+                v.v_meta <- List.filter (fun (m,_,_) -> m <> Meta.MultiReturn) v.v_meta;
+                v.v_meta <- (Meta.Custom ":lua_mr_box", [], v.v_pos) :: v.v_meta;
+                e
+
+            | _ ->
+                Type.map_expr loop e
+        in
         let transform_field f =
             check_multireturn_param ctx f.cf_type f.cf_pos;
             match f.cf_expr with
-            | Some e ->
-                let is_multireturn t =
-                    match follow t with
-                    | TInst (c, _) when Meta.has Meta.MultiReturn c.cl_meta -> true
-                    | _ -> false
-                in
-                let rec loop e =
-                    match e.eexpr with
-                    (*
-                        if we found a var declaration initialized by a multi-return call, mark it with @:multiReturn meta,
-                        so it will later be generated as multiple locals unpacking the value
-                    *)
-                    | TVar (v, Some ({ eexpr = TCall _ } as ecall)) when is_multireturn v.v_type ->
-                        v.v_meta <- (Meta.MultiReturn,[],v.v_pos) :: v.v_meta;
-                        let ecall = Type.map_expr loop ecall in
-                        { e with eexpr = TVar (v, Some ecall) }
-
-                    (* if we found a field access for the multi-return call, generate select call *)
-                    | TField ({ eexpr = TCall _ } as ecall, f) when is_multireturn ecall.etype ->
-                        let ecall = Type.map_expr loop ecall in
-                        mk_mr_select ctx.com.basic e ecall (field_name f)
-
-                    (* if we found a multi-return call used as a value, box it *)
-                    | TCall _ when is_multireturn e.etype ->
-                        let e = Type.map_expr loop e in
-                        mk_mr_box ctx e
-
-                    (* Don't bother wrapping multireturn function results if we don't use the return values *)
-                    | TBlock el ->
-                        let el2 = List.map (fun x ->
-                            match x.eexpr with
-                            | TCall (e2, el) when is_multireturn x.etype ->
-                                mk (TCall (e2, List.map(fun x-> Type.map_expr loop x) el)) x.etype x.epos
-                            | _ -> loop x) el in
-                        mk (TBlock el2) e.etype e.epos;
-
-
-                        (* if we found a field access for a multi-return local - that's fine, because it'll be generated as a local var *)
-                    | TField ({ eexpr = TLocal v}, _) when Meta.has Meta.MultiReturn v.v_meta ->
-                        e
-                    | TReturn Some(e2) ->
-                        if is_multireturn e2.etype then
-                            raise_typing_error "You cannot return a multireturn type from a haxe function" e2.epos
-                        else
-                            Type.map_expr loop e;
-     (*
-						if we found usage of local var we previously marked with @:multiReturn as a value itself,
-						remove the @:multiReturn meta and add "box me" meta so it'll be boxed on var initialization
-					*)
-                    | TLocal v when Meta.has Meta.MultiReturn v.v_meta ->
-                        v.v_meta <- List.filter (fun (m,_,_) -> m <> Meta.MultiReturn) v.v_meta;
-                        v.v_meta <- (Meta.Custom ":lua_mr_box", [], v.v_pos) :: v.v_meta;
-                        e
-
-                    | _ ->
-                        Type.map_expr loop e
-                in
-                f.cf_expr <- Some (loop e);
+            | Some e -> f.cf_expr <- Some (loop e);
             | _ -> ()
         in
         List.iter transform_field c.cl_ordered_fields;
         List.iter transform_field c.cl_ordered_statics;
         Option.may transform_field c.cl_constructor;
+        (* Also transform __init__ expressions *)
+        (match TClass.get_cl_init c with
+         | Some e -> TClass.set_cl_init c (loop e)
+         | None -> ());
     | _ -> ()
 
 let generate com =

--- a/tests/unit/src/unit/issues/Issue12540.hx
+++ b/tests/unit/src/unit/issues/Issue12540.hx
@@ -37,6 +37,8 @@ class Issue12540 extends Test {
 		var v:MRValue = untyped MRHelper.getValue();
 		eq(v.a, 10);
 		eq(v.b, 15);
+		#else
+		noAssert();
 		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue12540.hx
+++ b/tests/unit/src/unit/issues/Issue12540.hx
@@ -1,0 +1,42 @@
+package unit.issues;
+
+#if lua
+@:multiReturn
+private extern class MRValue {
+	var a:Int;
+	var b:Int;
+}
+
+private class MRHelper {
+	public static function getValue():Dynamic {
+		return untyped __lua__("10, 15");
+	}
+}
+#end
+
+class Issue12540 extends Test {
+	#if lua
+	// Test that multiReturn works in __init__ - before fix, this would fail
+	// with "attempt to index a number value"
+	static var initA:Int;
+	static var initB:Int;
+
+	static function __init__() {
+		var v:MRValue = untyped MRHelper.getValue();
+		initA = v.a;
+		initB = v.b;
+	}
+	#end
+
+	function test() {
+		#if lua
+		// Verify multiReturn field access worked in __init__
+		eq(initA, 10);
+		eq(initB, 15);
+		// Also verify it works in regular methods
+		var v:MRValue = untyped MRHelper.getValue();
+		eq(v.a, 10);
+		eq(v.b, 15);
+		#end
+	}
+}

--- a/tests/unit/src/unit/issues/Issue12540.hx
+++ b/tests/unit/src/unit/issues/Issue12540.hx
@@ -26,10 +26,8 @@ class Issue12540 extends Test {
 		initA = v.a;
 		initB = v.b;
 	}
-	#end
 
 	function test() {
-		#if lua
 		// Verify multiReturn field access worked in __init__
 		eq(initA, 10);
 		eq(initB, 15);
@@ -37,8 +35,6 @@ class Issue12540 extends Test {
 		var v:MRValue = untyped MRHelper.getValue();
 		eq(v.a, 10);
 		eq(v.b, 15);
-		#else
-		noAssert();
-		#end
 	}
+	#end
 }


### PR DESCRIPTION
## Summary
- Fix `@:multiReturn` field access in static `__init__` functions, which was failing with "attempt to index a number value"
- Refactored `transform_multireturn` to extract the transformation logic so it can be reused for `cl_init` expressions
- Added test case in Issue12540.hx

## Problem
When using `@:multiReturn` types in static `__init__` functions, the multiReturn transformation wasn't being applied. This caused the Lua code to try to index a number instead of properly unpacking the multiple return values.

```haxe
@:multiReturn extern class MRValue {
    var a:Int;
    var b:Int;
}

class Test {
    static var initA:Int;
    static function __init__() {
        var v:MRValue = getMRValue();
        initA = v.a;  // Failed: "attempt to index a number value"
    }
}
```

## Fix
The `transform_multireturn` function now also processes `cl_init` expressions using `TClass.get_cl_init` and `TClass.set_cl_init`.

Fixes #12540