### PR TITLE
[lua] Fix closure on string method causing runtime error

### DIFF
--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -762,17 +762,30 @@ and gen_expr ?(local=true) ctx e = begin
         gen_tbinop ctx op e1 e2;
     | TField (x,FClosure (_,f)) ->
         add_feature ctx "use._hx_bind";
+        let fname = if Meta.has Meta.SelfCall f.cf_meta then "" else (field f.cf_name) in
+        if is_string_expr x then begin
+            add_feature ctx "use.string";
+            (match x.eexpr with
+             | TConst _ | TLocal _ ->
+                 print ctx "_hx_bind(";
+                 gen_value ctx x;
+                 print ctx ",String.prototype%s)" fname
+             | _ ->
+                 print ctx "(function() local __=";
+                 gen_value ctx x;
+                 print ctx "; return _hx_bind(__,String.prototype%s) end)()" fname)
+        end else
         (match x.eexpr with
          | TConst _ | TLocal _ ->
              print ctx "_hx_bind(";
              gen_value ctx x;
              print ctx ",";
              gen_value ctx x;
-             print ctx "%s)" (if Meta.has Meta.SelfCall f.cf_meta then "" else (field f.cf_name))
+             print ctx "%s)" fname
          | _ ->
              print ctx "(function() local __=";
              gen_value ctx x;
-             print ctx "; return _hx_bind(__,__%s) end)()" (if Meta.has Meta.SelfCall f.cf_meta then "" else (field f.cf_name)))
+             print ctx "; return _hx_bind(__,__%s) end)()" fname)
     | TEnumParameter (x,_,i) ->
         gen_value ctx x;
         print ctx "[%i]" (i + 2)

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -553,7 +553,12 @@ and gen_call ctx e el =
              let el =
                 if (match ef with FAnon _ | FDynamic _ -> true | _ -> false) && is_possible_string_field field_owner s then
                     begin
-                        gen_expr ctx e;
+                        add_feature ctx "use._hx_wrap_if_string_field";
+                        add_feature ctx "use.string";
+                        spr ctx "_hx_wrap_if_string_field(";
+                        gen_value ctx field_owner;
+                        print ctx ",'%s'" s;
+                        spr ctx ")";
                         field_owner :: el
                     end
                 else
@@ -638,8 +643,14 @@ and gen_loop ctx cond do_while e =
 
 
 and is_possible_string_field e field_name=
-    (* Special case for String fields *)
-    let structural_type = is_structural_type e.etype in
+    (* Special case for String fields — only for truly structural types,
+       not statics tables (which are TAnon but never strings) *)
+    let structural_type = match follow e.etype with
+        | TAnon a -> (match !(a.a_status) with
+            | ClassStatics _ | EnumStatics _ | AbstractStatics _ -> false
+            | _ -> true)
+        | _ -> is_structural_type e.etype
+    in
     if not structural_type then
         false
     else match field_name with
@@ -802,9 +813,10 @@ and gen_expr ?(local=true) ctx e = begin
             spr ctx ", nil, nil, true)";
         )
     | TField (e, ef) when is_possible_string_field e (field_name ef)  ->
-        add_feature ctx "use._hx_wrap_if_string_field";
+        add_feature ctx "use._hx_wrap_if_string_field_closure";
+        add_feature ctx "use._hx_bind";
         add_feature ctx "use.string";
-        spr ctx "_hx_wrap_if_string_field(";
+        spr ctx "_hx_wrap_if_string_field_closure(";
         gen_value ctx e;
         print ctx ",'%s')" (field_name ef)
     | TField (x, (FInstance(_,_,f) | FStatic(_,f) | FAnon(f))) when Meta.has Meta.SelfCall f.cf_meta ->
@@ -2195,6 +2207,7 @@ let generate com =
         "use._hx_box_mr", "lua/_lua/_hx_box_mr.lua";
         "use._hx_table", "lua/_lua/_hx_table.lua";
         "use._hx_wrap_if_string_field", "lua/_lua/_hx_wrap_if_string_field.lua";
+        "use._hx_wrap_if_string_field_closure", "lua/_lua/_hx_wrap_if_string_field_closure.lua";
         "use._hx_dyn_add", "lua/_lua/_hx_dyn_add.lua";
     ];
 

