### PR TITLE
Unify atomics, NativeStackTrace and ThreadImpl interfaces

### DIFF
--- a/src/macro/eval/evalPrototype.ml
+++ b/src/macro/eval/evalPrototype.ml
@@ -347,8 +347,11 @@ let add_types ctx types ready =
 			DynArray.add fl_static (create_static_prototype ctx mt);
 		| TAbstractDecl a ->
 			DynArray.add fl_static (create_static_prototype ctx mt);
-			(* Create a fake instance prototype for coreType abstracts in case something inspects them (#8778). *)
-			if Meta.has Meta.CoreType a.a_meta then
+			(* Create a fake instance prototype for coreType abstracts in case something inspects them (#8778).
+			   Also do this for extern abstracts with Any as underlying type - these are native opaque types
+			   that use the typedef trick to satisfy @:coreApi checks. *)
+			let is_native_opaque = a.a_extern && (match follow a.a_this with TAbstract({a_path=[],"Any"},_) -> true | _ -> false) in
+			if Meta.has Meta.CoreType a.a_meta || is_native_opaque then
 				DynArray.add fl_instance (create_instance_prototype ctx {null_class with cl_path = a.a_path})
 		| _ ->
 			()

--- a/std/cpp/_std/haxe/NativeStackTrace.hx
+++ b/std/cpp/_std/haxe/NativeStackTrace.hx
@@ -2,6 +2,8 @@ package haxe;
 
 import haxe.CallStack.StackItem;
 
+private typedef NativeTrace = Array<String>;
+
 /**
 	Do not use manually.
 **/
@@ -13,17 +15,17 @@ class NativeStackTrace {
 	}
 
 	@:noDebug //Do not mess up the exception stack
-	static public function callStack():Array<String> {
+	static public function callStack():NativeTrace {
 		return untyped __global__.__hxcpp_get_call_stack(true);
 	}
 
 	@:noDebug //Do not mess up the exception stack/
-	static public function exceptionStack():Array<String> {
+	static public function exceptionStack():NativeTrace {
 		return untyped __global__.__hxcpp_get_exception_stack();
 	}
 
-	static public function toHaxe(native:Array<String>, skip:Int = 0):Array<StackItem> {
-		var stack:Array<String> = native;
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
+		var stack:NativeTrace = nativeStackTrace;
 		var m = new Array<StackItem>();
 		for (i in 0...stack.length) {
 			if(skip > i) {

--- a/std/cpp/_std/haxe/atomic/AtomicBool.hx
+++ b/std/cpp/_std/haxe/atomic/AtomicBool.hx
@@ -1,21 +1,8 @@
 package haxe.atomic;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicBool {
-	public function new(value:Bool):Void;
+private typedef AtomicBoolData = AtomicInt;
 
-	public function compareExchange(expected:Bool, replacement:Bool):Bool;
-
-	public function exchange(value:Bool):Bool;
-
-	public function load():Bool;
-
-	public function store(value:Bool):Bool;
-}
-#else
-abstract AtomicBool(AtomicInt) {
+abstract AtomicBool(AtomicBoolData) {
 	private inline function toInt(v:Bool):Int {
 		return v ? 1 : 0;
 	}
@@ -44,4 +31,3 @@ abstract AtomicBool(AtomicInt) {
 		return toBool(this.store(toInt(value)));
 	}
 }
-#end

--- a/std/cpp/_std/haxe/atomic/AtomicInt.hx
+++ b/std/cpp/_std/haxe/atomic/AtomicInt.hx
@@ -1,40 +1,18 @@
 package haxe.atomic;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicInt {
-	public function new(value:Int):Void;
-
-	public function add(b:Int):Int;
-
-	public function sub(b:Int):Int;
-
-	public function and(b:Int):Int;
-
-	public function or(b:Int):Int;
-
-	public function xor(b:Int):Int;
-
-	public function compareExchange(expected:Int, replacement:Int):Int;
-
-	public function exchange(value:Int):Int;
-
-	public function load():Int;
-
-	public function store(value:Int):Int;
-}
-#else
 private final class Data {
 	public var value:Int;
 	public function new(value:Int) {
 		this.value = value;
 	}
 }
+
+private typedef AtomicIntData = Data;
+
 #if cppia
 extern
 #end
-abstract AtomicInt(Data) {
+abstract AtomicInt(AtomicIntData) {
 	#if cppia
 	public function new(value:Int):Void;
 
@@ -97,4 +75,3 @@ abstract AtomicInt(Data) {
 	}
 	#end
 }
-#end

--- a/std/cpp/_std/haxe/atomic/AtomicObject.hx
+++ b/std/cpp/_std/haxe/atomic/AtomicObject.hx
@@ -1,23 +1,11 @@
 package haxe.atomic;
 
-#if doc_gen
-@:coreType
-abstract AtomicObject<T:{}> {
-	public function new(value:T):Void;
+private typedef AtomicObjectData<T:{}> = Dynamic;
 
-	public function compareExchange(expected:T, replacement:T):T;
-
-	public function exchange(value:T):T;
-
-	public function load():T;
-
-	public function store(value:T):T;
-}
-#else
 #if cppia
 extern
 #end
-abstract AtomicObject<T: {}>(Dynamic) {
+abstract AtomicObject<T: {}>(AtomicObjectData<T>) {
 	#if cppia
 	public function new(value:T):Void;
 
@@ -50,4 +38,3 @@ abstract AtomicObject<T: {}>(Dynamic) {
 	}
 	#end
 }
-#end

--- a/std/cpp/_std/sys/thread/ThreadImpl.hx
+++ b/std/cpp/_std/sys/thread/ThreadImpl.hx
@@ -34,8 +34,8 @@ abstract ThreadImpl(ThreadHandle) {
 		return untyped __global__.__hxcpp_thread_current();
 	}
 
-	public static #if !scriptable inline #end function create(callb:Void->Void):ThreadImpl {
-		return untyped __global__.__hxcpp_thread_create(callb);
+	public static #if !scriptable inline #end function create(job:Void->Void):ThreadImpl {
+		return untyped __global__.__hxcpp_thread_create(job);
 	}
 
 	public static function setName( t : ThreadImpl, name : String ) {

--- a/std/eval/_std/haxe/NativeStackTrace.hx
+++ b/std/eval/_std/haxe/NativeStackTrace.hx
@@ -2,6 +2,8 @@ package haxe;
 
 import haxe.CallStack.StackItem;
 
+private typedef NativeTrace = Array<StackItem>;
+
 /**
 	Do not use manually.
 **/
@@ -12,21 +14,21 @@ class NativeStackTrace {
 	static public inline function saveStack(exception:Any):Void {
 	}
 
-	static public function callStack():Array<StackItem> {
+	static public function callStack():NativeTrace {
 		return _callStack();
 	}
 
 	//implemented in the compiler
-	static function _callStack():Array<StackItem> {
+	static function _callStack():NativeTrace {
 		return null;
 	}
 
 	//implemented in the compiler
-	static public function exceptionStack():Array<StackItem> {
+	static public function exceptionStack():NativeTrace {
 		return null;
 	}
 
-	static public inline function toHaxe(stack:Array<StackItem>, skip:Int = 0):Array<StackItem> {
-		return skip > 0 ? stack.slice(skip) : stack;
+	static public inline function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
+		return skip > 0 ? nativeStackTrace.slice(skip) : nativeStackTrace;
 	}
 }

--- a/std/flash/_std/haxe/NativeStackTrace.hx
+++ b/std/flash/_std/haxe/NativeStackTrace.hx
@@ -3,6 +3,8 @@ package haxe;
 import flash.errors.Error;
 import haxe.CallStack.StackItem;
 
+private typedef NativeTrace = String;
+
 /**
 	Do not use manually.
 **/
@@ -11,25 +13,25 @@ import haxe.CallStack.StackItem;
 @:allow(haxe.Exception)
 class NativeStackTrace {
 	@:ifFeature('haxe.NativeStackTrace.exceptionStack')
-	static public inline function saveStack(e:Any):Void {
+	static public inline function saveStack(exception:Any):Void {
 	}
 
-	static public inline function callStack():String {
+	static public inline function callStack():NativeTrace {
 		return normalize(new Error().getStackTrace(), 1);
 	}
 
-	static public function exceptionStack():String {
+	static public function exceptionStack():NativeTrace {
 		var err:Null<Error> = untyped flash.Boot.lastError;
 		return err == null ? '' : normalize(err.getStackTrace());
 	}
 
-	static public function toHaxe(native:String, skip:Int = 0):Array<StackItem> {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
 		var a = new Array();
 		var r = ~/at ([^\/]+?)\$?(\/[^\(]+)?\(\)(\[(.*?):([0-9]+)\])?/;
 		var rlambda = ~/^MethodInfo-([0-9]+)$/g;
 		var cnt = 0;
-		while (r.match(native)) {
-			native = r.matchedRight();
+		while (r.match(nativeStackTrace)) {
+			nativeStackTrace = r.matchedRight();
 			if(skip > cnt++) {
 				continue;
 			}
@@ -50,7 +52,7 @@ class NativeStackTrace {
 		return a;
 	}
 
-	static function normalize(stack:String, skipItems:Int = 0):String {
+	static function normalize(stack:NativeTrace, skipItems:Int = 0):NativeTrace {
 		switch (stack:String).substring(0, 6) {
 			case 'Error:' | 'Error\n': skipItems += 1;
 			case _:
@@ -58,7 +60,7 @@ class NativeStackTrace {
 		return skipLines(stack, skipItems);
 	}
 
-	static function skipLines(stack:String, skip:Int, pos:Int = 0):String {
+	static function skipLines(stack:NativeTrace, skip:Int, pos:Int = 0):NativeTrace {
 		return if(skip > 0) {
 			pos = stack.indexOf('\n', pos);
 			return pos < 0 ? '' : skipLines(stack, --skip, pos + 1);

--- a/std/haxe/NativeStackTrace.hx
+++ b/std/haxe/NativeStackTrace.hx
@@ -2,6 +2,8 @@ package haxe;
 
 import haxe.CallStack.StackItem;
 
+private typedef NativeTrace = Any;
+
 /**
 	Do not use manually.
 **/
@@ -9,7 +11,7 @@ import haxe.CallStack.StackItem;
 @:noCompletion
 extern class NativeStackTrace {
 	static public function saveStack(exception:Any):Void;
-	static public function callStack():Any;
-	static public function exceptionStack():Any;
-	static public function toHaxe(nativeStackTrace:Any, skip:Int = 0):Array<StackItem>;
+	static public function callStack():NativeTrace;
+	static public function exceptionStack():NativeTrace;
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem>;
 }

--- a/std/haxe/atomic/AtomicBool.hx
+++ b/std/haxe/atomic/AtomicBool.hx
@@ -4,13 +4,13 @@ package haxe.atomic;
 #error "Atomic operations are not supported on this target!"
 #end
 
+private typedef AtomicBoolData = Any;
+
 /**
 	Atomic boolean.
 	(js) The Atomics and SharedArrayBuffer objects need to be available. Errors will be thrown if this is not the case.
 **/
-@:coreApi
-@:coreType
-abstract AtomicBool {
+extern abstract AtomicBool(AtomicBoolData) {
 	public function new(value:Bool):Void;
 
 	/**

--- a/std/haxe/atomic/AtomicInt.hx
+++ b/std/haxe/atomic/AtomicInt.hx
@@ -4,12 +4,13 @@ package haxe.atomic;
 #error "This target does not support atomic operations."
 #end
 
+private typedef AtomicIntData = Any;
+
 /**
 	Atomic integer.
 	(js) The Atomics and SharedArrayBuffer objects need to be available. Errors will be thrown if this is not the case.
 **/
-@:coreType
-abstract AtomicInt {
+extern abstract AtomicInt(AtomicIntData) {
 	public function new(value:Int):Void;
 
 	/**

--- a/std/haxe/atomic/AtomicObject.hx
+++ b/std/haxe/atomic/AtomicObject.hx
@@ -8,12 +8,13 @@ package haxe.atomic;
 #error "JavaScript does not support AtomicObject"
 #end
 
+private typedef AtomicObjectData<T:{}> = Any;
+
 /**
 	Atomic object. Use with care, this does not magically make it thread-safe to mutate objects.
 	Not supported on JavaScript.
 **/
-@:coreType
-abstract AtomicObject<T:{}> {
+extern abstract AtomicObject<T:{}>(AtomicObjectData<T>) {
 	public function new(value:T):Void;
 
 	/**

--- a/std/hl/_std/haxe/NativeStackTrace.hx
+++ b/std/hl/_std/haxe/NativeStackTrace.hx
@@ -7,6 +7,8 @@ import haxe.CallStack.StackItem;
 @:dox(hide)
 typedef Symbol = #if (hl_ver >= version("1.12.0")) hl.Abstract<"hl_symbol"> #else hl.Bytes #end
 
+private typedef NativeTrace = NativeArray<Symbol>;
+
 /**
 	Do not use manually.
 **/
@@ -19,14 +21,14 @@ class NativeStackTrace {
 
 	#if (hl_ver >= version("1.12.0") )
 
-	static public function exceptionStack():NativeArray<Symbol> {
+	static public function exceptionStack():NativeTrace {
 		var count = exceptionStackRaw(null);
 		var arr = new NativeArray(count);
 		exceptionStackRaw(arr);
 		return arr;
 	}
 
-	static public inline function callStack():NativeArray<Symbol> {
+	static public inline function callStack():NativeTrace {
 		var count = callStackRaw(null);
 		var arr = new NativeArray(count);
 		callStackRaw(arr);
@@ -53,13 +55,13 @@ class NativeStackTrace {
 	#else
 
 	@:hlNative("std", "exception_stack")
-	static public function exceptionStack():NativeArray<Bytes> {
+	static public function exceptionStack():NativeTrace {
 		return null;
 	}
 
 	//TODO: implement in hashlink like `exceptionStack`
-	static public function callStack():NativeArray<Bytes> {
-		var stack:NativeArray<Bytes> = try {
+	static public function callStack():NativeTrace {
+		var stack:NativeTrace = try {
 			throw new Exception('', null, 'stack');
 		} catch (e:Exception) {
 			exceptionStack();
@@ -77,7 +79,7 @@ class NativeStackTrace {
 
 	#end
 
-	static public function toHaxe(native:NativeArray<Symbol>, skip:Int=0 ):Array<StackItem> {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int=0 ):Array<StackItem> {
 		var stack = [];
 		var r = ~/^([A-Za-z0-9.$_]+)\.([~A-Za-z0-9_]+(\.[0-9]+)?)\((.+):([0-9]+)\)$/;
 		var r_fun = ~/^fun\$([0-9]+)\((.+):([0-9]+)\)$/;
@@ -85,14 +87,14 @@ class NativeStackTrace {
 		var maxLen = 1024;
 		var tmpBuf = @:privateAccess hl.Bytes.alloc(maxLen);
 		#end
-		for (i in 0...native.length-1) {
+		for (i in 0...nativeStackTrace.length-1) {
 			if( i < skip ) continue;
 			#if (hl_ver >= version("1.12.0"))
 			var len = maxLen;
-			var bytes = resolveSymbol(native[i],tmpBuf,len);
+			var bytes = resolveSymbol(nativeStackTrace[i],tmpBuf,len);
 			if( bytes == null ) continue;
 			#else
-			var bytes = native[i];
+			var bytes = nativeStackTrace[i];
 			#end
 			var str = @:privateAccess String.fromUCS2(bytes);
 			if (r.match(str))

--- a/std/hl/_std/haxe/atomic/AtomicBool.hx
+++ b/std/hl/_std/haxe/atomic/AtomicBool.hx
@@ -1,21 +1,8 @@
 package haxe.atomic;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicBool {
-	public function new(value:Bool):Void;
+private typedef AtomicBoolData = AtomicInt;
 
-	public function compareExchange(expected:Bool, replacement:Bool):Bool;
-
-	public function exchange(value:Bool):Bool;
-
-	public function load():Bool;
-
-	public function store(value:Bool):Bool;
-}
-#else
-abstract AtomicBool(AtomicInt) {
+abstract AtomicBool(AtomicBoolData) {
 	private inline function toInt(v:Bool):Int {
 		return v ? 1 : 0;
 	}
@@ -44,4 +31,3 @@ abstract AtomicBool(AtomicInt) {
 		return toBool(this.store(toInt(value)));
 	}
 }
-#end

--- a/std/hl/_std/haxe/atomic/AtomicInt.hx
+++ b/std/hl/_std/haxe/atomic/AtomicInt.hx
@@ -5,32 +5,9 @@ package haxe.atomic;
 #end
 import hl.Atomics;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicInt {
-	public function new(value:Int):Void;
+private typedef AtomicIntData = hl.NativeArray<Int>;
 
-	public function add(b:Int):Int;
-
-	public function sub(b:Int):Int;
-
-	public function and(b:Int):Int;
-
-	public function or(b:Int):Int;
-
-	public function xor(b:Int):Int;
-
-	public function compareExchange(expected:Int, replacement:Int):Int;
-
-	public function exchange(value:Int):Int;
-
-	public function load():Int;
-
-	public function store(value:Int):Int;
-}
-#else
-abstract AtomicInt(hl.NativeArray<Int>) {
+abstract AtomicInt(AtomicIntData) {
 	public inline function new(value:Int):Void {
 		this = new hl.NativeArray(1);
 		this[0] = value;
@@ -72,4 +49,3 @@ abstract AtomicInt(hl.NativeArray<Int>) {
 		return Atomics.store32(this.getRef(), value);
 	}
 }
-#end

--- a/std/hl/_std/haxe/atomic/AtomicObject.hx
+++ b/std/hl/_std/haxe/atomic/AtomicObject.hx
@@ -5,23 +5,11 @@ package haxe.atomic;
 #end
 import hl.Atomics;
 
-#if doc_gen
-@:coreType
-abstract AtomicObject<T:{}> {
-	public function new(value:T):Void;
-
-	public function compareExchange(expected:T, replacement:T):T;
-
-	public function exchange(value:T):T;
-
-	public function load():T;
-
-	public function store(value:T):T;
-}
-#else
 // use hl.NativeArray<Dynamic> instead of hl.NativeArray<T>
 // so that the compiler doesn't get confused and emit hl.Ref.make(this.getRef())
-abstract AtomicObject<T:{}>(hl.NativeArray<Dynamic>) {
+private typedef AtomicObjectData<T:{}> = hl.NativeArray<Dynamic>;
+
+abstract AtomicObject<T:{}>(AtomicObjectData<T>) {
 	public inline function new(value:T):Void {
 		this = new hl.NativeArray(1);
 		this[0] = value;
@@ -43,4 +31,3 @@ abstract AtomicObject<T:{}>(hl.NativeArray<Dynamic>) {
 		return Atomics.storePtr(this.getRef(), value);
 	}
 }
-#end

--- a/std/hl/_std/sys/thread/ThreadImpl.hx
+++ b/std/hl/_std/sys/thread/ThreadImpl.hx
@@ -27,7 +27,7 @@ private typedef ThreadHandle = hl.Abstract<"hl_thread">;
 abstract ThreadImpl(ThreadHandle) {
 
 	@:hlNative("std", "thread_create")
-	public static function create(callb:Void->Void):ThreadImpl {
+	public static function create(job:Void->Void):ThreadImpl {
 		return null;
 	}
 
@@ -36,15 +36,15 @@ abstract ThreadImpl(ThreadHandle) {
 		return null;
 	}
 
-	public static function setName( impl : ThreadImpl, name : String ) {
+	public static function setName( t : ThreadImpl, name : String ) {
 		#if (hl_ver >= version("1.13.0"))
-		set_name(impl, @:privateAccess name.toUtf8());
+		set_name(t, @:privateAccess name.toUtf8());
 		#end
 	}
 
-	public static function getName( impl : ThreadImpl ) : Null<String> {
+	public static function getName( t : ThreadImpl ) : Null<String> {
 		#if (hl_ver >= version("1.13.0"))
-		var name = get_name(impl);
+		var name = get_name(t);
 		return name == null ? null : @:privateAccess String.fromUTF8(name);
 		#else
 		return null;

--- a/std/js/_std/haxe/NativeStackTrace.hx
+++ b/std/js/_std/haxe/NativeStackTrace.hx
@@ -17,6 +17,8 @@ private typedef V8CallSite = {
 	function getColumnNumber():Int;
 }
 
+private typedef NativeTrace = Any;
+
 /**
 	Do not use manually.
 **/
@@ -27,15 +29,15 @@ class NativeStackTrace {
 	static var lastError:Error;
 
 	// support for source-map-support module
-	@:noCompletion
+	@:noCompletion @:hack
 	public static var wrapCallSite:V8CallSite->V8CallSite;
 
 	@:ifFeature('haxe.NativeStackTrace.exceptionStack')
-	static public inline function saveStack(e:Error):Void {
-		lastError = e;
+	static public inline function saveStack(exception:Any):Void {
+		lastError = (exception : Error);
 	}
 
-	static public function callStack():Any {
+	static public function callStack():NativeTrace {
 		var e:Null<Error> = new Error('');
 		var stack = tryHaxeStack(e);
 		//Internet Explorer provides call stack only if error was thrown
@@ -46,16 +48,16 @@ class NativeStackTrace {
 		return normalize(stack, 2);
 	}
 
-	static public function exceptionStack():Any {
+	static public function exceptionStack():NativeTrace {
 		return normalize(tryHaxeStack(lastError));
 	}
 
-	static public function toHaxe(s:Null<Any>, skip:Int = 0):Array<StackItem> {
-		if (s == null) {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
+		if (nativeStackTrace == null) {
 			return [];
-		} else if (Syntax.typeof(s) == "string") {
+		} else if (Syntax.typeof(nativeStackTrace) == "string") {
 			// Return the raw lines in browsers that don't support prepareStackTrace
-			var stack:Array<String> = (s:String).split("\n");
+			var stack:Array<String> = (nativeStackTrace:String).split("\n");
 			if (stack[0] == "Error")
 				stack.shift();
 			var m = [];
@@ -79,14 +81,14 @@ class NativeStackTrace {
 				}
 			}
 			return m;
-		} else if(skip > 0 && Syntax.code('Array.isArray({0})', s)) {
-			return (s:Array<StackItem>).slice(skip);
+		} else if(skip > 0 && Syntax.code('Array.isArray({0})', nativeStackTrace)) {
+			return (nativeStackTrace:Array<StackItem>).slice(skip);
 		} else {
-			return cast s;
+			return cast nativeStackTrace;
 		}
 	}
 
-	static function tryHaxeStack(e:Null<Error>):Any {
+	static function tryHaxeStack(e:Null<Error>):NativeTrace {
 		if (e == null) {
 			return [];
 		}
@@ -98,7 +100,7 @@ class NativeStackTrace {
 		return stack;
 	}
 
-	static function prepareHxStackTrace(e:Error, callsites:Array<V8CallSite>):Any {
+	static function prepareHxStackTrace(e:Error, callsites:Array<V8CallSite>):NativeTrace {
 		var stack = [];
 		for (site in callsites) {
 			if (wrapCallSite != null)
@@ -124,7 +126,7 @@ class NativeStackTrace {
 		return stack;
 	}
 
-	static function normalize(stack:Any, skipItems:Int = 0):Any {
+	static function normalize(stack:NativeTrace, skipItems:Int = 0):NativeTrace {
 		if(Syntax.code('Array.isArray({0})', stack) && skipItems > 0) {
 			return (stack:Array<StackItem>).slice(skipItems);
 		} else if(Syntax.typeof(stack) == "string") {

--- a/std/js/_std/haxe/atomic/AtomicBool.hx
+++ b/std/js/_std/haxe/atomic/AtomicBool.hx
@@ -1,21 +1,8 @@
 package haxe.atomic;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicBool {
-	public function new(value:Bool):Void;
+private typedef AtomicBoolData = AtomicInt;
 
-	public function compareExchange(expected:Bool, replacement:Bool):Bool;
-
-	public function exchange(value:Bool):Bool;
-
-	public function load():Bool;
-
-	public function store(value:Bool):Bool;
-}
-#else
-abstract AtomicBool(AtomicInt) {
+abstract AtomicBool(AtomicBoolData) {
 	private inline function toInt(v:Bool):Int {
 		return v ? 1 : 0;
 	}
@@ -44,4 +31,3 @@ abstract AtomicBool(AtomicInt) {
 		return toBool(this.store(toInt(value)));
 	}
 }
-#end

--- a/std/js/_std/haxe/atomic/AtomicInt.hx
+++ b/std/js/_std/haxe/atomic/AtomicInt.hx
@@ -2,32 +2,9 @@ package haxe.atomic;
 
 import js.lib.Atomics;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicInt {
-	public function new(value:Int):Void;
+private typedef AtomicIntData = js.lib.Int32Array;
 
-	public function add(b:Int):Int;
-
-	public function sub(b:Int):Int;
-
-	public function and(b:Int):Int;
-
-	public function or(b:Int):Int;
-
-	public function xor(b:Int):Int;
-
-	public function compareExchange(expected:Int, replacement:Int):Int;
-
-	public function exchange(value:Int):Int;
-
-	public function load():Int;
-
-	public function store(value:Int):Int;
-}
-#else
-abstract AtomicInt(js.lib.Int32Array) {
+abstract AtomicInt(AtomicIntData) {
 	public inline function new(value:Int) {
 		this = new js.lib.Int32Array(new js.lib.SharedArrayBuffer(js.lib.Int32Array.BYTES_PER_ELEMENT));
 		this[0] = value;
@@ -73,4 +50,3 @@ abstract AtomicInt(js.lib.Int32Array) {
 		return Atomics.store(asArray(), 0, value);
 	}
 }
-#end

--- a/std/jvm/_std/haxe/NativeStackTrace.hx
+++ b/std/jvm/_std/haxe/NativeStackTrace.hx
@@ -7,38 +7,41 @@ import java.lang.Thread;
 import java.lang.StackTraceElement;
 import haxe.CallStack.StackItem;
 
+private typedef NativeTrace = NativeArray<StackTraceElement>;
+
 /**
 	Do not use manually.
 **/
 @:dox(hide)
 @:noCompletion
 class NativeStackTrace {
-	static var exception = new ThreadLocal<Throwable>();
+	// named exceptionStore (not exception) to avoid shadowing the saveStack parameter
+	static var exceptionStore = new ThreadLocal<Throwable>();
 
 	@:ifFeature('haxe.NativeStackTrace.exceptionStack')
-	static public inline function saveStack(e:Throwable):Void {
-		exception.set(e);
+	static public inline function saveStack(exception:Any):Void {
+		exceptionStore.set((exception : Throwable));
 	}
 
-	static public function callStack():NativeArray<StackTraceElement> {
+	static public function callStack():NativeTrace {
 		var stack = Thread.currentThread().getStackTrace();
 		return stack.length <= 3 ? stack : java.util.Arrays.copyOfRange(stack, 3, stack.length);
 	}
 
-	static public function exceptionStack():NativeArray<StackTraceElement> {
-		return switch exception.get() {
+	static public function exceptionStack():NativeTrace {
+		return switch exceptionStore.get() {
 			case null: new NativeArray(0);
 			case e: e.getStackTrace();
 		}
 	}
 
-	static public function toHaxe(native:NativeArray<StackTraceElement>, skip:Int = 0):Array<StackItem> {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
 		var stack = [];
-		for (i in 0...native.length) {
+		for (i in 0...nativeStackTrace.length) {
 			if(skip > i) {
 				continue;
 			}
-			var el = native[i];
+			var el = nativeStackTrace[i];
 			var className = el.getClassName();
 			var methodName = el.getMethodName();
 			var fileName = el.getFileName();

--- a/std/jvm/_std/haxe/atomic/AtomicBool.hx
+++ b/std/jvm/_std/haxe/atomic/AtomicBool.hx
@@ -1,22 +1,10 @@
 package haxe.atomic;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicBool {
-	public function new(value:Bool):Void;
 
-	public function compareExchange(expected:Bool, replacement:Bool):Bool;
+private typedef AtomicBoolData = AtomicBoolean;
 
-	public function exchange(value:Bool):Bool;
-
-	public function load():Bool;
-
-	public function store(value:Bool):Bool;
-}
-#else
-abstract AtomicBool(AtomicBoolean) {
+abstract AtomicBool(AtomicBoolData) {
 	public inline function new(value:Bool) {
 		this = new AtomicBoolean(value);
 	}
@@ -46,4 +34,3 @@ abstract AtomicBool(AtomicBoolean) {
 		return value;
 	}
 }
-#end

--- a/std/jvm/_std/haxe/atomic/AtomicInt.hx
+++ b/std/jvm/_std/haxe/atomic/AtomicInt.hx
@@ -2,32 +2,9 @@ package haxe.atomic;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-#if doc_gen
-@:coreApi
-@:coreType
-abstract AtomicInt {
-	public function new(value:Int):Void;
+private typedef AtomicIntData = AtomicInteger;
 
-	public function add(b:Int):Int;
-
-	public function sub(b:Int):Int;
-
-	public function and(b:Int):Int;
-
-	public function or(b:Int):Int;
-
-	public function xor(b:Int):Int;
-
-	public function compareExchange(expected:Int, replacement:Int):Int;
-
-	public function exchange(value:Int):Int;
-
-	public function load():Int;
-
-	public function store(value:Int):Int;
-}
-#else
-abstract AtomicInt(AtomicInteger) {
+abstract AtomicInt(AtomicIntData) {
 	public inline function new(value:Int) {
 		this = new AtomicInteger(value);
 	}
@@ -87,4 +64,3 @@ abstract AtomicInt(AtomicInteger) {
 		return value;
 	}
 }
-#end

--- a/std/jvm/_std/haxe/atomic/AtomicObject.hx
+++ b/std/jvm/_std/haxe/atomic/AtomicObject.hx
@@ -2,21 +2,9 @@ package haxe.atomic;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-#if doc_gen
-@:coreType
-abstract AtomicObject<T:{}> {
-	public function new(value:T):Void;
+private typedef AtomicObjectData<T:{}> = AtomicReference<T>;
 
-	public function compareExchange(expected:T, replacement:T):T;
-
-	public function exchange(value:T):T;
-
-	public function load():T;
-
-	public function store(value:T):T;
-}
-#else
-abstract AtomicObject<T:{}>(AtomicReference<T>) {
+abstract AtomicObject<T:{}>(AtomicObjectData<T>) {
 	public inline function new(value:T) {
 		this = new AtomicReference(value);
 	}
@@ -46,4 +34,3 @@ abstract AtomicObject<T:{}>(AtomicReference<T>) {
 		return value;
 	}
 }
-#end

--- a/std/lua/_std/haxe/NativeStackTrace.hx
+++ b/std/lua/_std/haxe/NativeStackTrace.hx
@@ -2,6 +2,8 @@ package haxe;
 
 import haxe.CallStack.StackItem;
 
+private typedef NativeTrace = Array<String>;
+
 /**
 	Do not use manually.
 **/
@@ -12,21 +14,21 @@ class NativeStackTrace {
 	static public inline function saveStack(exception:Any):Void {
 	}
 
-	static public function callStack():Array<String> {
+	static public function callStack():NativeTrace {
 		return switch lua.Debug.traceback() {
 			case null: [];
 			case s: s.split('\n').slice(3);
 		}
 	}
 
-	static public function exceptionStack():Array<String> {
+	static public function exceptionStack():NativeTrace {
 		return []; //Not implemented. Maybe try xpcal instead of pcal in genlua.
 	}
 
-	static public function toHaxe(native:Array<String>, skip:Int = 0):Array<StackItem> {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
 		var stack = [];
 		var cnt = -1;
-		for (item in native) {
+		for (item in nativeStackTrace) {
 			var parts = item.substr(1).split(":"); //`substr` to skip a tab at the beginning of a line
 			var file = parts[0];
 			if(file == '[C]') {

--- a/std/neko/_std/haxe/NativeStackTrace.hx
+++ b/std/neko/_std/haxe/NativeStackTrace.hx
@@ -25,13 +25,13 @@ class NativeStackTrace {
 		return { skip:0, stack:untyped __dollar__excstack() };
 	}
 
-	static public function toHaxe(native:NativeTrace, skip:Int = 0):Array<StackItem> {
-		skip += native.skip;
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
+		skip += nativeStackTrace.skip;
 		var a = new Array();
-		var l = untyped __dollar__asize(native.stack);
+		var l = untyped __dollar__asize(nativeStackTrace.stack);
 		var i = 0;
 		while (i < l) {
-			var x = native.stack[l - i - 1];
+			var x = nativeStackTrace.stack[l - i - 1];
 			//skip all CFunctions until we skip required amount of hx entries
 			if(x == null && skip > i) {
 				skip++;

--- a/std/neko/_std/sys/thread/ThreadImpl.hx
+++ b/std/neko/_std/sys/thread/ThreadImpl.hx
@@ -36,8 +36,8 @@ abstract ThreadImpl(Dynamic) {
 		return thread_current();
 	}
 
-	public static function create( callb ) {
-		return thread_create((_) -> callb(),null);
+	public static function create( job ) {
+		return thread_create((_) -> job(),null);
 	}
 
 	public static function getName( t : ThreadImpl ) {

--- a/std/php/_std/haxe/NativeStackTrace.hx
+++ b/std/php/_std/haxe/NativeStackTrace.hx
@@ -17,12 +17,13 @@ class NativeStackTrace {
 		@param String - generated php file name.
 		@param Int - Line number in generated file.
 	**/
-	static public var mapPosition:String->Int->Null<{?source:String, ?originalLine:Int}>;
+	@:hack static public var mapPosition:String->Int->Null<{?source:String, ?originalLine:Int}>;
 
 	static var lastExceptionTrace:Null<NativeTrace>;
 
 	@:ifFeature('haxe.NativeStackTrace.exceptionStack')
-	static public function saveStack(e:Throwable) {
+	static public function saveStack(exception:Any) {
+		var e:Throwable = exception;
 		var nativeTrace = e.getTrace();
 
 		// Reduce exception stack to the place where exception was caught
@@ -58,20 +59,20 @@ class NativeStackTrace {
 		return lastExceptionTrace == null ? new NativeIndexedArray() : lastExceptionTrace;
 	}
 
-	static public function toHaxe(native:NativeTrace, skip:Int = 0):Array<StackItem> {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
 		var result = [];
-		var count = Global.count(native);
+		var count = Global.count(nativeStackTrace);
 
 		for (i in 0...count) {
 			if(skip > i) {
 				continue;
 			}
 
-			var entry = native[i];
+			var entry = nativeStackTrace[i];
 			var item = null;
 
 			if (i + 1 < count) {
-				var next = native[i + 1];
+				var next = nativeStackTrace[i + 1];
 
 				if (!Global.isset(next['function']))
 					next['function'] = '';

--- a/std/python/_std/haxe/NativeStackTrace.hx
+++ b/std/python/_std/haxe/NativeStackTrace.hx
@@ -32,13 +32,13 @@ class NativeStackTrace {
 		}
 	}
 
-	static public function toHaxe(native:NativeTrace, skip:Int = 0):Array<StackItem> {
+	static public function toHaxe(nativeStackTrace:NativeTrace, skip:Int = 0):Array<StackItem> {
 		var stack = [];
-		for(i in 0...native.length) {
+		for(i in 0...nativeStackTrace.length) {
 			if(skip > i) {
 				continue;
 			}
-			var elem = native[i];
+			var elem = nativeStackTrace[i];
 			stack.push(FilePos(Method(null, elem._3), elem._1, elem._2));
 		}
 		return stack;

--- a/std/python/_std/sys/thread/ThreadImpl.hx
+++ b/std/python/_std/sys/thread/ThreadImpl.hx
@@ -30,8 +30,8 @@ abstract ThreadImpl(NativeThread) {
 		return cast python.lib.Threading.current_thread();
 	}
 
-	public static function create(callb:Void->Void):ThreadImpl {
-		var t = new NativeThread({target:callb, daemon: true});
+	public static function create(job:Void->Void):ThreadImpl {
+		var t = new NativeThread({target:job, daemon: true});
 		t.start();
 		return cast t;
 	}

--- a/std/sys/thread/ThreadImpl.hx
+++ b/std/sys/thread/ThreadImpl.hx
@@ -24,7 +24,7 @@ package sys.thread;
 
 abstract ThreadImpl(Dynamic) {
 
-	public static function create( f : Void -> Void ) : ThreadImpl {
+	public static function create( job : Void -> Void ) : ThreadImpl {
 		throw "Not implemented for this platform";
 	}
 


### PR DESCRIPTION
Some cleanup pulled from #12688:

* All atomics are now declared as `abstract AtomicSomething(UnderlyingType)` on all targets, which allows individual targets to specify `UnderlyingType` without breaking `@:coreApi` or documentation generation. This requires a small hack to Eval in order to pick up the correct paths due to the loss of `@:coreType`. I'll check later if that's really necessary.
* Similarly, `NativeStackTrace` now works with `NativeTrace` to avoid target differences. Claude put a `@:hack` in the PHP implementation (edit: and JS) which I haven't checked out yet, which is also in the "later" category.
* Some names in `ThreadImpl` were inconsistent and are now consistent.

These changes make all the types here `@:coreApi`-compatible, which was verified on the linked PR.