### PR TITLE
[tests] Add regression test for exception patching issue

### DIFF
--- a/tests/misc/projects/Issue12208/compile.hxml
+++ b/tests/misc/projects/Issue12208/compile.hxml
@@ -1,0 +1,3 @@
+Main
+--interp
+--macro exclude("haxe.Exception")


### PR DESCRIPTION
Closes #12208

The issue was that when `haxe.Exception` is excluded (e.g. by the sample `export_classes.info`), `haxe.ValueException` is removed by DCE but patch_constructors was being run on the array of types that wasn't updated after DCE. Fixed in: fc0748d0b2bfa866ad19cd5deeb71013351ad48f

Without that commit, this test gives:
```
Running haxe projects/Issue12208/compile.hxml
/.../std/haxe/ValueException.hx:17: characters 7-21 : Could not patch constructor on this function because there isn't one
```