### PR TITLE
[lua] Add lua.Lib.getModuleVarargs() for module-level varargs capture

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -2016,6 +2016,7 @@ let generate com =
 
     if has_feature ctx "Class" || has_feature ctx "Type.getClassName" then add_feature ctx "lua.Boot.isClass";
     if has_feature ctx "Enum" || has_feature ctx "Type.getEnumName" then add_feature ctx "lua.Boot.isEnum";
+    if has_feature ctx "lua.Lib.getModuleVarargs" then add_feature ctx "use._hx_module_varargs";
 
     let print_file path =
         let file_content = Std.input_file ~bin:true path in
@@ -2168,6 +2169,7 @@ let generate com =
         "use._hx_table", "lua/_lua/_hx_table.lua";
         "use._hx_wrap_if_string_field", "lua/_lua/_hx_wrap_if_string_field.lua";
         "use._hx_dyn_add", "lua/_lua/_hx_dyn_add.lua";
+        "use._hx_module_varargs", "lua/_lua/_hx_module_varargs.lua";
     ];
 
     print_file (find_file "lua/_lua/_hx_handle_error.lua");

--- a/std/lua/Lib.hx
+++ b/std/lua/Lib.hx
@@ -71,6 +71,15 @@ class Lib {
 	}
 
 	/**
+		Returns the module-level varargs (`...`) passed to the Lua chunk.
+		Useful in environments like ComputerCraft where script arguments
+		are only available via module-level varargs, not `_G.arg`.
+	**/
+	public static function getModuleVarargs():Table<Int, String> {
+		return untyped _hx_module_varargs;
+	}
+
+	/**
 		Simple test for the presence of an available shell.
 	**/
 	public static function isShellAvailable():Bool {

--- a/std/lua/_lua/_hx_module_varargs.lua
+++ b/std/lua/_lua/_hx_module_varargs.lua
@@ -1,0 +1,1 @@
+_hx_module_varargs = {...}


### PR DESCRIPTION
## Summary

- Addresses #10753
- Environments like ComputerCraft pass script arguments via module-level `...` (varargs) rather than populating `_G.arg`. The generated Lua wraps everything in functions, so `...` becomes inaccessible.
- Adds `lua.Lib.getModuleVarargs()` — an opt-in API that returns the module-level varargs as a `Table<Int, String>`. Users can convert to an array with `Table.toArray()`.
- The runtime helper (`_hx_module_varargs = {...}`) is only included in the output when `getModuleVarargs()` is actually used (gated behind DCE feature detection).

## Test plan

- [x] `make haxe` builds successfully
- [x] All 11,696 Lua unit tests pass
- [x] Verified `getModuleVarargs()` captures args when invoked as `lua script.lua arg1 arg2`
- [x] Verified the runtime helper is NOT included when `getModuleVarargs()` is not called