### PR TITLE
[lua] Fix createEmptyInstance losing fields on round-trip

### DIFF
--- a/std/lua/_std/Type.hx
+++ b/std/lua/_std/Type.hx
@@ -93,9 +93,7 @@ enum ValueType {
 
 	public static function createEmptyInstance<T>(cl:Class<T>):T
 		untyped {
-			var ret = __lua_table__();
-			Lua.setmetatable(ret, untyped {__index: cl.prototype});
-			return ret;
+			return _hx_new(cl.prototype);
 		}
 
 	public static function createEnum<T>(e:Enum<T>, constr:String, ?params:Array<Dynamic>):T {

--- a/tests/unit/src/unit/issues/Issue9484.hx
+++ b/tests/unit/src/unit/issues/Issue9484.hx
@@ -1,0 +1,24 @@
+package unit.issues;
+
+private class Hoge {
+	public var x:Int;
+
+	public function new(x:Int) {
+		this.x = x;
+	}
+}
+
+class Issue9484 extends Test {
+	function test() {
+		#if lua
+		var a = new Hoge(5);
+		var serializedA = haxe.Serializer.run(a);
+		var unserialized:Hoge = haxe.Unserializer.run(serializedA);
+		eq(unserialized.x, 5);
+		var serializedB = haxe.Serializer.run(unserialized);
+		eq(serializedA, serializedB);
+		#else
+		noAssert();
+		#end
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #9484.

`Type.createEmptyInstance` on the Lua target created a bare table with only `__index` set to the class prototype. This meant instances created by `Unserializer` had no `__fields__` tracking or `__newindex` metamethod, so dynamically-set fields were invisible to `Reflect.fields()` and lost on re-serialization.

- Replace bare table creation with `_hx_new(cl.prototype)`, which matches normal instance creation (`__fields__`, `__newindex`, `__tostring`)
- Add regression test: serialize → unserialize → re-serialize round-trip preserves fields

## Test plan

- [x] `lua` unit tests pass (11670 assertions, 0 failures)
- [x] Standalone repro from issue confirms `serializedA == serializedB`