### PR TITLE
[lua] Skip luv runtime when -D lua-vanilla is set

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -2231,8 +2231,9 @@ let generate com =
     println ctx "_hx_array_mt.__index = Array.prototype";
     newline ctx;
 
-    (* Functions to support auto-run of libuv loop *)
-    print_file (find_file "lua/_lua/_hx_luv.lua");
+    (* Functions to support auto-run of libuv loop - skip in vanilla mode *)
+    if not ctx.lua_vanilla then
+        print_file (find_file "lua/_lua/_hx_luv.lua");
 
     let b = open_block ctx in
     (* Localize init variables inside a do-block *)
@@ -2297,15 +2298,20 @@ let generate com =
 
     Option.may (fun e ->
         spr ctx "local success, err = _G.xpcall(";
-            let luv_run =
-                (* Runs libuv loop if needed *)
-                mk_lua_code ctx.com.basic "_hx_luv.run()" [] ctx.com.basic.tvoid Globals.null_pos
+            let main_block =
+                if ctx.lua_vanilla then [e]
+                else
+                    let luv_run =
+                        (* Runs libuv loop if needed *)
+                        mk_lua_code ctx.com.basic "_hx_luv.run()" [] ctx.com.basic.tvoid Globals.null_pos
+                    in
+                    [e;luv_run]
             in
             let fn =
                 {
                     tf_args = [];
                     tf_type = com.basic.tvoid;
-                    tf_expr = mk (TBlock [e;luv_run]) com.basic.tvoid e.epos;
+                    tf_expr = mk (TBlock main_block) com.basic.tvoid e.epos;
                 }
             in
             gen_value ctx { e with eexpr = TFunction fn; etype = TFun ([],com.basic.tvoid) };


### PR DESCRIPTION
## Summary
Fix `-D lua-vanilla` to actually skip the luv library dependency.

## Problem
When using `-D lua-vanilla`, the generated Lua code still included:
- The `_hx_luv.lua` runtime file
- The `_hx_luv.run()` call after main

This meant the output still referenced luv, even though vanilla mode is supposed to have no library dependencies.

## Fix
- Skip including `_hx_luv.lua` when `lua_vanilla` is set
- Skip appending `_hx_luv.run()` to main when `lua_vanilla` is set

Before (with `-D lua-vanilla`):
```lua
if package.loaded.luv then
  _hx_luv = _G.require("luv");
...
  _hx_luv.run();
```

After (with `-D lua-vanilla`):
```lua
-- no luv references at all
```

Fixes #12063