### PR TITLE
[hl] use fast_eq instead of physical equality for cache checks

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -376,7 +376,7 @@ let is_excluded c =
 
 let get_rec_cache ctx t none_callback not_found_callback =
 	try
-		match !(List.assq t ctx.rec_cache) with
+		match !(snd (List.find (fun (t',_) -> fast_eq t' t) ctx.rec_cache)) with
 		| None -> none_callback()
 		| Some t -> t
 	with Not_found ->

--- a/tests/unit/.vscode/settings.json
+++ b/tests/unit/.vscode/settings.json
@@ -3,6 +3,7 @@
 		{"label": "Java", "args": ["compile-java.hxml", "-cmd", "java -jar bin/java/TestMain-debug.jar"]},
 		{"label": "JavaScript", "args": ["compile-js.hxml", "-cmd", "node -e \"require('./bin/unit.js').unit.TestMain.main()\""]},
 		{"label": "JVM", "args": ["compile-jvm-only.hxml", "-cmd", "java -jar bin/unit.jar"]},
+		{"label": "HL", "args": ["compile-hl.hxml", "-cmd", "hl bin/unit.hl"]},
 		{"label": "Interp", "args": ["compile-macro.hxml"]},
 		{"label": "Lua", "args": ["compile-lua.hxml", "-cmd", "lua bin/unit.lua"]},
 		{"label": "Python", "args": ["compile-python.hxml", "-cmd", "python3 bin/unit.py"]},

--- a/tests/unit/src/unit/issues/Issue12539.hx
+++ b/tests/unit/src/unit/issues/Issue12539.hx
@@ -1,0 +1,48 @@
+package unit.issues;
+
+private typedef Recursive<F> = Recursive<F>->F;
+private typedef YDef<P, R> = Recursive<P->R>;
+
+@:callable private abstract Y<P, R>(YDef<P, R>) from YDef<P, R> to YDef<P, R> {
+	@:noUsing static public inline function lift<P, R>(self:YDef<P, R>):Y<P, R> {
+		return new Y(self);
+	}
+
+	static public function unit<P, R>():Y<P, R> {
+		return function(fn:Recursive<P->R>):P->R return fn(fn);
+	}
+
+	@:noUsing static public function pure<P, R>(f:P->R):Y<P, R> {
+		return function(fn:Recursive<P->R>) return f;
+	}
+
+	public function new(self:YDef<P, R>) {
+		this = self;
+	}
+
+	public function reply():P->R {
+		return this(this);
+	}
+
+	public function reverse(that:YDef<P, R>) {
+		return that(this);
+	}
+}
+
+private typedef Recursive2<F> = Recursive2<F>->F;
+
+function unit() {
+	return function(fn:Recursive2<Any>) return fn(null);
+}
+
+class Issue12539 extends Test {
+	function testFull() {
+		final a = Y.unit();
+		utest.Assert.pass();
+	}
+
+	function testSimple() {
+		unit();
+		utest.Assert.pass();
+	}
+}


### PR DESCRIPTION
I think the problem with `List.assq` is that `apply_typedef` makes a new instance with a different physical identity every time.

Closes #12539