### PR TITLE
Generalize anon-id by passing in uctx

### DIFF
--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -1016,7 +1016,7 @@ module HxbWriter = struct
 			Chunk.write_u8 writer.chunk 0;
 			Chunk.write_uleb128 writer.chunk index
 		with Not_found ->
-			let pfm = writer.anon_id#identify_anon ~strict:true an in
+			let pfm = writer.anon_id#identify_anon AnonIdMode.strict an in
 			try
 				let index = Pool.get writer.anons pfm.pfm_path in
 				Chunk.write_u8 writer.chunk 0;

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -50,6 +50,7 @@ type unification_context = {
 	allow_abstract_cast     : bool; (* allows a non-transitive abstract cast (from,to,@:from,@:to) *)
 	allow_dynamic_to_cast   : bool; (* allows a cast from dynamic to non-dynamic *)
 	allow_arg_name_mismatch : bool;
+	allow_optional_mismatch : bool; (* allows optional vs. non-optional fields *)
 	equality_kind           : eq_kind;
 	equality_underlying     : bool;
 	strict_field_kind       : bool;
@@ -83,6 +84,7 @@ let default_unification_context () = {
 	allow_abstract_cast     = true;
 	allow_dynamic_to_cast   = true;
 	allow_arg_name_mismatch = true;
+	allow_optional_mismatch = true;
 	equality_kind           = EqStrict;
 	equality_underlying     = false;
 	strict_field_kind       = false;
@@ -99,6 +101,7 @@ let native_unification_context = {
 	allow_transitive_cast = false;
 	allow_abstract_cast   = false;
 	allow_dynamic_to_cast = false;
+	allow_optional_mismatch = true;
 	equality_kind         = EqStrict;
 	equality_underlying   = false;
 	allow_arg_name_mismatch = true;

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -723,7 +723,7 @@ class texpr_to_jvm
 			jm#invokestatic haxe_jvm_path "readField" (method_sig [object_sig;string_sig] (Some object_sig));
 			cast();
 		in
-		match gctx.anon_identification#identify true t with
+		match gctx.anon_identification#identify AnonIdMode.default true t with
 		| Some pfm ->
 			let cf = PMap.find cf.cf_name pfm.pfm_fields in
 			let path = pfm.pfm_path in
@@ -873,7 +873,7 @@ class texpr_to_jvm
 			jm#putfield c.cl_path cf.cf_name jsig_cf
 		| TField(e1,FAnon cf) ->
 			self#texpr rvalue_any e1;
-			begin match gctx.anon_identification#identify true e1.etype with
+			begin match gctx.anon_identification#identify AnonIdMode.default true e1.etype with
 			| Some pfm ->
 				let cf = PMap.find cf.cf_name pfm.pfm_fields in
 				let path = pfm.pfm_path in
@@ -1762,7 +1762,7 @@ class texpr_to_jvm
 			jm#invokestatic en.e_path ef.ef_name (method_sig tl (Some tr));
 			Some tr
 		| TField(e11,FAnon cf) ->
-			begin match gctx.anon_identification#identify false e11.etype with
+			begin match gctx.anon_identification#identify AnonIdMode.default false e11.etype with
 			| Some {pfm_path=path_anon} ->
 				begin match gctx.typedef_interfaces#get_interface_class path_anon with
 				| Some c ->
@@ -2246,7 +2246,7 @@ class texpr_to_jvm
 				PMap.add name cf acc
 			) PMap.empty fl in
 			let t = mk_anon ~fields (ref Closed) in
-			let td = gctx.anon_identification#identify true t in
+			let td = gctx.anon_identification#identify AnonIdMode.default true t in
 			begin match td with
 			| Some pfm when not !had_invalid_field_name ->
 				let lut = Hashtbl.create 0 in

--- a/src/generators/genshared.ml
+++ b/src/generators/genshared.ml
@@ -331,7 +331,7 @@ class ['a] typedef_interfaces (infos : 'a info_context) (anon_identification : '
 			try
 				let path_inner,is_extern = try Hashtbl.find interface_rewrites pfm.pfm_path with Not_found -> path_inner,false in
 				if self#implements_recursively c path_inner then raise (Unify_error [Unify_custom "already implemented"]);
-				anon_identification#unify ~strict:false tc pfm;
+				anon_identification#unify AnonIdMode.default tc pfm;
 				let ci = self#make_interface_class pfm path_inner is_extern in
 				c.cl_implements <- (ci,[]) :: c.cl_implements;
 				(* print_endline (Printf.sprintf "%s IMPLEMENTS %s" (s_type_path c.cl_path) (s_type_path path_inner)); *)

--- a/src/typing/tanon_identification.ml
+++ b/src/typing/tanon_identification.ml
@@ -40,6 +40,27 @@ let pfm_of_typedef td = match follow td.t_type with
 	| _ ->
 		die "" __LOC__
 
+module AnonIdMode = struct
+	let default = {(default_unification_context()) with equality_kind = EqDoNotFollowNull}
+
+	let strict = {
+		allow_transitive_cast = false;
+		allow_abstract_cast = false;
+		allow_dynamic_to_cast = false;
+		allow_arg_name_mismatch = false;
+		allow_optional_mismatch = false;
+		equality_kind = EqStricter;
+		equality_underlying = false;
+		strict_field_kind = true;
+		type_param_mode = TpDefault;
+		unify_stack = new_rec_stack();
+		eq_stack = new_rec_stack();
+		variance_stack = new_rec_stack();
+		abstract_cast_stack = new_rec_stack();
+		unify_new_monos = new_rec_stack();
+	}
+end
+
 class ['a] tanon_identification =
 	let is_normal_anon an = match !(an.a_status) with
 		| Closed | Const -> true
@@ -64,23 +85,7 @@ object(self)
 		Hashtbl.replace pfms path pfm;
 		Mutex.unlock add_pfm_mutex
 
-	method unify ~(strict:bool) (tc : Type.t) (pfm : 'a path_field_mapping) =
-		let uctx = if strict then {
-			allow_transitive_cast = false;
-			allow_abstract_cast = false;
-			allow_dynamic_to_cast = false;
-			allow_arg_name_mismatch = false;
-			equality_kind = EqStricter;
-			equality_underlying = false;
-			strict_field_kind = true;
-			type_param_mode = TpDefault;
-			unify_stack = new_rec_stack();
-			eq_stack = new_rec_stack();
-			variance_stack = new_rec_stack();
-			abstract_cast_stack = new_rec_stack();
-			unify_new_monos = new_rec_stack();
-		} else {(default_unification_context()) with equality_kind = EqDoNotFollowNull} in
-
+	method unify uctx (tc : Type.t) (pfm : 'a path_field_mapping) =
 		let check () =
 			let pair_up fields =
 				PMap.fold (fun cf acc ->
@@ -104,7 +109,7 @@ object(self)
 					let monos = List.map (fun _ -> mk_mono()) pfm.pfm_params in
 					let map = apply_params pfm.pfm_params monos in
 					List.iter (fun (cf,cf') ->
-						if strict && (Meta.has Meta.Optional cf.cf_meta) != (Meta.has Meta.Optional cf'.cf_meta) then raise (Unify_error [Unify_custom "optional mismatch"]);
+						if not uctx.allow_optional_mismatch && (Meta.has Meta.Optional cf.cf_meta) != (Meta.has Meta.Optional cf'.cf_meta) then raise (Unify_error [Unify_custom "optional mismatch"]);
 						if not (unify_kind ~strict:uctx.strict_field_kind cf'.cf_kind cf.cf_kind) then raise (Unify_error [Unify_custom "kind mismatch"]);
 						fields := PMap.remove cf.cf_name !fields;
 						type_eq_custom uctx cf'.cf_type (map (monomorphs cf.cf_params cf.cf_type))
@@ -127,7 +132,7 @@ object(self)
 		with Not_found ->
 			raise (Unify_error [])
 
-	method find_compatible ~(strict : bool) (arity : int) (tc : Type.t) =
+	method find_compatible uctx (arity : int) (tc : Type.t) =
 		if arity >= DynArray.length pfm_by_arity then
 			raise Not_found;
 		let d = DynArray.get pfm_by_arity arity in
@@ -138,7 +143,7 @@ object(self)
 				raise Not_found;
 			let pfm = DynArray.unsafe_get d i in
 			try
-				self#unify ~strict tc pfm;
+				self#unify uctx tc pfm;
 				pfm
 			with Unify_error _ ->
 				loop (i + 1)
@@ -158,7 +163,7 @@ object(self)
 		in
 		loop td.t_type
 
-	method identify_anon ?(strict:bool = false) (an : tanon) =
+	method identify_anon uctx (an : tanon) =
 		let make_pfm path = {
 			pfm_path = path;
 			pfm_params = [];
@@ -177,13 +182,13 @@ object(self)
 			)
 		| _ ->
 			let arity,fields = PMap.fold (fun cf (i,acc) ->
-				let t = replace_mono (not strict) cf.cf_type in
+				let t = replace_mono (uctx.equality_kind <> EqStricter (* TODO: not very robust*) ) cf.cf_type in
 				(i + 1),(PMap.add cf.cf_name {cf with cf_type = t} acc)
 			) an.a_fields (0,PMap.empty) in
 			let an = { a_fields = fields; a_status = an.a_status; } in
 			Mutex.protect pfm_mutex (fun () ->
 				try
-					self#find_compatible ~strict arity (TAnon an)
+					self#find_compatible uctx arity (TAnon an)
 				with Not_found ->
 					let id = num in
 					num <- num + 1;
@@ -199,24 +204,26 @@ object(self)
 					pfm
 			)
 
-	method identify ?(strict:bool = false) (accept_anons : bool) (t : Type.t) =
-		match t with
-		| TType(td,tl) ->
-			begin try
-				Some (Mutex.protect pfm_mutex (fun () -> Hashtbl.find pfms td.t_path))
-			with Not_found ->
-				self#identify accept_anons (apply_typedef td tl)
-			end
-		| TMono {tm_type = Some t} ->
-			self#identify accept_anons t
-		| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) ->
-			self#identify accept_anons (Abstract.get_underlying_type a tl)
-		| TAbstract({a_path=([],"Null")},[t]) ->
-			self#identify accept_anons t
-		| TLazy f ->
-			self#identify accept_anons (lazy_type f)
-		| TAnon an when accept_anons && not (PMap.is_empty an.a_fields) ->
-			Some (self#identify_anon ~strict an)
-		| _ ->
-			None
+	method identify uctx (accept_anons : bool) (t : Type.t) =
+		let rec loop t = match t with
+			| TType(td,tl) ->
+				begin try
+					Some (Mutex.protect pfm_mutex (fun () -> Hashtbl.find pfms td.t_path))
+				with Not_found ->
+					loop (apply_typedef td tl)
+				end
+			| TMono {tm_type = Some t} ->
+				loop t
+			| TAbstract(a,tl) when not (Meta.has Meta.CoreType a.a_meta) ->
+				loop (Abstract.get_underlying_type a tl)
+			| TAbstract({a_path=([],"Null")},[t]) ->
+				loop t
+			| TLazy f ->
+				loop (lazy_type f)
+			| TAnon an when accept_anons && not (PMap.is_empty an.a_fields) ->
+				Some (self#identify_anon uctx an)
+			| _ ->
+				None
+		in
+		loop t
 end


### PR DESCRIPTION
Instead of having the notion of `strict`, we just pass in a uctx. This allows additional flexibility and maybe makes it compatible with what we need for #12682.

Also related to #12714 but I'm intentionally not changing any behavior here. There's one TODO in `identity_anon` which also seems quite related.