### PR TITLE
[cpp] Optimise Bytes.ofString utf8

### DIFF
--- a/std/cpp/_std/haxe/io/Bytes.hx
+++ b/std/cpp/_std/haxe/io/Bytes.hx
@@ -253,14 +253,7 @@ class Bytes {
 		if (Ascii.isEncoded(s)) {
 			return s.asCharView().asBytesView().toBytes();
 		} else {
-			final count = Utf8.getByteCount(s);
-			final bytes = Bytes.alloc(Int64.toInt(count));
-
-			if (Utf8.encode(s, bytes.asView()) != count) {
-				throw new haxe.Exception('Failed to encode string to UTF8');
-			} else {
-				return bytes;
-			}
+			return Bytes.ofData(Utf8.encode(s));
 		}
 	}
 

--- a/std/cpp/encoding/Utf8.hx
+++ b/std/cpp/encoding/Utf8.hx
@@ -52,6 +52,14 @@ extern class Utf8 {
      */
     static overload function encode(codepoint:Char32, buffer:View<UInt8>):Int;
 
+	/**
+	 * Encodes all characters in the string to UTF-8 bytes.
+	 *
+	 * @param string String to encode.
+	 * @return Array containing UTF-8 bytes.
+	 */
+	static overload function encode(string:String):Array<UInt8>;
+
     /**
      * Decodes all bytes in the buffer into a string. An empty string is returned if the buffer is empty.
      */


### PR DESCRIPTION
To use the current Utf8.encode method, we have to run getByteCount which iterates through the string to create a buffer which is the right size. However, since Utf8.encode is a public function, it has to validate that the size of the buffer is correct, which means it iterates through the string again.

This new Utf8.encode method without a buffer argument creates its own array and returns it, avoiding the unnecessary check.

This requires the method to be added to hxcpp: https://github.com/HaxeFoundation/hxcpp/pull/1306.