### PR TITLE
[lua] Clean up _hx_bit inclusion logic

### DIFF
--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -2,9 +2,14 @@ local hasBit32, bit32 = pcall(require, 'bit32')
 if hasBit32 then --if we are on Lua 5.1, bit32 will be the default.
   _hx_bit_raw = bit32
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
-  -- lua 5.2 weirdness
+  -- bit32 weirdness
   _hx_bit.bnot = function(...) return _hx_bit_clamp(_hx_bit_raw.bnot(...)) end
   _hx_bit.bxor = function(...) return _hx_bit_clamp(_hx_bit_raw.bxor(...)) end
+  -- see https://github.com/HaxeFoundation/haxe/issues/8849
+  _hx_bit.bor = function(...) return _hx_bit_clamp(_hx_bit_raw.bor(...)) end
+  _hx_bit.band = function(...) return _hx_bit_clamp(_hx_bit_raw.band(...)) end
+  _hx_bit.arshift = function(...) return _hx_bit_clamp(_hx_bit_raw.arshift(...)) end
+  _hx_bit.lshift = function(...) return _hx_bit_clamp(_hx_bit_raw.lshift(...)) end
 else
   --If we do not have bit32, fallback to 'bit'
   local hasBit, bit = pcall(require, 'bit')
@@ -14,9 +19,3 @@ else
   _hx_bit_raw = bit
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
 end
-
--- see https://github.com/HaxeFoundation/haxe/issues/8849
-_hx_bit.bor = function(...) return _hx_bit_clamp(_hx_bit_raw.bor(...)) end
-_hx_bit.band = function(...) return _hx_bit_clamp(_hx_bit_raw.band(...)) end
-_hx_bit.arshift = function(...) return _hx_bit_clamp(_hx_bit_raw.arshift(...)) end
-_hx_bit.lshift = function(...) return _hx_bit_clamp(_hx_bit_raw.lshift(...)) end

--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -1,8 +1,8 @@
-local hasBit32, bit32 = pcall(require, 'bit32')
-if hasBit32 then --if we are on Lua 5.1, bit32 will be the default.
-  _hx_bit_raw = bit32
+if _G.bit32 or pcall(require, 'bit32') then
+  -- lua 5.2 and 5.3 have bit32 builtin, or it maybe be an external library on 5.1
+  _hx_bit_raw = _G.bit32 or require('bit32')
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
-  -- bit32 weirdness
+  -- bit32 operations require manual clamping
   _hx_bit.bnot = function(...) return _hx_bit_clamp(_hx_bit_raw.bnot(...)) end
   _hx_bit.bxor = function(...) return _hx_bit_clamp(_hx_bit_raw.bxor(...)) end
   -- see https://github.com/HaxeFoundation/haxe/issues/8849
@@ -10,12 +10,10 @@ if hasBit32 then --if we are on Lua 5.1, bit32 will be the default.
   _hx_bit.band = function(...) return _hx_bit_clamp(_hx_bit_raw.band(...)) end
   _hx_bit.arshift = function(...) return _hx_bit_clamp(_hx_bit_raw.arshift(...)) end
   _hx_bit.lshift = function(...) return _hx_bit_clamp(_hx_bit_raw.lshift(...)) end
-else
-  --If we do not have bit32, fallback to 'bit'
-  local hasBit, bit = pcall(require, 'bit')
-  if not hasBit then
-    error("Failed to load bit or bit32")
-  end
-  _hx_bit_raw = bit
+elseif _G.bit or pcall(require, 'bit') then
+  --If we do not have bit32, fallback to 'bit', default on luajit
+  _hx_bit_raw = _G.bit or require('bit')
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
+else
+  error("Failed to load bit or bit32")
 end

--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -15,5 +15,7 @@ elseif _G.bit or pcall(require, 'bit') then
   _hx_bit_raw = _G.bit or require('bit')
   _hx_bit = _hx_bit_raw
 else
