### PR TITLE
[coro] Add @:coroutine.scope and @:coroutine.restrictedSuspension

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -149,6 +149,18 @@
 		"targets": ["TClassField"]
 	},
 	{
+		"name": "CoroutineRestrictedSuspension",
+		"metadata": ":coroutine.restrictedSuspension",
+		"doc": "Marks a type as a coroutine scope with restricted suspension. Implies @:coroutine.scope.",
+		"targets": ["TClass", "TEnum", "TTypedef", "TAbstract"]
+	},
+	{
+		"name": "CoroutineScope",
+		"metadata": ":coroutine.scope",
+		"doc": "Marks a type as a coroutine scope, disallowing its usage in other scopes.",
+		"targets": ["TClass", "TEnum", "TTypedef", "TAbstract"]
+	},
+	{
 		"name": "CoroutineTransformed",
 		"metadata": ":coroutine.transformed",
 		"doc": "Marks a field as being a coroutine that has already been transformed",

--- a/src/core/tPrinting.ml
+++ b/src/core/tPrinting.ml
@@ -621,6 +621,12 @@ module Printer = struct
 			"v_capture",string_of_bool (has_var_flag v VCaptured);
 			"v_extra",s_opt s_tvar_extra v.v_extra;
 			"v_meta",s_metadata v.v_meta;
+			"v_flags",
+				(let s_flags = match v.v_flags with
+					| 0 -> ""
+					| _ -> Printf.sprintf "(%s)" (s_flags v.v_flags flag_tvar_names)
+				in
+				s_flags);
 			"v_pos",s_pos v.v_pos;
 		]
 

--- a/src/core/tType.ml
+++ b/src/core/tType.ml
@@ -559,7 +559,9 @@ type flag_tvar =
 	| VUsedByTyper (* Set if the typer looked up this variable *)
 	| VHxb (* Flag used by hxb *)
 	| VCoroCaptured
+	| VCoroScope
+	| VCoroRestrictedSuspension
 
 let flag_tvar_names = [
-	"VCaptured";"VFinal";"VAnalyzed";"VAssigned";"VCaught";"VStatic";"VUsedByTyper"
+	"VCaptured";"VFinal";"VAnalyzed";"VAssigned";"VCaught";"VStatic";"VUsedByTyper";"VHxb";"VCoroCaptured";"VCoroScope";"VRestrictedSuspension"
 ]

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -507,8 +507,17 @@ let fun_to_coro ctx coro_type =
 		in
 
 	let cb_root = make_block ctx (Some(expr.etype, coro_class.name_pos)) in
-
-	ignore(CoroFromTexpr.expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root expr);
+	let scope = match args with
+		| (v,_) :: _ ->
+			if has_var_flag v VCoroScope then Some {
+				scope_var = v;
+				restricted_suspension = has_var_flag v VCoroRestrictedSuspension
+			} else
+				None
+		| _ ->
+			None
+	in
+	ignore(CoroFromTexpr.expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope expr);
 	let exprs = {CoroToTexpr.econtinuation;ecompletion;estate;eresult;egoto;eerror;etmp_result;etmp_error;etmp_error_unwrapped} in
 	let stack_item_inserter pos =
 		let field, eargs =

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -67,7 +67,7 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 		let ret = RMapExpr(ret,f) in
 		(ret,(fun e -> if e == e_no_value then e else f e))
 	in
-	let scope_allows_suspension_call_on e1 =
+	let scope_allows_suspension_call_on e1 el =
 		match scope with
 		| None ->
 			true
@@ -80,7 +80,14 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 				| TField(e1,_) ->
 					is_scope_local_expr e1
 				| _ ->
-					false
+					(* Allow calls where the scope var is the first argument because that's what happens when
+					   using `scope.staticExtension()`. *)
+					begin match el with
+					| e1 :: _ when is_scope_local_expr e1 ->
+						true
+					| _ ->
+						false
+					end
 			in
 			is_scope_local_expr e1
 	in
@@ -209,7 +216,7 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 					| e1 :: el ->
 						begin match follow_with_coro e1.etype with
 						| Coro _ ->
-							if not (scope_allows_suspension_call_on e1) then
+							if not (scope_allows_suspension_call_on e1 el) then
 								Error.raise_typing_error "Invalid suspension call in restricted suspension scope" e.epos;
 							let cb_next = block_from_e e1 in
 							add_block_flag cb_next CbResumeState;

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -210,7 +210,7 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 						begin match follow_with_coro e1.etype with
 						| Coro _ ->
 							if not (scope_allows_suspension_call_on e1) then
