### PR TITLE
Wrap TLS.value in Null<T>

### DIFF
--- a/std/cpp/_std/sys/thread/Tls.hx
+++ b/std/cpp/_std/sys/thread/Tls.hx
@@ -38,7 +38,7 @@ class Tls<T> {
 		return untyped __global__.__hxcpp_tls_get(mTLSID);
 	}
 
-	function set_value(v:T):T {
+	function set_value(v:Null<T>):Null<T> {
 		untyped __global__.__hxcpp_tls_set(mTLSID, v);
 		return v;
 	}

--- a/std/cpp/_std/sys/thread/Tls.hx
+++ b/std/cpp/_std/sys/thread/Tls.hx
@@ -28,13 +28,13 @@ class Tls<T> {
 
 	var mTLSID:Int;
 
-	public var value(get, set):T;
+	public var value(get, set):Null<T>;
 
 	public function new() {
 		mTLSID = sFreeSlot++;
 	}
 
-	function get_value():T {
+	function get_value():Null<T> {
 		return untyped __global__.__hxcpp_tls_get(mTLSID);
 	}
 

--- a/std/hl/_std/sys/thread/Tls.hx
+++ b/std/hl/_std/sys/thread/Tls.hx
@@ -42,7 +42,7 @@ abstract Tls<T>(hl.Abstract<"hl_tls">) {
 		return tls_get(this);
 	}
 
-	function set_value(v:T) {
+	function set_value(v:Null<T>) {
 		tls_set(this, v);
 		return v;
 	}

--- a/std/hl/_std/sys/thread/Tls.hx
+++ b/std/hl/_std/sys/thread/Tls.hx
@@ -25,20 +25,20 @@ package sys.thread;
 #if doc_gen
 @:coreApi
 extern class Tls<T> {
-	var value(get, set):T;
+	var value(get, set):Null<T>;
 	function new():Void;
 }
 #else
 
 @:hlNative("std")
 abstract Tls<T>(hl.Abstract<"hl_tls">) {
-	public var value(get, set):T;
+	public var value(get, set):Null<T>;
 
 	public function new() {
 		this = tls_alloc(true);
 	}
 
-	function get_value():T {
+	function get_value():Null<T> {
 		return tls_get(this);
 	}
 

--- a/std/jvm/_std/sys/thread/Tls.hx
+++ b/std/jvm/_std/sys/thread/Tls.hx
@@ -22,17 +22,17 @@
 
 package sys.thread;
 
-// @:coreApi // causes some overload error...
+@:coreApi
 @:native('haxe.java.vm.Tls') class Tls<T> {
 	var t:java.lang.ThreadLocal<T>;
 
-	public var value(get, set):T;
+	public var value(get, set):Null<T>;
 
 	public function new() {
 		this.t = new java.lang.ThreadLocal();
 	}
 
-	inline private function get_value():T {
+	inline private function get_value():Null<T> {
 		return t.get();
 	}
 

--- a/std/jvm/_std/sys/thread/Tls.hx
+++ b/std/jvm/_std/sys/thread/Tls.hx
@@ -24,7 +24,7 @@ package sys.thread;
 
 @:coreApi
 @:native('haxe.java.vm.Tls') class Tls<T> {
-	var t:java.lang.ThreadLocal<T>;
+	var t:java.lang.ThreadLocal<Null<T>>;
 
 	public var value(get, set):Null<T>;
 
@@ -36,7 +36,7 @@ package sys.thread;
 		return t.get();
 	}
 
-	inline private function set_value(v:T):T {
+	inline private function set_value(v:Null<T>):Null<T> {
 		t.set(v);
 		return v;
 	}

--- a/std/neko/_std/sys/thread/Tls.hx
+++ b/std/neko/_std/sys/thread/Tls.hx
@@ -36,7 +36,7 @@ class Tls<T> {
 		return tls_get(t);
 	}
 
-	function set_value(v:T):T {
+	function set_value(v:Null<T>):Null<T> {
 		tls_set(t, v);
 		return v;
 	}

--- a/std/neko/_std/sys/thread/Tls.hx
+++ b/std/neko/_std/sys/thread/Tls.hx
@@ -26,13 +26,13 @@ package sys.thread;
 class Tls<T> {
 	var t:Dynamic;
 
-	public var value(get, set):T;
+	public var value(get, set):Null<T>;
 
 	public function new() {
 		t = tls_create();
 	}
 
-	function get_value():T {
+	function get_value():Null<T> {
 		return tls_get(t);
 	}
 

--- a/std/python/_std/sys/thread/Tls.hx
+++ b/std/python/_std/sys/thread/Tls.hx
@@ -26,5 +26,5 @@ package sys.thread;
 @:native("local")
 extern class Tls<T> {
 	function new():Void;
-	var value(default, default):T;
+	var value(default, default):Null<T>;
 }

--- a/std/sys/thread/Tls.hx
+++ b/std/sys/thread/Tls.hx
@@ -30,7 +30,7 @@ package sys.thread;
 	A thread-local storage to store per-thread values.
 **/
 extern class Tls<T> {
-	var value(get, set):T;
+	var value(get, set):Null<T>;
 
 	/**
 		Creates thread local storage. This is placeholder that can store

--- a/tests/nullsafety/src/cases/TestStrictThreaded.hx
+++ b/tests/nullsafety/src/cases/TestStrictThreaded.hx
@@ -18,4 +18,13 @@ class TestStrictThreaded {
 			));
 		}
 	}
+
+	#if target.threaded
+
+	function tls() {
+		final tls = new sys.thread.Tls<String>();
+		tls.value = null;
+	}
+
+	#end
 }


### PR DESCRIPTION
By its nature, this is always nullable so it makes sense to express that accordingly. That way we don't have to manually say `Tls<Null<X>>` everywhere in order to make null-safety happy.

The test I'm adding doesn't actually test anything. I'm not sure how the null-safety tests work exactly, but I think they run in cross-mode where `target.threaded` isn't true. Adding `--interp` to `test.hxml` gives me two other failures though, which I don't want to look into right now.