### PR TITLE
[lua] Fix pairsMap callback signature

### DIFF
--- a/std/lua/PairTools.hx
+++ b/std/lua/PairTools.hx
@@ -40,7 +40,7 @@ class PairTools {
 		return ret;
 	}
 
-	public static function pairsMap<A, B, C>(table:Table<A, B>, func:A->B->C->C):Table<A, C> {
+	public static function pairsMap<A, B, C>(table:Table<A, B>, func:A->B->C):Table<A, C> {
 		var ret:Table<A, C> = Table.create();
 		Syntax.code("for k,v in {0}({1}) do {2}[k] = ({3})(k,v) end", Lua.pairs, table, ret, func);
 		return ret;

--- a/tests/unit/src/unit/issues/Issue10879.hx
+++ b/tests/unit/src/unit/issues/Issue10879.hx
@@ -6,9 +6,7 @@ class Issue10879 extends Test {
 		// Test that pairsMap callback takes (key, value) and returns the mapped value.
 		// Before fix, the signature was A->B->C->C (3 args) but the Lua code
 		// only calls the callback with 2 args (k, v).
-		var t:lua.Table<Int, String> = lua.Table.create();
-		t[1] = "hello";
-		t[2] = "world";
+		var t = lua.Table.create(["hello", "world"]);
 
 		var mapped = lua.PairTools.pairsMap(t, function(k:Int, v:String):String {
 			return v + "!";

--- a/tests/unit/src/unit/issues/Issue10879.hx
+++ b/tests/unit/src/unit/issues/Issue10879.hx
@@ -16,6 +16,8 @@ class Issue10879 extends Test {
 
 		eq(mapped[1], "hello!");
 		eq(mapped[2], "world!");
+		#else
+		noAssert();
 		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue10879.hx
+++ b/tests/unit/src/unit/issues/Issue10879.hx
@@ -1,0 +1,21 @@
+package unit.issues;
+
+class Issue10879 extends Test {
+	function test() {
+		#if lua
+		// Test that pairsMap callback takes (key, value) and returns the mapped value.
+		// Before fix, the signature was A->B->C->C (3 args) but the Lua code
+		// only calls the callback with 2 args (k, v).
+		var t:lua.Table<Int, String> = lua.Table.create();
+		t[1] = "hello";
+		t[2] = "world";
+
+		var mapped = lua.PairTools.pairsMap(t, function(k:Int, v:String):String {
+			return v + "!";
+		});
+
+		eq(mapped[1], "hello!");
+		eq(mapped[2], "world!");
+		#end
+	}
+}


### PR DESCRIPTION
## Summary
Fix incorrect callback signature in `PairTools.pairsMap`.

## Problem
The signature was `func:A->B->C->C` (3 args + return) but the function is only called with 2 arguments:
```lua
({3})(k,v)  -- only key and value
```

## Fix
Changed to `func:A->B->C` to match the actual usage and be consistent with `ipairsMap` which correctly has `func:Int->A->B`.

Fixes #10879