### PR TITLE
forLoop.ml cleanup

### DIFF
--- a/src/typing/fields.ml
+++ b/src/typing/fields.ml
@@ -10,20 +10,20 @@ open FieldAccess
 module TypeFieldConfig = struct
 	type t = {
 		allow_resolve : bool;
+		allow_dynamic : bool;
+		allow_open_mono : bool;
 		do_resume : bool;
 	}
-
-	let allow_resolve cfg = cfg.allow_resolve
-
-	let do_resume cfg = cfg.do_resume
 
 	let default = {
 		allow_resolve = true;
 		do_resume = false;
+		allow_dynamic = true;
+		allow_open_mono = true;
 	}
 
 	let create resume = {
-		allow_resolve = true;
+		default with
 		do_resume = resume;
 	}
 
@@ -281,6 +281,8 @@ let field_access ctx mode f fh e pfield =
 let class_field ctx c tl name p =
 	raw_class_field (fun f -> field_type ctx c tl f p) c tl name
 
+open TypeFieldConfig
+
 (* Resolves field [i] on typed expression [e] using the given [mode]. *)
 (* Note: if mode = MCall, with_type (if known) refers to the return type *)
 let type_field cfg ctx e i p mode (with_type : WithType.t) =
@@ -401,13 +403,15 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 					| Var ({ v_write = AccNo } as acc) when is_open && is_set -> f.cf_kind <- Var { acc with v_write = AccNormal }
 					| _ -> ());
 					field_access f FHAnon
-				with Not_found when is_open ->
+				with Not_found when is_open && cfg.allow_open_mono ->
 					let f = mk_field() in
 					Monomorph.add_down_constraint r (MField f);
 					field_access f FHAnon
 				)
 			| CTypes tl ->
 				type_field_by_list (fun (t,_) -> type_field_by_et type_field_by_type e t) tl
+			| CUnknown when not cfg.allow_open_mono ->
+				raise Not_found
 			| CUnknown ->
 				if not (List.exists (fun (m,_) -> m == r) ctx.e.monomorphs) && not (ctx.f.untyped && ctx.com.platform = Neko) then
 					ctx.e.monomorphs <- (r,p) :: ctx.e.monomorphs;
@@ -558,11 +562,11 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 			with Not_found when PMap.mem i c.cl_statics ->
 				raise_typing_error ("Cannot access static field " ^ i ^ " from a class instance") pfield;
 			)