-								Error.raise_typing_error "Invalid suspension call on restricted suspension scope" e.epos;
+								Error.raise_typing_error "Invalid suspension call in restricted suspension scope" e.epos;
 							let cb_next = block_from_e e1 in
 							add_block_flag cb_next CbResumeState;
 							add_block_flag cb CbSuspendState;

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -67,7 +67,7 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 		let ret = RMapExpr(ret,f) in
 		(ret,(fun e -> if e == e_no_value then e else f e))
 	in
-	let scope_allows_suspension_call_on e1 el =
+	let scope_allows_suspension_call_on e1 args el =
 		match scope with
 		| None ->
 			true
@@ -85,9 +85,19 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 			let has_scope_local_first_argument () =
 			(* Allow calls where the scope var is the first argument because that's what happens when
 			   using `scope.staticExtension()`. *)
-				begin match el with
-				| e1 :: _ when is_scope_local_expr e1 ->
-					true
+				begin match args,el with
+				| ((_,_,t) :: _),arg1 :: _ when is_scope_local_expr arg1 ->
+					begin match e1.eexpr with
+					| TField(_,FStatic({cl_kind = KAbstractImpl a}, cf)) when has_class_field_flag cf CfImpl ->
+						Meta.has Meta.CoroutineRestrictedSuspension a.a_meta
+					| _ ->
+						begin try
+							let mt = t_infos (module_type_of_type t) in
+							Meta.has Meta.CoroutineRestrictedSuspension mt.mt_meta
+						with Exit ->
+							false
+						end
+					end
 				| _ ->
 					false
 				end
@@ -218,9 +228,9 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 				begin match el with
 					| e1 :: el ->
 						begin match follow_with_coro e1.etype with
-						| Coro _ ->
-							if not (scope_allows_suspension_call_on e1 el) then
-								Error.raise_typing_error "Invalid suspension call in restricted suspension scope" e.epos;
+						| Coro (args,_) ->
+							if not (scope_allows_suspension_call_on e1 args el) then
+								Common.display_error ctx.typer.com "Invalid suspension call in restricted suspension scope" e.epos;
 							let cb_next = block_from_e e1 in
 							add_block_flag cb_next CbResumeState;
 							add_block_flag cb CbSuspendState;

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -12,7 +12,7 @@ type coro_ret =
 	| RBlock
 	| RMapExpr of coro_ret * (texpr -> texpr)
 
-let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root e =
+let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 
 	(* TODO : Not have this be copy and pasted from capturedVars with slight modifications *)
 	let wrapper = ctx.typer.com.local_wrapper in
@@ -67,11 +67,38 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root e =
 		let ret = RMapExpr(ret,f) in
 		(ret,(fun e -> if e == e_no_value then e else f e))
 	in
+	let scope_allows_suspension_call_on e1 =
+		match scope with
+		| None ->
+			true
+		| Some scope when not scope.restricted_suspension ->
+			true
+		| Some scope ->
+			let rec is_scope_local_expr e = match (Texpr.skip e).eexpr with
+				| TLocal v when v == scope.scope_var ->
+					true
+				| TField(e1,_) ->
+					is_scope_local_expr e1
+				| _ ->
+					false
+			in
+			is_scope_local_expr e1
+	in
+	let scope_allows_access_to v = match scope with
+		| Some scope when scope.scope_var == v ->
+			true
+		| None ->
+			true (* I think? *)
+		| _ ->
+			false
+	in
 	let loop_stack = ref [] in
 	let rec loop cb ret e = match e.eexpr with
 		(* special cases *)
 		| TConst TThis | TBlock [] ->
 			Some (cb,e)
+		| TLocal v when (has_var_flag v VCoroScope) && not (scope_allows_access_to v) ->
+			Error.raise_typing_error "Invalid usage of a coroutine scope in a different coroutine scope" e.epos
 		(* simple values *)
 		| TConst _ | TLocal _ | TTypeExpr _ | TIdent _ ->
 			Some (cb,e)
@@ -182,6 +209,8 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root e =
 					| e1 :: el ->
 						begin match follow_with_coro e1.etype with
 						| Coro _ ->
+							if not (scope_allows_suspension_call_on e1) then
+								Error.raise_typing_error "Invalid suspension call on restricted suspension scope" e.epos;
 							let cb_next = block_from_e e1 in
 							add_block_flag cb_next CbResumeState;
 							add_block_flag cb CbSuspendState;

