### PR TITLE
[cpp] Don't erase coroutine references to dynamic

### DIFF
--- a/src/generators/cpp/cppRetyper.ml
+++ b/src/generators/cpp/cppRetyper.ml
@@ -69,7 +69,7 @@ let is_lvalue_expr expr =
   in
   checker expr
 
-let rec cpp_type_of stack value_type_handler haxe_type =
+let rec cpp_type_of stack basic value_type_handler haxe_type =
   if List.exists (fast_eq haxe_type) stack then
     TCppDynamic
   else
@@ -78,20 +78,28 @@ let rec cpp_type_of stack value_type_handler haxe_type =
     | TMono r -> (
       match r.tm_type with
       | None -> TCppDynamic
-      | Some t -> cpp_type_of stack value_type_handler t)
+      | Some t -> cpp_type_of stack basic value_type_handler t)
     | TEnum (enum, params) -> TCppEnum enum
     | TInst ({ cl_path = [], "Array"; cl_kind = KTypeParameter _ }, _) ->
       TCppObject
     | TInst ({ cl_kind = KTypeParameter _ }, _) -> TCppDynamic
     | TInst (klass, params) ->
-      cpp_instance_type stack klass params value_type_handler
+      cpp_instance_type stack basic klass params value_type_handler
+    | TAbstract({ a_path = (["haxe";"coro"],"Coroutine"); a_pos = pos },[t]) ->
+      begin match follow t with
+        | TFun(args,ret) ->
+          let args,ret = Common.expand_coro_type basic args ret in
+          cpp_type_of stack basic value_type_handler (TFun (args, ret))
+        | t ->
+          cpp_abort CppError.InternalError pos
+      end
     | TAbstract (abs, pl) when is_marshalling_native_enum abs ->
       TCppMarshalNativeType (ValueEnum abs, value_type_handler())
     | TAbstract (abs, pl) when not (Meta.has Meta.CoreType abs.a_meta) ->
-      cpp_type_from_path stack abs.a_path pl value_type_handler (fun () ->
-        cpp_type_of stack value_type_handler (Abstract.get_underlying_type ~return_first:true abs pl))
+      cpp_type_from_path stack basic abs.a_path pl value_type_handler (fun () ->
+        cpp_type_of stack basic value_type_handler (Abstract.get_underlying_type ~return_first:true abs pl))
     | TAbstract (a, params) ->
