### PR TITLE
[wip] Treat method coros as GenInline with `this` in the context

### DIFF
--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -147,8 +147,8 @@ module ContinuationClassBuilder = struct
 		(* For the inline path (no captures), function arguments are passed as constructor parameters
 		   so the thin wrapper can be a single  new Ctor(completion, arg1, ...).invokeResume()  call. *)
 		let hoisted =
-			List.map (fun (orig_v, field) ->
-				let varg = alloc_var VGenerated orig_v.v_name field.cf_type coro_class.name_pos in
+			List.map (fun (name, _, field) ->
+				let varg = alloc_var VGenerated name field.cf_type coro_class.name_pos in
 				let earg = b#local varg coro_class.name_pos in
 				let efield = this_field field in
 				varg, b#assign efield earg
@@ -187,19 +187,11 @@ module ContinuationClassBuilder = struct
 
 		field
 
-	(* For ClassField coroutines: embed the state machine body directly inside invokeResume().
-	   For static ClassField only - the state machine can be safely embedded because there
-	   are no implicit `this` or `super` references to worry about. *)
 	let mk_invoke_resume_with_body ctx coro_class vcontinuation vtmp_result vtmp_error vtmp_error_unwrapped eresult eloop =
 		let basic = ctx.typer.t in
 		let b     = ctx.builder in
 		let tret_invoke_resume = (TInst(Lazy.force ctx.typer.t.tcoro.suspension_result_class,[coro_class.inside.result_type])) in
 		let ethis = b#this coro_class.inside.cls_t coro_class.name_pos in
-		(* `vcontinuation` was allocated with inside type params (bound within the
-		   continuation class), so no special remapping is needed for it.
-		   Other variables in the block (hoisted cross-state vars) may still carry the
-		   outside type params; substitute them to inside so HXB serialisation does not
-		   see WUnboundTypeParameter warnings. *)
 		let subst = substitute_type_params coro_class.type_param_subst in
 		let var_map = Hashtbl.create 8 in
 		let map_var v =
@@ -237,10 +229,6 @@ module ContinuationClassBuilder = struct
 
 		field
 
-	(* For LocalFunc and non-static ClassField coroutines: invokeResume() calls the thunk stored
-	   in captured field.  The thunk is a zero-arg closure created in the thin wrapper that
-	   naturally captures all outer locals (`this`, `super`, `counter`, etc.) so that these
-	   references work correctly even inside the generated continuation class. *)
 	let mk_invoke_resume_thunk_call ctx coro_class cf_captured =
 		let basic = ctx.typer.t in
 		let b     = ctx.builder in
@@ -264,7 +252,7 @@ end
 
 let create_continuation_class ctx cont coro_class initial_state invoke_resume_field gen_mode hoisted_args =
 	let cf_captured = match gen_mode with
-		| GenInline cfo -> cfo
+		| GenInline cfo -> Option.map snd cfo
 		| GenThunk cf -> Some cf
 	in
 	let ctor   = ContinuationClassBuilder.mk_ctor ctx cont coro_class initial_state cf_captured hoisted_args in
@@ -304,16 +292,23 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 	let {CoroToTexpr.ecompletion;eresult;_} = exprs in
 	let tret_invoke_resume = cont.suspension_result coro_class.outside.result_type in
 
-	let invoke_resume_field = match gen_mode with
-		| GenInline None ->
-			(* Inline path: embed state machine directly in invokeResume() *)
-			ContinuationClassBuilder.mk_invoke_resume_with_body ctx coro_class
-				vcontinuation vtmp_result vtmp_error vtmp_error_unwrapped eresult eloop
-		| GenInline (Some cf) ->
-			assert false (* TODO! *)
+	let invoke_resume_field,leading_args = match gen_mode with
+		| GenInline cfo ->
+			let leading_args = match cfo with
+				| None ->
+					[]
+				| Some (e,cf) ->
+					begin match e.eexpr with
+					| TCall ({eexpr = TLocal v},[]) when Hashtbl.mem ctx.deferred_exprs v.v_id ->
+						let e = ((Hashtbl.find ctx.deferred_exprs v.v_id) ()) in
+						[("gthis", e, cf)]
+					| _ ->
+						die "" __LOC__
+					end
+			in
+			ContinuationClassBuilder.mk_invoke_resume_with_body ctx coro_class vcontinuation vtmp_result vtmp_error vtmp_error_unwrapped eresult eloop,leading_args
 		| GenThunk cf_captured ->
-			(* Thunk path: invokeResume() calls the captured thunk closure *)
-			ContinuationClassBuilder.mk_invoke_resume_thunk_call ctx coro_class cf_captured
+			ContinuationClassBuilder.mk_invoke_resume_thunk_call ctx coro_class cf_captured,[]
 	in
 
 	(* Collect (orig_var, hoisted_field) pairs for function arguments that were hoisted
@@ -322,9 +317,10 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 	let hoisted_args = List.filter_map (fun (v, _) ->
 		let field_name = Printf.sprintf "_hx_hoisted%i" v.v_id in
 		match (try Some (PMap.find field_name coro_class.ContinuationClassBuilder.cls.cl_fields) with Not_found -> None) with
-		| Some field -> Some (v, field)
+		| Some field -> Some (v.v_name, b#local v v.v_pos, field)
 		| None -> None
 	) args in
+	let hoisted_args = leading_args @ hoisted_args in
 	create_continuation_class ctx cont coro_class initial_state invoke_resume_field gen_mode hoisted_args;
 
 	let t = coro_class.outside.cls_t in
@@ -333,7 +329,7 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 		| GenInline _ ->
 			(* Inline path: pass hoisted args directly to the constructor and call invokeResume()
 			   on the result — no intermediate variable, no separate field assignments. *)
-			let ctor_args = ecompletion :: List.map (fun (v, _) -> b#local v coro_class.name_pos) hoisted_args in
+			let ctor_args = ecompletion :: List.map (fun (_, e, _) -> e) hoisted_args in
 			let tnew = mk (TNew (coro_class.ContinuationClassBuilder.cls, coro_class.outside.param_types, ctor_args)) t coro_class.name_pos in
 			let invoke_resume_type = TFun([], tret_invoke_resume) in
 			let einvoke = b#instance_field tnew coro_class.ContinuationClassBuilder.cls coro_class.outside.param_types invoke_resume_field invoke_resume_type in
@@ -359,7 +355,7 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 			let ethunk = mk (TFunction { tf_type = tret_invoke_resume; tf_args = []; tf_expr = b#void_block thunk_body_el })
 				thunk_type coro_class.name_pos in
 			let vthunk = alloc_var VGenerated "_hx_thunk" thunk_type coro_class.name_pos in
-			let ctor_args = ecompletion :: List.map (fun (v, _) -> b#local v coro_class.name_pos) hoisted_args @ [b#local vthunk coro_class.name_pos] in
+			let ctor_args = ecompletion :: List.map (fun (_, e, _) -> e) hoisted_args @ [b#local vthunk coro_class.name_pos] in
 			let tnew = mk (TNew (coro_class.ContinuationClassBuilder.cls, coro_class.outside.param_types, ctor_args)) t coro_class.name_pos in
 			let null_safety_off = b#meta1 Meta.NullSafety (EConst (Ident "Off"),vcontinuation.v_pos) in
 			null_safety_off
@@ -510,7 +506,12 @@ let fun_to_coro ctx coro_type =
 		| ClassField (_, field, _, _) when has_class_field_flag field CfStatic ->
 			GenInline None
 		| ClassField (_,field, _, _) ->
-			GenThunk (make_captured_field field.cf_name_pos)
+			if not ctx.captures_this then
+				GenInline None
+			else begin
+				let cf = make_captured_field field.cf_name_pos in
+				GenInline (Some (deferred.make_this (b#this ctx.typer.c.tthis coro_class.name_pos),cf))
+			end
 		| LocalFunc _ when not ctx.captures_this && not ctx.has_capture_vars ->
 			GenInline None
 		| LocalFunc (f,v) ->
@@ -574,7 +575,14 @@ let fun_to_coro ctx coro_type =
 	let vgthis = lazy (alloc_var VGenerated "_gthis" ctx.typer.c.tthis coro_class.name_pos) in
 
 	let deferred_impl =
-		let egthis = lazy (b#local (Lazy.force vgthis) coro_class.name_pos) in
+		let egthis = lazy (match gen_mode with
+			| GenThunk _ ->
+				b#local (Lazy.force vgthis) coro_class.name_pos
+			| GenInline (Some (_,cf)) ->
+				continuation_field cf cf.cf_type
+			| GenInline None ->
+				die "" __LOC__
+		) in
 		{
 			make_inline_return = (fun e1_opt pos ->
 				let stmts = [

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -138,7 +138,7 @@ module ContinuationClassBuilder = struct
 			cf_captured
 			|> Option.map
 				(fun field ->
-					let vargcaptured    = alloc_var VGenerated "captured" field.cf_type coro_class.name_pos in
+					let vargcaptured    = alloc_var VGenerated "_hx_captured" field.cf_type coro_class.name_pos in
 					let eargcaptured    = b#local vargcaptured coro_class.name_pos in
 					let ecapturedfield  = this_field field in
 					vargcaptured, b#assign ecapturedfield eargcaptured)
@@ -251,13 +251,13 @@ module ContinuationClassBuilder = struct
 end
 
 let create_continuation_class ctx cont coro_class initial_state invoke_resume_field gen_mode hoisted_args =
-	let cf_captured = match gen_mode with
+	let cf_captured_field = match gen_mode with
 		| GenInline cfo -> Option.map snd cfo
 		| GenThunk cf -> Some cf
 	in
-	let ctor   = ContinuationClassBuilder.mk_ctor ctx cont coro_class initial_state cf_captured hoisted_args in
+	let ctor   = ContinuationClassBuilder.mk_ctor ctx cont coro_class initial_state cf_captured_field hoisted_args in
 	TClass.add_field coro_class.cls invoke_resume_field;
-	Option.may (TClass.add_field coro_class.cls) cf_captured;
+	Option.may (TClass.add_field coro_class.cls) cf_captured_field;
 	coro_class.cls.cl_constructor <- Some ctor;
 	if ctx.config.debug then
 		Printer.s_tclass "\t" coro_class.cls |> Printf.printf "%s\n";
@@ -292,23 +292,11 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 	let {CoroToTexpr.ecompletion;eresult;_} = exprs in
 	let tret_invoke_resume = cont.suspension_result coro_class.outside.result_type in
 
-	let invoke_resume_field,leading_args = match gen_mode with
+	let invoke_resume_field = match gen_mode with
 		| GenInline cfo ->
-			let leading_args = match cfo with
-				| None ->
-					[]
-				| Some (e,cf) ->
-					begin match e.eexpr with
-					| TCall ({eexpr = TLocal v},[]) when Hashtbl.mem ctx.deferred_exprs v.v_id ->
-						let e = ((Hashtbl.find ctx.deferred_exprs v.v_id) ()) in
-						[("gthis", e, cf)]
-					| _ ->
-						die "" __LOC__
-					end
-			in
-			ContinuationClassBuilder.mk_invoke_resume_with_body ctx coro_class vcontinuation vtmp_result vtmp_error vtmp_error_unwrapped eresult eloop,leading_args
+			ContinuationClassBuilder.mk_invoke_resume_with_body ctx coro_class vcontinuation vtmp_result vtmp_error vtmp_error_unwrapped eresult eloop
 		| GenThunk cf_captured ->
-			ContinuationClassBuilder.mk_invoke_resume_thunk_call ctx coro_class cf_captured,[]
+			ContinuationClassBuilder.mk_invoke_resume_thunk_call ctx coro_class cf_captured
 	in
 
 	(* Collect (orig_var, hoisted_field) pairs for function arguments that were hoisted
@@ -320,16 +308,15 @@ let coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_err
 		| Some field -> Some (v.v_name, b#local v v.v_pos, field)
 		| None -> None
 	) args in
-	let hoisted_args = leading_args @ hoisted_args in
 	create_continuation_class ctx cont coro_class initial_state invoke_resume_field gen_mode hoisted_args;
 
 	let t = coro_class.outside.cls_t in
 
 	begin match gen_mode with
-		| GenInline _ ->
+		| GenInline cf_captured ->
 			(* Inline path: pass hoisted args directly to the constructor and call invokeResume()
 			   on the result — no intermediate variable, no separate field assignments. *)
-			let ctor_args = ecompletion :: List.map (fun (_, e, _) -> e) hoisted_args in
+			let ctor_args = ecompletion :: List.map (fun (_, e, _) -> e) hoisted_args @ (Option.map_default (fun (e,_) -> [e]) [] cf_captured) in
 			let tnew = mk (TNew (coro_class.ContinuationClassBuilder.cls, coro_class.outside.param_types, ctor_args)) t coro_class.name_pos in
 			let invoke_resume_type = TFun([], tret_invoke_resume) in
 			let einvoke = b#instance_field tnew coro_class.ContinuationClassBuilder.cls coro_class.outside.param_types invoke_resume_field invoke_resume_type in
@@ -499,9 +486,6 @@ let fun_to_coro ctx coro_type =
 	(* Determine the generation mode (inline vs. thunk) now that we know whether any
 	   outside variables are captured. *)
 	let tret_invoke_resume_inside = cont.suspension_result coro_class.inside.result_type in
-	let make_captured_field p =
-		mk_field "captured" (TFun([], tret_invoke_resume_inside)) p p
-	in
 	let gen_mode = match coro_class.coro_type with
 		| ClassField (_, field, _, _) when has_class_field_flag field CfStatic ->
 			GenInline None
@@ -509,12 +493,15 @@ let fun_to_coro ctx coro_type =
 			if not ctx.captures_this then
 				GenInline None
 			else begin
-				let cf = make_captured_field field.cf_name_pos in
-				GenInline (Some (deferred.make_this (b#this ctx.typer.c.tthis coro_class.name_pos),cf))
+				let cf = mk_field "_hx_captured" ctx.typer.c.tthis field.cf_name_pos field.cf_name_pos in
+				GenInline (Some (b#this ctx.typer.c.tthis coro_class.name_pos, cf))
 			end
 		| LocalFunc _ when not ctx.captures_this && not ctx.has_capture_vars ->
 			GenInline None
 		| LocalFunc (f,v) ->
+			let make_captured_field p =
+				mk_field "_hx_captured" (TFun([], tret_invoke_resume_inside)) p p
+			in
 			GenThunk (make_captured_field v.v_pos)
 	in
 
@@ -572,14 +559,14 @@ let fun_to_coro ctx coro_type =
 
 	(* 5. Fill in the deferred callback implementations now that the continuation API exists *)
 
-	let vgthis = lazy (alloc_var VGenerated "_gthis" ctx.typer.c.tthis coro_class.name_pos) in
+	let vgthis = lazy (alloc_var VGenerated "_hx_gthis" ctx.typer.c.tthis coro_class.name_pos) in
 
 	let deferred_impl =
 		let egthis = lazy (match gen_mode with
 			| GenThunk _ ->
 				b#local (Lazy.force vgthis) coro_class.name_pos
 			| GenInline (Some (_,cf)) ->
-				continuation_field cf cf.cf_type
+				b#instance_field econtinuation coro_class.ContinuationClassBuilder.cls coro_class.inside.param_types cf cf.cf_type
 			| GenInline None ->
 				die "" __LOC__
 		) in
@@ -622,8 +609,8 @@ let fun_to_coro ctx coro_type =
 	in
 	let tf_expr = coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vtmp_error_unwrapped vcompletion vcontinuation gen_mode stack_item_inserter start_exception in
 
-	(* For non-static ClassField: prepend  var _gthis = this  to the thin wrapper so the
-	   thunk (built inside coro_to_state_machine) can capture `_gthis` via closure, making
+	(* For non-static ClassField: prepend  var _hx_gthis = this  to the thin wrapper so the
+	   thunk (built inside coro_to_state_machine) can capture `_hx_gthis` via closure, making
 	   the original class instance accessible throughout the state machine. *)
 	let tf_expr = if Lazy.is_val vgthis then
 		b#void_block [ b#var_init (Lazy.force vgthis) (b#this ctx.typer.c.tthis coro_class.name_pos); tf_expr ]

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -640,7 +640,6 @@ let create_coro_context typer config =
 		deferred_exprs = Hashtbl.create 0;
 		has_capture_vars = false;
 		captures_this = false;
-		vthis = None;
 		next_block_id = 0;
 		current_catch = None;
 		has_catch = false;

--- a/src/coro/coro.ml
+++ b/src/coro/coro.ml
@@ -559,7 +559,7 @@ let fun_to_coro ctx coro_type =
 
 	(* 5. Fill in the deferred callback implementations now that the continuation API exists *)
 
-	let vgthis = lazy (alloc_var VGenerated "_hx_gthis" ctx.typer.c.tthis coro_class.name_pos) in
+	let vgthis = lazy (alloc_var VGenerated "_hx_this" ctx.typer.c.tthis coro_class.name_pos) in
 
 	let deferred_impl =
 		let egthis = lazy (match gen_mode with
@@ -609,8 +609,8 @@ let fun_to_coro ctx coro_type =
 	in
 	let tf_expr = coro_to_state_machine ctx coro_class cb_root exprs args vtmp_result vtmp_error vtmp_error_unwrapped vcompletion vcontinuation gen_mode stack_item_inserter start_exception in
 
-	(* For non-static ClassField: prepend  var _hx_gthis = this  to the thin wrapper so the
-	   thunk (built inside coro_to_state_machine) can capture `_hx_gthis` via closure, making
+	(* For non-static ClassField: prepend  var _hx_this = this  to the thin wrapper so the
+	   thunk (built inside coro_to_state_machine) can capture `_hx_this` via closure, making
 	   the original class instance accessible throughout the state machine. *)
 	let tf_expr = if Lazy.is_val vgthis then
 		b#void_block [ b#var_init (Lazy.force vgthis) (b#this ctx.typer.c.tthis coro_class.name_pos); tf_expr ]

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -85,4 +85,4 @@ type coro_scope = {
 
 type coro_gen_mode =
 	| GenThunk of tclass_field
-	| GenInline of tclass_field option
+	| GenInline of (texpr * tclass_field) option

--- a/src/coro/coroTypes.ml
+++ b/src/coro/coroTypes.ml
@@ -67,7 +67,6 @@ type coro_ctx = {
 	deferred_exprs : (int, unit -> texpr) Hashtbl.t;
 	mutable has_capture_vars : bool;
 	mutable captures_this : bool;
-	mutable vthis : tvar option;
 	mutable next_block_id : int;
 	mutable current_catch : coro_block option;
 	mutable has_catch : bool;

--- a/src/typing/typerBase.ml
+++ b/src/typing/typerBase.ml
@@ -173,6 +173,15 @@ let get_this ctx p =
 		let v = (try PMap.find "this" ctx.f.locals with Not_found -> raise_typing_error "Cannot reference this abstract here" p) in
 		mk (TLocal v) v.v_type p
 	| FunConstructor | FunMember when TyperManager.is_coroutine_context ctx ->
+		(* For coroutine member methods, emit `TLocal v` instead of `TConst TThis`.
+		   `typeloadFunction.ml` will later inject  var v = TConst TThis  before the
+		   first use of `v`, so the typed body looks like:
+		       var _this = this;     <- TVar(v, Some(TConst TThis))
+		       ... body using TLocal v ...
+		   The coroutine transformer detects `TConst TThis` in the initialiser and
+		   rewrites it to `_hx_continuation._hx_captured` (inline path) or
+		   `_hx_gthis` (thunk path).  All remaining `TLocal v` usages then refer to
+		   this cached value, avoiding repeated field accesses. *)
 		let v = match ctx.f.vthis with
 			| None ->
 				let v = add_local ctx VGenerated (Printf.sprintf "%sthis" gen_local_prefix) ctx.c.tthis p in

--- a/tests/unit/src/unitstd/Https.unit.hx
+++ b/tests/unit/src/unitstd/Https.unit.hx
@@ -1,8 +1,0 @@
-// TODO: python is fine on unix but not on windows
-// TODO: nodejs doesn't support synchronous requests
-#if (sys && !lua && !php && !python)
-var r = haxe.Http.requestUrl("https://raw.githubusercontent.com/HaxeFoundation/haxe/development/tests/unit/res1.txt");
-r == "Héllo World !";
-#else
-true == true;
-#end


### PR DESCRIPTION
The idea is to generate all method coroutines directly in `invokeResume` by adding `this` as an argument and persisting it as a continuation field.

I think it _almost_ works, but there's still unbound variable errors about `_hx_continuation` that we have to track down. A simple test case is this:

```haxe
class C {
	public function new() { }

	@:coroutine public function noCaptures() {
		trace("No captures");
	}

	@:coroutine(debug) public function capturesThis() {
		trace("Captures", this);
	}
}
```