### PR TITLE
[hl] fix gnull match in common type

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -1033,7 +1033,7 @@ let common_type ctx e1 e2 for_eq p =
 		let ti1 = get_inner_type t1 in
 		let ti2 = get_inner_type t2 in
 		HNull (common_type_number ti1 ti2)
-	| GNull, _, _, _ | _, GNull, _, _->
+	| GNull, (GInt | GFloat | GBool), _, _ | (GInt | GFloat | GBool), GNull, _, _->
 		let ti1 = get_inner_type t1 in
 		let ti2 = get_inner_type t2 in
 		if for_eq then HNull (common_type_number ti1 ti2) else common_type_number ti1 ti2

--- a/tests/unit/src/unit/issues/Issue12657.hx
+++ b/tests/unit/src/unit/issues/Issue12657.hx
@@ -1,0 +1,15 @@
+package unit.issues;
+
+class Issue12657 extends Test {
+	function test() {
+		var d : Dynamic = 1;
+		var ni : Null<Int> = 1;
+		var nf : Null<Float> = 1.;
+		t( d == ni );
+		f( d > ni );
+		f( d < ni );
+		t( d == nf );
+		f( d > nf );
+		f( d < nf );
+	}
+}


### PR DESCRIPTION
Bug introduced in recent change on tgroup
- https://github.com/HaxeFoundation/haxe/pull/12632

The 2nd case (`GNull, _`) was too wide.