-		| TDynamic t ->
+		| TDynamic t when cfg.allow_dynamic ->
 			AKExpr (mk (TField (e,FDynamic i)) (match t with None -> t_dynamic | Some t -> t) p)
 		| TAbstract (a,tl) ->
 			(try
-				if not (TypeFieldConfig.allow_resolve cfg) then raise Not_found;
+				if not cfg.allow_resolve then raise Not_found;
 				let c = find_some a.a_impl in
 				let f = find_some (if is_set then a.a_write else a.a_read) in
 				let sea = make_abstract_static_extension_access a tl c f e false p in
@@ -604,7 +608,7 @@ let type_field cfg ctx e i p mode (with_type : WithType.t) =
 		type_field_by_fallback e t
 	with Not_found -> try
 		type_field_by_module e t
-	with Not_found when not (TypeFieldConfig.do_resume cfg) ->
+	with Not_found when not cfg.do_resume ->
 		if not ctx.f.untyped then begin
 			let has_special_field a =
 				List.exists (fun (_,cf) -> cf.cf_name = i) a.a_ops

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -122,7 +122,7 @@ module IterationKind = struct
 		display_error com (Printf.sprintf "Cannot iterate on %s" (s_type (print_context()) e.etype)) e.epos;
 		mk (TConst TNull) t_dynamic e.epos,t_dynamic
 
-	let check_iterator ?(resume=false) ctx s e p =
+	let check_iterator ?(resume=false) ctx s e =
 		match try_iterator_unification ctx e with
 		| Some r ->
 			r
@@ -190,7 +190,7 @@ module IterationKind = struct
 	let of_texpr ?(resume=false) ctx e unroll_params p =
 		let check_iterator () =
 			try
-				let (e,t) = check_iterator ~resume:true ctx "iterator" e p in
+				let (e,t) = check_iterator ~resume:true ctx "iterator" e in
 				(IteratorIterator,e,t)
 			with Not_found -> try
 				of_texpr_by_array_access ctx e p
@@ -494,7 +494,7 @@ let type_for_loop ctx handle_display ik e1 e2 unroll p =
 	| IKKeyValue((ikey,pkey,dkokey),(ivalue,pvalue,dkovalue)) ->
 		if force_unroll then
 			display_error ctx.com "Cannot force inlining on key => value loops" p;
-		let e1,pt = IterationKind.check_iterator ctx "keyValueIterator" e1 e1.epos in
+		let e1,pt = IterationKind.check_iterator ctx "keyValueIterator" e1 in
 		let vtmp = gen_local ctx e1.etype e1.epos in
 		let etmp = make_local vtmp vtmp.v_pos in
 		let ehasnext = build_call ctx (type_field_default_cfg ctx etmp "hasNext" etmp.epos (MCall []) (WithType.with_type ctx.t.tbool)) [] WithType.value etmp.epos in

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -92,51 +92,53 @@ module IterationKind = struct
 		let pt = spawn_monomorph ctx p in
 		let t = ctx.t.titerator pt in
 		let dynamic_iterator = ref None in
-		let e1 = try
-			let e = AbstractCast.cast_or_unify_raise ctx t e p in
-			match Abstract.follow_with_abstracts e.etype with
-			| TDynamic _ | TMono _ ->
-				(* try to find something better than a dynamic value to iterate on *)
-				dynamic_iterator := Some e;
-				raise_error_msg (Unify [Unify_custom "Avoid iterating on a dynamic value"]) p
-			| _ -> e
-		with Error { err_message = Unify _ } ->
-			let try_last_resort after =
-				try
-					match last_resort with
-					| Some fn -> fn()
-					| None -> raise Not_found
-				with Not_found ->
-					after()
-			in
-			let try_acc acc =
-				let acc_expr = build_call ctx acc [] WithType.value e.epos in
-				try
-					unify_raise acc_expr.etype t acc_expr.epos;
-					acc_expr
-				with Error ({ err_message = Unify _ } as err) ->
-					try_last_resort (fun () ->
-						match !dynamic_iterator with
-						| Some e -> e
-						| None ->
-							if resume then raise Not_found;
-							display_error_ext ctx.com (make_error ~sub:[err] (Custom "Field iterator has an invalid type") acc_expr.epos);
-							mk (TConst TNull) t_dynamic p
-					)
-			in
+		let handle_dynamic_value e =
+			dynamic_iterator := Some e;
+			raise_error_msg (Unify [Unify_custom "Avoid iterating on a dynamic value"]) p
+		in
+		let try_last_resort after =
 			try
-				let acc = type_field ({do_resume = true;allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
-				try_acc acc;
+				match last_resort with
+				| Some fn -> fn ()
+				| None -> raise Not_found
 			with Not_found ->
+				after ()
+		in
+		let try_acc acc =
+			let acc_expr = build_call ctx acc [] WithType.value e.epos in
+			try
+				unify_raise acc_expr.etype t acc_expr.epos;
+				acc_expr
+			with Error ({ err_message = Unify _ } as err) ->
 				try_last_resort (fun () ->
 					match !dynamic_iterator with
 					| Some e -> e
 					| None ->
-						let acc = type_field ({do_resume = resume;allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
-						try_acc acc
+						if resume then raise Not_found;
+						display_error_ext ctx.com (make_error ~sub:[err] (Custom "Field iterator has an invalid type") acc_expr.epos);
+						mk (TConst TNull) t_dynamic p
 				)
 		in
-		e1,pt
+		let get_acc () =
+			try
+				let acc = type_field ({do_resume = true; allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
+				try_acc acc
+			with Not_found ->
+				try_last_resort (fun () ->
+					let acc = type_field ({do_resume = resume; allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
+					try_acc acc
+				)
+		in
+		let e1 =
+			try
+				let e = AbstractCast.cast_or_unify_raise ctx t e p in
+				match Abstract.follow_with_abstracts e.etype with
+				| TDynamic _ | TMono _ -> handle_dynamic_value e
+				| _ -> e
+			with Error { err_message = Unify _ } ->
+				get_acc ()
+		in
+		e1, pt
 
 	let of_texpr_by_array_access ctx e p =
 		match follow e.etype with

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -81,64 +81,57 @@ module IterationKind = struct
 	}
 
 	let type_field_config = {
-		Fields.TypeFieldConfig.do_resume = true;
+		(Fields.TypeFieldConfig.create true) with
 		allow_resolve = false;
+		allow_dynamic = false;
+		allow_open_mono = false;
 	}
 
 	let get_next_array_element arr iexpr pt p =
 		(mk (TArray (arr,iexpr)) pt p)
 
-	let check_iterator ?(resume=false) ?last_resort ctx s e p =
-		let pt = spawn_monomorph ctx p in
+	let try_iterator_unification ctx e =
+		let pt = spawn_monomorph ctx e.epos in
 		let t = ctx.t.titerator pt in
-		let dynamic_iterator = ref None in
-		let handle_dynamic_value e =
-			dynamic_iterator := Some e;
-			raise_error_msg (Unify [Unify_custom "Avoid iterating on a dynamic value"]) p
-		in
-		let try_last_resort after =
-			try
-				match last_resort with
-				| Some fn -> fn ()
-				| None -> raise Not_found
-			with Not_found ->
-				after ()
-		in
-		let try_acc acc =
+		try
+			let e = AbstractCast.cast_or_unify_raise ctx t e e.epos in
+			Some (e,pt)
+		with Error ({ err_message = Unify _ }) ->
+			None
+
+	let try_iterator_unification ctx e =
+		match Abstract.follow_with_abstracts e.etype with
+		| TDynamic _ | TMono _ ->
+			(* Unification from these always succeeds, so let's reject it. *)
+			None
+		| _ ->
+			try_iterator_unification ctx e
+
+	let try_iterator_field ctx e s =
+		let pt = spawn_monomorph ctx e.epos in
+		let t_iterator = ctx.t.titerator pt in
+		try
+			let acc = type_field type_field_config ctx e s e.epos (MCall []) (WithType.with_type t_iterator) in
 			let acc_expr = build_call ctx acc [] WithType.value e.epos in
-			try
-				unify_raise acc_expr.etype t acc_expr.epos;
-				acc_expr
-			with Error ({ err_message = Unify _ } as err) ->
-				try_last_resort (fun () ->
-					match !dynamic_iterator with
-					| Some e -> e
-					| None ->
-						if resume then raise Not_found;
-						display_error_ext ctx.com (make_error ~sub:[err] (Custom "Field iterator has an invalid type") acc_expr.epos);
-						mk (TConst TNull) t_dynamic p
-				)
-		in
-		let get_acc () =
-			try
-				let acc = type_field ({do_resume = true; allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
-				try_acc acc
-			with Not_found ->
-				try_last_resort (fun () ->
-					let acc = type_field ({do_resume = resume; allow_resolve = false}) ctx e s e.epos (MCall []) (WithType.with_type t) in
-					try_acc acc
-				)
-		in
-		let e1 =
-			try
-				let e = AbstractCast.cast_or_unify_raise ctx t e p in
-				match Abstract.follow_with_abstracts e.etype with
-				| TDynamic _ | TMono _ -> handle_dynamic_value e
-				| _ -> e
-			with Error { err_message = Unify _ } ->
-				get_acc ()
-		in
-		e1, pt
+			unify_raise acc_expr.etype t_iterator acc_expr.epos;
+			Some (acc_expr,pt)
+		with Error ({ err_message = Unify _ }) | Not_found ->
+			None
+
+	let cannot_iterate_on com e =
+		display_error com (Printf.sprintf "Cannot iterate on %s" (s_type (print_context()) e.etype)) e.epos;
+		mk (TConst TNull) t_dynamic e.epos,t_dynamic
+
+	let check_iterator ?(resume=false) ctx s e p =
+		match try_iterator_unification ctx e with
+		| Some r ->
+			r
+		| None -> match try_iterator_field ctx e s with
+			| Some r ->
+				r
+			| None ->
+				if resume then raise Not_found;
+				cannot_iterate_on ctx.com e
 
 	let of_texpr_by_array_access ctx e p =
 		match follow e.etype with
@@ -195,23 +188,16 @@ module IterationKind = struct
 				None
 
 	let of_texpr ?(resume=false) ctx e unroll_params p =
-		let dynamic_iterator e =
-			display_error ctx.com "You can't iterate on a Dynamic value, please specify Iterator or Iterable" e.epos;
-			IteratorDynamic,e,t_dynamic
-		in
 		let check_iterator () =
-			let array_access_result = ref None in
-			let last_resort () =
-				array_access_result := Some (of_texpr_by_array_access ctx e p);
-				mk (TConst TNull) t_dynamic p
-			in
-			let e1,pt = check_iterator ~resume ~last_resort ctx "iterator" e p in
-			match !array_access_result with
-			| Some result -> result
-			| None ->
-				match Abstract.follow_with_abstracts e1.etype with
-					| (TMono _ | TDynamic _) -> dynamic_iterator e1;
-					| _ -> (IteratorIterator,e1,pt)
+			try
+				let (e,t) = check_iterator ~resume:true ctx "iterator" e p in
+				(IteratorIterator,e,t)
+			with Not_found -> try
+				of_texpr_by_array_access ctx e p
+			with Not_found ->
+				if resume then raise Not_found;
+				let (e,t) = cannot_iterate_on ctx.com e in
+				(IteratorIterator,e,t)
 		in
 		let cannot_force () = match unroll_params with
 			| Some {force_unroll = true} ->
@@ -293,7 +279,8 @@ module IterationKind = struct
 			cannot_force();
 			IteratorGenericStack c,e,pt
 		| _,(TMono _ | TDynamic _) ->
-			dynamic_iterator e
+			let (e,t) = cannot_iterate_on ctx.com e in
+			(IteratorDynamic,e,t_dynamic)
 		| _ ->
 			cannot_force();
 			check_iterator ()
@@ -505,14 +492,8 @@ let type_for_loop ctx handle_display ik e1 e2 unroll p =
 		old_locals();
 		IterationKind.to_texpr ctx i iterator e2 p
 	| IKKeyValue((ikey,pkey,dkokey),(ivalue,pvalue,dkovalue)) ->
-		(match follow e1.etype with
-		| TDynamic _ | TMono _ ->
-			display_error ctx.com "You can't iterate on a Dynamic value, please specify KeyValueIterator or KeyValueIterable" e1.epos;
-		| _ ->
-			if force_unroll then
-				display_error ctx.com "Cannot force inlining on key => value loops" p;
-			()
-		);
+		if force_unroll then
+			display_error ctx.com "Cannot force inlining on key => value loops" p;
 		let e1,pt = IterationKind.check_iterator ctx "keyValueIterator" e1 e1.epos in
 		let vtmp = gen_local ctx e1.etype e1.epos in
 		let etmp = make_local vtmp vtmp.v_pos in

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -527,7 +527,7 @@ and display_expr ctx e_ast e dk mode with_type p =
 		in
 		let keyValueIterator =
 			try begin
-				let _,pt = ForLoop.IterationKind.check_iterator ~resume:true ctx "keyValueIterator" e e.epos in
+				let _,pt = ForLoop.IterationKind.check_iterator ~resume:true ctx "keyValueIterator" e in
 				match follow pt with
 					| TAnon a ->
 						let key = PMap.find "key" a.a_fields in

--- a/tests/misc/projects/Issue7363/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue7363/compile-fail.hxml.stderr
@@ -1,2 +1,2 @@
-Main.hx:4: characters 17-18 : You can't iterate on a Dynamic value, please specify Iterator or Iterable
-Main.hx:8: characters 17-18 : You can't iterate on a Dynamic value, please specify Iterator or Iterable
+Main.hx:4: characters 17-18 : Cannot iterate on Object
+Main.hx:8: characters 17-18 : Cannot iterate on ForwardedObject

--- a/tests/misc/projects/Issue9245/compile-fail.hxml.stderr
+++ b/tests/misc/projects/Issue9245/compile-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Main.hx:4: characters 24-27 : You can't iterate on a Dynamic value, please specify KeyValueIterator or KeyValueIterable
+Main.hx:4: characters 24-27 : Cannot iterate on Unknown<0>

--- a/tests/unit/src/unit/TestKeyValueIterator.hx
+++ b/tests/unit/src/unit/TestKeyValueIterator.hx
@@ -97,7 +97,7 @@ class TestKeyValueIterator extends Test {
 		var s = HelperMacros.typeErrorText(
 			for (key => value in 1) { }
 		);
-		eq("Int has no field keyValueIterator", s);
+		eq("Cannot iterate on Int", s);
 	}
 
 	function testError2() {


### PR DESCRIPTION
This tries to clean up the nightmare that is `check_iterator` in forLoop.ml. It's such a mess that for the first time ever I asked Copilot for help in an effort to make sense of it. The AI basically apologized and offered me a refund, but after some fiddling "we" managed to refactor the function to something more humane. Broken, but humane.

I then did what I usually do: delete code until the tests stop working, then figure out what's different. The entire specification here with regards to iterators, iterables, array access and whatnot is a mess. I'll try to extract something that looks like it was intentionally designed by someone and didn't just grow into some monstrosity over two decades.