### PR TITLE
[lua] Remove unnecessary do...end wrappers around tail returns

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -64,6 +64,7 @@ type ctx = {
     mutable lua_vanilla : bool;
     mutable lua_ver : float;
     mutable declared_locals : (string, unit) Hashtbl.t;
+    mutable in_pcall : bool;
 }
 
 type object_store = {
@@ -826,7 +827,7 @@ and gen_expr ?(local=true) ctx e = begin
         gen_paren ctx [e];
     | TMeta (_,e) ->
         gen_expr ctx e
-    | TReturn eo -> gen_return ctx e eo true;
+    | TReturn eo -> gen_return ctx e eo ctx.in_pcall;
     | TBreak ->
         if not ctx.loop_ctx.in_loop then unsupported e.epos;
         if ctx.loop_ctx.handle_continue then
@@ -1079,7 +1080,10 @@ and gen_expr ?(local=true) ctx e = begin
             ctx.loop_ctx <- { ctx.loop_ctx with in_loop_try = true };
         println ctx "local _hx_status, _hx_result = pcall(function() ";
         let b = open_block ctx in
+        let old_in_pcall = ctx.in_pcall in
+        ctx.in_pcall <- true;
         gen_expr ctx e;
+        ctx.in_pcall <- old_in_pcall;
         b();
         println ctx "return _hx_pcall_default";
         println ctx "end)";
@@ -1200,6 +1204,10 @@ and gen_block_element ctx e  =
                 | [] -> ()
                 | [e] -> gen_block_element ctx e
                 | _ -> Globals.die "" __LOC__)
+        | TReturn eo ->
+            newline ctx;
+            gen_return ctx e eo ctx.in_pcall;
+            semicolon ctx;
         | _ ->
             newline ctx;
             gen_expr ctx e;
@@ -1515,6 +1523,8 @@ and gen_bitop ctx op e1 e2 =
     spr ctx ",";
     gen_value ctx e2;
     spr ctx ")"
+
+
 
 and gen_return ctx e eo wrap =
     if ctx.in_value <> None then unsupported e.epos;
@@ -1922,6 +1932,7 @@ let alloc_ctx com =
                 float_of_string (Gctx.defined_value com Define.LuaVer)
             with | Not_found -> 5.2);
         declared_locals = Hashtbl.create 0;
+        in_pcall = false;
     } in
     ctx.type_accessor <- (fun t ->
         let p = t_path t in

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -696,7 +696,7 @@ and gen_func_block ctx ret_expr el =
             (match hd.eexpr with
              | TReturn eo ->
                  newline ctx;
-                 gen_return ctx ret_expr eo;
+                 gen_return ctx ret_expr eo false;
              | _ -> gen_block_element ctx hd)
         | hd :: tl ->
             gen_block_element ctx hd;
@@ -826,7 +826,7 @@ and gen_expr ?(local=true) ctx e = begin
         gen_paren ctx [e];
     | TMeta (_,e) ->
         gen_expr ctx e
-    | TReturn eo -> gen_return ctx e eo;
+    | TReturn eo -> gen_return ctx e eo true;
     | TBreak ->
         if not ctx.loop_ctx.in_loop then unsupported e.epos;
         if ctx.loop_ctx.handle_continue then
@@ -854,10 +854,7 @@ and gen_expr ?(local=true) ctx e = begin
             let fblock = fun_block ctx f e.epos in
             (match fblock.eexpr with
              | TBlock el ->
-                 let bend = open_block ctx in
-                 List.iter (gen_block_element ctx) el;
-                 bend();
-                 newline ctx;
+                 gen_func_block ctx e el;
              |_ -> ());
             spr ctx "end");
         ctx.declared_locals <- old_declared_locals;
@@ -1221,10 +1218,7 @@ and gen_anon_value ctx e =
             let fblock = fun_block ctx f e.epos in
             (match fblock.eexpr with
              | TBlock el ->
-                 let bend = open_block ctx in
-                 List.iter (gen_block_element ctx) el;
-                 bend();
-                 newline ctx;
+                 gen_func_block ctx e el;
              |_ -> ());
             spr ctx "end");
         ctx.separator <- true
@@ -1522,31 +1516,35 @@ and gen_bitop ctx op e1 e2 =
     gen_value ctx e2;
     spr ctx ")"
 
-and gen_return ctx e eo =
+and gen_return ctx e eo wrap =
     if ctx.in_value <> None then unsupported e.epos;
+    let open_ret () = if wrap then spr ctx "do return " else spr ctx "return " in
+    let close_ret () = if wrap then spr ctx " end" in
     (match eo with
      | None ->
-         spr ctx "do return end"
+         if wrap then spr ctx "do return end"
+         else spr ctx "return"
      | Some e ->
          (match e.eexpr with
           | TField (e2, ((FAnon tcf | FInstance (_,_,tcf)) as t)) when ((is_function_type tcf.cf_type) && (not(is_dot_access e2 t)))->
               (* See issue #6259 *)
               add_feature ctx "use._hx_bind";
-              spr ctx "do return ";
+              open_ret ();
               print ctx "_hx_bind(";
               gen_value ctx e2;
               spr ctx ",";
               gen_value ctx e;
-              spr ctx ") end";
+              spr ctx ")";
+              close_ret ();
           | TBinop(OpAssign, e1, e2) ->
               gen_expr ctx e;
-              spr ctx " do return ";
+              if wrap then spr ctx " do return " else spr ctx " return ";
               gen_value ctx e1;
-              spr ctx " end";
+              close_ret ();
           | _ ->
-              spr ctx "do return ";
+              open_ret ();
               gen_value ctx e;
-              spr ctx " end");
+              close_ret ());
     )
 
 and gen_iife_assign ctx f =


### PR DESCRIPTION
## Summary

- Partial fix for #7350 (addresses `do return end` wrappers; other codegen issues in that issue remain)
- When `return` is the last statement in a function body, the `do...end` wrapper is unnecessary. This adds a `wrap` parameter to `gen_return` and a shared `gen_func_block` helper that emits bare `return` at tail position in all four function body handlers.
- Non-tail returns outside pcall also use bare `return`.
- Returns inside pcall callbacks (try-catch) still use `do return end` since the compiler appends `return _hx_pcall_default` after user code.

## Test plan

- [x] `make haxe` builds successfully
- [x] All 11,711 Lua unit tests pass
- [x] Verified bare `return` at function tail positions in generated output
- [x] Verified `do return end` still used for returns inside try-catch (pcall)
- [x] Added regression test (Issue7350) covering both pcall return wrapping and tail return cleanup
- [x] ~80% reduction in unnecessary `do...end` wrappers (5,897 → 1,198 in test output)