### PR TITLE
[lua] Add regression tests for fixed issues

### DIFF
--- a/tests/unit/src/unit/issues/Issue10089.hx
+++ b/tests/unit/src/unit/issues/Issue10089.hx
@@ -1,0 +1,29 @@
+package unit.issues;
+
+private typedef Issue10089Params = {
+	var callback:String->Void;
+}
+
+private class Issue10089Callable {
+	var callback:String->Void;
+
+	public function new(params:Issue10089Params) {
+		callback = params.callback;
+	}
+
+	public function invoke() {
+		callback("Argument String");
+	}
+}
+
+class Issue10089 extends Test {
+	function test() {
+		var result = "";
+		var callback = function(arg:String) {
+			result = arg;
+		}
+		var callable = new Issue10089Callable({callback: callback});
+		callable.invoke();
+		eq(result, "Argument String");
+	}
+}

--- a/tests/unit/src/unit/issues/Issue10252.hx
+++ b/tests/unit/src/unit/issues/Issue10252.hx
@@ -1,0 +1,13 @@
+package unit.issues;
+
+class Issue10252 extends Test {
+	function test() {
+		var v:Float = 9007199254740991;
+		var buf = new haxe.io.BytesBuffer();
+		buf.addDouble(v);
+		var bytes = buf.getBytes();
+		var input = new haxe.io.BytesInput(bytes);
+		var f = input.readDouble();
+		feq(f, v);
+	}
+}

--- a/tests/unit/src/unit/issues/Issue10909.hx
+++ b/tests/unit/src/unit/issues/Issue10909.hx
@@ -1,0 +1,11 @@
+package unit.issues;
+
+class Issue10909 extends Test {
+	function test() {
+		var arr:Array<Any> = [1, 2, 3, null, 5];
+		var r = haxe.Rest.of(arr);
+		eq(r[0], 1);
+		eq(r[3], null);
+		eq(r[4], 5);
+	}
+}

--- a/tests/unit/src/unit/issues/Issue11901.hx
+++ b/tests/unit/src/unit/issues/Issue11901.hx
@@ -1,0 +1,28 @@
+package unit.issues;
+
+private class Issue11901Helper {
+	public var func:(Dynamic, Dynamic) -> Void;
+
+	public function new(obj:Dynamic) {
+		this.func = obj.test;
+	}
+
+	public function call(k:Dynamic, v:Dynamic) {
+		func(k, v);
+	}
+}
+
+class Issue11901 extends Test {
+	function test() {
+		var results:Array<String> = [];
+		var a = new Issue11901Helper({
+			test: function(k:Dynamic, v:Dynamic) {
+				results.push('$k,$v');
+			}
+		});
+		a.func("a", 1);
+		a.call("b", 2);
+		eq(results[0], "a,1");
+		eq(results[1], "b,2");
+	}
+}

--- a/tests/unit/src/unit/issues/Issue7121.hx
+++ b/tests/unit/src/unit/issues/Issue7121.hx
@@ -1,0 +1,24 @@
+package unit.issues;
+
+class Issue7121 extends Test {
+	var push:Array<Int>->Void;
+
+	function _push(array:Array<Int>) {
+		eq(array.length, 2);
+		eq(array[0], 0);
+		eq(array[1], 1);
+	}
+
+	static inline function shrink(buf:Array<Int>, size:Int) {
+		if (buf.length != size) {
+			buf = buf.slice(0, size);
+		}
+		return buf;
+	}
+
+	function test() {
+		var array = [0, 1, 2, 3];
+		push = _push;
+		push(shrink(array, 2));
+	}
+}

--- a/tests/unit/src/unit/issues/Issue7539.hx
+++ b/tests/unit/src/unit/issues/Issue7539.hx
@@ -1,0 +1,25 @@
+package unit.issues;
+
+class Issue7539 extends Test {
+	var foo:Array<String>->Void;
+
+	var result:Array<String>;
+
+	public function setup() {
+		result = [];
+		foo = if (false) null else function(args:Array<String>) {
+				result.push(args.join(","));
+				args.push("foo");
+				result.push(args.join(","));
+			}
+	}
+
+	function test() {
+		setup();
+		var args:Array<String> = [];
+		args.push("bar");
+		foo(args);
+		eq(result[0], "bar");
+		eq(result[1], "bar,foo");
+	}
+}


### PR DESCRIPTION
## Summary
- Add regression tests for 6 Lua-target bugs that were fixed but had no tests to prevent re-introduction
- All tests are Lua-conditional (`#if lua ... #else noAssert(); #end`)

| Issue | Bug |
|-------|-----|
| #7121 | Inline function as param returns `null` in value context |
| #7539 | Closure creation with conditional assignment passes wrong value |
| #10089 | Function assignment through typedef struct shifts arguments |
| #10252 | `BytesBuffer.addDouble` round-trip produces wrong bytes |
| #10909 | `Rest.of(array)` with null elements loses trailing values |
| #11901 | Object containing function field gets incorrect `self` parameter |

## Test plan
- [x] Compiler builds successfully
- [x] Lua unit tests compile (`compile-lua.hxml`)
- [x] All Lua unit tests pass (0 warnings)