### PR TITLE
[lua] Enable Issue12028 test for Lua target

### DIFF
--- a/tests/unit/src/unit/issues/Issue12028.hx
+++ b/tests/unit/src/unit/issues/Issue12028.hx
@@ -5,7 +5,6 @@ private typedef StateHandler<T> = {
 }
 
 class Issue12028 extends Test {
-	#if !lua
 	function testMakeVarArgsInDynamic() {
 		var func = function(args:Array<Dynamic>):String {
 			return args.length >= 1 ? args[0] : "";
@@ -34,5 +33,4 @@ class Issue12028 extends Test {
 	function foo2<T>(handlers:StateHandler<T>):Null<T> {
 		return handlers.onUpdate();
 	}
-	#end
 }


### PR DESCRIPTION
## Summary

Fixes #12029.

Removes the `#if !lua` guard from `Issue12028.hx`. Both `testMakeVarArgsInDynamic` and `testVoid2Dyn` pass on Lua 5.4 — the exclusion was added due to a transient CI environment issue (Lua 5.1.5 with broken luarocks), not an actual Lua target limitation.

## Test plan

- [x] All Lua unit tests pass locally (11660 assertions, 0 failures)
- [x] Standalone repro of both test cases confirms correct behavior