--- a/src/coro/coroFromTexpr.ml
+++ b/src/coro/coroFromTexpr.ml
@@ -80,16 +80,19 @@ let expr_to_coro ctx etmp_result etmp_error_unwrapped cb_root scope e =
 				| TField(e1,_) ->
 					is_scope_local_expr e1
 				| _ ->
-					(* Allow calls where the scope var is the first argument because that's what happens when
-					   using `scope.staticExtension()`. *)
-					begin match el with
-					| e1 :: _ when is_scope_local_expr e1 ->
-						true
-					| _ ->
-						false
-					end
+					false
 			in
-			is_scope_local_expr e1
+			let has_scope_local_first_argument () =
+			(* Allow calls where the scope var is the first argument because that's what happens when
+			   using `scope.staticExtension()`. *)
+				begin match el with
+				| e1 :: _ when is_scope_local_expr e1 ->
+					true
+				| _ ->
+					false
+				end
+			in
+			is_scope_local_expr e1 || has_scope_local_first_argument ()
 	in
 	let scope_allows_access_to v = match scope with
 		| Some scope when scope.scope_var == v ->

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -76,4 +76,9 @@ type cb_flag =
 	| CbSuspendState
 	| CbResumeState
 
+type coro_scope = {
+	scope_var : tvar;
+	restricted_suspension : bool;
+}
+
 exception CoroTco of coro_block

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -60,6 +60,18 @@ class function_arguments
 		l
 	in
 
+	let check_coroutine_scope v =
+		try
+			let mt = t_infos (module_type_of_type v.v_type) in
+			if (Meta.has Meta.CoroutineRestrictedSuspension mt.mt_meta) then begin
+				add_var_flag v VCoroScope;
+				add_var_flag v VCoroRestrictedSuspension
+			end else if (Meta.has Meta.CoroutineScope mt.mt_meta) then begin
+				add_var_flag v VCoroScope
+			end
+		with Exit ->
+			()
+	in
 object(self)
 
 	val mutable type_repr = None
@@ -109,6 +121,7 @@ object(self)
 					let v = make_local name (VUser TVOArgument) t m pn in
 					if do_display && DisplayPosition.display_position#enclosed_in pn then
 						DisplayEmitter.display_variable ctx v pn;
+					if acc = [] && TyperManager.is_coroutine_context ctx then check_coroutine_scope v;
 					loop ((v,eo) :: acc) false syntax typed
 				| [],[] ->
 					List.rev acc

--- a/tests/misc/projects/coro/nested-scopes/DisallowNestedScopes.hx
+++ b/tests/misc/projects/coro/nested-scopes/DisallowNestedScopes.hx
@@ -1,0 +1,18 @@
+@:coroutine.scope
+class MyScope {}
+
+function main() {
+	@:coroutine function outer(scope:MyScope) {
+		@:coroutine function inner() {
+			// inner has no own scope, so this is fine
+			trace(scope);
+		}
+	}
+
+	@:coroutine function outer(scope:MyScope) {
+		@:coroutine function inner(otherScope:MyScope) {
+			// inner has own scope, should error
+			trace(scope);
+		}
+	}
+}

--- a/tests/misc/projects/coro/nested-scopes/compile-fail.hxml
+++ b/tests/misc/projects/coro/nested-scopes/compile-fail.hxml
@@ -1,0 +1,1 @@
+--main DisallowNestedScopes

--- a/tests/misc/projects/coro/nested-scopes/compile-fail.hxml.stderr
+++ b/tests/misc/projects/coro/nested-scopes/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+DisallowNestedScopes.hx:15: characters 10-15 : Invalid usage of a coroutine scope in a different coroutine scope

--- a/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionAbstract.hx
+++ b/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionAbstract.hx
@@ -1,0 +1,15 @@
+abstract UnrestrictedAbstract(Int) { }
+
+@:coroutine.restrictedSuspension
+abstract RestrictedAbstract(UnrestrictedAbstract) to UnrestrictedAbstract {
+	@:coroutine public function test() {}
+}
+
+@:coroutine function passToUnretrictedAbstract(_:UnrestrictedAbstract) { }
+
+function main() {
+	@:coroutine function run(scope:RestrictedAbstract) {
+		scope.test();
+		passToUnretrictedAbstract(scope);
+	}
+}