-      cpp_type_from_path stack a.a_path params value_type_handler (fun () ->
+      cpp_type_from_path stack basic a.a_path params value_type_handler (fun () ->
         if is_scalar_abstract a then
           match get_meta_string a.a_meta Meta.Native with
           | Some s -> TCppScalar s
@@ -133,18 +141,18 @@ let rec cpp_type_of stack value_type_handler haxe_type =
             false
         in
       if find [] haxe_type then
-        cpp_type_from_path stack type_def.t_path params value_type_handler (fun () -> TCppDynamic)
+        cpp_type_from_path stack basic type_def.t_path params value_type_handler (fun () -> TCppDynamic)
       else
-        cpp_type_from_path stack type_def.t_path params value_type_handler (fun () -> cpp_type_of stack value_type_handler (apply_typedef type_def params))
+        cpp_type_from_path stack basic type_def.t_path params value_type_handler (fun () -> cpp_type_of stack basic value_type_handler (apply_typedef type_def params))
     | TFun (arguments, return) ->
-      let retyped_arguments = List.map (fun (_, o, t) -> cpp_tfun_arg_type_of stack o with_reference_value_type t) arguments in
-      let retyped_return    = cpp_type_of stack with_stack_value_type return in
+      let retyped_arguments = List.map (fun (_, o, t) -> cpp_tfun_arg_type_of stack basic o with_reference_value_type t) arguments in
+      let retyped_return    = cpp_type_of stack basic with_stack_value_type return in
       TCppCallable (retyped_arguments, retyped_return)
     | TAnon _ -> TCppObject
     | TDynamic _ -> TCppDynamic
-    | TLazy func -> cpp_type_of stack value_type_handler (lazy_type func)
+    | TLazy func -> cpp_type_of stack basic value_type_handler (lazy_type func)
 
-and cpp_type_from_path stack path params value_type_handler default =
+and cpp_type_from_path stack basic path params value_type_handler default =
   match (path, params) with
   | ([], "Void"), _ -> TCppVoid
   | ([], "void"), _ -> TCppVoid (* for old code with @:void *)
@@ -173,22 +181,22 @@ and cpp_type_from_path stack path params value_type_handler default =
   | ([ "cpp" ], "AutoCast"), _ -> TCppAutoCast
   | ([], "String"), [] -> TCppString
   (* Things with type parameters hxcpp knows about ... *)
-  | ([ "cpp" ], "FastIterator"), [ p ] -> TCppFastIterator (cpp_type_of stack value_type_handler p)
-  | ([ "cpp" ], "Pointer"), [ p ] -> TCppPointer ("Pointer", cpp_type_of stack value_type_handler p)
+  | ([ "cpp" ], "FastIterator"), [ p ] -> TCppFastIterator (cpp_type_of stack basic value_type_handler p)
+  | ([ "cpp" ], "Pointer"), [ p ] -> TCppPointer ("Pointer", cpp_type_of stack basic value_type_handler p)
   | ([ "cpp" ], "ConstPointer"), [ p ] ->
-      TCppPointer ("ConstPointer", cpp_type_of stack value_type_handler p)
-  | ([ "cpp" ], "RawPointer"), [ p ] -> TCppRawPointer ("", cpp_type_of stack value_type_handler p)
+      TCppPointer ("ConstPointer", cpp_type_of stack basic value_type_handler p)
+  | ([ "cpp" ], "RawPointer"), [ p ] -> TCppRawPointer ("", cpp_type_of stack basic value_type_handler p)
   | ([ "cpp" ], "RawConstPointer"), [ p ] ->
-      TCppRawPointer ("const ", cpp_type_of stack value_type_handler p)
+      TCppRawPointer ("const ", cpp_type_of stack basic value_type_handler p)
   | ([ "cpp" ], "Function"), [ function_type; abi ] ->
-      cpp_function_type_of stack function_type abi value_type_handler
+      cpp_function_type_of stack basic function_type abi value_type_handler
   | ([ "cpp" ], "Callable"), [ function_type ]
   | ([ "cpp" ], "CallableData"), [ function_type ] ->
-      cpp_function_type_of_string stack function_type "" value_type_handler
+      cpp_function_type_of_string stack basic function_type "" value_type_handler
   | ("cpp" :: [ "objc" ], "ObjcBlock"), [ function_type ] ->
-      let args, ret = cpp_function_type_of_args_ret stack value_type_handler function_type in
+      let args, ret = cpp_function_type_of_args_ret stack basic value_type_handler function_type in
       TCppObjCBlock (args, ret)
-  | ([ "cpp" ], "Rest"), [ rest ] -> TCppRest (cpp_type_of stack value_type_handler rest)
+  | ([ "cpp" ], "Rest"), [ rest ] -> TCppRest (cpp_type_of stack basic value_type_handler rest)
   | ("cpp" :: [ "objc" ], "Protocol"), [ interface_type ] -> (
       match follow interface_type with
       | TInst (klass, []) when has_class_flag klass CInterface ->
@@ -198,14 +206,14 @@ and cpp_type_from_path stack path params value_type_handler default =
           print_endline "cpp.objc.Protocol must refer to an interface";
           die "" __LOC__)
   | ([ "cpp" ], "Reference"), [ param ] ->
-      TCppReference (cpp_type_of stack value_type_handler param)
-  | ([ "cpp" ], "Struct"), [ param ] -> TCppStruct (cpp_type_of stack value_type_handler param)
+      TCppReference (cpp_type_of stack basic value_type_handler param)
+  | ([ "cpp" ], "Struct"), [ param ] -> TCppStruct (cpp_type_of stack basic value_type_handler param)
   | ([ "cpp" ], "Star"), [ param ] ->
-      TCppStar (cpp_type_of_pointer stack value_type_handler param, false)
+      TCppStar (cpp_type_of_pointer stack basic value_type_handler param, false)
   | ([ "cpp" ], "ConstStar"), [ param ] ->
-      TCppStar (cpp_type_of_pointer stack value_type_handler param, true)
+      TCppStar (cpp_type_of_pointer stack basic value_type_handler param, true)
   | ([], "Array"), [ p ] -> (
-      let arrayOf = cpp_type_of stack with_promoted_value_type p in
+      let arrayOf = cpp_type_of stack basic with_promoted_value_type p in
       match arrayOf with
       | TCppVoid (* ? *) | TCppDynamic -> TCppDynamicArray
       | TCppObject | TCppObjectPtr | TCppReference _ | TCppStruct _ | TCppStar _
@@ -214,57 +222,57 @@ and cpp_type_from_path stack path params value_type_handler default =
       | TCppMarshalManagedType _ | TCppCallable _ ->
         TCppObjectArray arrayOf
       | _ -> TCppScalarArray arrayOf)
-  | ([], "Null"), [ p ] -> cpp_type_of_null stack value_type_handler p
+  | ([], "Null"), [ p ] -> cpp_type_of_null stack basic value_type_handler p
   | _ -> default ()
 
-and cpp_type_of_null stack value_type_handler p =
-  match cpp_type_of stack with_promoted_value_type p with
+and cpp_type_of_null stack basic value_type_handler p =
+  match cpp_type_of stack basic with_promoted_value_type p with
   | other when is_cpp_scalar other || type_has_meta_key Meta.NotNull p ->
     TCppObject
   | other ->
     other
 
-and cpp_type_of_pointer stack value_type_handler p =
+and cpp_type_of_pointer stack basic value_type_handler p =
   match p with
-  | TAbstract ({ a_path = [], "Null" }, [ t ]) -> cpp_type_of stack value_type_handler t
-  | x -> cpp_type_of stack value_type_handler x
+  | TAbstract ({ a_path = [], "Null" }, [ t ]) -> cpp_type_of stack basic value_type_handler t
+  | x -> cpp_type_of stack basic value_type_handler x
 
 (* Optional types are Dynamic if they norally could not be null *)
-and cpp_fun_arg_type_of tvar opt value_type_handler =
+and cpp_fun_arg_type_of basic tvar opt value_type_handler =
   match opt with
-  | Some _ -> cpp_type_of_null [] value_type_handler tvar.v_type
-  | _ -> cpp_type_of [] value_type_handler tvar.v_type
+  | Some _ -> cpp_type_of_null [] basic value_type_handler tvar.v_type
+  | _ -> cpp_type_of [] basic value_type_handler tvar.v_type
 
-and cpp_tfun_arg_type_of stack opt value_type_handler t =
-  if opt then cpp_type_of_null stack value_type_handler t else cpp_type_of stack value_type_handler t
+and cpp_tfun_arg_type_of stack basic opt value_type_handler t =
+  if opt then cpp_type_of_null stack basic value_type_handler t else cpp_type_of stack basic value_type_handler t
 
-and cpp_function_type_of stack function_type abi value_type_handler =
+and cpp_function_type_of stack basic function_type abi value_type_handler =
   let abi =
     match follow abi with
     | TInst (klass1, _) ->
         get_meta_string klass1.cl_meta Meta.Abi |> Option.default ""
     | _ -> die "" __LOC__
   in
-  cpp_function_type_of_string stack function_type abi value_type_handler
+  cpp_function_type_of_string stack basic function_type abi value_type_handler
 
-and cpp_function_type_of_string stack function_type abi_string value_type_handler =
-  let args, ret = cpp_function_type_of_args_ret stack value_type_handler function_type in
+and cpp_function_type_of_string stack basic function_type abi_string value_type_handler =
+  let args, ret = cpp_function_type_of_args_ret stack basic value_type_handler function_type in
   TCppFunction (args, ret, abi_string)
 
-and cpp_function_type_of_args_ret stack value_type_handler function_type =
+and cpp_function_type_of_args_ret stack basic value_type_handler function_type =
   match follow function_type with
   | TFun (args, ret) ->
       (* Optional types are Dynamic if they norally could not be null *)
       let cpp_arg_type_of (_, optional, haxe_type) =
-        if optional then cpp_type_of_null stack value_type_handler haxe_type
-        else cpp_type_of stack value_type_handler haxe_type
+        if optional then cpp_type_of_null stack basic value_type_handler haxe_type
+        else cpp_type_of stack basic value_type_handler haxe_type
       in
-      (List.map cpp_arg_type_of args, cpp_type_of stack value_type_handler ret)
+      (List.map cpp_arg_type_of args, cpp_type_of stack basic value_type_handler ret)
   | _ ->
       (* ? *)
       ([ TCppVoid ], TCppVoid)
 
-and cpp_instance_type stack klass params value_type_handler =
+and cpp_instance_type stack basic klass params value_type_handler =
   let fallback_handler () =
     if is_objc_class klass then TCppObjC klass
     else if has_class_flag klass CInterface && is_native_gen_class klass then
@@ -273,23 +281,23 @@ and cpp_instance_type stack klass params value_type_handler =
       TCppInterface klass
     else if has_class_flag klass CExtern && not (is_internal_class klass.cl_path) then
       if is_marshalling_native_value_class klass then
-        let tcpp_params = List.map (cpp_type_of stack with_stack_value_type) params in
+        let tcpp_params = List.map (cpp_type_of stack basic with_stack_value_type) params in
         TCppMarshalNativeType (ValueClass (klass, tcpp_params), value_type_handler ())
       else if is_marshalling_native_pointer klass then
-        let tcpp_params = List.map (cpp_type_of stack with_stack_value_type) params in
+        let tcpp_params = List.map (cpp_type_of stack basic with_stack_value_type) params in
         TCppMarshalNativeType (Pointer (klass, tcpp_params), value_type_handler ())
       else if is_marshalling_managed_class klass then
-        let tcpp_params = List.map (cpp_type_of stack value_type_handler) params in
+        let tcpp_params = List.map (cpp_type_of stack basic value_type_handler) params in
         TCppMarshalManagedType (klass, tcpp_params)
       else
-        let tcpp_params = List.map (cpp_type_of stack value_type_handler) params in
+        let tcpp_params = List.map (cpp_type_of stack basic value_type_handler) params in
         TCppInst (klass, tcpp_params)
     else
-      let tcpp_params = List.map (cpp_type_of stack value_type_handler) params in
+      let tcpp_params = List.map (cpp_type_of stack basic value_type_handler) params in
       TCppInst (klass, tcpp_params)
   in
 
-  cpp_type_from_path stack klass.cl_path params value_type_handler fallback_handler
+  cpp_type_from_path stack basic klass.cl_path params value_type_handler fallback_handler
 
 let cpp_type_of = cpp_type_of []
 let cpp_type_from_path = cpp_type_from_path []
@@ -322,7 +330,7 @@ let sanitise_stack_only_type pos tcpp =
   | _ ->
     tcpp
 
-let retype_tvar tvar =
+let retype_tvar basic tvar =
   let copying_var =
     match tvar.v_kind with
     | VUser (TVOLocalVariable | TVOArgument | TVOForVariable | TVOCatchVariable)
@@ -339,12 +347,12 @@ let retype_tvar tvar =
       
   {
     tcppv_var        = tvar;
-    tcppv_type       = cpp_type_of handler tvar.v_type |> sanitise_stack_only_type tvar.v_pos;
+    tcppv_type       = cpp_type_of basic handler tvar.v_type |> sanitise_stack_only_type tvar.v_pos;
     tcppv_name       = cpp_var_name_of tvar;
     tcppv_debug_name = keyword_remap tvar.v_name
   }
 
-let retype_func_arg tvar expr =
+let retype_func_arg basic tvar expr =
   let handler =
     match tvar.v_kind with
     | VAbstractThis -> with_reference_value_type
@@ -353,16 +361,16 @@ let retype_func_arg tvar expr =
   
   {
     tcppv_var        = tvar;
-    tcppv_type       = cpp_fun_arg_type_of tvar expr handler |> sanitise_stack_only_type tvar.v_pos;
+    tcppv_type       = cpp_fun_arg_type_of basic tvar expr handler |> sanitise_stack_only_type tvar.v_pos;
     tcppv_name       = cpp_var_name_of tvar;
     tcppv_debug_name = keyword_remap tvar.v_name
   }
 
-let retype_arg handler (name, opt, t) =
+let retype_arg basic handler (name, opt, t) =
   {
     tfa_name     = keyword_remap name;
     tfa_optional = opt;
-    tfa_type     = cpp_type_of handler t
+    tfa_type     = cpp_type_of basic handler t
   }
 
 let expression ctx request_type function_args function_type expression_tree forInjection =
@@ -404,6 +412,14 @@ let expression ctx request_type function_args function_type expression_tree forI
 
     new_ctx, resolver
   in
+
+  let cpp_type_of = cpp_type_of ctx.ctx_common.basic in
+  let retype_tvar = retype_tvar ctx.ctx_common.basic in
+  let retype_func_arg = retype_func_arg ctx.ctx_common.basic in
+  let cpp_tfun_arg_type_of = cpp_tfun_arg_type_of ctx.ctx_common.basic in
+  let cpp_function_type_of_args_ret = cpp_function_type_of_args_ret ctx.ctx_common.basic in
+  let cpp_instance_type = cpp_instance_type ctx.ctx_common.basic in
+  let cpp_type_from_path = cpp_type_from_path ctx.ctx_common.basic in
 
   let cpp_return_type ctx haxe_type =
     match follow_with_coro haxe_type with
@@ -1726,6 +1742,8 @@ let native_field_name_remap field =
 
 let rec tcpp_class_from_tclass ctx ids slots class_def class_params =
   let scriptable = Gctx.defined ctx.ctx_common Define.Scriptable in
+  let cpp_type_of = cpp_type_of ctx.ctx_common.basic in
+  let retype_func_arg = retype_func_arg ctx.ctx_common.basic in
 
   let create_function field func = {
     tcf_field = field;
@@ -2018,7 +2036,9 @@ let rec tcpp_class_from_tclass ctx ids slots class_def class_params =
 
 and tcpp_interface_from_tclass ctx slots class_def =
 
-  let scriptable = Gctx.defined ctx.ctx_common Define.Scriptable && not class_def.cl_private in
+  let scriptable  = Gctx.defined ctx.ctx_common Define.Scriptable && not class_def.cl_private in
+  let cpp_type_of = cpp_type_of ctx.ctx_common.basic in
+  let retype_arg  = retype_arg ctx.ctx_common.basic in
 
   let function_filter handler (slots, fields) field =
     match (field.cf_type, field.cf_kind) with
@@ -2080,6 +2100,8 @@ and tcpp_interface_from_tclass ctx slots class_def =
   (slots, iface)
 
 and tcpp_enum_from_tenum ctx ids enum_def =
+  let retype_arg  = retype_arg ctx.ctx_common.basic in
+  
   let sort_constructors f1 f2 =
     f1.ef_index - f2.ef_index in
 

--- a/src/generators/cpp/gen/cppCppia.ml
+++ b/src/generators/cpp/gen/cppCppia.ml
@@ -15,7 +15,7 @@ type script_type =
   | ScriptObject
   | ScriptVoid
 
-let cpp_type_of = CppRetyper.cpp_type_of CppRetyper.with_reference_value_type
+let cpp_type_of basic = CppRetyper.cpp_type_of basic CppRetyper.with_reference_value_type
 
 let to_script_type tcpp =
   match tcpp with
@@ -528,9 +528,10 @@ and is_dynamic_in_cppia ctx expr =
   | TCast (_, None) -> true
   | _ -> is_dynamic_in_cpp ctx expr
 
-class script_writer ctx filename asciiOut =
+class script_writer ctx filename asciiOut basic =
   object (this)
     val debug = asciiOut
+    val basic = basic
 
     val doComment =
       asciiOut && Gctx.defined ctx.ctx_common Define.AnnotateSource
@@ -606,7 +607,7 @@ class script_writer ctx filename asciiOut =
 
     method typeText typeT =
       let tname =
-        if cppiaAst then script_cpptype_string (cpp_type_of typeT)
+        if cppiaAst then script_cpptype_string (cpp_type_of basic typeT)
         else script_type_string typeT
       in
       string_of_int (this#typeId tname) ^ " "
@@ -617,7 +618,7 @@ class script_writer ctx filename asciiOut =
     method writeType typeT = this#write (this#typeText typeT)
 
     method toCppType etype =
-      string_of_int (this#typeId (script_cpptype_string (cpp_type_of etype)))
+      string_of_int (this#typeId (script_cpptype_string (cpp_type_of basic etype)))
       ^ " "
 
     method boolText value = if value then "1" else "0"
@@ -755,9 +756,9 @@ class script_writer ctx filename asciiOut =
         match fieldExpression with
         | Some ({ eexpr = TFunction function_def } as e) ->
             if cppiaAst then (
-              let args = List.map (fun (v, e) -> (CppRetyper.retype_tvar v), e) function_def.tf_args in
+              let args = List.map (fun (v, e) -> (CppRetyper.retype_tvar basic v), e) function_def.tf_args in
               let cppExpr =
-                CppRetyper.expression ctx TCppVoid args (cpp_type_of function_def.tf_type)
+                CppRetyper.expression ctx TCppVoid args (cpp_type_of basic function_def.tf_type)
                   function_def.tf_expr false
               in
               this#begin_expr;
@@ -789,7 +790,7 @@ class script_writer ctx filename asciiOut =
       match varExpr with
       | Some expression ->
           if cppiaAst then
-            let varType = cpp_type_of expression.etype in
+            let varType = cpp_type_of basic expression.etype in
             let cppExpr =
               CppRetyper.expression ctx varType [] TCppDynamic expression false
             in
@@ -892,7 +893,7 @@ class script_writer ctx filename asciiOut =
           match init with
           | Some { eexpr = TConst TNull } -> this#write "0\n"
           | Some const ->
-              let argType = cpp_type_of const.etype in
+              let argType = cpp_type_of basic const.etype in
               if is_cpp_scalar argType || argType == TCppString then (
                 this#write "1 ";
                 this#gen_expression_only const;
@@ -954,7 +955,7 @@ class script_writer ctx filename asciiOut =
             ^ this#typeText function_def.tf_type
             ^ string_of_int (List.length function_def.tf_args)
             ^ "\n");
-          let close = this#gen_func_args (List.map (fun (v, e) -> CppRetyper.retype_tvar v, e) function_def.tf_args) in
+          let close = this#gen_func_args (List.map (fun (v, e) -> CppRetyper.retype_tvar basic v, e) function_def.tf_args) in
           let pop = this#pushReturn function_def.tf_type in
           this#gen_expression function_def.tf_expr;
           pop ();
@@ -1903,7 +1904,7 @@ let generate_cppia ctx =
   let common_ctx = ctx.ctx_common in
   let debug = ctx.ctx_debug_level in
   Path.mkdir_from_path common_ctx.file;
-  let script = new script_writer ctx common_ctx.file common_ctx.debug in
+  let script = new script_writer ctx common_ctx.file common_ctx.debug common_ctx.basic in
   ignore (script#stringId "");
   ignore (script#typeId "");
 

--- a/src/generators/cpp/gen/cppGen.ml
+++ b/src/generators/cpp/gen/cppGen.ml
@@ -18,10 +18,10 @@ type tinject = {
   inj_tail : string;
 }
 
-let cpp_type_of = CppRetyper.cpp_type_of CppRetyper.with_stack_value_type
+let cpp_type_of basic = CppRetyper.cpp_type_of basic CppRetyper.with_stack_value_type
 let cpp_type_of_null = CppRetyper.cpp_type_of_null
 let cpp_instance_type = CppRetyper.cpp_instance_type
-let type_to_string haxe_type = tcpp_to_string (cpp_type_of haxe_type)
+let type_to_string basic haxe_type = tcpp_to_string (cpp_type_of basic haxe_type)
 
 let type_cant_be_null tcpp =
   match tcpp with TCppScalar _ -> true | _ -> false
@@ -77,16 +77,16 @@ let cpp_member_name_of member =
   | Some n -> n
   | None -> keyword_remap member.cf_name
 
-let function_signature include_names tfun abi =
+let function_signature basic include_names tfun abi =
   let print_tfun_arg_list include_names arg_list =
     arg_list
-    |> List.map (CppRetyper.retype_arg CppRetyper.with_stack_value_type)
+    |> List.map (CppRetyper.retype_arg basic CppRetyper.with_stack_value_type)
     |> print_retyped_tfun_arg_list include_names
   in
 
   match follow tfun with
   | TFun (args, ret) ->
-      type_to_string ret ^ " " ^ abi ^ "("
+      type_to_string basic ret ^ " " ^ abi ^ "("
       ^ print_tfun_arg_list include_names args
       ^ ")"
   | _ -> "void *"
@@ -132,7 +132,7 @@ let func_to_callable_string wrapper func =
 let mk_injection prologue set_var tail =
   Some { inj_prologue = prologue; inj_setvar = set_var; inj_tail = tail }
 
-let gen_type ctx haxe_type = ctx.ctx_output (type_to_string haxe_type)
+let gen_type ctx haxe_type = ctx.ctx_output (type_to_string ctx.ctx_common.basic haxe_type)
 
 let cpp_macro_var_type_of var =
   let t = tcpp_to_string var.tcppv_type in
@@ -446,6 +446,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
   let lastLine = ref (-1) in
   let tempId = ref 0 in
   let strq = strq ctx.ctx_common in
+  let cpp_type_of = cpp_type_of ctx.ctx_common.basic in
 
   let spacer = if ctx.ctx_debug_level > 0 then "            \t" else "" in
   let output_i value =
@@ -832,7 +833,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
         gen e;
         out "))"
     | CppFunctionAddress (klass, member) ->
-        let signature = function_signature false member.cf_type "" in
+        let signature = function_signature ctx.ctx_common.basic false member.cf_type "" in
         let name = cpp_member_name_of member in
         (*let void_cast = has_meta_key field.cf_meta Meta.Void in*)
         out ("::cpp::Function< " ^ signature ^ ">(::hx::AnyCast(");

--- a/src/generators/cpp/gen/cppGenClassHeader.ml
+++ b/src/generators/cpp/gen/cppGenClassHeader.ml
@@ -155,6 +155,7 @@ let generate_native_header base_ctx tcpp_class =
   let class_def  = tcpp_class.tcl_class in
   let class_path = class_def.cl_path in
   let scriptable = has_tcpp_class_flag tcpp_class Scriptable in
+  let cpp_instance_type = cpp_instance_type common_ctx.basic in
 
   let h_file = new_header_file common_ctx common_ctx.file class_path in
   let ctx = file_context base_ctx h_file tcpp_class.tcl_debug_level true in
@@ -214,6 +215,7 @@ let generate_managed_header base_ctx tcpp_class =
   let ptr_name = class_pointer class_def in
   let can_quick_alloc = has_tcpp_class_flag tcpp_class QuickAlloc in
   let gcName = gen_gc_name class_def.cl_path in
+  let cpp_instance_type = cpp_instance_type common_ctx.basic in
 
   let constructor_type_args =
     tcpp_class

--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -43,7 +43,7 @@ let write_callable_trailer captures output =
 
 let gen_function ctx tcpp_class is_static func =
   let output      = ctx.ctx_output in
-  let return_type = cpp_type_of func.tcf_func.tf_type in
+  let return_type = cpp_type_of ctx.ctx_common.basic func.tcf_func.tf_type in
 
   let ret, is_void, return_type_str =
     match return_type with
@@ -101,8 +101,8 @@ let gen_function ctx tcpp_class is_static func =
 let gen_function_closures ctx tcpp_class is_static func =
   if (not func.tcf_is_virtual || not func.tcf_is_overriding) && func.tcf_is_reflective then
     let output          = ctx.ctx_output in
-    let return_type_str = type_to_string func.tcf_func.tf_type in
-    let return_type     = cpp_type_of func.tcf_func.tf_type in
+    let return_type_str = type_to_string ctx.ctx_common.basic func.tcf_func.tf_type in
+    let return_type     = cpp_type_of ctx.ctx_common.basic func.tcf_func.tf_type in
     let is_void         = return_type = TCppVoid in
     let callable_name   = Printf.sprintf "__%s%s" tcpp_class.tcl_name func.tcf_name in
     let full_name       = (tcpp_class.tcl_class.cl_path |> fst |> List.map keyword_remap |> String.concat "::") ^ "::" ^ tcpp_class.tcl_name in
@@ -327,7 +327,7 @@ let generate_managed_class base_ctx tcpp_class =
   let class_super_name =
     match class_def.cl_super with
     | Some (klass, params) ->
-        tcpp_to_string_suffix "_obj" (cpp_instance_type klass params CppRetyper.with_stack_value_type)
+        tcpp_to_string_suffix "_obj" (cpp_instance_type ctx.ctx_common.basic klass params CppRetyper.with_stack_value_type)
     | _ -> ""
   in
 
@@ -556,7 +556,7 @@ let generate_managed_class base_ctx tcpp_class =
     let rec find_next_super_iteration cls =
       match cls.tcl_super with
       | Some ({ tcl_container = Some Current } as super) ->
-        Some (tcpp_to_string_suffix "_obj" (cpp_instance_type super.tcl_class super.tcl_params CppRetyper.with_stack_value_type))
+        Some (tcpp_to_string_suffix "_obj" (cpp_instance_type ctx.ctx_common.basic super.tcl_class super.tcl_params CppRetyper.with_stack_value_type))
       | Some super ->
         find_next_super_iteration super
       | None ->
@@ -617,7 +617,7 @@ let generate_managed_class base_ctx tcpp_class =
   in
 
   let get_wrapper field value =
-    match CppRetyper.cpp_type_of CppRetyper.with_promoted_value_type field.cf_type with
+    match CppRetyper.cpp_type_of ctx.ctx_common.basic CppRetyper.with_promoted_value_type field.cf_type with
     | TCppInst (t, _) as inst when Meta.has Meta.StructAccess t.cl_meta ->
       Printf.sprintf "(::cpp::Struct< %s >) %s" (tcpp_to_string inst) value
     | TCppStar _ ->
@@ -812,7 +812,7 @@ let generate_managed_class base_ctx tcpp_class =
     Printf.sprintf "void %s::__GetFields(::Array< ::String >& outFields)\n{\n%s\n}\n\n" class_name fields |> output_cpp);
 
   let storage field =
-    match cpp_type_of field.cf_type with
+    match cpp_type_of ctx.ctx_common.basic field.cf_type with
     | TCppScalar "bool" -> "::hx::fsBool"
     | TCppScalar "int" -> "::hx::fsInt"
     | TCppScalar "Float" -> "::hx::fsFloat"

--- a/src/generators/cpp/gen/cppGenInterfaceHeader.ml
+++ b/src/generators/cpp/gen/cppGenInterfaceHeader.ml
@@ -97,7 +97,7 @@ let generate_native_interface base_ctx tcpp_interface =
   let parent, super =
     match tcpp_interface.if_class.cl_super with
     | Some (klass, params) ->
-      let name = tcpp_to_string_suffix "_obj" (cpp_instance_type klass params CppRetyper.with_stack_value_type) in
+      let name = tcpp_to_string_suffix "_obj" (cpp_instance_type common_ctx.basic klass params CppRetyper.with_stack_value_type) in
       ( "virtual " ^ name, name )
     | None ->
       ("virtual ::hx::NativeInterface", "::hx::NativeInterface")
@@ -144,7 +144,7 @@ let generate_managed_interface base_ctx tcpp_interface =
   let super =
     match tcpp_interface.if_class.cl_super with
     | Some (klass, params) ->
-      tcpp_to_string_suffix "_obj" (cpp_instance_type klass params CppRetyper.with_stack_value_type)
+      tcpp_to_string_suffix "_obj" (cpp_instance_type common_ctx.basic klass params CppRetyper.with_stack_value_type)
     | None ->
       "::hx::Object"
   in

--- a/src/generators/cpp/gen/cppReferences.ml
+++ b/src/generators/cpp/gen/cppReferences.ml
@@ -192,7 +192,7 @@ let find_referenced_types_flags ctx obj filter super_deps constructor_deps heade
           | _ ->
               print_endline
                 ("TSuper : Odd etype ?"
-                ^ (CppRetyper.cpp_type_of CppRetyper.with_reference_value_type expression.etype |> tcpp_to_string)))
+                ^ (CppRetyper.cpp_type_of ctx.ctx_common.basic CppRetyper.with_reference_value_type expression.etype |> tcpp_to_string)))
       | _ -> ());
       Type.iter visit_expression expression;
       visit_type (follow expression.etype)


### PR DESCRIPTION
I found the actual fix for #12586 but in doing so coroutines started to break... I realised that coroutine references were being incorrectly erased to dynamic instead of become a typed callable. i.e

```haxe
function invokeCoroutine<T>(f:haxe.coro.Coroutine<() -> T>)
```

would become

```C++
invokeCoroutine(::Dynamic f);
```

The changes look like a fair bit but thats just because I've got to pass around the context again (I got rid of that with a gencpp refactor...) to expand the coroutine.

Generated C++ with these changes.

```C++
invokeCoroutine(::hx::Callable<  ::haxe::coro::SuspensionResult (::Dynamic) > f)
```