### PR TITLE
[tests] Add test for non empty directory deletion

### DIFF
--- a/tests/sys/src/TestFileSystem.hx
+++ b/tests/sys/src/TestFileSystem.hx
@@ -1,5 +1,6 @@
 import sys.FileSystem;
 import utest.Assert;
+import haxe.io.Path;
 using StringTools;
 
 class TestFileSystem extends utest.Test {
@@ -154,5 +155,28 @@ class TestFileSystem extends utest.Test {
 			p = p.replace("/", "\\");
 		}
 		return p;
+	}
+
+	function testDeleteDirectory() {
+		final path = Path.join([dir, "test"]);
+		FileSystem.createDirectory(path);
+
+		final file = Path.join([path, "file.txt"]);
+		final subDir = Path.join([path, "subdir"]);
+
+		sys.io.File.saveContent(file, "hello");
+		FileSystem.createDirectory(subDir);
+
+		try {
+			// cannot delete if not empty
+			FileSystem.deleteDirectory(path);
+			Assert.isFalse(true);
+		} catch (_) {
+			Assert.isTrue(true);
+		}
+
+		FileSystem.deleteFile(file);
+		FileSystem.deleteDirectory(subDir);
+		FileSystem.deleteDirectory(path);
 	}
 }


### PR DESCRIPTION
This is already the behaviour of all haxe targets, and is specified by the documentation:

https://github.com/HaxeFoundation/haxe/blob/ed28f2f28f0c7c13404f974e3a1d2702ed8cedb9/std/sys/FileSystem.hx#L93-L94

The discussion is still pending in #5585, but I wanted to open a PR to not forget about this patch.