--- a/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionAssign.hx
+++ b/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionAssign.hx
@@ -1,0 +1,39 @@
+import haxe.coro.Coroutine;
+
+interface MyUnrestrictedInterface {}
+
+class MyUnrestrictedClass implements MyUnrestrictedInterface {
+	public function new() {}
+}
+
+@:coroutine.restrictedSuspension
+typedef MyRestrictedTypedef = MyUnrestrictedClass;
+
+@:coroutine.restrictedSuspension
+class MyRestrictedChildClass extends MyUnrestrictedClass {}
+
+@:coroutine function passToUnrestrictedClass(_:MyUnrestrictedClass) { }
+@:coroutine function passToUnrestrictedInterface(_:MyUnrestrictedInterface) { }
+@:coroutine function passToDynamic(_:Dynamic) { }
+
+// failures here
+
+@:coroutine function typedefToClass(scope:MyRestrictedTypedef) {
+	passToUnrestrictedClass(scope);
+}
+
+@:coroutine function classToClass(scope:MyRestrictedChildClass) {
+	passToUnrestrictedClass(scope);
+}
+
+@:coroutine function classToInterface(scope:MyRestrictedChildClass) {
+	passToUnrestrictedInterface(scope);
+}
+
+@:coroutine function classToDynamic(scope:MyRestrictedChildClass) {
+	passToDynamic(scope);
+}
+
+function main() {
+
+}

--- a/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionCall.hx
+++ b/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionCall.hx
@@ -1,0 +1,13 @@
+import haxe.coro.Coroutine;
+
+@:coroutine function someOtherCoro() {}
+
+@:coroutine.restrictedSuspension
+typedef MyScope = Coroutine<() -> Void>;
+
+function main() {
+	@:coroutine function run(scope:MyScope) {
+		scope(); // this is allowed
+		someOtherCoro(); // this is not
+	}
+}

--- a/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionFieldAccess.hx
+++ b/tests/misc/projects/coro/restricted-suspension/RestrictedSuspensionFieldAccess.hx
@@ -1,0 +1,13 @@
+@:coroutine function someOtherCoro() {}
+
+@:coroutine.restrictedSuspension
+class MyScope {
+	@:coroutine public function scopeCoro() {}
+}
+
+function main() {
+	@:coroutine function run(scope:MyScope) {
+		scope.scopeCoro(); // this is allowed
+		someOtherCoro(); // this is not
+	}
+}

--- a/tests/misc/projects/coro/restricted-suspension/compile-abstract-fail.hxml
+++ b/tests/misc/projects/coro/restricted-suspension/compile-abstract-fail.hxml
@@ -1,0 +1,1 @@
+--main RestrictedSuspensionAbstract

--- a/tests/misc/projects/coro/restricted-suspension/compile-abstract-fail.hxml.stderr
+++ b/tests/misc/projects/coro/restricted-suspension/compile-abstract-fail.hxml.stderr
@@ -1,0 +1,1 @@
+RestrictedSuspensionAbstract.hx:13: characters 3-35 : Invalid suspension call in restricted suspension scope

--- a/tests/misc/projects/coro/restricted-suspension/compile-assign-fail.hxml
+++ b/tests/misc/projects/coro/restricted-suspension/compile-assign-fail.hxml
@@ -1,0 +1,1 @@
+--main RestrictedSuspensionAssign

--- a/tests/misc/projects/coro/restricted-suspension/compile-assign-fail.hxml.stderr
+++ b/tests/misc/projects/coro/restricted-suspension/compile-assign-fail.hxml.stderr
@@ -1,0 +1,4 @@
+RestrictedSuspensionAssign.hx:22: characters 2-32 : Invalid suspension call in restricted suspension scope
+RestrictedSuspensionAssign.hx:26: characters 2-32 : Invalid suspension call in restricted suspension scope
+RestrictedSuspensionAssign.hx:30: characters 2-36 : Invalid suspension call in restricted suspension scope
+RestrictedSuspensionAssign.hx:34: characters 2-22 : Invalid suspension call in restricted suspension scope

--- a/tests/misc/projects/coro/restricted-suspension/compile-call-fail.hxml
+++ b/tests/misc/projects/coro/restricted-suspension/compile-call-fail.hxml
@@ -1,0 +1,1 @@
+--main RestrictedSuspensionFieldAccess

