### PR TITLE
[tests] Enable Float32Array precision check on all targets

### DIFF
--- a/tests/unit/src/unitstd/haxe/io/Float32Array.unit.hx
+++ b/tests/unit/src/unitstd/haxe/io/Float32Array.unit.hx
@@ -10,9 +10,7 @@ b[1] == 1.25;
 // check loss of precision due to 32 bits
 b[1] = 8589934591.;
 
-#if typedarray_precision_check // see issue #7407
 b[1] == 8589934592.;
-#end
 
 
 // set


### PR DESCRIPTION
## Summary

Fixes #7407.

Removes the `#if typedarray_precision_check` guard from `Float32Array.unit.hx`. The precision truncation test (`8589934591. -> 8589934592.`) was disabled in 2018 because Python and Lua were failing. Both now pass — the software `_floatToI32`/`_i32ToFloat` implementation in `FPHelper` handles IEEE 754 single-precision correctly.

Verified locally on Lua 5.4 and Python 3. Letting CI verify all other targets (JS, JVM, HL, CPP, Neko, etc.).

## Test plan

- [x] Lua unit tests pass with precision check enabled
- [x] Python unit tests pass with precision check enabled
- [ ] CI: all other targets