### PR TITLE
[lua] Revert use of untyped for utf8 windows check

### DIFF
--- a/std/lua/_std/sys/io/File.hx
+++ b/std/lua/_std/sys/io/File.hx
@@ -37,7 +37,7 @@ import lua.lib.luv.fs.FileSystem as LFileSystem;
 class File {
 	#if lua.windows_utf8_io
 	private static function __init__():Void {
-		if (untyped __lua__("package.config:sub(1,1)") == "\\") {
+		if (lua.Package.config.charAt(0) == "\\") {
 			lua.Os.setlocale(".UTF8", Ctype);
 		}
 	}


### PR DESCRIPTION
With #12567, multireturns generate properly in `__init__`, so we can avoid untyped again