### PR TITLE
Remove Thread.isBlocking

### DIFF
--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -94,7 +94,6 @@ class EventLoop {
 	static var eventsTls:sys.thread.Tls<EventLoop>;
 	static var threadsToEventLoops:IntMap<EventLoop>;
 	static var threadsToEventLoopsMutex:sys.thread.Mutex;
-	static final numPendingThreadTasks = new AtomicInt(0);
 	#end
 
 	var events : Event;
@@ -105,6 +104,7 @@ class EventLoop {
 	#if target.threaded
 	var mutex : sys.thread.Mutex;
 	var lockTime : sys.thread.Lock;
+	final numPendingThreadTasks : AtomicInt;
 	/**
 		The reference thread for this loop. If set, the loop can only be run within this thread.
 	**/
@@ -117,6 +117,7 @@ class EventLoop {
 		#if target.threaded
 		mutex = new sys.thread.Mutex();
 		lockTime = new sys.thread.Lock();
+		numPendingThreadTasks = new AtomicInt(0);
 		#end
 	}
 
@@ -435,7 +436,7 @@ class EventLoop {
 		#if !target.threaded
 		return false;
 		#else
-		return numPendingThreadTasks.load() > 0;
+		return main.numPendingThreadTasks.load() > 0;
 		#end
 	}
 
@@ -462,10 +463,17 @@ class EventLoop {
 	}
 
 	/**
-		Add a task to be run either on another thread or as part of the main event loop if the
-		platform does not support threads.
+		Adds `f` as a thread task on the main thread.
 	**/
 	public static function addTask( f : Void -> Void, blocking = true ) {
+		main.addThreadTask(f, blocking);
+	}
+
+	/**
+		Add a task to be run either on another thread or as part of this event loop if the
+		platform does not support threads.
+	**/
+	public function addThreadTask( f : Void -> Void, blocking = true ) {
 		#if target.threaded
 		if (blocking) {
 			numPendingThreadTasks.add(1);
@@ -474,7 +482,7 @@ class EventLoop {
 			sys.thread.Thread.create(f);
 		}
 		#else
-		main.add(f).isBlocking = blocking;
+		add(f).isBlocking = blocking;
 		#end
 	}
 

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -135,7 +135,7 @@ class EventLoop {
 	**/
 	public function loop() {
 		checkThread();
-		while( hasEvents(true) || promiseCount > 0 || (this == main && hasRunningThreads()) ) {
+		while( hasEvents(true) || promiseCount > 0 || hasRunningThreadTasks() ) {
 			var time = getNextTick();
 			// disable wait if we have our native loop alive
 			if( nativeLoop != null && time > 0 && nativeLoop.isAlive() )
@@ -433,10 +433,14 @@ class EventLoop {
 		Tells if we currently have blocking unfinished threads.
 	**/
 	public static function hasRunningThreads() {
+		return main.numPendingThreadTasks.load() > 0;
+	}
+
+	function hasRunningThreadTasks() {
 		#if !target.threaded
 		return false;
 		#else
-		return main.numPendingThreadTasks.load() > 0;
+		return numPendingThreadTasks.load() > 0;
 		#end
 	}
 
@@ -477,7 +481,10 @@ class EventLoop {
 		#if target.threaded
 		if (blocking) {
 			numPendingThreadTasks.add(1);
-			sys.thread.Thread.create(f, { onExit: () -> numPendingThreadTasks.sub(1) });
+			sys.thread.Thread.create(f, { onExit: () -> {
+				numPendingThreadTasks.sub(1);
+				wakeup();
+		 	}});
 		} else {
 			sys.thread.Thread.create(f);
 		}

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -1,7 +1,8 @@
 package haxe;
 
-import haxe.ds.IntMap;
 import haxe.EntryPoint;
+import haxe.atomic.AtomicInt;
+import haxe.ds.IntMap;
 
 class Event {
 
@@ -93,6 +94,7 @@ class EventLoop {
 	static var eventsTls:sys.thread.Tls<EventLoop>;
 	static var threadsToEventLoops:IntMap<EventLoop>;
 	static var threadsToEventLoopsMutex:sys.thread.Mutex;
+	static final numPendingThreadTasks = new AtomicInt(0);
 	#end
 
 	var events : Event;
@@ -433,7 +435,7 @@ class EventLoop {
 		#if !target.threaded
 		return false;
 		#else
-		return @:privateAccess sys.thread.Thread.hasBlocking();
+		return numPendingThreadTasks.load() > 0;
 		#end
 	}
 
@@ -465,7 +467,12 @@ class EventLoop {
 	**/
 	public static function addTask( f : Void -> Void, blocking = true ) {
 		#if target.threaded
-		sys.thread.Thread.create(f).isBlocking = blocking;
+		if (blocking) {
+			numPendingThreadTasks.add(1);
+			sys.thread.Thread.create(f, { onExit: () -> numPendingThreadTasks.sub(1) });
+		} else {
+			sys.thread.Thread.create(f);
+		}
 		#else
 		main.add(f).isBlocking = blocking;
 		#end

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -135,16 +135,27 @@ class EventLoop {
 	**/
 	public function loop() {
 		checkThread();
-		while( hasEvents(true) || promiseCount > 0 || hasRunningThreadTasks() ) {
-			var time = getNextTick();
-			// disable wait if we have our native loop alive
-			if( nativeLoop != null && time > 0 && nativeLoop.isAlive() )
-				time = -1;
-			if( time > 0 ) {
-				wait(time);
-				continue;
+		while (true) {
+			if (hasEvents(true)) {
+				var time = getNextTick();
+				// disable wait if we have our native loop alive
+				if( nativeLoop != null && time > 0 && nativeLoop.isAlive() )
+					time = -1;
+				if( time > 0 ) {
+					wait(time);
+					continue;
+				}
+				loopOnce(false);
+			} else if (promiseCount > 0 || hasRunningThreadTasks()) {
+				#if target.threaded
+				// wait till we get notified
+				lockTime.wait();
+				#else
+				// ?
+				#end
+			} else {
+				break;
 			}
-			loopOnce(false);
 		}
 	}
 

--- a/std/haxe/EventLoop.hx
+++ b/std/haxe/EventLoop.hx
@@ -433,7 +433,7 @@ class EventLoop {
 		Tells if we currently have blocking unfinished threads.
 	**/
 	public static function hasRunningThreads() {
-		return main.numPendingThreadTasks.load() > 0;
+		return main.hasRunningThreadTasks();
 	}
 
 	function hasRunningThreadTasks() {

--- a/std/haxe/atomic/AtomicInt.hx
+++ b/std/haxe/atomic/AtomicInt.hx
@@ -147,6 +147,7 @@ private typedef AtomicIntData = AtomicIntValue;
 
 /**
 	Atomic integer.
+	(js) The Atomics and SharedArrayBuffer objects need to be available. Errors will be thrown if this is not the case.
 **/
 abstract AtomicInt(AtomicIntData) {
 	public function new(value:Int):Void {

--- a/std/sys/thread/Thread.hx
+++ b/std/sys/thread/Thread.hx
@@ -73,11 +73,6 @@ class Thread {
 	final callbacks : ThreadCallbackManager;
 
 	/**
-		Tells if we needs to wait for the thread to terminate before we stop the main loop (default:true).
-	**/
-	public var isBlocking : Bool = true;
-
-	/**
 		Allows to query or change the name of the thread. On some platforms this might allow debugger to identify threads.
 	**/
 	public var name(default,set) : Null<String>;
@@ -289,19 +284,6 @@ class Thread {
 		var name = this.name;
 		if( name == null ) name = "" else name = " "+name;
 		Sys.println("THREAD"+name+" ABORTED : "+e.message+haxe.CallStack.toString(e.stack));
-	}
-
-	static function hasBlocking() {
-		// let's check if we have blocking threads running other that our calling thread
-		var me = current();
-		mutex.acquire();
-		for( t in threads )
-			if( t.impl != me.impl && t.isBlocking ) {
-				mutex.release();
-				return true;
-			}
-		mutex.release();
-		return false;
 	}
 
 	static function __init__() {

--- a/tests/threads/src/cases/TestEvents.hx
+++ b/tests/threads/src/cases/TestEvents.hx
@@ -77,6 +77,8 @@ class TestEvents extends utest.Test {
 		});
 	}
 
+	#if !python // EventLoop waiting is broken in the absence of events, needs a separate fix.
+
 	function testBlocking() {
 		var threadValue = null;
 		EventLoop.addTask(() -> {
@@ -103,4 +105,6 @@ class TestEvents extends utest.Test {
 
 		Assert.equals("ok", threadValue);
 	}
+
+	#end
 }

--- a/tests/threads/src/cases/TestEvents.hx
+++ b/tests/threads/src/cases/TestEvents.hx
@@ -1,5 +1,6 @@
 package cases;
 
+import utest.Assert;
 import haxe.EventLoop;
 
 @:timeout(2000)
@@ -76,4 +77,17 @@ class TestEvents extends utest.Test {
 		});
 	}
 
+	function testBlocking() {
+		var threadValue = null;
+		EventLoop.addTask(() -> {
+			Sys.sleep(0.1);
+			threadValue = "ok";
+		});
+
+		while (EventLoop.hasRunningThreads()) {
+			Sys.sleep(0.01);
+		}
+
+		Assert.equals("ok", threadValue);
+	}
 }

--- a/tests/threads/src/cases/TestEvents.hx
+++ b/tests/threads/src/cases/TestEvents.hx
@@ -77,8 +77,6 @@ class TestEvents extends utest.Test {
 		});
 	}
 
-	#if !python // EventLoop waiting is broken in the absence of events, needs a separate fix.
-
 	function testBlocking() {
 		var threadValue = null;
 		EventLoop.addTask(() -> {
@@ -105,6 +103,4 @@ class TestEvents extends utest.Test {
 
 		Assert.equals("ok", threadValue);
 	}
-
-	#end
 }

--- a/tests/threads/src/cases/TestEvents.hx
+++ b/tests/threads/src/cases/TestEvents.hx
@@ -90,4 +90,17 @@ class TestEvents extends utest.Test {
 
 		Assert.equals("ok", threadValue);
 	}
+
+	function testBlockingInstance() {
+		var threadValue = null;
+		final loop = new EventLoop();
+		loop.addThreadTask(() -> {
+			Sys.sleep(0.1);
+			threadValue = "ok";
+		});
+
+		loop.loop();
+
+		Assert.equals("ok", threadValue);
+	}
 }


### PR DESCRIPTION
This wasn't used by Thread itself and was another EventLoop-specific value, so it should be handled over there. That's now easy to do with our thread API because we can simply count threads.

I had this as a static value like before first, but it makes more sense to me to track this value per event loop. The static `addTask` simply adds the task to the main loop, which should give the same behavior as before. Tested with this:

```haxe
import haxe.EventLoop;

function main() {
	var threadValue = null;
	EventLoop.addTask(() -> {
		trace("Thread sleeping");
		Sys.sleep(0.5);
		trace("Thread done");
		threadValue = "ok";
	});

	trace("Main looping");
	EventLoop.current.loop();
	trace("Main done");
	trace(threadValue);
}
```

```
source/Main.hx:12: Main looping
source/Main.hx:6: Thread sleeping
source/Main.hx:8: Thread done
source/Main.hx:14: Main done
source/Main.hx:15: ok
```

And the instance version works the same way:

```haxe
import haxe.EventLoop;

function main() {
	var threadValue = null;

	final loop = new EventLoop();
	loop.addThreadTask(() -> {
		trace("Thread sleeping");
		Sys.sleep(0.1);
		trace("Thread done");
		threadValue = "ok";
	});

	trace("Loop looping");
	loop.loop();
	trace("Loop done");
	trace(threadValue);
}
```

```
source/Main.hx:8: Thread sleeping
source/Main.hx:14: Loop looping
source/Main.hx:10: Thread done
source/Main.hx:16: Loop done
source/Main.hx:17: ok
```