### PR TITLE
[hl] remove recursive on GNull tgroup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,7 +36,7 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           set -ex
-          opam init -c ${{ env.OCAML_VERSION }} --no-setup
+          opam init -c ${{ env.OCAML_VERSION }}
           opam pin add haxe . --no-action
           opam install haxe --deps-only --assume-depexts
           opam list

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,7 +36,7 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           set -ex
-          opam init -c ${{ env.OCAML_VERSION }}
+          opam init -c ${{ env.OCAML_VERSION }} --no-setup
           opam pin add haxe . --no-action
           opam install haxe --deps-only --assume-depexts
           opam list

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -1029,13 +1029,15 @@ let common_type ctx e1 e2 for_eq p =
 	let t2 = to_type ctx e2.etype in
 	if t1 == t2 then t1 else
 	match get_group t1, get_group t2, t1, t2 with
-	| (GInt | GFloat), (GInt | GFloat), _, _ -> common_type_number t1 t2
-	| ((GInt | GFloat) | GNull (GInt | GFloat)), ((GInt | GFloat) | GNull (GInt | GFloat)), _, _ ->
+	| GNull, GNull, _, _ ->
+		let ti1 = get_inner_type t1 in
+		let ti2 = get_inner_type t2 in
+		HNull (common_type_number ti1 ti2)
+	| GNull, _, _, _ | _, GNull, _, _->
 		let ti1 = get_inner_type t1 in
 		let ti2 = get_inner_type t2 in
 		if for_eq then HNull (common_type_number ti1 ti2) else common_type_number ti1 ti2
-	| GBool, GNull GBool, _, _ when for_eq -> t2
-	| GNull GBool, GBool, _, _ when for_eq -> t1
+	| (GInt | GFloat), (GInt | GFloat), _, _ -> common_type_number t1 t2
 	| _, (GInt | GFloat), HDyn, _ -> HF64
 	| (GInt | GFloat), _, _, HDyn -> HF64
 	| _, _, HDyn, _ -> HDyn
@@ -1270,34 +1272,36 @@ and cast_to ?(force=false) ctx (r:reg) (t:ttype) p =
 		j();
 		op ctx (ONull out);
 		out
-	| (GInt | GFloat), GNull GFloat, _, HNull t ->
+	| (GInt | GFloat), GNull, _, HNull t ->
 		let tmp = alloc_tmp ctx t in
-		op ctx (OToSFloat (tmp, r));
+		(match get_group t with
+		| GFloat -> op ctx (OToSFloat (tmp, r))
+		| GInt -> op ctx (OToInt (tmp, r))
+		| _ -> die "" __LOC__
+		);
 		let r = alloc_tmp ctx (HNull t) in
 		op ctx (OToDyn (r,tmp));
 		r
-	| (GInt | GFloat), GNull GInt, _, HNull t ->
-		let tmp = alloc_tmp ctx t in
-		op ctx (OToInt (tmp, r));
-		let r = alloc_tmp ctx (HNull t) in
-		op ctx (OToDyn (r,tmp));
-		r
-	| GNull (GInt | GFloat), GFloat, HNull it, _ ->
+	| GNull, GFloat, HNull it, _ when get_group it <> GBool ->
 		let i = alloc_tmp ctx it in
 		op ctx (OSafeCast (i,r));
 		let tmp = alloc_tmp ctx t in
 		op ctx (OToSFloat (tmp, i));
 		tmp
-	| GNull GFloat, GInt, HNull it, _ ->
-		let i = alloc_tmp ctx it in
-		op ctx (OSafeCast (i,r));
-		let tmp = alloc_tmp ctx t in
-		op ctx (OToInt (tmp, i));
-		tmp
-	| GNull GInt, GInt, _, _ ->
-		let out = alloc_tmp ctx t in
-		op ctx (OSafeCast (out, r));
-		out
+	| GNull, GInt, HNull it, _ ->
+		(match get_group it with
+		| GFloat ->
+			let i = alloc_tmp ctx it in
+			op ctx (OSafeCast (i,r));
+			let tmp = alloc_tmp ctx t in
+			op ctx (OToInt (tmp, i));
+			tmp
+		| GInt ->
+			let out = alloc_tmp ctx t in
+			op ctx (OSafeCast (out, r));
+			out
+		| _ -> die "" __LOC__
+		)
 	| _, _, HFun (args1,ret1), HFun (args2, ret2) when List.length args1 = List.length args2 ->
 		let fid = gen_method_wrapper ctx rt t p in
 		let fr = alloc_tmp ctx t in
@@ -1564,8 +1568,8 @@ and jump_expr ctx e jcond =
 		let t1 = to_type ctx e1.etype in
 		let t2 = to_type ctx e2.etype in
 		(match get_group t1, get_group t2 with
-		| GNull _, (GInt | GFloat | GBool)
-		| (GInt | GFloat | GBool), GNull _
+		| GNull, (GInt | GFloat | GBool)
+		| (GInt | GFloat | GBool), GNull
 			->
 			let ti1 = get_inner_type t1 in
 			let ti2 = get_inner_type t2 in
@@ -1606,7 +1610,7 @@ and jump_expr ctx e jcond =
 				| _ -> die "" __LOC__
 		) in
 		(match get_group t1, get_group t2, t1, t2 with
-		| ((GInt | GFloat) | GNull (GInt | GFloat)), ((GInt | GFloat) | GNull (GInt | GFloat)), _, _
+		| ((GInt | GFloat) | GNull), ((GInt | GFloat) | GNull), _, _
 			->
 			let ti1 = get_inner_type t1 in
 			let ti2 = get_inner_type t2 in
@@ -2680,7 +2684,7 @@ and eval_expr ctx e =
 				free ctx r;
 				op ctx (OFloat (tmp,alloc_float ctx 1.));
 				if uop = Increment then op ctx (OAdd (r,r,tmp)) else op ctx (OSub (r,r,tmp))
-			| GNull (GInt | GFloat), HNull t ->
+			| GNull, HNull t ->
 				hold ctx r;
 				let tmp = alloc_tmp ctx t in
 				free ctx r;

--- a/src/generators/hlcode.ml
+++ b/src/generators/hlcode.ml
@@ -89,7 +89,7 @@ type tgroup =
 	| GInt
 	| GFloat
 	| GBool
-	| GNull of tgroup
+	| GNull
 	| GOther
 
 type unused = int
@@ -280,9 +280,9 @@ let get_group t =
 	| HUI8 | HUI16 | HI32 | HI64 | HGUID -> GInt
 	| HF32 | HF64 -> GFloat
 	| HBool -> GBool
-	| HNull (HUI8 | HUI16 | HI32 | HI64 | HGUID) -> GNull GInt
-	| HNull (HF32 | HF64) -> GNull GFloat
-	| HNull HBool -> GNull GBool
+	| HNull (HUI8 | HUI16 | HI32 | HI64 | HGUID) -> GNull
+	| HNull (HF32 | HF64) -> GNull
+	| HNull HBool -> GNull
 	| HNull _ -> Globals.die "" __LOC__
 	| _ -> GOther
 
@@ -324,7 +324,7 @@ let is_number t =
 
 let is_nullt t =
 	match get_group t with
-	| GNull _ -> true
+	| GNull -> true
 	| _ -> false
 
 (*


### PR DESCRIPTION
As Simon said in
- https://github.com/HaxeFoundation/haxe/pull/12628#issuecomment-3931977142

And
> but then I start to wonder why GNull itself should be recursive because it seems more robust to just have it as a constant too and then always use get_inner_type

This PR is based on some assumptions that Bool(Null Bool) are never compared/cast with Int/Float