### PR TITLE
[tests] Fix hl tests with preinstalled hl

### DIFF
--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -70,7 +70,7 @@ class RunCi {
 					case Hl:
 						final withJitTests = !Sys.args().contains("--skip-hl-jit");
 						final withHlcTests = !Sys.args().contains("--skip-hlc");
-						runci.targets.Hl.run(args, withJitTests, false);
+						runci.targets.Hl.run(args, withJitTests, withHlcTests);
 					case t:
 						throw new Exception("unknown target: " + t);
 				}

--- a/tests/runci/System.hx
+++ b/tests/runci/System.hx
@@ -140,17 +140,6 @@ class System {
 		}
 	}
 
-	static public function addToLIBPATH(path:String):Void {
-		infoMsg('Prepending $path to loader path.');
-		switch (systemName) {
-			case "Windows": // pass
-			case "Linux":
-				Sys.putEnv("LD_LIBRARY_PATH", path + ":" + Sys.getEnv("LD_LIBRARY_PATH"));
-			case "Mac":
-				Sys.putEnv("DYLD_LIBRARY_PATH", path + ":" + Sys.getEnv("DYLD_LIBRARY_PATH"));
-		}
-	}
-
 	static function isLibraryInstalled(library:String):Bool {
 		return new Process("haxelib", ["path", library]).exitCode() == 0;
 	}

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -26,7 +26,7 @@ class Hl {
 	static final miscHlcDir = getMiscSubDir('hlc');
 
 	static var withJitTests = true;
-	static var withHlcTests = false;
+	static var withHlcTests = true;
 
 	static public function getHlDependencies() {
 		if (FileSystem.exists(hlBinary)) {
@@ -139,7 +139,7 @@ class Hl {
 
 	static public function run(args:Array<String>, withJitTests:Bool, withHlcTests:Bool) {
 		Hl.withJitTests = withJitTests;
-		Hl.withHlcTests = withHlcTests;
+		Hl.withHlcTests = if (isCi()) false else withHlcTests;
 
 		getHlDependencies();
 

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -1,27 +1,26 @@
 package runci.targets;
 
-import haxe.io.Path;
 import sys.FileSystem;
 import runci.System.*;
 import runci.Config.*;
 
 using StringTools;
+using haxe.io.Path;
 
 class Hl {
 	static final hlSrc = Path.join([getDownloadPath(), "hashlink"]);
 
 	static final hlBuild = Path.join([getDownloadPath(), "hashlink_build"]);
 
-	static final hlInstallDir = Path.join([getInstallPath(), "hashlink"]);
-	static final hlInstallBinDir = if (systemName == "Windows") hlInstallDir else Path.join([hlInstallDir, "bin"]);
-	static final hlInstallLibDir = if (systemName == "Windows") hlInstallDir else Path.join([hlInstallDir, "lib"]);
-
-	static final hlBinary =
-		if (!commandSucceed("hl", ["--version"])){
-			Path.join([hlInstallBinDir, "hl"]) + ((systemName == "Windows") ? ".exe" : "");
+	static final hlBinary = if (!commandSucceed("hl", ["--version"])) {
+			Path.join([getInstallPath(), "hashlink", systemName == 'Windows' ? '' : 'bin', "hl" + ((systemName == "Windows") ? ".exe" : "")]);
 		} else {
-			commandResult(if(systemName == "Windows") "where" else "which", ["hl"]).stdout.trim();
+			commandResult(if (systemName == "Windows") "where" else "which", ["hl"]).stdout.trim();
 		};
+
+	static final hlInstallBinDir = hlBinary.directory();
+	static final hlInstallDir = if (systemName == "Windows") hlInstallBinDir else hlInstallBinDir.directory();
+	static final hlInstallLibDir = if (systemName == "Windows") hlInstallDir else Path.join([hlInstallDir, "lib"]);
 
 	static final miscHlDir = getMiscSubDir('hl');
 	static final miscHlcDir = getMiscSubDir('hlc');
@@ -73,7 +72,6 @@ class Hl {
 		runCommand("cmake", ["--build", hlBuild, "--target", "install"]);
 
 		addToPATH(hlInstallBinDir);
-		addToLIBPATH(hlInstallLibDir);
 		if (withJitTests) {
 			runCommand(hlBinary, ["--version"]);
 		}
@@ -93,7 +91,8 @@ class Hl {
 		final compiler = if (systemName == "Mac") "clang" else "gcc";
 		final extraCompilerFlags = switch (systemName) {
 			case "Windows": ["-ldbghelp", "-municode"];
-			case _: [];
+			case "Mac": ["-rpath", hlInstallLibDir];
+			case _: ['-Wl,-rpath,$hlInstallLibDir'];
 		};
 
 		runCommand(compiler, [


### PR DESCRIPTION
hlInstall*Dir variables are now set based on the actual installation being used, rather than being hardcoded to the download directory.

We need to set the rpath on the hlc binaries so that they can locate libhl and hdlls. This way we also don't have to modify the global loader path.