--- a/std/lua/_lua/_hx_bind.lua
+++ b/std/lua/_lua/_hx_bind.lua
@@ -1,5 +1,8 @@
 _hx_bind = function(o,m)
   if m == nil then return nil end;
+  if _G.type(o) ~= 'table' then
+    return function(...) return m(o, ...) end;
+  end
   local f;
   if o._hx__closures == nil then
     _G.rawset(o, '_hx__closures', {});

--- a/std/lua/_lua/_hx_wrap_if_string_field_closure.lua
+++ b/std/lua/_lua/_hx_wrap_if_string_field_closure.lua
@@ -1,0 +1,19 @@
+_hx_wrap_if_string_field_closure = function(o, fld)
+  if _G.type(o) == 'string' then
+    if fld == 'length' then
+      return _G.string.len(o)
+    else
+      local m = String.prototype[fld]
+      if m ~= nil then
+        return function(...) return m(o, ...) end
+      end
+      return nil
+    end
+  else
+    local v = o[fld]
+    if _G.type(v) == 'function' then
+      return _hx_bind(o, v)
+    end
+    return v
+  end
+end

--- a/tests/unit/src/unit/issues/Issue8068.hx
+++ b/tests/unit/src/unit/issues/Issue8068.hx
@@ -1,0 +1,15 @@
+package unit.issues;
+
+class Issue8068 extends Test {
+	function test() {
+		#if lua
+		var f = "foo";
+		var o = {charAt: f.charAt};
+		eq(o.charAt(0), "f");
+		eq(o.charAt(1), "o");
+		eq(o.charAt(2), "o");
+		#else
+		noAssert();
+		#end
+	}
+}

--- a/tests/unit/src/unit/issues/Issue8068.hx
+++ b/tests/unit/src/unit/issues/Issue8068.hx
@@ -2,7 +2,6 @@ package unit.issues;
 
 class Issue8068 extends Test {
 	function test() {
-		#if lua
 		var f = "foo";
 		var o = {charAt: f.charAt};
 		eq(o.charAt(0), "f");
@@ -15,8 +14,5 @@ class Issue8068 extends Test {
 		eq(fn(0), "b");
 		eq(fn(1), "a");
 		eq(fn(2), "r");
-		#else
-		noAssert();
-		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue8068.hx
+++ b/tests/unit/src/unit/issues/Issue8068.hx
@@ -8,6 +8,13 @@ class Issue8068 extends Test {
 		eq(o.charAt(0), "f");
 		eq(o.charAt(1), "o");
 		eq(o.charAt(2), "o");
+
+		// Dynamic string closure should also bind correctly
+		var d:Dynamic = "bar";
+		var fn = d.charAt;
+		eq(fn(0), "b");
+		eq(fn(1), "a");
+		eq(fn(2), "r");
 		#else
 		noAssert();
 		#end

--- a/tests/unit/src/unit/issues/Issue8068.hx
+++ b/tests/unit/src/unit/issues/Issue8068.hx
@@ -1,6 +1,7 @@
 package unit.issues;
 
 class Issue8068 extends Test {
+	#if (hl || lua || interp || php)
 	function test() {
 		var f = "foo";
 		var o = {charAt: f.charAt};
@@ -15,4 +16,5 @@ class Issue8068 extends Test {
 		eq(fn(1), "a");
 		eq(fn(2), "r");
 	}
+	#end
 }


### PR DESCRIPTION
## Summary

Fixes #8068 on the Lua target.

Extracting a method from a string as a closure (`var o = {charAt: f.charAt}`) crashes at runtime because:

1. **Native Lua strings don't have Haxe methods on their metatable.** The generator emits `_hx_bind(f, f.charAt)`, but `f.charAt` resolves to `nil` through Lua's default string metatable. Fixed by looking up the method from `String.prototype` instead when the expression is String-typed.

2. **`_hx_bind` crashes on non-table primitives.** It calls `rawset(o, '_hx__closures', {})` which fails on strings. Fixed by detecting non-table types and returning a fresh bound closure without caching. This covers the `Dynamic`/untyped case where the generator can't know the type at compile time.

Note: the JS target has the same `$bind` issue (tries to set `hx__closures__` on a string primitive). This PR only addresses Lua.

## Test plan

- [x] New regression test `Issue8068` — extracts `charAt` from a string, calls it through an anonymous object
- [x] All Lua unit tests pass (11661 assertions, 0 failures)
- [x] Standalone repro from original issue returns correct result