### PR TITLE
[lua] Fix @:native on extern enums to preserve dots

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -2028,7 +2028,7 @@ let alloc_ctx com =
         | TClassDecl c when (has_class_flag c CExtern) &&  not (Meta.has Meta.LuaRequire c.cl_meta)
             -> dot_path p
         | TEnumDecl e when has_enum_flag e EnExtern
-            -> s_path ctx p
+            -> dot_path p
         | _ -> s_path ctx p);
     ctx
 


### PR DESCRIPTION
## Summary
Fix `@:native` metadata on extern enums to preserve dots in the generated Lua code.

## Problem
When using `@:native("a.b")` on an extern enum, the dots were being mangled to underscores:

```haxe
@:native("a.b")
extern enum Test {
    val1;
}
```

Generated: `__a_b.val1` (wrong)
Expected: `a.b.val1` (correct)

## Fix
Changed the `type_accessor` function to use `dot_path` for extern enums, consistent with how extern classes are handled.

Before:
```ocaml
| TEnumDecl e when has_enum_flag e EnExtern -> s_path ctx p
```

After:
```ocaml
| TEnumDecl e when has_enum_flag e EnExtern -> dot_path p
```

Fixes #10177