--- a/tests/misc/projects/coro/restricted-suspension/compile-call-fail.hxml.stderr
+++ b/tests/misc/projects/coro/restricted-suspension/compile-call-fail.hxml.stderr
@@ -1,1 +1,1 @@
-RestrictedSuspensionFieldAccess.hx:11: characters 3-18 : Invalid suspension call on restricted suspension scope
+RestrictedSuspensionFieldAccess.hx:11: characters 3-18 : Invalid suspension call in restricted suspension scope

--- a/tests/misc/projects/coro/restricted-suspension/compile-call-fail.hxml.stderr
+++ b/tests/misc/projects/coro/restricted-suspension/compile-call-fail.hxml.stderr
@@ -1,0 +1,1 @@
+RestrictedSuspensionFieldAccess.hx:11: characters 3-18 : Invalid suspension call on restricted suspension scope

--- a/tests/misc/projects/coro/restricted-suspension/compile-field-access-fail.hxml
+++ b/tests/misc/projects/coro/restricted-suspension/compile-field-access-fail.hxml
@@ -1,0 +1,1 @@
+--main RestrictedSuspensionFieldAccess

--- a/tests/misc/projects/coro/restricted-suspension/compile-field-access-fail.hxml.stderr
+++ b/tests/misc/projects/coro/restricted-suspension/compile-field-access-fail.hxml.stderr
@@ -1,1 +1,1 @@
-RestrictedSuspensionFieldAccess.hx:11: characters 3-18 : Invalid suspension call on restricted suspension scope
+RestrictedSuspensionFieldAccess.hx:11: characters 3-18 : Invalid suspension call in restricted suspension scope

--- a/tests/misc/projects/coro/restricted-suspension/compile-field-access-fail.hxml.stderr
+++ b/tests/misc/projects/coro/restricted-suspension/compile-field-access-fail.hxml.stderr
@@ -1,0 +1,1 @@
+RestrictedSuspensionFieldAccess.hx:11: characters 3-18 : Invalid suspension call on restricted suspension scope


### PR DESCRIPTION
We need just a little bit more compiler support for hxcoro that relates to coroutine scopes. This gives special semantics to the first argument of a `@:coroutine` function, which works like this:

## @:coroutine.scope

This now gives an error:

```haxe
@:coroutine.scope
class MyScope {}

function main() {
	@:coroutine function outer(outerScope:MyScope) {
		@:coroutine function inner(innerScope:MyScope) {
			outerScope; // Invalid usage of a coroutine scope in a different coroutine scope
		}
	}
}
```

You can think of these scopes as some kind of "coroutine-this", where keeping an orderly structure is important. This is relevant for structured concurrency where we really don't want users to accidentally have children mess with their parent's scope. For example, I've had code like this before:

```haxe
import hxcoro.CoroRun;

function main() {
	CoroRun.run(node -> {
		node.async(_ -> {
			node.async(_ -> {});
		});
	});
}
```

Since the child coro doesn't shadow `node`, this accesses the parent's node in its body, which is not very structured. With this PR there's now a proper error.

Note that this only restricts access if there exists a nested scope, so normal capturing in closures still works as expected, which includes coroutines that don't have a scope:

```haxe
@:coroutine.scope
class MyScope {}

function main() {
	@:coroutine function outer(outerScope:MyScope) {
		@:coroutine function inner() {
			outerScope; // ok
		}
	}
}
```

## @:coroutine.restrictedSuspension

This meta implies `@:coroutine.scope` and restricts which coroutines we're allowed to call:

```haxe
@:coroutine function someOtherCoro() {}

@:coroutine.restrictedSuspension
class MyRestrictedScope {
	public function new() {}

	@:coroutine public function scopeCoro() {
		someOtherCoro();
	}
}

function main() {
	@:coroutine function runRestricted(scope:MyRestrictedScope) {
		someOtherCoro(); // Invalid suspension call on restricted suspension scope
		scope.scopeCoro(); // ok
	}
}
```

In the current implementation it allows all `@:coroutine` field access calls on the current scope, as well as direct calls if the scope supports that:

```haxe
import haxe.coro.Coroutine;

@:coroutine.restrictedSuspension
typedef MyRestrictedScope = Coroutine<() -> Void>;

function main() {
	@:coroutine function runRestricted(scope:MyRestrictedScope) {
		scope(); // ok
	}
}
```

There might be more cases we want to allow, which can be looked into later. This feature is necessary in order to support generators which are not supposed to invoke arbitrary coroutines.