### PR TITLE
[cpp] Fix switching with an enum from a callable

### DIFF
--- a/src/generators/cpp/cppRetyper.ml
+++ b/src/generators/cpp/cppRetyper.ml
@@ -1163,6 +1163,11 @@ let expression ctx request_type function_args function_type expression_tree forI
               let arg_types = List.map (fun _ -> TCppUnchanged) args in
               let retyper_ctx, retypedArgs = retype_function_args retyper_ctx args arg_types in
               (retyper_ctx, CppCall (FuncExtern (name, isGlobal), retypedArgs), cppType)
+            | CppVar VarLocal { tcppv_type = TCppCallable (callable_args, callable_ret) } ->
+              let retyper_ctx, retypedArgs = retype_function_args retyper_ctx args callable_args in
+              (retyper_ctx,
+                CppCall (FuncExpression retypedFunc, retypedArgs),
+                callable_ret)
             | _ ->
               let arg_types = List.map (fun _ -> TCppDynamic) args in
               let retyper_ctx, retypedArgs = retype_function_args retyper_ctx args arg_types in

--- a/tests/unit/src/unit/issues/Issue12586.hx
+++ b/tests/unit/src/unit/issues/Issue12586.hx
@@ -1,0 +1,16 @@
+package unit.issues;
+
+import utest.Assert;
+
+private enum E {
+	A;
+	B;
+}
+
+class Issue12586 extends Test {
+	function test() {
+		final callback:() -> E = () -> A;
+
+		eq(A, callback());
+	}
+}


### PR DESCRIPTION
Fixes #12586

I don't really understand why I need to switch on a variable of a cpp callable type there, but it fixes it.