-  error("Failed to load bit or bit32")
+  _hx_bit = setmetatable({}, {__index = function()
+    error("Failed to load bit or bit32")
+  end})
 end

--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -1,5 +1,5 @@
 if _G.bit32 or pcall(require, 'bit32') then
-  -- lua 5.2 and 5.3 have bit32 builtin, or it maybe be an external library on 5.1
+  -- lua 5.2 and 5.3 have bit32 builtin, otherwise it may be an external library
   _hx_bit_raw = _G.bit32 or require('bit32')
   _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
   -- bit32 operations require manual clamping
@@ -11,7 +11,7 @@ if _G.bit32 or pcall(require, 'bit32') then
   _hx_bit.arshift = function(...) return _hx_bit_clamp(_hx_bit_raw.arshift(...)) end
   _hx_bit.lshift = function(...) return _hx_bit_clamp(_hx_bit_raw.lshift(...)) end
 elseif _G.bit or pcall(require, 'bit') then
-  --If we do not have bit32, fallback to 'bit', default on luajit
+  -- if we do not have bit32, fallback to bit, default on luajit
   _hx_bit_raw = _G.bit or require('bit')
   _hx_bit = _hx_bit_raw
 else

--- a/std/lua/_lua/_hx_bit.lua
+++ b/std/lua/_lua/_hx_bit.lua
@@ -13,7 +13,7 @@ if _G.bit32 or pcall(require, 'bit32') then
 elseif _G.bit or pcall(require, 'bit') then
   --If we do not have bit32, fallback to 'bit', default on luajit
   _hx_bit_raw = _G.bit or require('bit')
-  _hx_bit = setmetatable({}, { __index = _hx_bit_raw })
+  _hx_bit = _hx_bit_raw
 else
   error("Failed to load bit or bit32")
 end

--- a/tests/misc/lua/projects/Issue9412/Main.hx
+++ b/tests/misc/lua/projects/Issue9412/Main.hx
@@ -1,0 +1,11 @@
+function keep(a:Int) untyped {}
+
+function test(a:Int, b:Int) {
+	keep(a & b);
+	keep(a | b);
+	keep(a ^ b);
+}
+
+function main() {
+	test(0xF0F0, 0x0FF0);
+}

--- a/tests/misc/lua/projects/Issue9412/RunScript.hx
+++ b/tests/misc/lua/projects/Issue9412/RunScript.hx
@@ -1,0 +1,28 @@
+using StringTools;
+
+function noBuiltinBit() {
+	final proc = new sys.io.Process("lua", ["-v"]);
+	proc.exitCode();
+	final err = proc.stderr.readAll().toString();
+	final out = proc.stdout.readAll().toString();
+	proc.close();
+	return err.startsWith("Lua 5.1.") || out.startsWith("Lua 5.4.");
+}
+
+function main() {
+	// emulate no require, rely on builtin module
+	var noRequirePass = Sys.command("lua", ["-e", "require = nil", "bin/main.lua"]) == 0;
+
+	if (noBuiltinBit()) {
+		// lua 5.1 and 5.4+ don't have a builtin module, so will fail without require.
+		// ignore these failures for now
+		noRequirePass = !noRequirePass;
+	}
+
+	// emulate no builtin bit32/bit, needs require
+	final noBuiltinPass = Sys.command("lua", ["-e", "bit32, bit = nil, nil", "bin/main.lua"]) == 0;
+
+	if (!(noRequirePass && noBuiltinPass)) {
+		Sys.exit(1);
+	}
+}

