### PR TITLE
[tests] Enable luajit 2.1 tests on arm64

### DIFF
--- a/tests/runci/Linux.hx
+++ b/tests/runci/Linux.hx
@@ -5,17 +5,6 @@ import runci.System.*;
 using StringTools;
 
 class Linux {
-	static public var arch(get, null):Arch;
-
-	static function get_arch() {
-		if(arch == null)
-			arch = switch commandResult('arch', []).stdout.replace('\n', '') {
-				case 'arm64' | 'aarch64': Arm64;
-				case _: Amd64;
-			}
-		return arch;
-	}
-
 	static public function isAptPackageInstalled(aptPackage:String):Bool {
 		return commandSucceed("dpkg-query", ["-W", "-f='${Status}'", aptPackage]);
 	}
@@ -41,9 +30,4 @@ class Linux {
 			runNetworkCommand("sudo", baseCommand.concat(notYetInstalled));
 		}
 	}
-}
-
-enum abstract Arch(Int) {
-	final Arm64;
-	final Amd64;
 }

--- a/tests/runci/System.hx
+++ b/tests/runci/System.hx
@@ -14,6 +14,11 @@ class CommandFailure extends haxe.Exception {
 	}
 }
 
+enum abstract Arch(Int) {
+	final Arm64;
+	final Amd64;
+}
+
 class System {
 	static public function successMsg(msg:String):Void {
 		Sys.println(colorSupported ? '\x1b[32m' + msg + '\x1b[0m' : msg);
@@ -255,4 +260,13 @@ class System {
 		return installPath + "/downloads";
 	}
 
+	static public var arch(get, null):Arch;
+	static function get_arch() {
+		if (arch == null)
+			arch = switch commandResult('arch', []).stdout.replace('\n', '') {
+				case 'arm64' | 'aarch64': Arm64;
+				case _: Amd64;
+			}
+		return arch;
+	}
 }

--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -13,10 +13,8 @@ class Cpp {
 
 		//hxcpp dependencies
 		switch (systemName) {
-			case "Linux":
-				if (Linux.arch == Amd64) {
-					Linux.requireAptPackages(["gcc-multilib", "g++-multilib"]);
-				}
+			case "Linux" if (System.arch == Amd64):
+				Linux.requireAptPackages(["gcc-multilib", "g++-multilib"]);
 			case "Mac":
 				//pass
 		}
@@ -57,7 +55,7 @@ class Cpp {
 			runCommand("haxe", ["compile-cppia.hxml"].concat(args));
 			runCpp("bin/cppia/Host-debug", ["bin/unit.cppia"]);
 
-			if (!(systemName == 'Linux' && Linux.arch == Arm64)) // FIXME
+			if (!(systemName == 'Linux' && System.arch == Arm64)) // FIXME
 				runCpp("bin/cppia/Host-debug", ["bin/unit.cppia", "-jit"]);
 		}
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -92,7 +92,7 @@ class Lua {
 
 		getLuaDependencies();
 
-		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4"].concat(systemName == 'Linux' && Linux.arch == Arm64 ? [] : ["-j2.0", "-j2.1"])) {
+		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4"].concat(systemName == 'Linux' && System.arch == Arm64 ? [] : ["-j2.0", "-j2.1"])) {
 			final envpath = getInstallPath() + '/lua_env/lua$lv';
 			addToPATH(envpath + '/bin');
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -56,7 +56,7 @@ class Lua {
 			infoMsg('hererocks has already been installed.');
 		} else {
 			runCommand("pipx", ["ensurepath"]);
-			runCommand("pipx", ["install", "git+https://github.com/luarocks/hererocks"]);
+			runCommand("pipx", ["install", "git+https://github.com/tobil4sk/hererocks.git@fix/windows-msys-shell"]);
 		}
 	}
 
@@ -96,7 +96,7 @@ class Lua {
 			// luajit 2.0 was missing arm64 support
 			if (System.arch == Arm64 && lv == "-j2.0") continue;
 
-			final envpath = getInstallPath() + '/lua_env/lua$lv';
+			final envpath = getInstallPath() + '/lua_env/lua${lv.replace("@v", "")}';
 			addToPATH(envpath + '/bin');
 
 			Sys.println('--------------------');

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -92,11 +92,13 @@ class Lua {
 
 		getLuaDependencies();
 
-		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4"].concat(systemName == 'Linux' && System.arch == Arm64 ? [] : ["-j2.0", "-j2.1"])) {
+		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4", "-j2.0", "-j2.1"]) {
+			// luajit 2.0 was missing arm64 support
+			if (System.arch == Arm64 && lv == "-j2.0") continue;
+
 			final envpath = getInstallPath() + '/lua_env/lua$lv';
 			addToPATH(envpath + '/bin');
 
-			if (systemName == "Mac" && lv.startsWith("-j")) continue;
 			Sys.println('--------------------');
 			Sys.println('Lua Version: $lv');
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -92,7 +92,7 @@ class Lua {
 
 		getLuaDependencies();
 
-		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4", "-j2.0", "-j2.1"]) {
+		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4", "-j2.0", "-j@v2.1"]) {
 			// luajit 2.0 was missing arm64 support
 			if (System.arch == Arm64 && lv == "-j2.0") continue;
 

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -56,7 +56,7 @@ class Lua {
 			infoMsg('hererocks has already been installed.');
 		} else {
 			runCommand("pipx", ["ensurepath"]);
-			runCommand("pipx", ["install", "hererocks"]);
+			runCommand("pipx", ["install", "git+https://github.com/luarocks/hererocks"]);
 		}
 	}
 

--- a/tests/runci/targets/Python.hx
+++ b/tests/runci/targets/Python.hx
@@ -18,7 +18,7 @@ class Python {
 				if (commandSucceed(pypy, ["-V"])) {
 					infoMsg('pypy3 has already been installed.');
 				} else {
-					final pypyVersion = "pypy3.8-v7.3.7-" + (switch Linux.arch {
+					final pypyVersion = "pypy3.8-v7.3.7-" + (switch System.arch {
 						case Arm64: "aarch64";
 						case Amd64: "linux64";
 					});


### PR DESCRIPTION
luajit 2.1 has arm64 support, unlike 2.0. See: https://luajit.org/status.html#architectures

Currently hererocks is hardcoded to a very old version of 2.1 if you just use `-j2.1`: https://github.com/luarocks/hererocks/issues/52. It's possible to override it and tell it to use the `v2.1` (rolling release) branch with `-j@v2.1`.

We have to use a git version of hererocks for the rolling release to build properly on mac, but that requires this windows patch: https://github.com/luarocks/hererocks/pull/54