### PR TITLE
Fix exception constructor patch error

### DIFF
--- a/src/filters/exception/saveStacks.ml
+++ b/src/filters/exception/saveStacks.ml
@@ -66,8 +66,13 @@ let insert_save_stacks ectx scom =
 *)
 let patch_constructors ectx =
 	match fst (AtomicLazy.force ectx.haxe_exception) with
-	(* Add only if `__shiftStack` method exists *)
-	| TInst(cls,_) when PMap.mem "__shiftStack" cls.cl_fields ->
+	(*
+		Add only if `__shiftStack` method exists and has a constructor.
+
+		If it doesn't have a constructor, that means it wasn't called and was removed during DCE.
+		In this case, there is no need to patch it because the exception is never instantiated.
+	*)
+	| TInst(cls,_) when PMap.mem "__shiftStack" cls.cl_fields && cls.cl_constructor != None ->
 		(fun mt ->
 			match mt with
 			| TClassDecl cls when not (has_class_flag cls CExtern) && cls.cl_path <> haxe_exception_type_path && is_haxe_exception_class cls ->
@@ -90,7 +95,6 @@ let patch_constructors ectx =
 						make_call ectx.scom efield [] rt p
 					| _ -> raise_typing_error "haxe.Exception.__shiftStack is expected to be an instance method" p
 				in
-				(* TypeloadFunction.add_constructor tctx cls true cls.cl_name_pos; *) (* TODO: why? *)
 				Option.may (fun cf -> ignore(follow cf.cf_type)) cls.cl_constructor;
 				(match cls.cl_constructor with
 				| Some ({ cf_expr = Some e_ctor } as ctor) ->
@@ -109,8 +113,6 @@ let patch_constructors ectx =
 							}
 						| _ -> die "" __LOC__
 					)
-				| None ->
-					raise_typing_error "Could not patch constructor on this function because there isn't one" cls.cl_name_pos
 				| _ -> ()
 				)
 			| _ -> ()

--- a/tests/misc/projects/Issue12208/ConstructorException.hx
+++ b/tests/misc/projects/Issue12208/ConstructorException.hx
@@ -1,0 +1,10 @@
+@:dce
+class ConstructorException extends haxe.Exception {
+	function new() {
+		super("custom");
+	}
+}
+
+function test() {
+	return null is ConstructorException;
+}

--- a/tests/misc/projects/Issue12208/NoConstructorException.hx
+++ b/tests/misc/projects/Issue12208/NoConstructorException.hx
@@ -1,0 +1,6 @@
+@:dce
+class NoConstructorException extends haxe.Exception {}
+
+function test() {
+	return null is NoConstructorException;
+}

--- a/tests/misc/projects/Issue12208/constructor-exception.hxml
+++ b/tests/misc/projects/Issue12208/constructor-exception.hxml
@@ -1,0 +1,3 @@
+ConstructorException
+--interp
+--macro exclude("haxe.Exception")

--- a/tests/misc/projects/Issue12208/no-constructor-exception.hxml
+++ b/tests/misc/projects/Issue12208/no-constructor-exception.hxml
@@ -1,0 +1,3 @@
+NoConstructorException
+--interp
+--macro exclude("haxe.Exception")


### PR DESCRIPTION
If an exception constructor is removed by dce then it means it is never instantiated, so there is no need to patch it.

We might have to do some more investigation into `pf_overload = true` targets, see: https://github.com/HaxeFoundation/haxe/pull/12575/changes/45eb213567fc0d540ae2194838f582ae8deb1270 and https://github.com/HaxeFoundation/haxe/pull/12575#issuecomment-3922739916.

I've added the test cases to the #12208 tests, because this is a similar regression triggered by the add_constructor call being removed combined with excluding `haxe.Exception` (which stops `__unshiftStack` from being DCE'd).

```
Running haxe projects/Issue12208/constructor-exception.hxml
ConstructorException.hx:2: characters 7-27 : Could not patch constructor on this function because there isn't one
Running haxe projects/Issue12208/no-constructor-exception.hxml
NoConstructorException.hx:2: characters 7-29 : Could not patch constructor on this function because there isn't one
```