--- a/tests/misc/lua/projects/Issue9412/RunScript.hx
+++ b/tests/misc/lua/projects/Issue9412/RunScript.hx
@@ -10,7 +10,6 @@ function noBuiltinBit() {
 }
 
 function main() {
-	// emulate no require, rely on builtin module
 	var noRequirePass = Sys.command("lua", ["-e", "require = nil", "bin/main.lua"]) == 0;
 
 	if (noBuiltinBit()) {
@@ -19,10 +18,7 @@ function main() {
 		noRequirePass = !noRequirePass;
 	}
 
-	// emulate no builtin bit32/bit, needs require
-	final noBuiltinPass = Sys.command("lua", ["-e", "bit32, bit = nil, nil", "bin/main.lua"]) == 0;
-
-	if (!(noRequirePass && noBuiltinPass)) {
+	if (!(noRequirePass)) {
 		Sys.exit(1);
 	}
 }

--- a/tests/misc/lua/projects/Issue9412/compile.hxml
+++ b/tests/misc/lua/projects/Issue9412/compile.hxml
@@ -1,0 +1,5 @@
+--lua bin/main.lua
+--main Main
+-D lua-vanilla
+--next
+--run RunScript

--- a/tests/misc/lua/projects/Issue9412/compile.hxml
+++ b/tests/misc/lua/projects/Issue9412/compile.hxml
@@ -1,5 +1,9 @@
 --lua bin/main.lua
 --main Main
 -D lua-vanilla
+# emulate no builtin bit32/bit, needs require
+--cmd lua -e "bit32, bit = nil, nil" bin/main.lua
+
+# emulate no require, needs builtin module. skips if not available
 --next
 --run RunScript

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -74,6 +74,16 @@ class Lua {
 		}
 	}
 
+	static function getVersionDefine(hererocksFlag:String) {
+		if (hererocksFlag.startsWith("-l")) {
+			return ["-D", 'lua-ver=${hererocksFlag.substr(2)}'];
+		} else if (hererocksFlag.startsWith("-j")) {
+			return ["-D", "lua-jit"];
+		} else {
+			throw "unknown version";
+		}
+	}
+
 	static public function run(args:Array<String>) {
 
 		getLuaDependencies();
@@ -129,8 +139,10 @@ class Lua {
 			installLib("https://raw.githubusercontent.com/HaxeFoundation/hx-lua-simdjson/master/hx-lua-simdjson-scm-1.rockspec", "");
 
 			changeDirectory(unitDir);
-			runCommand("haxe", ["compile-lua.hxml"].concat(args));
-			runCommand("lua", ["bin/unit.lua"]);
+			for (versionFlags in [[], getVersionDefine(lv)]) {
+				runCommand("haxe", ["compile-lua.hxml"].concat(args).concat(versionFlags));
+				runCommand("lua", ["bin/unit.lua"]);
+			}
 
 			Display.maybeRunDisplayTests(Lua);
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -52,8 +52,12 @@ class Lua {
 				}
 
 		}
-		runCommand("pipx", ["ensurepath"]);
-		runCommand("pipx", ["install", "hererocks"]);
+		if (commandSucceed("hererocks", ["--version"])) {
+			infoMsg('hererocks has already been installed.');
+		} else {
+			runCommand("pipx", ["ensurepath"]);
+			runCommand("pipx", ["install", "hererocks"]);
+		}
 	}
 
 	static function installLib(lib : String, version : String, ?server :String){


### PR DESCRIPTION
- Apply bit op clamping only for bit32 library
The luajit bit library doesn't need additional clamping, so we can use it directly. Behaviour is verified by existing tests for #8849 and #11888
- Allow bit or bit32 to be preloaded
On some environments require doesn't work so we should also check if it's preloaded. See: https://github.com/HaxeFoundation/haxe/issues/5954#issuecomment-275103172, #9412, and https://github.com/HaxeFoundation/haxe/issues/9475#issuecomment-633341516. Also added test for this case, and the other case where require works but it's not preloaded.
- Delay _hx_bit error until usage
Don't show an error until the bit methods are actually used. It means we can try to load it and see if it succeeds.

Lua 5.1 now throws if no bit32 is available, which is consistent with other apis with `-D lua_vanilla` #12063.

Still doesn't solve:
- For lua 5.3+ we should use native bitwise operators instead of these libraries, see #8852 and #9475