### PR TITLE
Add RequestQueue and WorkerDomain to server

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -1,6 +1,6 @@
 open Globals
 open Common
-open CompilationContext
+open ParsedArg
 
 let columns = lazy (match Terminal_size.get_columns () with None -> 80 | Some c -> c)
 
@@ -27,49 +27,234 @@ let usage_string ?(print_cat=true) arg_spec usage =
 		Printf.sprintf "  %s%s  %s" label (String.make (max_length - (String.length label)) ' ') doc
 	) (List.filter (fun (cat', _, _, _, _, _) -> (if List.mem cat' cat_order then cat' else "Miscellaneous") = cat) args))) cats)))
 
-let process_args arg_spec =
-	List.flatten(List.map (fun (cat, ok, dep, spec, hint, doc) ->
-		(* official argument names *)
-		(List.map (fun (arg) -> (arg, spec, doc)) ok) @
-		let dep_fun arg spec = () in
-		let dep_spec arg spec = match spec with
-			| Arg.String f -> Arg.String (fun x -> dep_fun arg spec; f x)
-			| Arg.Unit f -> Arg.Unit (fun x -> dep_fun arg spec; f x)
-			| Arg.Bool f -> Arg.Bool (fun x -> dep_fun arg spec; f x)
-			| _ -> spec in
-		(List.map (fun (arg) -> (arg, dep_spec arg spec, doc)) dep)
-	) arg_spec)
+(** Static arg descriptions used for generating help strings via [usage_string].
+    [usage_string] only reads the category, primary-flag names, hint, and doc
+    fields — the [Arg.t] value is never invoked, so [Arg.Unit ignore] is used
+    everywhere.  Entries with an empty primary-flag list ([ok = []]) are already
+    filtered out by [usage_string], so they are omitted here. *)
+let basic_args_descriptions = [
+	("Target",          ["--js"],               ["-js"],              Arg.Unit ignore, "<file>",            "generate JavaScript code into target file");
+	("Target",          ["--lua"],              ["-lua"],             Arg.Unit ignore, "<file>",            "generate Lua code into target file");
+	("Target",          ["--swf"],              ["-swf"],             Arg.Unit ignore, "<file>",            "generate Flash SWF bytecode into target file");
+	("Target",          ["--neko"],             ["-neko"],            Arg.Unit ignore, "<file>",            "generate Neko bytecode into target file");
+	("Target",          ["--php"],              ["-php"],             Arg.Unit ignore, "<directory>",       "generate PHP code into target directory");
+	("Target",          ["--cpp"],              ["-cpp"],             Arg.Unit ignore, "<directory>",       "generate C++ code into target directory");
+	("Target",          ["--cppia"],            ["-cppia"],           Arg.Unit ignore, "<file>",            "generate Cppia bytecode into target file");
+	("Target",          ["--jvm"],              ["-jvm"],             Arg.Unit ignore, "<file>",            "generate JVM bytecode into target file");
+	("Target",          ["--python"],           ["-python"],          Arg.Unit ignore, "<file>",            "generate Python code into target file");
+	("Target",          ["--hl"],               ["-hl"],              Arg.Unit ignore, "<file>",            "generate HashLink .hl bytecode or .c code into target file");
+	("Target",          ["--custom-target"],    ["-custom"],          Arg.Unit ignore, "<name[=path]>",     "generate code for a custom target");
+	("Target",          ["--interp"],           [],                   Arg.Unit ignore, "",                  "interpret the program using internal macro system");
+	("Target",          ["--run"],              [],                   Arg.Unit ignore, "<module> [args...]","interpret a Haxe module with command line arguments");
+	("Compilation",     ["-p";"--class-path"],  ["-cp"],              Arg.Unit ignore, "<path>",            "add a directory to find source files");
+	("Compilation",     ["--hxb-lib"],          ["-hxb-lib"],         Arg.Unit ignore, "<path>",            "add a hxb library");
+	("Compilation",     ["-m";"--main"],        ["-main"],            Arg.Unit ignore, "<class>",           "select startup class");
+	("Compilation",     ["-L";"--library"],     ["-lib"],             Arg.Unit ignore, "<name[:ver]>",      "use a haxelib library");
+	("Compilation",     ["-D";"--define"],      [],                   Arg.Unit ignore, "<var[=value]>",     "define a conditional compilation flag");
+	("Compilation",     ["--undefine"],         [],                   Arg.Unit ignore, "<var>",             "remove a conditional compilation flag");
+	("Debug",           ["-v";"--verbose"],     [],                   Arg.Unit ignore, "",                  "turn on verbose mode");
+	("Debug",           ["--debug"],            ["-debug"],           Arg.Unit ignore, "",                  "add debug information to the compiled code");
+	("Miscellaneous",   ["--version"],          ["-version"],         Arg.Unit ignore, "",                  "print version and exit");
+	("Miscellaneous",   ["-h";"--help"],        ["-help"],            Arg.Unit ignore, "",                  "show extended help information");
+	("Miscellaneous",   ["--help-defines"],     [],                   Arg.Unit ignore, "",                  "print help for all compiler specific defines");
+	("Miscellaneous",   ["--help-user-defines"],[],                   Arg.Unit ignore, "",                  "print help for all user defines");
+	("Miscellaneous",   ["--help-metas"],       [],                   Arg.Unit ignore, "",                  "print help for all compiler metadatas");
+	("Miscellaneous",   ["--help-user-metas"],  [],                   Arg.Unit ignore, "",                  "print help for all user metadatas");
+]
 
-type parsed_arg =
-	| SetPlatform of platform * string
+let adv_args_descriptions = [
+	("Optimization",          ["--dce"],              ["-dce"],           Arg.Unit ignore, "[std|full|no]",      "set the dead code elimination mode (default std)");
+	("Target-specific",       ["--swf-version"],      ["-swf-version"],   Arg.Unit ignore, "<version>",          "change the SWF version");
+	("Target-specific",       ["--swf-lib"],          ["-swf-lib"],       Arg.Unit ignore, "<file>",             "add the SWF library to the compiled SWF");
+	("Target-specific",       ["--swf-lib-extern"],   ["-swf-lib-extern"],Arg.Unit ignore, "<file>",             "use the SWF library for type checking");
+	("Target-specific",       ["--java-lib"],         ["-java-lib"],      Arg.Unit ignore, "<file>",             "add an external JAR or directory of JAR files");
+	("Target-specific",       ["--java-lib-extern"],  [],                 Arg.Unit ignore, "<file>",             "use an external JAR or directory of JAR files for type checking");
+	("Compilation",           ["-r";"--resource"],    ["-resource"],      Arg.Unit ignore, "<file>[@name]",      "add a named resource file");
+	("Debug",                 ["--prompt"],            ["-prompt"],        Arg.Unit ignore, "",                   "prompt on error");
+	("Compilation",           ["--cmd"],               ["-cmd"],           Arg.Unit ignore, "<command>",          "run the specified command after successful compilation");
+	("Batch",                 ["--next"],              [],                 Arg.Unit ignore, "",                   "separate several haxe compilations");
+	("Batch",                 ["--each"],              [],                 Arg.Unit ignore, "",                   "append preceding parameters to all Haxe compilations separated by --next");
+	("Services",              ["--display"],           [],                 Arg.Unit ignore, "",                   "display code tips");
+	("Services",              ["--xml"],               ["-xml"],           Arg.Unit ignore, "<file>",             "generate XML types description");
+	("Services",              ["--json"],              [],                 Arg.Unit ignore, "<file>",             "generate JSON types description");
+	("Services",              ["--hxb"],               [],                 Arg.Unit ignore, "<file>",             "generate haxe binary representation to target archive");
+	("Optimization",          ["--no-output"],         [],                 Arg.Unit ignore, "",                   "compiles but does not generate any file");
+	("Debug",                 ["--times"],             [],                 Arg.Unit ignore, "",                   "measure compilation times");
+	("Compilation",           ["--remap"],             [],                 Arg.Unit ignore, "<package:target>",   "remap a package to another one");
+	("Compilation",           ["--custom-extension"],  [],                 Arg.Unit ignore, "<extension>",        "custom extension used to shadow modules with Module.custom.hx files");
+	("Compilation",           ["--macro"],             [],                 Arg.Unit ignore, "<macro>",            "call the given macro before typing anything else");
+	("Compilation Server",    ["--server-listen"],     ["--wait"],         Arg.Unit ignore, "[[host:]port]|stdio]","wait on the given port (or use standard i/o) for commands to run");
+	("Compilation Server",    ["--server-connect"],    [],                 Arg.Unit ignore, "[host:]port]",       "connect to the given port and wait for commands to run");
+	("Compilation Server",    ["--connect"],           [],                 Arg.Unit ignore, "<[host:]port>",      "connect on the given port and run commands there");
+	("Compilation",           ["-C";"--cwd"],          [],                 Arg.Unit ignore, "<directory>",        "set current working directory");
+	("Compilation",           ["--haxelib-global"],    [],                 Arg.Unit ignore, "",                   "pass --global argument to haxelib");
+	("Compilation",           ["-w"],                  [],                 Arg.Unit ignore, "<warning list>",     "enable or disable specific warnings");
+]
 
-let parse_args_new sctx args =
+(** Pre-parse a flat string list into a [parsed_arg list].
+    This does NOT expand hxml files (they become [HxmlFile] markers) and does
+    NOT call out to haxelib (libraries become [AddLib] markers). Both are
+    handled lazily when the request is later processed.
+
+    The translation is mostly 1-to-1: one CLI flag group → one [parsed_arg].
+    Compound expansions (e.g. adding [php.Boot] for [--php], setting
+    [actx.interp] for [--interp]) are deferred to [process_args]. *)
+let parse_args (_sctx : ServerCompilationContext.t) args =
 	let parsed = DynArray.create () in
-	let set_platform platform file =
-		DynArray.add parsed (SetPlatform(platform,file))
+	let add a = DynArray.add parsed a in
+	let rec loop = function
+		| [] -> ()
+		| ("--next" | "-next") :: rest ->
+			add Next; loop rest
+		| ("--each" | "-each") :: rest ->
+			add Each; loop rest
+		| ("--cwd" | "-C") :: dir :: rest ->
+			add (Cwd dir); loop rest
+		| ("--js" | "-js") :: file :: rest ->
+			add (SetPlatform (Js, file)); loop rest
+		| ("--lua" | "-lua") :: file :: rest ->
+			add (SetPlatform (Lua, file)); loop rest
+		| ("--swf" | "-swf") :: file :: rest ->
+			add (SetPlatform (Flash, file)); loop rest
+		| ("--neko" | "-neko") :: file :: rest ->
+			add (SetPlatform (Neko, file)); loop rest
+		| ("--php" | "-php") :: dir :: rest ->
+			add (SetPlatform (Php, dir)); loop rest
+		| ("--cpp" | "-cpp") :: dir :: rest ->
+			add (SetPlatform (Cpp, dir)); loop rest
+		| ("--cppia" | "-cppia") :: file :: rest ->
+			add (SetCppiaTarget file); loop rest
+		| ("--jvm" | "-jvm") :: file :: rest ->
+			add (SetPlatform (Jvm, file));
+			add (AddLib "hxjava");
+			loop rest
+		| ("--python" | "-python") :: dir :: rest ->
+			add (SetPlatform (Python, dir)); loop rest
+		| ("--hl" | "-hl") :: file :: rest ->
+			add (SetPlatform (Hl, file)); loop rest
+		| ("--custom-target" | "-custom") :: target :: rest ->
+			let name, path = try ExtString.String.split target "=" with _ -> target, "" in
+			add (SetCustomTarget (name, path)); loop rest
+		| "-x" :: cl :: rest ->
+			(* -x is non-terminal: subsequent args remain build args *)
+			add (RunX cl); loop rest
+		| "--interp" :: rest ->
+			add Interp; loop rest
+		| "--run" :: cl :: rest ->
+			add (Run (cl, rest))
+			(* --run consumes all remaining tokens as runtime args *)
+		| ("--class-path" | "-p" | "-cp") :: path :: rest ->
+			add (AddClassPath path); loop rest
+		| "-libcp" :: path :: rest ->
+			add (AddLibClassPath path); loop rest
+		| ("--hxb-lib" | "-hxb-lib") :: file :: rest ->
+			add (AddHxbLib file); loop rest
+		| ("--main" | "-m" | "-main") :: cl :: rest ->
+			let cpath = Path.parse_type_path cl in
+			add (SetMain cpath); loop rest
+		| ("--library" | "-L" | "-lib") :: name :: rest ->
+			add (AddLib name); loop rest
+		| ("--define" | "-D") :: var :: rest ->
+			let flag, value = try let split = ExtString.String.split var "=" in (fst split, Some (snd split)) with _ -> var, None in
+			add (Define (flag, value)); loop rest
+		| "--undefine" :: var :: rest ->
+			add (Undefine var); loop rest
+		| ("--verbose" | "-v") :: rest ->
+			add SetVerbose; loop rest
+		| ("--debug" | "-debug") :: rest ->
+			add SetDebug; loop rest
+		| ("--version" | "-version") :: _ ->
+			add ShowVersion
+			(* consume remaining args - ShowVersion raises immediately in process_args *)
+		| ("--help" | "-h" | "-help") :: _ ->
+			add ShowHelp
+		| "--help-defines" :: _ ->
+			add ShowHelpDefines
+		| "--help-metas" :: _ ->
+			add ShowHelpMetas
+		| "--help-user-defines" :: _ ->
+			add ShowHelpUserDefines
+		| "--help-user-metas" :: _ ->
+			add ShowHelpUserMetas
+		| ("--dce" | "-dce") :: mode :: rest ->
+			add (SetDce mode); loop rest
+		| ("--swf-version" | "-swf-version") :: v :: rest ->
+			(try add (SetSwfVersion (float_of_string v)) with _ -> ());
+			loop rest
+		| ("--swf-lib" | "-swf-lib") :: file :: rest ->
+			add (AddNativeLib (create_native_lib file false SwfLib)); loop rest
+		| "--neko-lib-path" :: dir :: rest ->
+			add (AddNekoLibPath dir); loop rest
+		| ("--swf-lib-extern" | "-swf-lib-extern") :: file :: rest ->
+			add (AddNativeLib (create_native_lib file true SwfLib)); loop rest
+		| ("--java-lib" | "-java-lib") :: file :: rest ->
+			add (AddNativeLib (create_native_lib file false JavaLib)); loop rest
+		| "--java-lib-extern" :: file :: rest ->
+			add (AddNativeLib (create_native_lib file true JavaLib)); loop rest
+		| ("--resource" | "-r" | "-resource") :: res :: rest ->
+			(match ExtString.String.nsplit res "@" with
+			| [file; name] -> add (AddResource (file, name))
+			| [file] -> add (AddResource (file, file))
+			| _ -> ());
+			loop rest
+		| ("--prompt" | "-prompt") :: rest ->
+			add SetPrompt; loop rest
+		| ("--cmd" | "-cmd") :: cmd :: rest ->
+			add (RunCmd (Helper.unquote cmd)); loop rest
+		| "--display" :: input :: rest ->
+			add (SetDisplayArg input); loop rest
+		| ("--xml" | "-xml") :: file :: rest ->
+			add (SetXmlOut file); loop rest
+		| "--json" :: file :: rest ->
+			add (SetJsonOut file); loop rest
+		| "--hxb" :: file :: rest ->
+			add (SetHxbOut file); loop rest
+		| "--no-output" :: rest ->
+			add SetNoOutput; loop rest
+		| "--times" :: rest ->
+			add SetMeasureTimes; loop rest
+		| ("--remap" | "-remap") :: s :: rest ->
+			(try
+				let pack, target = ExtString.String.split s ":" in
+				add (Remap (pack, target))
+			with _ -> ());
+			loop rest
+		| "--custom-extension" :: ext :: rest ->
+			add (SetCustomExtension ext); loop rest
+		| ("--macro" | "-macro") :: e :: rest ->
+			add (AddMacro e); loop rest
+		| ("--server-listen" | "--wait") :: hp :: rest ->
+			add (ServerListen hp); loop rest
+		| "--server-connect" :: hp :: rest ->
+			add (ServerConnect hp); loop rest
+		| "--connect" :: hp :: rest ->
+			add (Connect hp); loop rest
+		| "--haxelib-global" :: rest ->
+			add HaxelibGlobal; loop rest
+		| "-w" :: s :: rest ->
+			add (AddWarning s); loop rest
+		| arg :: rest ->
+			(match List.rev (ExtString.String.nsplit arg ".") with
+			| "hxml" :: _ :: _ ->
+				add (HxmlFile arg)
+			| _ ->
+				(try
+					let path, name = Path.parse_path arg in
+					if StringHelper.starts_uppercase_identifier name then
+						add (AddClass (path, name))
+					else
+						add (IncludeModule arg)
+				with Failure _ ->
+					add (IncludeModule arg)));
+			loop rest
 	in
-	let basic_args_spec = [
-		("Target",["--js"],["-js"],Arg.String (set_platform Js),"<file>","generate JavaScript code into target file");
-	] in
-	let adv_args_spec = [
-		(* ... *)
-	] in
-	let all_args = (basic_args_spec @ adv_args_spec) in
-	ignore(all_args);
-	(* args parsing like in parse_args *)
+	loop args;
 	DynArray.to_list parsed
 
-let process_args_new sctx com parsed_args =
-	let process_arg arg = match arg with
-		| SetPlatform (platform, file) -> set_platform com platform file
-	in
-	List.iter process_arg parsed_args
-
-let parse_args (com : Common.context) =
-	let usage = Printf.sprintf
-		"Haxe Compiler %s - (C)2005-2025 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files and dot paths...]\n"
-		(s_version_full com.sctx.version) (if Sys.os_type = "Win32" then ".exe" else "")
-	in
+(** Apply a single-part [parsed_arg list] to [com], returning the populated
+    [arg_context].  Higher-level concerns ([Next], [Each], [AddLib] expansion,
+    hxml expansion) are handled by [Compiler.HighLevel.process_params]. *)
+let process_args (com : Common.context) (parsed_args : parsed_arg list) =
 	let actx = {
 		classes = [([],"Std")];
 		xml_out = None;
@@ -88,318 +273,248 @@ let parse_args (com : Common.context) =
 		native_libs = [];
 		raise_usage = (fun () -> ());
 		display_arg = None;
-		deprecations = [];
 		measure_times = false;
 	} in
-	let add_deprecation s =
-		actx.deprecations <- s :: actx.deprecations
+	let usage = Printf.sprintf
+		"Haxe Compiler %s - (C)2005-2025 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files and dot paths...]\n"
+		(s_version_full com.sctx.version) (if Sys.os_type = "Win32" then ".exe" else "")
 	in
-	let add_native_lib file extern kind =
-		let lib = create_native_lib file extern kind in
-		actx.native_libs <- lib :: actx.native_libs
-	in
-	let basic_args_spec = [
-		("Target",["--js"],["-js"],Arg.String (set_platform com Js),"<file>","generate JavaScript code into target file");
-		("Target",["--lua"],["-lua"],Arg.String (set_platform com Lua),"<file>","generate Lua code into target file");
-		("Target",["--swf"],["-swf"],Arg.String (set_platform com Flash),"<file>","generate Flash SWF bytecode into target file");
-		("Target",["--neko"],["-neko"],Arg.String (set_platform com Neko),"<file>","generate Neko bytecode into target file");
-		("Target",["--php"],["-php"],Arg.String (fun dir ->
-			actx.classes <- (["php"],"Boot") :: actx.classes;
-			set_platform com Php dir;
-		),"<directory>","generate PHP code into target directory");
-		("Target",["--cpp"],["-cpp"],Arg.String (fun dir ->
-			set_platform com Cpp dir;
-		),"<directory>","generate C++ code into target directory");
-		("Target",["--cppia"],["-cppia"],Arg.String (fun file ->
+	let process_one arg = match arg with
+		| SetPlatform (platform, file) ->
+			(match platform with
+			| Php ->
+				(* --php also adds the php.Boot class *)
+				actx.classes <- (["php"],"Boot") :: actx.classes
+			| Jvm ->
+				(* --jvm also sets the jvm_flag *)
+				actx.jvm_flag <- true
+			| _ -> ());
+			set_platform com platform file
+		| SetCppiaTarget file ->
+			(* --cppia: enable cppia define and target cpp *)
 			Common.define com Define.Cppia;
-			set_platform com Cpp file;
-		),"<file>","generate Cppia bytecode into target file");
-		("Target",["--jvm"],["-jvm"],Arg.String (fun dir ->
-			actx.jvm_flag <- true;
-			set_platform com Jvm dir;
-		),"<file>","generate JVM bytecode into target file");
-		("Target",["--python"],["-python"],Arg.String (fun dir ->
-			set_platform com Python dir;
-		),"<file>","generate Python code into target file");
-		("Target",["--hl"],["-hl"],Arg.String (fun file ->
-			set_platform com Hl file;
-		),"<file>","generate HashLink .hl bytecode or .c code into target file");
-		("Target",["--custom-target"],["-custom"],Arg.String (fun target ->
-			let name, path = try let split = ExtString.String.split target "=" in split with _ -> target, "" in
-			set_custom_target com name path;
-		),"<name[=path]>","generate code for a custom target");
-		("Target",[],["-x"], Arg.String (fun cl ->
-			let cpath = Path.parse_type_path cl in
-			(match com.main.main_path with
-				| Some c -> if cpath <> c then raise (Arg.Bad "Multiple --main classes specified")
-				| None -> com.main.main_path <- Some cpath);
-			actx.classes <- cpath :: actx.classes;
-			Common.define com Define.Interp;
-			set_platform com Eval "";
-			actx.interp <- true;
-		),"<class>","interpret the program using internal macro system");
-		("Target",["--interp"],[], Arg.Unit (fun() ->
-			Common.define com Define.Interp;
-			set_platform com Eval "";
-			actx.interp <- true;
-		),"","interpret the program using internal macro system");
-		("Target",["--run"],[], Arg.Unit (fun() ->
-			raise (Arg.Bad "--run requires an argument: a Haxe module name")
-		), "<module> [args...]","interpret a Haxe module with command line arguments");
-		("Compilation",["-p";"--class-path"],["-cp"],Arg.String (fun path ->
-			com.class_paths#add (new ClassPath.directory_class_path (Path.add_trailing_slash path) User);
-		),"<path>","add a directory to find source files");
-		("Compilation",[],["-libcp"],Arg.String (fun path ->
-			com.class_paths#add (new ClassPath.directory_class_path (Path.add_trailing_slash path) Lib);
-		),"<path>","add a directory to find source files");
-		("Compilation",["--hxb-lib"],["-hxb-lib"],Arg.String (fun file ->
-			let lib = create_native_lib file false HxbLib in
-			actx.hxb_libs <- lib :: actx.hxb_libs
-		),"<path>","add a hxb library");
-		("Compilation",["-m";"--main"],["-main"],Arg.String (fun cl ->
+			set_platform com Cpp file
+		| SetCustomTarget (name, path) ->
+			set_custom_target com name path
+		| AddClassPath path ->
+			com.class_paths#add (new ClassPath.directory_class_path (Path.add_trailing_slash path) User)
+		| AddLibClassPath path ->
+			com.class_paths#add (new ClassPath.directory_class_path (Path.add_trailing_slash path) Lib)
+		| AddHxbLib file ->
+			actx.hxb_libs <- create_native_lib file false HxbLib :: actx.hxb_libs
+		| SetMain cpath ->
 			if com.main.main_path <> None then raise (Arg.Bad "Multiple --main classes specified");
-			let cpath = Path.parse_type_path cl in
 			com.main.main_path <- Some cpath;
+			(* --main also adds the class for compilation (matches old parse_args behaviour) *)
 			actx.classes <- cpath :: actx.classes
-		),"<class>","select startup class");
-		("Compilation",["-L";"--library"],["-lib"],Arg.String (fun _ -> ()),"<name[:ver]>","use a haxelib library");
-		("Compilation",["-D";"--define"],[],Arg.String (fun var ->
-			let flag, value = try let split = ExtString.String.split var "=" in (fst split, Some (snd split)) with _ -> var, None in
-			match value with
-				| Some value -> Common.external_define_value com flag value
-				| None -> Common.external_define com flag;
-		),"<var[=value]>","define a conditional compilation flag");
-		("Compilation",["--undefine"],[],Arg.String (fun var ->
+		| AddLib _ | HaxelibGlobal ->
+			(* handled at the process_params level *)
+			()
+		| Define (flag, value) ->
+			(match value with
+			| Some v -> Common.external_define_value com flag v
+			| None -> Common.external_define com flag);
+			(* --no-opt also disables the foptimize flag (mirroring parse_args behavior) *)
+			if flag = "no-opt" then com.foptimize <- false
+		| Undefine var ->
 			Common.external_undefine com var
-		),"","remove a conditional compilation flag");
-		("Debug",["-v";"--verbose"],[],Arg.Unit (fun () ->
+		| SetVerbose ->
 			com.verbose <- true
-		),"","turn on verbose mode");
-		("Debug",["--debug"],["-debug"], Arg.Unit (fun() ->
+		| SetDebug ->
 			Common.define com Define.Debug;
-			com.debug <- true;
-		),"","add debug information to the compiled code");
-		("Miscellaneous",["--version"],["-version"],Arg.Unit (fun() ->
-			raise (Helper.HelpMessage (s_version_full com.sctx.version));
-		),"","print version and exit");
-		("Miscellaneous", ["-h";"--help"], ["-help"], Arg.Unit (fun () ->
-			raise (Arg.Help "")
-		),"","show extended help information");
-		("Miscellaneous",["--help-defines"],[], Arg.Unit (fun() ->
-			let all,max_length = Define.get_documentation_list com.user_defines in
-			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-			raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
-		),"","print help for all compiler specific defines");
-		("Miscellaneous",["--help-user-defines"],[], Arg.Unit (fun() ->
-			actx.did_something <- true;
-			com.callbacks#add_after_init_macros (fun() ->
-				let all,max_length = Define.get_user_documentation_list com.user_defines in
-				let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-				raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
-			)
-		),"","print help for all user defines");
-		("Miscellaneous",["--help-metas"],[], Arg.Unit (fun() ->
-			let all,max_length = Meta.get_documentation_list com.user_metas in
-			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-			raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
-		),"","print help for all compiler metadatas");
-		("Miscellaneous",["--help-user-metas"],[], Arg.Unit (fun() ->
-			actx.did_something <- true;
-			com.callbacks#add_after_init_macros (fun() ->
-				let all,max_length = Meta.get_user_documentation_list com.user_metas in
-				let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
-				raise (Helper.HelpMessage (ExtLib.String.join "\n" all));
-			)
-		),"","print help for all user metadatas");
-	] in
-	let adv_args_spec = [
-		("Optimization",["--dce"],["-dce"],Arg.String (fun mode ->
-			(match mode with
-			| "std" | "full" | "no" -> ()
-			| _ -> raise (Arg.Bad "Invalid DCE mode, expected std | full | no"));
-			Common.define_value com Define.Dce mode
-		),"[std|full|no]","set the dead code elimination mode (default std)");
-		("Target-specific",["--swf-version"],["-swf-version"],Arg.Float (fun v ->
-			if not actx.swf_version || com.flash_version < v then com.flash_version <- v;
-			actx.swf_version <- true;
-		),"<version>","change the SWF version");
-		("Target-specific",["--swf-header"],["-swf-header"],Arg.String (fun h ->
-			add_deprecation "-swf-header has been deprecated, use -D swf-header instead";
-			define_value com Define.SwfHeader h
-		),"<header>","define SWF header (width:height:fps:color)");
-		("Target-specific",["--flash-strict"],[],Arg.Unit (fun () ->
-			add_deprecation "--flash-strict has been deprecated, use -D flash-strict instead";
-			Common.define com Define.FlashStrict
-		), "","more type strict flash API");
-		("Target-specific",["--swf-lib"],["-swf-lib"],Arg.String (fun file ->
-			add_native_lib file false SwfLib;
-		),"<file>","add the SWF library to the compiled SWF");
-		("Target-specific",[],["--neko-lib-path"],Arg.String (fun dir ->
-			com.neko_lib_paths <- dir :: com.neko_lib_paths
-		),"<directory>","add the neko library path");
-		("Target-specific",["--swf-lib-extern"],["-swf-lib-extern"],Arg.String (fun file ->
-			add_native_lib file true SwfLib;
-		),"<file>","use the SWF library for type checking");
-		("Target-specific",["--java-lib"],["-java-lib"],Arg.String (fun file ->
-			add_native_lib file false JavaLib;
-		),"<file>","add an external JAR or directory of JAR files");
-		("Target-specific",["--java-lib-extern"],[],Arg.String (fun file ->
-			add_native_lib file true JavaLib;
-		),"<file>","use an external JAR or directory of JAR files for type checking");
-		("Compilation",["-r";"--resource"],["-resource"],Arg.String (fun res ->
-			let file, name = (match ExtString.String.nsplit res "@" with
-				| [file; name] -> file, name
-				| [file] -> file, file
-				| _ -> raise (Arg.Bad "Invalid Resource format, expected file@name")
-			) in
+			com.debug <- true
+		| Interp ->
+			(* --interp: define interp, set eval platform, mark actx.interp *)
+			Common.define com Define.Interp;
+			set_platform com Eval "";
+			actx.interp <- true
+		| Run _ | RunX _ ->
+			(* --run / -x: handled at process_params level *)
+			()
+		| AddResource (file, name) ->
 			let file = (try Common.find_file com file with Not_found -> file) in
 			let data = (try
 				let s = Std.input_file ~bin:true file in
 				if String.length s > 12000000 then raise Exit;
-				s;
+				s
 			with
-				| Sys_error _ -> failwith ("Resource file not found: " ^ file)
-				| _ -> failwith ("Resource '" ^ file ^ "' excess the maximum size of 12MB")
-			) in
+			| Sys_error _ -> failwith ("Resource file not found: " ^ file)
+			| _ -> failwith ("Resource '" ^ file ^ "' excess the maximum size of 12MB"))
+			in
 			if Hashtbl.mem com.resources name then failwith ("Duplicate resource name " ^ name);
 			Hashtbl.add com.resources name data
-		),"<file>[@name]","add a named resource file");
-		("Debug",["--prompt"],["-prompt"], Arg.Unit (fun() -> Helper.prompt := true),"","prompt on error");
-		("Compilation",["--cmd"],["-cmd"], Arg.String (fun cmd ->
-			actx.cmds <- Helper.unquote cmd :: actx.cmds
-		),"<command>","run the specified command after successful compilation");
-		("Optimization",["--no-traces"],[], Arg.Unit (fun () ->
-			add_deprecation "--no-traces has been deprecated, use -D no-traces instead";
-			Common.define com Define.NoTraces
-		), "","don't compile trace calls in the program");
-		("Batch",["--next"],[], Arg.Unit (fun() -> die "" __LOC__), "","separate several haxe compilations");
-		("Batch",["--each"],[], Arg.Unit (fun() -> die "" __LOC__), "","append preceding parameters to all Haxe compilations separated by --next");
-		("Services",["--display"],[], Arg.String (fun input ->
-			actx.display_arg <- Some input;
-		),"","display code tips");
-		("Services",["--xml"],["-xml"],Arg.String (fun file ->
-			actx.xml_out <- Some file
-		),"<file>","generate XML types description");
-		("Services",["--json"],[],Arg.String (fun file ->
-			actx.json_out <- Some file
-		),"<file>","generate JSON types description");
-		("Services",["--hxb"],[], Arg.String (fun file ->
-			actx.hxb_out <- Some file;
-		),"<file>", "generate haxe binary representation to target archive");
-		("Optimization",["--no-output"],[], Arg.Unit (fun() -> actx.no_output <- true),"","compiles but does not generate any file");
-		("Debug",["--times"],[], Arg.Unit (fun() ->
-			actx.measure_times <- true
-		),"","measure compilation times");
-		("Optimization",["--no-inline"],[],Arg.Unit (fun () ->
-			add_deprecation "--no-inline has been deprecated, use -D no-inline instead";
-			Common.define com Define.NoInline
-		), "","disable inlining");
-		("Optimization",["--no-opt"],[], Arg.Unit (fun() ->
-			com.foptimize <- false;
-			Common.define com Define.NoOpt;
-		), "","disable code optimizations");
-		("Compilation",["--remap"],[], Arg.String (fun s ->
-			let pack, target = (try ExtString.String.split s ":" with _ -> raise (Arg.Bad "Invalid remap format, expected source:target")) in
-			com.package_rules <- PMap.add pack (Remap target) com.package_rules;
-		),"<package:target>","remap a package to another one");
-		("Compilation",["--custom-extension"],[],Arg.String (fun ext ->
-			com.custom_ext <- Some ext;
-		),"<extension>","custom extension used to shadow modules with Module.custom.hx files");
-		("Compilation",["--macro"],[], Arg.String (fun e ->
+		| RunCmd cmd ->
+			actx.cmds <- cmd :: actx.cmds
+		| SetSwfVersion v ->
+			if not actx.swf_version || com.flash_version < v then com.flash_version <- v;
+			actx.swf_version <- true
+		| SetDce mode ->
+			(match mode with
+			| "std" | "full" | "no" -> ()
+			| _ -> raise (Arg.Bad "Invalid DCE mode, expected std | full | no"));
+			Common.define_value com Define.Dce mode
+		| AddNativeLib lib ->
+			actx.native_libs <- lib :: actx.native_libs
+		| AddNekoLibPath dir ->
+			com.neko_lib_paths <- dir :: com.neko_lib_paths
+		| Remap (pack, target) ->
+			com.package_rules <- PMap.add pack (Common.Remap target) com.package_rules
+		| SetCustomExtension ext ->
+			com.custom_ext <- Some ext
+		| AddMacro e ->
 			actx.force_typing <- true;
 			actx.config_macros <- e :: actx.config_macros
-		),"<macro>","call the given macro before typing anything else");
-		("Compilation Server",["--server-listen"],["--wait"], Arg.String (fun hp ->
-			die "" __LOC__
-		),"[[host:]port]|stdio]","wait on the given port (or use standard i/o) for commands to run");
-		("Compilation Server",["--server-connect"],[], Arg.String (fun hp ->
-			die "" __LOC__
-		),"[host:]port]","connect to the given port and wait for commands to run");
-		("Compilation Server",["--connect"],[],Arg.String (fun _ ->
-			die "" __LOC__
-		),"<[host:]port>","connect on the given port and run commands there");
-		("Compilation",["-C";"--cwd"],[], Arg.String (fun dir ->
-			(try Unix.chdir dir with _ -> raise (Arg.Bad ("Invalid directory: " ^ dir)));
-			actx.did_something <- true;
-		),"<directory>","set current working directory");
-		("Compilation",["--haxelib-global"],[], Arg.Unit (fun () -> ()),"","pass --global argument to haxelib");
-		("Compilation",["-w"],[], Arg.String (fun s ->
+		| SetDisplayArg input ->
+			actx.display_arg <- Some input
+		| SetXmlOut file ->
+			actx.xml_out <- Some file
+		| SetJsonOut file ->
+			actx.json_out <- Some file
+		| SetHxbOut file ->
+			actx.hxb_out <- Some file
+		| SetNoOutput ->
+			actx.no_output <- true
+		| SetMeasureTimes ->
+			actx.measure_times <- true
+		| AddWarning s ->
 			let p = fake_pos ("-w " ^ s) in
 			let l = Warning.parse_options s p in
 			com.warning_options <- l :: com.warning_options
-		),"<warning list>","enable or disable specific warnings");
-	] in
-	let args_callback cl =
-		begin try
-			let path,name = Path.parse_path cl in
-			if StringHelper.starts_uppercase_identifier name then
-				actx.classes <- (path,name) :: actx.classes
-			else begin
-				actx.force_typing <- true;
-				actx.config_macros <- (Printf.sprintf "include('%s', true, null, null, true)" cl) :: actx.config_macros;
-			end
-		with Failure _ when ignore_error com ->
-			()
-		end
-	in
-	let all_args = (basic_args_spec @ adv_args_spec) in
-	let all_args_spec = process_args all_args in
-	let process args =
-		let current = ref 0 in
-		(try
-			let rec loop acc args = match args with
-				| "--display" :: arg :: args ->
-					loop (arg :: "--display" :: acc) args
-				| arg :: args ->
-					loop (Helper.expand_env arg :: acc) args
-				| [] ->
-					List.rev acc
-			in
-			let args = loop [] args in
-			Arg.parse_argv ~current (Array.of_list ("Haxe" :: args)) all_args_spec args_callback "";
-		with
-		| Arg.Help _ ->
-			raise (Helper.HelpMessage (usage_string all_args usage))
-		| Arg.Bad msg ->
-			(* Strip error prefix added by ocaml's arg parser *)
-			let msg = if ExtLib.String.starts_with msg "Haxe: " then (String.sub msg 6 ((String.length msg) - 6)) else msg in
-			let first_line = List.nth (Str.split (Str.regexp "\n") msg) 0 in
-			let new_msg = (Printf.sprintf "%s" first_line) in
-			let r = Str.regexp "unknown option [`']?\\([-A-Za-z]+\\)[`']?" in
-			try
-				ignore(Str.search_forward r msg 0);
-				let s = Str.matched_group 1 msg in
-				let sl = List.map (fun (s,_,_) -> s) all_args_spec in
-				let sl = StringError.get_similar s sl in
-				begin match sl with
-				| [] -> raise Not_found
-				| _ ->
-					let spec = List.filter (fun (_,sl',sl'',_,_,_) ->
-						List.exists (fun s -> List.mem s sl) (sl' @ sl'')
-					) all_args in
-					let new_msg = (Printf.sprintf "%s\nDid you mean:\n%s" first_line (usage_string ~print_cat:false spec "")) in
-					raise (Arg.Bad new_msg)
-				end;
-			with Not_found ->
-				raise (Arg.Bad new_msg));
-		if com.platform = Globals.Cpp && not (Define.defined com.defines DisableUnicodeStrings) && not (Define.defined com.defines HxcppSmartStings) then begin
-			Define.define com.defines HxcppSmartStings;
-		end;
-		if Define.raw_defined com.defines "gen_hx_classes" then begin
-			(* TODO: this is something we're gonna remove once we have something nicer for generating flash externs *)
+		| AddClass cpath ->
+			actx.classes <- cpath :: actx.classes
+		| IncludeModule cl ->
 			actx.force_typing <- true;
-			actx.pre_compilation <- (fun() ->
-				let process_lib lib =
-					if not (lib#has_flag NativeLibraries.FlagIsStd) then
-						List.iter (fun path -> if path <> (["java";"lang"],"String") then actx.classes <- path :: actx.classes) lib#list_modules
-				in
-				List.iter process_lib com.native_libs.swf_libs;
-				List.iter process_lib com.native_libs.java_libs;
-			) :: actx.pre_compilation;
-			actx.xml_out <- Some "hx"
-		end;
+			actx.config_macros <- (Printf.sprintf "include('%s', true, null, null, true)" cl) :: actx.config_macros
+		| SetPrompt ->
+			Helper.prompt := true
+		| Cwd dir ->
+			(* Re-apply chdir: process_params applies it eagerly for hxml resolution,
+			   but entry restores the original cwd before execute_ctx, so we must
+			   re-apply here to compile in the right directory. *)
+			(try Unix.chdir dir with _ -> raise (Arg.Bad ("Invalid directory: " ^ dir)));
+			actx.did_something <- true
+		| HxmlFile _ ->
+			(* hxml files should have been expanded before reaching process_args *)
+			()
+		| Next | Each ->
+			(* batch directives handled at process_params level *)
+			()
+		| ServerListen _ | ServerConnect _ | Connect _ ->
+			(* server modes handled at process_params level *)
+			()
+		| ShowVersion ->
+			raise (Helper.HelpMessage (s_version_full com.sctx.version))
+		| ShowHelp ->
+			raise (Helper.HelpMessage (usage_string (basic_args_descriptions @ adv_args_descriptions) usage))
+		| ShowHelpDefines ->
+			let all, max_length = Define.get_documentation_list com.user_defines in
+			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
+			raise (Helper.HelpMessage (ExtLib.String.join "\n" all))
+		| ShowHelpMetas ->
+			let all, max_length = Meta.get_documentation_list com.user_metas in
+			let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
+			raise (Helper.HelpMessage (ExtLib.String.join "\n" all))
+		| ShowHelpUserDefines ->
+			actx.did_something <- true;
+			com.callbacks#add_after_init_macros (fun () ->
+				let all, max_length = Define.get_user_documentation_list com.user_defines in
+				let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
+				raise (Helper.HelpMessage (ExtLib.String.join "\n" all))
+			)
+		| ShowHelpUserMetas ->
+			actx.did_something <- true;
+			com.callbacks#add_after_init_macros (fun () ->
+				let all, max_length = Meta.get_user_documentation_list com.user_metas in
+				let all = List.map (fun (n,doc) -> Printf.sprintf " %-*s: %s" max_length n (limit_string doc (max_length + 3))) all in
+				raise (Helper.HelpMessage (ExtLib.String.join "\n" all))
+			)
 	in
-	actx.raise_usage <- (fun () -> raise (Helper.HelpMessage (usage_string basic_args_spec usage)));
-	(* Handle CLI arguments *)
-	process com.args;
+	List.iter process_one parsed_args;
+	if com.platform = Globals.Cpp && not (Define.defined com.defines DisableUnicodeStrings) && not (Define.defined com.defines HxcppSmartStings) then
+		Define.define com.defines HxcppSmartStings;
+	if Define.raw_defined com.defines "gen_hx_classes" then begin
+		actx.force_typing <- true;
+		actx.pre_compilation <- (fun() ->
+			let process_lib lib =
+				if not (lib#has_flag NativeLibraries.FlagIsStd) then
+					List.iter (fun path -> if path <> (["java";"lang"],"String") then actx.classes <- path :: actx.classes) lib#list_modules
+			in
+			List.iter process_lib com.native_libs.swf_libs;
+			List.iter process_lib com.native_libs.java_libs;
+		) :: actx.pre_compilation;
+		actx.xml_out <- Some "hx"
+	end;
+	actx.raise_usage <- (fun () ->
+		raise (Helper.HelpMessage (usage_string basic_args_descriptions usage))
+	);
 	actx
+
+(** Serialize a [parsed_arg list] back to CLI tokens for the [--connect] wire
+    protocol.  Each variant is mapped to the string(s) a user would type.
+    This is used to forward a client's arguments to a remote compilation server. *)
+let to_raw_args (parsed_args : parsed_arg list) =
+	let s_platform = function
+		| Cross -> "cross" | Js -> "js" | Lua -> "lua" | Neko -> "neko"
+		| Flash -> "swf" | Php -> "php" | Cpp -> "cpp"
+		| Jvm -> "jvm" | Python -> "python" | Hl -> "hl" | Eval -> "eval"
+		| CustomTarget name -> name
+	in
+	let s_path (p, n) = String.concat "." (p @ [n]) in
+	List.concat_map (fun arg -> match arg with
+		| SetPlatform (platform, file) -> ["--" ^ s_platform platform; file]
+		| SetCppiaTarget file -> ["--cppia"; file]
+		| SetCustomTarget (name, path) ->
+			["--custom-target"; if path = "" then name else name ^ "=" ^ path]
+		| AddClassPath path -> ["-cp"; path]
+		| AddLibClassPath path -> ["-libcp"; path]
+		| AddHxbLib file -> ["--hxb-lib"; file]
+		| SetMain p -> ["--main"; s_path p]
+		| AddLib name -> ["-lib"; name]
+		| HaxelibGlobal -> ["--haxelib-global"]
+		| Define (flag, None) -> ["-D"; flag]
+		| Define (flag, Some value) -> ["-D"; flag ^ "=" ^ value]
+		| Undefine var -> ["--undefine"; var]
+		| SetVerbose -> ["-v"]
+		| SetDebug -> ["--debug"]
+		| Interp -> ["--interp"]
+		| Run (cl, _) -> ["--run"; cl]
+		| RunX cl -> ["-x"; cl]
+		| AddResource (file, name) ->
+			if file = name then ["-r"; file] else ["-r"; file ^ "@" ^ name]
+		| RunCmd cmd -> ["--cmd"; cmd]
+		| SetSwfVersion v -> ["--swf-version"; string_of_float v]
+		| SetDce mode -> ["--dce"; mode]
+		| AddNativeLib {lib_file; lib_extern = false; lib_kind = SwfLib} -> ["--swf-lib"; lib_file]
+		| AddNativeLib {lib_file; lib_extern = true; lib_kind = SwfLib} -> ["--swf-lib-extern"; lib_file]
+		| AddNativeLib {lib_file; lib_extern = false; lib_kind = JavaLib} -> ["--java-lib"; lib_file]
+		| AddNativeLib {lib_file; lib_extern = true; lib_kind = JavaLib} -> ["--java-lib-extern"; lib_file]
+		| AddNativeLib _ -> []
+		| AddNekoLibPath dir -> ["--neko-lib-path"; dir]
+		| Remap (pack, target) -> ["--remap"; pack ^ ":" ^ target]
+		| SetCustomExtension ext -> ["--custom-extension"; ext]
+		| AddMacro e -> ["--macro"; e]
+		| SetDisplayArg input -> ["--display"; input]
+		| SetXmlOut file -> ["--xml"; file]
+		| SetJsonOut file -> ["--json"; file]
+		| SetHxbOut file -> ["--hxb"; file]
+		| SetNoOutput -> ["--no-output"]
+		| SetMeasureTimes -> ["--times"]
+		| AddWarning s -> ["-w"; s]
+		| AddClass p -> [s_path p]
+		| IncludeModule cl -> [cl]
+		| SetPrompt -> ["--prompt"]
+		| Next -> ["--next"]
+		| Each -> ["--each"]
+		| ServerListen hp -> ["--wait"; hp]
+		| ServerConnect hp -> ["--server-connect"; hp]
+		| Connect hp -> ["--connect"; hp]
+		| Cwd dir -> ["--cwd"; dir]
+		| HxmlFile path -> [path]
+		| ShowVersion -> ["--version"]
+		| ShowHelp -> ["--help"]
+		| ShowHelpDefines -> ["--help-defines"]
+		| ShowHelpMetas -> ["--help-metas"]
+		| ShowHelpUserDefines -> ["--help-user-defines"]
+		| ShowHelpUserMetas -> ["--help-user-metas"]
+	) parsed_args
+

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -40,6 +40,31 @@ let process_args arg_spec =
 		(List.map (fun (arg) -> (arg, dep_spec arg spec, doc)) dep)
 	) arg_spec)
 
+type parsed_arg =
+	| SetPlatform of platform * string
+
+let parse_args_new sctx args =
+	let parsed = DynArray.create () in
+	let set_platform platform file =
+		DynArray.add parsed (SetPlatform(platform,file))
+	in
+	let basic_args_spec = [
+		("Target",["--js"],["-js"],Arg.String (set_platform Js),"<file>","generate JavaScript code into target file");
+	] in
+	let adv_args_spec = [
+		(* ... *)
+	] in
+	let all_args = (basic_args_spec @ adv_args_spec) in
+	ignore(all_args);
+	(* args parsing like in parse_args *)
+	DynArray.to_list parsed
+
+let process_args_new sctx com parsed_args =
+	let process_arg arg = match arg with
+		| SetPlatform (platform, file) -> set_platform com platform file
+	in
+	List.iter process_arg parsed_args
+
 let parse_args (com : Common.context) =
 	let usage = Printf.sprintf
 		"Haxe Compiler %s - (C)2005-2025 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files and dot paths...]\n"

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -40,10 +40,10 @@ let process_args arg_spec =
 		(List.map (fun (arg) -> (arg, dep_spec arg spec, doc)) dep)
 	) arg_spec)
 
-let parse_args com =
+let parse_args (com : Common.context) =
 	let usage = Printf.sprintf
 		"Haxe Compiler %s - (C)2005-2025 Haxe Foundation\nUsage: haxe%s <target> [options] [hxml files and dot paths...]\n"
-		(s_version_full com.version) (if Sys.os_type = "Win32" then ".exe" else "")
+		(s_version_full com.sctx.version) (if Sys.os_type = "Win32" then ".exe" else "")
 	in
 	let actx = {
 		classes = [([],"Std")];
@@ -155,7 +155,7 @@ let parse_args com =
 			com.debug <- true;
 		),"","add debug information to the compiled code");
 		("Miscellaneous",["--version"],["-version"],Arg.Unit (fun() ->
-			raise (Helper.HelpMessage (s_version_full com.version));
+			raise (Helper.HelpMessage (s_version_full com.sctx.version));
 		),"","print version and exit");
 		("Miscellaneous", ["-h";"--help"], ["-help"], Arg.Unit (fun () ->
 			raise (Arg.Help "")

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -67,8 +67,7 @@ type compilation_callbacks = {
 }
 
 type server_connection = {
-	support_nonblock : bool;
-	read : bool -> string option;
+	read : unit -> string;
 	write : string -> unit;
 	close : unit -> unit;
 	get_stdin : unit -> in_channel option;

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -1,4 +1,5 @@
 open Globals
+open ParsedArg
 
 exception Abort
 
@@ -6,39 +7,6 @@ type server_mode =
 	| SMNone
 	| SMListen of string
 	| SMConnect of string
-
-type native_lib_kind =
-	| JavaLib
-	| SwfLib
-	| HxbLib
-
-type native_lib_arg = {
-	lib_file : string;
-	lib_kind : native_lib_kind;
-	lib_extern : bool;
-}
-
-type arg_context = {
-	mutable classes : Globals.path list;
-	mutable xml_out : string option;
-	mutable hxb_out : string option;
-	mutable json_out : string option;
-	mutable cmds : string list;
-	mutable config_macros : string list;
-	mutable no_output : bool;
-	mutable did_something : bool;
-	mutable force_typing : bool;
-	mutable pre_compilation : (unit -> unit) list;
-	mutable interp : bool;
-	mutable jvm_flag : bool;
-	mutable swf_version : bool;
-	mutable hxb_libs : native_lib_arg list;
-	mutable native_libs : native_lib_arg list;
-	mutable raise_usage : unit -> unit;
-	mutable display_arg : string option;
-	mutable deprecations : string list;
-	mutable measure_times : bool;
-}
 
 type communication = {
 	write_out : string -> unit;
@@ -56,6 +24,9 @@ and compilation_context = {
 	mutable has_error : bool;
 	comm : communication;
 	mutable runtime_args : string list;
+	(** The pre-parsed arguments for this compilation batch. Used by
+	    [Args.process_args_new] to apply arguments to [com]. *)
+	mutable parsed_args : parsed_arg list;
 }
 
 type server_connection = {
@@ -89,9 +60,3 @@ let error ctx ?(depth=0) ?(from_macro = false) msg p =
 
 let has_error ctx =
 	ctx.has_error || ctx.com.Common.has_error
-
-let create_native_lib file extern kind = {
-	lib_file = file;
-	lib_extern = extern;
-	lib_kind = kind;
-}

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -56,14 +56,6 @@ and compilation_context = {
 	mutable has_error : bool;
 	comm : communication;
 	mutable runtime_args : string list;
-	timer_ctx : Timer.timer_context;
-}
-
-type compilation_callbacks = {
-	before_anything : compilation_context -> unit;
-	after_target_init : compilation_context -> unit;
-	after_save : compilation_context -> unit;
-	after_compilation : compilation_context -> unit;
 }
 
 type server_connection = {
@@ -74,12 +66,6 @@ type server_connection = {
 }
 
 type server_accept = unit -> server_connection
-
-type server_api = {
-	sctx : ServerCompilationContext.t;
-	callbacks : compilation_callbacks;
-	on_context_create : unit -> int;
-}
 
 let message ctx msg =
 	ctx.messages <- msg :: ctx.messages

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -76,7 +76,7 @@ type server_connection = {
 type server_accept = unit -> server_connection
 
 type server_api = {
-	cache : CompilationCache.t;
+	sctx : ServerCompilationContext.t;
 	callbacks : compilation_callbacks;
 	on_context_create : unit -> int;
 }

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -77,7 +77,7 @@ let run_command ctx cmd =
 	result
 
 let run_command ctx cmd =
-	Timer.time ctx.timer_ctx ["command";cmd] (run_command ctx) cmd
+	Timer.time ctx.com.timer_ctx ["command";cmd] (run_command ctx) cmd
 
 module Setup = struct
 	let initialize_target ctx com actx =
@@ -348,14 +348,14 @@ let finalize_typing ctx tctx =
 	com.modules <- modules
 
 let finalize_typing ctx tctx =
-	Timer.time ctx.timer_ctx ["finalize"] (finalize_typing ctx) tctx
+	Timer.time ctx.com.timer_ctx ["finalize"] (finalize_typing ctx) tctx
 
 let filter ctx tctx ectx before_destruction =
-	Timer.time ctx.timer_ctx ["filters"] (fun () ->
+	Timer.time ctx.com.timer_ctx ["filters"] (fun () ->
 		run_or_diagnose ctx (fun () -> Filters.run tctx ectx before_destruction)
 	) ()
 
-let compile ctx actx callbacks =
+let compile ctx actx sctx =
 	let com = ctx.com in
 	(* Set up display configuration *)
 	DisplayProcessing.process_display_configuration ctx;
@@ -376,8 +376,8 @@ let compile ctx actx callbacks =
 	(* Initialize target: This allows access to the appropriate std packages and sets the -D defines. *)
 	let ext = Setup.initialize_target ctx com actx in
 	update_platform_config com; (* make sure to adapt all flags changes defined after platform *)
-	callbacks.after_target_init ctx;
-	Timer.time ctx.timer_ctx ["init"] (fun () ->
+	ServerCache.after_target_init sctx ctx;
+	Timer.time ctx.com.timer_ctx ["init"] (fun () ->
 		List.iter (fun f -> f()) (List.rev (actx.pre_compilation));
 		begin match actx.hxb_out with
 			| None ->
@@ -392,14 +392,14 @@ let compile ctx actx callbacks =
 		if actx.cmds = [] && not actx.did_something then actx.raise_usage();
 	end else begin
 		(* Actual compilation starts here *)
-		let (tctx,display_file_dot_path) = Timer.time ctx.timer_ctx ["typing"] (do_type ctx mctx actx) display_file_dot_path in
+		let (tctx,display_file_dot_path) = Timer.time ctx.com.timer_ctx ["typing"] (do_type ctx mctx actx) display_file_dot_path in
 		DisplayProcessing.handle_display_after_typing ctx tctx display_file_dot_path;
 		let ectx = ExceptionInit.create_exception_context tctx in
 		finalize_typing ctx tctx;
 		Dump.maybe_generate_dump ctx.com AfterTyping;
 		let is_compilation = is_compilation com in
 		com.callbacks#add_after_save (fun () ->
-			callbacks.after_save ctx;
+			ServerCache.after_save sctx ctx;
 			if is_compilation then match com.hxb_writer_config with
 				| Some config ->
 					Generate.check_hxb_output ctx config;
@@ -431,8 +431,8 @@ let compile ctx actx callbacks =
 		) (List.rev actx.cmds)
 	end
 
-let make_ice_message com msg backtrace =
-		let ver = (s_version_full com.version) in
+let make_ice_message (com : Common.context) msg backtrace =
+		let ver = (s_version_full com.sctx.version) in
 		let os_type = if Sys.unix then "unix" else "windows" in
 		Printf.sprintf "%s\nHaxe: %s; OS type: %s;\n%s" msg ver os_type backtrace
 let compile_safe ctx f =
@@ -487,7 +487,7 @@ let compile_safe ctx f =
 	try compile_safe ctx f with Abort -> ()
 
 let finalize ctx =
-	ctx.com.io.close ();
+	ctx.com.part_scope.io.close ();
 	List.iter (fun lib -> lib#close) ctx.com.hxb_libs;
 	(* In server mode any open libs are closed by the lib_build_task. In offline mode
 		we should do it here to be safe. *)
@@ -500,18 +500,18 @@ let emit_completion ctx str =
 	ServerMessage.completion str;
 	ctx.comm.write_err str
 
-let catch_completion_and_exit ctx callbacks run =
+let catch_completion_and_exit ctx sctx run =
 	try
 		run ctx;
 		if ctx.has_error then 1 else 0
 	with
 		| DisplayProcessingGlobals.Completion str ->
-			callbacks.after_compilation ctx;
+			ServerCache.after_compilation sctx ctx;
 			emit_completion ctx str;
 			finalize ctx;
 			0
 		| DisplayJson.JsonCompleted ->
-			callbacks.after_compilation ctx;
+			ServerCache.after_compilation sctx ctx;
 			finalize ctx;
 			0
 		| EvalTypes.Sys_exit i | Hlinterp.Sys_exit i ->
@@ -522,7 +522,7 @@ let catch_completion_and_exit ctx callbacks run =
 
 let process_actx ctx actx =
 	ctx.com.doinline <- ctx.com.display.dms_inline && not (Common.defined ctx.com Define.NoInline);
-	ctx.timer_ctx.measure_times <- (if actx.measure_times then Yes else No);
+	ctx.com.timer_ctx.measure_times <- (if actx.measure_times then Yes else No);
 	match DisplayProcessing.process_display_arg ctx actx with
 	| Completed ->
 		raise DisplayJson.JsonCompleted
@@ -534,17 +534,17 @@ let process_actx ctx actx =
 			ctx.com.warning_options <- [{wo_warning = WDeprecated; wo_mode = WMDisable}] :: ctx.com.warning_options
 		end
 
-let compile_ctx callbacks ctx =
+let compile_ctx sctx ctx =
 	let run ctx =
-		callbacks.before_anything ctx;
+		ServerCache.before_anything sctx ctx;
 		Setup.setup_common_context ctx;
 		compile_safe ctx (fun () ->
 			let actx = Args.parse_args ctx.com in
 			process_actx ctx actx;
-			compile ctx actx callbacks;
+			compile ctx actx sctx;
 		);
 		ctx.comm.flush ctx;
-		callbacks.after_compilation ctx;
+		ServerCache.after_compilation sctx ctx;
 		finalize ctx;
 	in
 	if ctx.has_error then begin
@@ -552,17 +552,9 @@ let compile_ctx callbacks ctx =
 		finalize ctx;
 		1 (* can happen if process_params fails already *)
 	end else
-		catch_completion_and_exit ctx callbacks run
+		catch_completion_and_exit ctx sctx run
 
-let create_context comm cs timer_ctx compilation_step params =
-	let version = {
-		version = version;
-		major = version_major;
-		minor = version_minor;
-		revision = version_revision;
-		pre = version_pre;
-		extra = Version.version_extra;
-	} in
+let create_context comm sctx request_scope compilation_step params =
 	let io = if comm.is_server then begin
 		(* In server mode, create pipes so that writing to stdout/stderr channels
 		   gets forwarded through the communication protocol to the client. *)
@@ -620,7 +612,12 @@ let create_context comm cs timer_ctx compilation_step params =
 			close = (fun () -> ());
 		}
 	in
-	let com = Common.create io timer_ctx compilation_step cs version params (DisplayTypes.DisplayMode.create DMNone) in
+	let part_scope = {
+		warned_positions = Hashtbl.create 0;
+		diagnostics_messages = [];
+		io;
+	} in
+	let com = Common.create sctx request_scope part_scope compilation_step params (DisplayTypes.DisplayMode.create DMNone) in
 	{
 		com;
 		messages = [];
@@ -628,7 +625,6 @@ let create_context comm cs timer_ctx compilation_step params =
 		has_error = false;
 		comm = comm;
 		runtime_args = [];
-		timer_ctx = timer_ctx;
 	}
 
 module HighLevel = struct
@@ -685,14 +681,15 @@ module HighLevel = struct
 			lines
 
 	(* Returns a list of contexts, but doesn't do anything yet *)
-	let process_params server_api timer_ctx create each_args has_display is_server args =
+	let process_params (sctx : ServerCompilationContext.t) (request_scope : request_scope) create each_args has_display is_server args =
 		(* We want the loop below to actually see all the --each params, so let's prepend them *)
 		let args = !each_args @ args in
 		let added_libs = Hashtbl.create 0 in
 		let server_mode = ref SMNone in
 		let hxml_stack = ref [] in
 		let create_context args =
-			let ctx = create (server_api.on_context_create()) args in
+			sctx.compilation_step <- sctx.compilation_step + 1;
+			let ctx = create sctx.compilation_step args in
 			ctx
 		in
 		let rec find_subsequent_libs acc args = match args with
@@ -743,7 +740,7 @@ module HighLevel = struct
 				let libs,args = find_subsequent_libs [name] args in
 				let libs = List.filter (fun l -> not (Hashtbl.mem added_libs l)) libs in
 				List.iter (fun l -> Hashtbl.add added_libs l ()) libs;
-				let lines = add_libs timer_ctx libs args server_api.sctx.cs has_display in
+				let lines = add_libs request_scope.timer_ctx libs args sctx.cs has_display in
 				loop acc (lines @ args)
 			| ("--jvm" | "-jvm" as arg) :: dir :: args ->
 				loop_lib arg dir "hxjava" acc args
@@ -765,7 +762,7 @@ module HighLevel = struct
 		let args,ctx = loop [] args in
 		args,!server_mode,ctx
 
-	let rec execute_ctx server_api ctx server_mode =
+	let rec execute_ctx (sctx : ServerCompilationContext.t) ctx server_mode =
 		begin match server_mode with
 		| SMListen hp ->
 			(* parse for com.verbose *)
@@ -781,12 +778,11 @@ module HighLevel = struct
 			let accept = Server.init_wait_connect host port in
 			Server.wait_loop entry ctx.com.verbose accept
 		| SMNone ->
-			compile_ctx server_api.callbacks ctx
+			compile_ctx sctx ctx
 		end
 
-	and entry server_api comm args =
-		let timer_ctx = Timer.make_context (Timer.make ["other"]) in
-		let create = create_context comm server_api.sctx timer_ctx in
+	and entry sctx request_scope comm args =
+		let create = create_context comm sctx request_scope in
 		let each_args = ref [] in
 		let curdir = Unix.getcwd () in
 		let has_display = ref false in
@@ -800,7 +796,7 @@ module HighLevel = struct
 		in
 		let rec loop args =
 			let args,server_mode,ctx = try
-				process_params server_api timer_ctx create each_args !has_display comm.is_server args
+				process_params sctx request_scope create each_args !has_display comm.is_server args
 			with Arg.Bad msg ->
 				let ctx = create 0 args in
 				error ctx ("Error: " ^ msg) null_pos;
@@ -810,7 +806,7 @@ module HighLevel = struct
 				| Some ctx ->
 					(* Need chdir here because --cwd is eagerly applied in process_params *)
 					Unix.chdir curdir;
-					execute_ctx server_api ctx server_mode
+					execute_ctx sctx ctx server_mode
 				| None ->
 					(* caused by --connect *)
 					0
@@ -823,5 +819,5 @@ module HighLevel = struct
 				code
 		in
 		let code = loop args in
-		comm.exit timer_ctx code
+		comm.exit request_scope.timer_ctx code
 end

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -743,7 +743,7 @@ module HighLevel = struct
 				let libs,args = find_subsequent_libs [name] args in
 				let libs = List.filter (fun l -> not (Hashtbl.mem added_libs l)) libs in
 				List.iter (fun l -> Hashtbl.add added_libs l ()) libs;
-				let lines = add_libs timer_ctx libs args server_api.cache has_display in
+				let lines = add_libs timer_ctx libs args server_api.sctx.cs has_display in
 				loop acc (lines @ args)
 			| ("--jvm" | "-jvm" as arg) :: dir :: args ->
 				loop_lib arg dir "hxjava" acc args
@@ -786,7 +786,7 @@ module HighLevel = struct
 
 	and entry server_api comm args =
 		let timer_ctx = Timer.make_context (Timer.make ["other"]) in
-		let create = create_context comm server_api.cache timer_ctx in
+		let create = create_context comm server_api.sctx timer_ctx in
 		let each_args = ref [] in
 		let curdir = Unix.getcwd () in
 		let has_display = ref false in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -33,6 +33,66 @@ let run_or_diagnose ctx f =
 	else
 		f ()
 
+module PipeThings = struct
+	open ServerCommunication
+
+	let run_command comm cmd =
+		let (child_stdin_r, child_stdin_w) = Unix.pipe ~cloexec:true () in
+		let (child_stdout_r, child_stdout_w) = Unix.pipe ~cloexec:true () in
+		let (child_stderr_r, child_stderr_w) = Unix.pipe ~cloexec:true () in
+		let shell, args =
+			if Sys.win32 then
+				"cmd.exe", [|"cmd.exe"; "/c"; cmd|]
+			else
+				"/bin/sh", [|"/bin/sh"; "-c"; cmd|]
+		in
+		let pid = Unix.create_process_env shell args (Unix.environment()) child_stdin_r child_stdout_w child_stderr_w in
+		Unix.close child_stdin_r;
+		Unix.close child_stdout_w;
+		Unix.close child_stderr_w;
+		let pout = Unix.in_channel_of_descr child_stdout_r in
+		let pin = Unix.out_channel_of_descr child_stdin_w in
+		let perr = Unix.in_channel_of_descr child_stderr_r in
+		let bout = Bytes.create 1024 in
+		let berr = Bytes.create 1024 in
+		let rec read_content channel buf f =
+			begin try
+				let i = input channel buf 0 1024 in
+				if i > 0 then begin
+					f (Bytes.unsafe_to_string (Bytes.sub buf 0 i));
+					read_content channel buf f
+				end
+			with Unix.Unix_error _ ->
+				()
+			end
+		in
+		let tin = match comm.stdin with
+			| Some stdin_pipe ->
+				Some (Thread.create (fun () ->
+					let buf = Bytes.create 1024 in
+					(try while true do
+						let i = input stdin_pipe buf 0 1024 in
+						if i = 0 then raise Exit;
+						output_string pin (Bytes.sub_string buf 0 i);
+						flush pin
+					done with _ -> ());
+					close_out_noerr pin
+				) ())
+			| None ->
+				close_out_noerr pin;
+				None
+		in
+		let tout = Thread.create (fun() -> read_content pout bout comm.write_out) () in
+		let terr = Thread.create (fun() -> read_content perr berr comm.write_err) () in
+		(match tin with Some t -> Thread.join t | None -> ());
+		Thread.join tout;
+		Thread.join terr;
+		close_in_noerr pout;
+		close_in_noerr perr;
+		let _, status = Unix.waitpid [] pid in
+		match status with Unix.WEXITED c | Unix.WSIGNALED c | Unix.WSTOPPED c -> c
+end
+
 let run_command ctx cmd =
 	(* TODO: this is a hack *)
 	let cmd = if ctx.comm.is_server then begin
@@ -52,27 +112,10 @@ let run_command ctx cmd =
 			(* In non-server mode, inherit stdin/stdout/stderr so that interactive commands work *)
 			Sys.command cmd
 		else begin
-			(* In server mode, capture stdout/stderr and send them through the communication channel *)
-			let pout, pin, perr = Unix.open_process_full cmd (Unix.environment()) in
-			let bout = Bytes.create 1024 in
-			let berr = Bytes.create 1024 in
-			let rec read_content channel buf f =
-				begin try
-					let i = input channel buf 0 1024 in
-					if i > 0 then begin
-						f (Bytes.unsafe_to_string (Bytes.sub buf 0 i));
-						read_content channel buf f
-					end
-				with Unix.Unix_error _ ->
-					()
-				end
-			in
-			let tout = Thread.create (fun() -> read_content pout bout ctx.comm.write_out) () in
-			let terr = Thread.create (fun() -> read_content perr berr ctx.comm.write_err) () in
-			Thread.join tout;
-			Thread.join terr;
-			let result = (match Unix.close_process_full (pout,pin,perr) with Unix.WEXITED c | Unix.WSIGNALED c | Unix.WSTOPPED c -> c) in
-			result
+			(* In server mode, capture stdout/stderr and forward stdin through the communication channel.
+			   We use create_process instead of open_process_full so that we can
+			   properly forward the client's stdin and close it to signal EOF. *)
+			PipeThings.run_command ctx.comm cmd
 		end
 	in
 	result

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -770,10 +770,7 @@ module HighLevel = struct
 		| SMListen hp ->
 			(* parse for com.verbose *)
 			ignore(Args.parse_args ctx.com);
-			let accept = match hp with
-			| "stdio" ->
-				Server.init_wait_stdio()
-			| _ ->
+			let accept =
 				let host, port = Helper.parse_host_port hp in
 				Server.init_wait_socket host port
 			in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -1,6 +1,7 @@
 open Globals
 open Common
 open CompilationContext
+open ParsedArg
 
 let handle_diagnostics ctx msg p kind =
 	ctx.has_error <- true;
@@ -527,9 +528,6 @@ let process_actx ctx actx =
 	| Completed ->
 		raise DisplayJson.JsonCompleted
 	| NotCompleted ->
-		List.iter (fun s ->
-			ctx.com.warning WDeprecated [] s null_pos
-		) actx.deprecations;
 		if defined ctx.com NoDeprecationWarnings then begin
 			ctx.com.warning_options <- [{wo_warning = WDeprecated; wo_mode = WMDisable}] :: ctx.com.warning_options
 		end
@@ -539,7 +537,7 @@ let compile_ctx sctx ctx =
 		ServerCache.before_anything sctx ctx;
 		Setup.setup_common_context ctx;
 		compile_safe ctx (fun () ->
-			let actx = Args.parse_args ctx.com in
+			let actx = Args.process_args ctx.com ctx.parsed_args in
 			process_actx ctx actx;
 			compile ctx actx sctx;
 		);
@@ -554,7 +552,7 @@ let compile_ctx sctx ctx =
 	end else
 		catch_completion_and_exit ctx sctx run
 
-let create_context comm sctx request_scope compilation_step params =
+let create_context comm sctx request_scope compilation_step (parsed_args : parsed_arg list) =
 	let io = if comm.is_server then begin
 		(* In server mode, create pipes so that writing to stdout/stderr channels
 		   gets forwarded through the communication protocol to the client. *)
@@ -617,7 +615,7 @@ let create_context comm sctx request_scope compilation_step params =
 		diagnostics_messages = [];
 		io;
 	} in
-	let com = Common.create sctx request_scope part_scope compilation_step params (DisplayTypes.DisplayMode.create DMNone) in
+	let com = Common.create sctx request_scope part_scope compilation_step (Args.to_raw_args parsed_args) (DisplayTypes.DisplayMode.create DMNone) in
 	{
 		com;
 		messages = [];
@@ -625,6 +623,7 @@ let create_context comm sctx request_scope compilation_step params =
 		has_error = false;
 		comm = comm;
 		runtime_args = [];
+		parsed_args;
 	}
 
 module HighLevel = struct
@@ -681,99 +680,113 @@ module HighLevel = struct
 			lines
 
 	(* Returns a list of contexts, but doesn't do anything yet *)
-	let process_params (sctx : ServerCompilationContext.t) (request_scope : request_scope) create each_args has_display is_server args =
+	let process_params (sctx : ServerCompilationContext.t) (request_scope : request_scope) create each_args has_display is_server (args : parsed_arg list) =
 		(* We want the loop below to actually see all the --each params, so let's prepend them *)
 		let args = !each_args @ args in
 		let added_libs = Hashtbl.create 0 in
 		let server_mode = ref SMNone in
 		let hxml_stack = ref [] in
-		let create_context args =
+		let create_context parsed =
 			sctx.compilation_step <- sctx.compilation_step + 1;
-			let ctx = create sctx.compilation_step args in
+			let ctx = create sctx.compilation_step parsed in
 			ctx
 		in
 		let rec find_subsequent_libs acc args = match args with
-		| ("-L" | "--library" | "-lib") :: name :: args ->
+		| AddLib name :: args ->
 			find_subsequent_libs (name :: acc) args
 		| _ ->
-			List.rev acc,args
+			List.rev acc, args
+		in
+		let expand_libs libs rest =
+			let libs = List.filter (fun l -> not (Hashtbl.mem added_libs l)) libs in
+			List.iter (fun l -> Hashtbl.add added_libs l ()) libs;
+			let global_repo = List.exists (fun a -> a = HaxelibGlobal) args in
+			let raw_lines = add_libs request_scope.timer_ctx libs (if global_repo then ["--haxelib-global"] else []) sctx.cs has_display in
+			(Args.parse_args sctx raw_lines) @ rest
 		in
 		let rec loop acc = function
 			| [] ->
-				[],Some (create_context (List.rev acc))
-			| "--next" :: l when acc = [] -> (* skip empty --next *)
+				[], Some (create_context (List.rev acc))
+			| Next :: l when acc = [] -> (* skip empty --next *)
 				loop [] l
-			| "--next" :: l ->
+			| Next :: l ->
 				let ctx = create_context (List.rev acc) in
 				ctx.has_next <- true;
-				l,Some ctx
-			| "--each" :: l ->
+				l, Some ctx
+			| Each :: l ->
 				each_args := List.rev acc;
 				loop acc l
-			| "--cwd" :: dir :: l | "-C" :: dir :: l ->
-				(* we need to change it immediately since it will affect hxml loading *)
-				(* Exceptions are ignored there to let arg parsing do the error handling in expected order *)
+			| Cwd dir :: l ->
+				(* Apply cwd eagerly for hxml file resolution *)
 				(try Unix.chdir dir with _ -> ());
-				(* Push the --cwd arg so the arg processor know we did something. *)
-				loop (dir :: "--cwd" :: acc) l
-			| "--connect" :: hp :: l ->
+				loop (Cwd dir :: acc) l
+			| Connect hp :: l ->
 				if is_server then
 					(* If we are already connected, ignore (issue #10813) *)
 					loop acc l
 				else begin
 					let host, port = Helper.parse_host_port hp in
+					(* Forward accumulated + remaining args to the remote server *)
 					ignore(Server.Connect.do_connect host port ((List.rev acc) @ l));
-					[],None
+					[], None
 				end
-			| "--server-connect" :: hp :: l ->
+			| ServerConnect hp :: l ->
 				server_mode := SMConnect hp;
 				loop acc l
-			| ("--server-listen" | "--wait") :: hp :: l ->
+			| ServerListen hp :: l ->
 				server_mode := SMListen hp;
 				loop acc l
-			| "--run" :: cl :: args ->
-				let acc = cl :: "-x" :: acc in
+			| Run (cl, runtime_args) :: _ ->
+				(* --run: expand into SetMain + Interp, then create context.
+				   This is terminal: remaining args become runtime_args (already in tuple).
+				   Normalise com.args to the -x form, matching old parse_args behaviour. *)
+				let cpath = Path.parse_type_path cl in
+				let acc = Interp :: SetMain cpath :: acc in
 				let ctx = create_context (List.rev acc) in
-				ctx.runtime_args <- args;
-				[],Some ctx
-			| ("-L" | "--library" | "-lib") :: name :: args ->
-				let libs,args = find_subsequent_libs [name] args in
-				let libs = List.filter (fun l -> not (Hashtbl.mem added_libs l)) libs in
-				List.iter (fun l -> Hashtbl.add added_libs l ()) libs;
-				let lines = add_libs request_scope.timer_ctx libs args sctx.cs has_display in
-				loop acc (lines @ args)
-			| ("--jvm" | "-jvm" as arg) :: dir :: args ->
-				loop_lib arg dir "hxjava" acc args
+				ctx.runtime_args <- runtime_args;
+				[], Some ctx
+			| RunX cl :: l ->
+				(* -x: non-terminal shorthand for SetMain + Interp; subsequent args are still build args *)
+				let cpath = Path.parse_type_path cl in
+				loop (Interp :: SetMain cpath :: acc) l
+			| AddLib name :: args ->
+				let libs, args = find_subsequent_libs [name] args in
+				loop acc (expand_libs libs args)
+			| HxmlFile path :: l ->
+				let full_path = try Extc.get_full_path path with Failure(_) -> raise (Arg.Bad (Printf.sprintf "File not found: %s" path)) in
+				if List.mem full_path !hxml_stack then
+					raise (Arg.Bad (Printf.sprintf "Duplicate hxml inclusion: %s" full_path))
+				else
+					hxml_stack := full_path :: !hxml_stack;
+				(* Separate "file not found" from "file exists but is empty/all-comments":
+				   an empty hxml (e.g. cleared by CI for platform reasons) is a no-op,
+				   not an error. *)
+				let hxml_raw, expanded =
+					try
+						let raw = Helper.parse_hxml path in
+						raw, Args.parse_args sctx raw
+					with Not_found ->
+						[], [IncludeModule (path ^ " (file not found)")]
+				in
+				loop acc (expanded @ l)
 			| arg :: l ->
-				match List.rev (ExtString.String.nsplit arg ".") with
-				| "hxml" :: _ :: _ when (match acc with "-cmd" :: _ | "--cmd" :: _ -> false | _ -> true) ->
-					let full_path = try Extc.get_full_path arg with Failure(_) -> raise (Arg.Bad (Printf.sprintf "File not found: %s" arg)) in
-					if List.mem full_path !hxml_stack then
-						raise (Arg.Bad (Printf.sprintf "Duplicate hxml inclusion: %s" full_path))
-					else
-						hxml_stack := full_path :: !hxml_stack;
-					let acc, l = (try acc, Helper.parse_hxml arg @ l with Not_found -> (arg ^ " (file not found)") :: acc, l) in
-					loop acc l
-				| _ ->
-					loop (arg :: acc) l
-		and loop_lib arg dir lib acc args =
-			loop (dir :: arg :: acc) ("-lib" :: lib :: args)
+				loop (arg :: acc) l
 		in
-		let args,ctx = loop [] args in
-		args,!server_mode,ctx
+		let args, ctx = loop [] args in
+		args, !server_mode, ctx
 
 	let rec execute_ctx (sctx : ServerCompilationContext.t) ctx server_mode =
 		begin match server_mode with
 		| SMListen hp ->
-			(* parse for com.verbose *)
-			ignore(Args.parse_args ctx.com);
+			(* Apply args to get com.verbose before starting the wait loop *)
+			ignore(Args.process_args ctx.com ctx.parsed_args);
 			let accept =
 				let host, port = Helper.parse_host_port hp in
 				Server.init_wait_socket host port
 			in
 			Server.wait_loop entry ctx.com.verbose accept
 		| SMConnect hp ->
-			ignore(Args.parse_args ctx.com);
+			ignore(Args.process_args ctx.com ctx.parsed_args);
 			let host, port = Helper.parse_host_port hp in
 			let accept = Server.init_wait_connect host port in
 			Server.wait_loop entry ctx.com.verbose accept
@@ -781,19 +794,11 @@ module HighLevel = struct
 			compile_ctx sctx ctx
 		end
 
-	and entry sctx request_scope comm args =
+	and entry sctx request_scope comm (args : parsed_arg list) =
 		let create = create_context comm sctx request_scope in
 		let each_args = ref [] in
 		let curdir = Unix.getcwd () in
-		let has_display = ref false in
-		(* put --display in front if it was last parameter *)
-		let args = match List.rev args with
-			| file :: "--display" :: pl when file <> "memory" ->
-				has_display := true;
-				"--display" :: file :: List.rev pl
-			| _ ->
-				args
-		in
+		let has_display = ref (List.exists (fun a -> match a with SetDisplayArg _ -> true | _ -> false) args) in
 		let rec loop args =
 			let args,server_mode,ctx = try
 				process_params sctx request_scope create each_args !has_display comm.is_server args

--- a/src/compiler/displayProcessing.ml
+++ b/src/compiler/displayProcessing.ml
@@ -1,6 +1,7 @@
 open Globals
 open Common
 open CompilationContext
+open ParsedArg
 open DisplayProcessingGlobals
 
 type display_path_kind =

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -68,7 +68,7 @@ let check_hxb_output ctx config =
 	let try_write from_cache =
 		let path = config.HxbWriterConfig.archive_path in
 		let path = Str.global_replace (Str.regexp "\\$target") (platform_name ctx.com.platform) path in
-		let t = Timer.start_timer ctx.timer_ctx ["generate";"hxb"] in
+		let t = Timer.start_timer ctx.com.timer_ctx ["generate";"hxb"] in
 		Path.mkdir_from_path path;
 		let zip = new Zip_output.zip_output path 6 in
 		let export com config =
@@ -77,7 +77,7 @@ let check_hxb_output ctx config =
 			let f m =
 				let sl_path = fst m.m_path @ [snd m.m_path] in
 				if not (match_path_list config.exclude sl_path) || match_path_list config.include' sl_path then
-					Timer.time ctx.timer_ctx ["generate";"hxb";s_type_path m.m_path] (export_hxb from_cache com config cc target) m
+					Timer.time ctx.com.timer_ctx ["generate";"hxb";s_type_path m.m_path] (export_hxb from_cache com config cc target) m
 				else
 					None
 			in
@@ -150,7 +150,7 @@ let generate ctx tctx ext actx =
 		| _ -> Path.mkdir_from_path com.file
 	end;
 	if actx.interp then begin
-		let timer = Timer.start_timer ctx.timer_ctx ["interp"] in
+		let timer = Timer.start_timer ctx.com.timer_ctx ["interp"] in
 		let old = tctx.com.args in
 		tctx.com.args <- ctx.runtime_args;
 		let restore () =

--- a/src/compiler/generate.ml
+++ b/src/compiler/generate.ml
@@ -1,5 +1,6 @@
 open Globals
 open CompilationContext
+open ParsedArg
 open TType
 open Tanon_identification
 

--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -59,4 +59,5 @@ set_binary_mode_out stdout true;
 set_binary_mode_out stderr true;
 let sctx = ServerCompilationContext.create false in
 let request_scope = Server.create_request_scope () in
-Server.process sctx request_scope Compiler.HighLevel.entry (ServerCommunication.Communication.create_stdio ()) args;
+let parsed_args = Args.parse_args sctx args in
+Server.process sctx request_scope Compiler.HighLevel.entry (ServerCommunication.Communication.create_stdio ()) parsed_args;

--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -58,4 +58,5 @@ let args = List.tl (Array.to_list Sys.argv) in
 set_binary_mode_out stdout true;
 set_binary_mode_out stderr true;
 let sctx = ServerCompilationContext.create false in
-Server.process sctx Compiler.HighLevel.entry (ServerCommunication.Communication.create_stdio ()) args;
+let request_scope = Server.create_request_scope () in
+Server.process sctx request_scope Compiler.HighLevel.entry (ServerCommunication.Communication.create_stdio ()) args;

--- a/src/compiler/parsedArg.ml
+++ b/src/compiler/parsedArg.ml
@@ -1,0 +1,99 @@
+open Globals
+open Ast
+
+type native_lib_kind =
+	| JavaLib
+	| SwfLib
+	| HxbLib
+
+type native_lib_arg = {
+	lib_file : string;
+	lib_kind : native_lib_kind;
+	lib_extern : bool;
+}
+
+type parsed_arg =
+	(* Targets *)
+	| SetPlatform of platform * string
+	| SetCustomTarget of string * string
+	| SetCppiaTarget of string   (** --cppia: cpp target with cppia define *)
+	(* Compilation *)
+	| AddClassPath of string
+	| AddLibClassPath of string
+	| AddHxbLib of string
+	| SetMain of path
+	| AddLib of string
+	| HaxelibGlobal
+	| Define of string * string option
+	| Undefine of string
+	| SetVerbose
+	| SetDebug
+	| Interp                    (** --interp: eval target + interp flag *)
+	| Run of string * string list (** --run: path + runtime args (terminal; rest becomes argv) *)
+	| RunX of string            (** -x: shorthand run (non-terminal; subsequent args are still build args) *)
+	| AddResource of string * string
+	| RunCmd of string
+	| SetSwfVersion of float
+	| SetDce of string
+	| AddNativeLib of native_lib_arg
+	| AddNekoLibPath of string
+	| Remap of string * string
+	| SetCustomExtension of string
+	| AddMacro of string
+	| SetDisplayArg of string
+	| SetXmlOut of string
+	| SetJsonOut of string
+	| SetHxbOut of string
+	| SetNoOutput
+	| SetMeasureTimes
+	| AddWarning of string
+
+	| AddClass of path
+	| IncludeModule of string
+	| SetPrompt
+	(* Batch *)
+	| Next
+	| Each
+	(* Server *)
+	| ServerListen of string
+	| ServerConnect of string
+	| Connect of string
+	(* Working directory - applied eagerly for hxml resolution *)
+	| Cwd of string
+	(* Hxml file reference - expanded lazily in process_params *)
+	| HxmlFile of string
+	(* Early-exit helpers (raise HelpMessage when processed) *)
+	| ShowVersion
+	| ShowHelp
+	| ShowHelpDefines
+	| ShowHelpMetas
+	| ShowHelpUserDefines
+	| ShowHelpUserMetas
+
+type arg_context = {
+	mutable classes : Globals.path list;
+	mutable xml_out : string option;
+	mutable hxb_out : string option;
+	mutable json_out : string option;
+	mutable cmds : string list;
+	mutable config_macros : string list;
+	mutable no_output : bool;
+	mutable did_something : bool;
+	mutable force_typing : bool;
+	mutable pre_compilation : (unit -> unit) list;
+	mutable interp : bool;
+	mutable jvm_flag : bool;
+	mutable swf_version : bool;
+	mutable hxb_libs : native_lib_arg list;
+	mutable native_libs : native_lib_arg list;
+	mutable raise_usage : unit -> unit;
+	mutable display_arg : string option;
+
+	mutable measure_times : bool;
+}
+
+let create_native_lib file extern kind = {
+	lib_file = file;
+	lib_extern = extern;
+	lib_kind = kind;
+}

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -12,46 +12,16 @@ open TypeloadCacheHook
 
 let mk_length_prefixed_communication allow_nonblock chin chout =
 	let sin = Unix.descr_of_in_channel chin in
+	Unix.clear_nonblock sin;
 	let chin = IO.input_channel chin in
 	let chout = IO.output_channel chout in
 
 	let bout = Buffer.create 0 in
 
-	let block () = Unix.clear_nonblock sin in
-	let unblock () = Unix.set_nonblock sin in
-
-	let read_nonblock _ =
+	let read () =
         let len = IO.read_i32 chin in
-        Some (IO.really_nread_string chin len)
+        IO.really_nread_string chin len
 	in
-	let read = if allow_nonblock then fun do_block ->
-		if do_block then begin
-			block();
-			read_nonblock true;
-		end else begin
-			let c0 =
-				unblock();
-				try
-					Some (IO.read_byte chin)
-				with
-				| Sys_blocked_io
-				(* TODO: We're supposed to catch Sys_blocked_io only, but that doesn't work on my PC... *)
-				| Sys_error _ ->
-					None
-			in
-			begin match c0 with
-			| Some c0 ->
-				block(); (* We got something, make sure we block until we're done. *)
-				let c1 = IO.read_byte chin in
-				let c2 = IO.read_byte chin in
-				let c3 = IO.read_byte chin in
-				let len = c3 lsl 24 + c2 lsl 16 + c1 lsl 8 + c0 in
-				Some (IO.really_nread_string chin len)
-			| None ->
-				None
-			end
-		end
-	else read_nonblock in
 
 	let write = Buffer.add_string bout in
 
@@ -64,7 +34,7 @@ let mk_length_prefixed_communication allow_nonblock chin chout =
 	in
 
 	fun () ->
-		{ support_nonblock = allow_nonblock; read; write; close; get_stdin = (fun () -> None) }
+		{ read; write; close; get_stdin = (fun () -> None) }
 
 let ssend sock str =
 	let rec loop pos len =
@@ -75,12 +45,6 @@ let ssend sock str =
 			loop (pos + s) (len - s)
 	in
 	loop 0 (Bytes.length str)
-
-(* The accept-function to wait for a stdio connection. *)
-let init_wait_stdio() =
-	set_binary_mode_in stdin true;
-	set_binary_mode_out stderr true;
-	mk_length_prefixed_communication false stdin stderr
 
 module Connect = struct
 
@@ -140,18 +104,8 @@ module Connect = struct
 			| Unix.Unix_error(code,_,_) -> failwith("Couldn't connect on " ^ host ^ ":" ^ string_of_int port ^ " (" ^ (Unix.error_message code) ^ ")");
 			| _ -> failwith ("Couldn't connect on " ^ host ^ ":" ^ string_of_int port)
 		);
-		let rec display_stdin args =
-			match args with
-			| [] -> ""
-			| "-D" :: ("display_stdin" | "display-stdin") :: _ ->
-				let accept = init_wait_stdio() in
-				let conn = accept() in
-				Option.default "" (conn.read true)
-			| _ :: args ->
-				display_stdin args
-		in
 		let args = ("--cwd " ^ Unix.getcwd()) :: args in
-		let s = (String.concat "" (List.map (fun a -> a ^ "\n") args)) ^ (display_stdin args) in
+		let s = (String.concat "" (List.map (fun a -> a ^ "\n") args)) in
 		ssend sock (Bytes.of_string (s ^ "\000"));
 		let has_error = ref false in
 		let print line =
@@ -363,26 +317,18 @@ let wait_loop entry verbose accept =
 	while true do
 		let conn = accept() in
 		begin try
-			(* Read arguments *)
-			let rec loop block =
-				match conn.read block with
-				| Some s ->
-					let stdin,hxml =
-						try
-							let idx = String.index s '\001' in
-							let stdin = (String.sub s (idx + 1) ((String.length s) - idx - 1)) in
-							Some stdin,(String.sub s 0 idx)
-						with Not_found ->
-							None,s
-					in
-					let stdin_pipe = conn.get_stdin () in
-					let data = Helper.parse_hxml_data hxml in
-					RequestQueue.add rq data stdin stdin_pipe conn;
-				| None ->
-					(* Tasks are now run by the worker domain between requests, so just block. *)
-					loop true
+			let s = conn.read () in
+			let stdin,hxml =
+				try
+					let idx = String.index s '\001' in
+					let stdin = (String.sub s (idx + 1) ((String.length s) - idx - 1)) in
+					Some stdin,(String.sub s 0 idx)
+				with Not_found ->
+					None,s
 			in
-			loop (not conn.support_nonblock)
+			let stdin_pipe = conn.get_stdin () in
+			let data = Helper.parse_hxml_data hxml in
+			RequestQueue.add rq data stdin stdin_pipe conn;
 		with Unix.Unix_error _ ->
 			ServerMessage.socket_message "Connection Aborted";
 			conn.close()
@@ -418,11 +364,11 @@ let init_wait_socket ip port =
 		Unix.set_nonblock sin;
 		ServerMessage.socket_message "Client connected";
 		let stdin_pipe = ref None in
-		let read = fun _ ->
+		let read () =
 			let req = SocketRequest.read sin bufsize in
 			Unix.clear_nonblock sin;
 			stdin_pipe := Some (req.stdin);
-			Some req.data
+			req.data
 		in
 		let get_stdin () = !stdin_pipe in
 		let closed = ref false in
@@ -438,6 +384,6 @@ let init_wait_socket ip port =
 				| Some _ -> close()
 				| None -> ssend sin (Bytes.unsafe_of_string s);
 		in
-		{ support_nonblock = false; read; write; close; get_stdin }
+		{ read; write; close; get_stdin }
 	) in
 	accept

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -59,11 +59,11 @@ let mk_length_prefixed_communication allow_nonblock chin chout =
 		flush stdout;
 		IO.write_i32 chout (Buffer.length bout);
 		IO.nwrite_string chout (Buffer.contents bout);
-		IO.flush chout
+		IO.flush chout;
+		Buffer.clear bout
 	in
 
 	fun () ->
-		Buffer.clear bout;
 		{ support_nonblock = allow_nonblock; read; write; close; get_stdin = (fun () -> None) }
 
 let ssend sock str =
@@ -269,6 +269,7 @@ module RequestQueue = struct
 	type request = {
 		args : string list;
 		stdin : string option;
+		stdin_pipe : in_channel option;
 		conn : server_connection;
 	}
 
@@ -285,17 +286,12 @@ module RequestQueue = struct
 			requests = []
 		}
 
-	let add rq args stdin conn =
+	let add rq args stdin stdin_pipe conn =
 		Mutex.lock rq.mutex;
-		rq.requests <- { args; stdin; conn } :: rq.requests;
+		rq.requests <- { args; stdin; stdin_pipe; conn } :: rq.requests;
 		Mutex.unlock rq.mutex;
 		Semaphore.Counting.release rq.semaphore
-
-	let is_empty rq =
-		rq.requests = []
 end
-
-let todo_semaphore = Semaphore.Binary.make false
 
 module WorkerDomain = struct
 	open RequestQueue
@@ -307,6 +303,7 @@ module WorkerDomain = struct
 
 	let create sctx entry rq =
 		let domain = Domain.spawn (fun () ->
+			let cs = sctx.cs in
 			let rec loop () =
 				Semaphore.Counting.acquire rq.semaphore;
 				Mutex.lock rq.mutex;
@@ -315,12 +312,12 @@ module WorkerDomain = struct
 					Mutex.unlock rq.mutex;
 					(* Done *)
 					()
-				|  {conn; stdin; args} :: l ->
+				| {conn; stdin; stdin_pipe; args} :: l ->
 					rq.requests <- l;
 					Mutex.unlock rq.mutex;
 					sctx.current_stdin <- stdin;
 					begin try
-						process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write sctx.current_stdin_pipe) args;
+						process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write stdin_pipe) args;
 					with e ->
 						let estr = Printexc.to_string e in
 						ServerMessage.uncaught_error estr;
@@ -331,7 +328,15 @@ module WorkerDomain = struct
 							exit (-1);
 						end;
 					end;
-					Semaphore.Binary.release todo_semaphore;
+					conn.close();
+					sctx.current_stdin <- None;
+					ServerCompilationContext.cleanup();
+					(* Add exploration task for full compilations, then run ALL pending tasks
+					   before picking up the next request. This ensures tasks never run
+					   concurrently with a compilation in another domain (OCaml 5 data race). *)
+					if sctx.was_compilation then
+						cs#add_task (new Tasks.server_exploration_task cs);
+					while cs#has_task do cs#get_task#run done;
 					loop()
 			in
 			loop ()
@@ -351,11 +356,10 @@ let wait_loop entry verbose accept =
 	(try Sys.set_signal 13 Sys.Signal_ignore with _ -> ());
 	(* Create server context and set up hooks for parsing and typing *)
 	let sctx = ServerCompilationContext.create verbose in
-	let cs = sctx.cs in
 	ServerCache.enable_cache_mode sctx;
 	let rq = RequestQueue.create () in
 	let worker = WorkerDomain.create sctx entry rq in
-	(* Main loop: accept connections and process arguments *)
+	(* Main loop: accept connections and enqueue requests for the worker *)
 	while true do
 		let conn = accept() in
 		begin try
@@ -371,37 +375,18 @@ let wait_loop entry verbose accept =
 						with Not_found ->
 							None,s
 					in
-					sctx.current_stdin_pipe <- conn.get_stdin ();
+					let stdin_pipe = conn.get_stdin () in
 					let data = Helper.parse_hxml_data hxml in
-					RequestQueue.add rq data stdin conn;
-					Semaphore.Binary.acquire todo_semaphore;
-				| None when not (RequestQueue.is_empty rq) ->
-					(* TODO: busy loop is bad *)
-					()
+					RequestQueue.add rq data stdin stdin_pipe conn;
 				| None ->
-					if not cs#has_task then
-						(* If there is no pending task, turn into blocking mode. *)
-						loop true
-					else begin
-						(* Otherwise run the task and loop to check if there are more or if there's a request now. *)
-						cs#get_task#run;
-						loop false
-					end;
+					(* Tasks are now run by the worker domain between requests, so just block. *)
+					loop true
 			in
 			loop (not conn.support_nonblock)
 		with Unix.Unix_error _ ->
-			ServerMessage.socket_message "Connection Aborted"
+			ServerMessage.socket_message "Connection Aborted";
+			conn.close()
 		end;
-		(* Close connection and perform some cleanup *)
-		conn.close();
-		sctx.current_stdin <- None;
-		sctx.current_stdin_pipe <- None;
-		ServerCompilationContext.cleanup();
-		(* If our connection always blocks, we have to execute all pending tasks now. *)
-		if not conn.support_nonblock then
-			while cs#has_task do cs#get_task#run done
-		else if sctx.was_compilation then
-			cs#add_task (new Tasks.server_exploration_task cs)
 	done;
 	Domain.join worker.domain;
 	0

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -240,11 +240,14 @@ module RequestQueue = struct
 			requests = []
 		}
 
+	let wake_up rq =
+		Semaphore.Counting.release rq.semaphore
+
 	let add rq args stdin stdin_pipe conn =
 		Mutex.lock rq.mutex;
 		rq.requests <- { args; stdin; stdin_pipe; conn } :: rq.requests;
 		Mutex.unlock rq.mutex;
-		Semaphore.Counting.release rq.semaphore
+		wake_up rq
 end
 
 module WorkerDomain = struct
@@ -264,8 +267,11 @@ module WorkerDomain = struct
 				match rq.requests with
 				| [] ->
 					Mutex.unlock rq.mutex;
-					(* Done *)
-					()
+					if cs#has_task then begin
+						cs#get_task#run;
+						RequestQueue.wake_up rq;
+					end;
+					loop()
 				| {conn; stdin; stdin_pipe; args} :: l ->
 					rq.requests <- l;
 					Mutex.unlock rq.mutex;
@@ -285,12 +291,9 @@ module WorkerDomain = struct
 					conn.close();
 					sctx.current_stdin <- None;
 					ServerCompilationContext.cleanup();
-					(* Add exploration task for full compilations, then run ALL pending tasks
-					   before picking up the next request. This ensures tasks never run
-					   concurrently with a compilation in another domain (OCaml 5 data race). *)
 					if sctx.was_compilation then
 						cs#add_task (new Tasks.server_exploration_task cs);
-					while cs#has_task do cs#get_task#run done;
+					RequestQueue.wake_up rq;
 					loop()
 			in
 			loop ()

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -6,6 +6,7 @@ open DisplayProcessingGlobals
 open Ipaddr
 open Json
 open CompilationContext
+open ParsedArg
 open MessageReporting
 open HxbData
 open TypeloadCacheHook
@@ -94,7 +95,7 @@ module Connect = struct
 		process_response ()
 
 	(* The connect function to connect to [host] at [port] and send arguments [args]. *)
-	let do_connect ip port args =
+	let do_connect ip port (args : parsed_arg list) =
 		let (domain, host) = match ip with
 			| V4 ip -> (Unix.PF_INET, V4.to_string ip)
 			| V6 ip -> (Unix.PF_INET6, V6.to_string ip)
@@ -104,8 +105,8 @@ module Connect = struct
 			| Unix.Unix_error(code,_,_) -> failwith("Couldn't connect on " ^ host ^ ":" ^ string_of_int port ^ " (" ^ (Unix.error_message code) ^ ")");
 			| _ -> failwith ("Couldn't connect on " ^ host ^ ":" ^ string_of_int port)
 		);
-		let args = ("--cwd " ^ Unix.getcwd()) :: args in
-		let s = (String.concat "" (List.map (fun a -> a ^ "\n") args)) in
+		let raw_args = ("--cwd " ^ Unix.getcwd()) :: Args.to_raw_args args in
+		let s = (String.concat "" (List.map (fun a -> a ^ "\n") raw_args)) in
 		ssend sock (Bytes.of_string (s ^ "\000"));
 		let has_error = ref false in
 		let print line =
@@ -205,9 +206,9 @@ let create_request_scope () =
 		cancellation_requested = false;
 	}
 
-let process sctx request_scope entry comm args =
+let process sctx request_scope entry comm (args : parsed_arg list) =
 	let t0 = Extc.time() in
-	ServerMessage.arguments args;
+	ServerMessage.arguments ["<" ^ string_of_int (List.length args) ^ " pre-parsed args>"];
 	ServerCompilationContext.reset sctx;
 	entry sctx request_scope comm args;
 	ServerCompilationContext.run_delays sctx;
@@ -215,7 +216,7 @@ let process sctx request_scope entry comm args =
 
 module RequestQueue = struct
 	type request = {
-		args : string list;
+		args : parsed_arg list;
 		stdin : string option;
 		stdin_pipe : in_channel option;
 		conn : server_connection;
@@ -364,9 +365,8 @@ let wait_loop entry verbose accept =
 				in
 				let stdin_pipe = conn.get_stdin () in
 				let data = Helper.parse_hxml_data hxml in
-				let parsed_args = Args.parse_args_new sctx data in
-				ignore(parsed_args);
-				RequestQueue.add rq data stdin stdin_pipe conn;
+				let parsed_args = Args.parse_args sctx data in
+				RequestQueue.add rq parsed_args stdin stdin_pipe conn;
 			with Unix.Unix_error _ ->
 				ServerMessage.socket_message "Connection Aborted";
 				conn.close()

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -265,6 +265,82 @@ let process sctx entry comm args =
 	ServerCompilationContext.run_delays sctx;
 	ServerMessage.stats stats (Extc.time() -. t0)
 
+module RequestQueue = struct
+	type request = {
+		args : string list;
+		stdin : string option;
+		conn : server_connection;
+	}
+
+	type t = {
+		mutex : Mutex.t;
+		semaphore : Semaphore.Counting.t;
+		mutable requests : request list;
+	}
+
+	let create () =
+		{
+			mutex = Mutex.create ();
+			semaphore = Semaphore.Counting.make 0;
+			requests = []
+		}
+
+	let add rq args stdin conn =
+		Mutex.lock rq.mutex;
+		rq.requests <- { args; stdin; conn } :: rq.requests;
+		Mutex.unlock rq.mutex;
+		Semaphore.Counting.release rq.semaphore
+
+	let is_empty rq =
+		rq.requests = []
+end
+
+let todo_semaphore = Semaphore.Binary.make false
+
+module WorkerDomain = struct
+	open RequestQueue
+	open ServerCompilationContext
+
+	type t = {
+		domain : unit Domain.t;
+	}
+
+	let create sctx entry rq =
+		let domain = Domain.spawn (fun () ->
+			let rec loop () =
+				Semaphore.Counting.acquire rq.semaphore;
+				Mutex.lock rq.mutex;
+				match rq.requests with
+				| [] ->
+					Mutex.unlock rq.mutex;
+					(* Done *)
+					()
+				|  {conn; stdin; args} :: l ->
+					rq.requests <- l;
+					Mutex.unlock rq.mutex;
+					sctx.current_stdin <- stdin;
+					begin try
+						process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write sctx.current_stdin_pipe) args;
+					with e ->
+						let estr = Printexc.to_string e in
+						ServerMessage.uncaught_error estr;
+						(try conn.write ("\x02\n" ^ estr); with _ -> ());
+						if Helper.is_debug_run then print_endline (estr ^ "\n" ^ Printexc.get_backtrace());
+						if e = Out_of_memory then begin
+							conn.close();
+							exit (-1);
+						end;
+					end;
+					Semaphore.Binary.release todo_semaphore;
+					loop()
+			in
+			loop ()
+		) in
+		{
+			domain;
+		}
+end
+
 (* The server main loop. Waits for the [accept] call to then process the sent compilation
    parameters through [process_params]. *)
 let wait_loop entry verbose accept =
@@ -277,6 +353,8 @@ let wait_loop entry verbose accept =
 	let sctx = ServerCompilationContext.create verbose in
 	let cs = sctx.cs in
 	ServerCache.enable_cache_mode sctx;
+	let rq = RequestQueue.create () in
+	let worker = WorkerDomain.create sctx entry rq in
 	(* Main loop: accept connections and process arguments *)
 	while true do
 		let conn = accept() in
@@ -285,17 +363,21 @@ let wait_loop entry verbose accept =
 			let rec loop block =
 				match conn.read block with
 				| Some s ->
-					let hxml =
+					let stdin,hxml =
 						try
 							let idx = String.index s '\001' in
-							sctx.current_stdin <- Some (String.sub s (idx + 1) ((String.length s) - idx - 1));
-							(String.sub s 0 idx)
+							let stdin = (String.sub s (idx + 1) ((String.length s) - idx - 1)) in
+							Some stdin,(String.sub s 0 idx)
 						with Not_found ->
-							s
+							None,s
 					in
 					sctx.current_stdin_pipe <- conn.get_stdin ();
 					let data = Helper.parse_hxml_data hxml in
-					process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write sctx.current_stdin_pipe) data
+					RequestQueue.add rq data stdin conn;
+					Semaphore.Binary.acquire todo_semaphore;
+				| None when not (RequestQueue.is_empty rq) ->
+					(* TODO: busy loop is bad *)
+					()
 				| None ->
 					if not cs#has_task then
 						(* If there is no pending task, turn into blocking mode. *)
@@ -309,15 +391,6 @@ let wait_loop entry verbose accept =
 			loop (not conn.support_nonblock)
 		with Unix.Unix_error _ ->
 			ServerMessage.socket_message "Connection Aborted"
-		| e ->
-			let estr = Printexc.to_string e in
-			ServerMessage.uncaught_error estr;
-			(try conn.write ("\x02\n" ^ estr); with _ -> ());
-			if Helper.is_debug_run then print_endline (estr ^ "\n" ^ Printexc.get_backtrace());
-			if e = Out_of_memory then begin
-				conn.close();
-				exit (-1);
-			end;
 		end;
 		(* Close connection and perform some cleanup *)
 		conn.close();
@@ -330,6 +403,7 @@ let wait_loop entry verbose accept =
 		else if sctx.was_compilation then
 			cs#add_task (new Tasks.server_exploration_task cs)
 	done;
+	Domain.join worker.domain;
 	0
 
 (* Connect to given host/port and return accept function for communication *)

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -198,33 +198,20 @@ module SocketRequest = struct
 		{ data; stdin }
 end
 
-let process sctx entry comm args =
+let create_request_scope () =
+	{
+		stats = Stats.create ();
+		timer_ctx = Timer.make_context (Timer.make ["other"]);
+		cancellation_requested = false;
+	}
+
+let process sctx request_scope entry comm args =
 	let t0 = Extc.time() in
 	ServerMessage.arguments args;
 	ServerCompilationContext.reset sctx;
-	Hashtbl.clear DeprecationCheck.warned_positions;
-
-	let stats = Stats.create () in
-	let after_compilation ctx =
-		ServerCache.after_compilation sctx ctx;
-		Stats.add stats ctx.com.stats;
-	in
-	let api = {
-		on_context_create = (fun () ->
-			sctx.compilation_step <- sctx.compilation_step + 1;
-			sctx.compilation_step;
-		);
-		sctx;
-		callbacks = {
-			before_anything = ServerCache.before_anything sctx;
-			after_target_init = ServerCache.after_target_init sctx;
-			after_save = ServerCache.after_save sctx;
-			after_compilation = after_compilation;
-		};
-	} in
-	entry api comm args;
+	entry sctx request_scope comm args;
 	ServerCompilationContext.run_delays sctx;
-	ServerMessage.stats stats (Extc.time() -. t0)
+	ServerMessage.stats request_scope.stats (Extc.time() -. t0)
 
 module RequestQueue = struct
 	type request = {
@@ -238,6 +225,7 @@ module RequestQueue = struct
 		mutex : Mutex.t;
 		semaphore : Semaphore.Counting.t;
 		mutable requests : request list;
+		mutable current_request : request_scope option;
 		shutdown_flag : bool Atomic.t;
 		cancel_token : bool Atomic.t;
 	}
@@ -247,6 +235,7 @@ module RequestQueue = struct
 			mutex = Mutex.create ();
 			semaphore = Semaphore.Counting.make 0;
 			requests = [];
+			current_request = None;
 			shutdown_flag = Atomic.make false;
 			cancel_token = Atomic.make false;
 		}
@@ -286,9 +275,9 @@ module WorkerDomain = struct
 			req.conn.close()
 		) pending
 
-	let run_request sctx entry {conn; stdin; stdin_pipe; args} =
+	let run_request sctx request_scope entry {conn; stdin; stdin_pipe; args} =
 		try
-			process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write stdin_pipe) args;
+			process sctx request_scope entry (ServerCommunication.Communication.create_pipe sctx conn.write stdin_pipe) args;
 		with
 		| Cancelled ->
 			ServerMessage.uncaught_error "Compilation cancelled";
@@ -304,10 +293,6 @@ module WorkerDomain = struct
 			end
 
 	let create sctx entry rq =
-		(* Install cancellation hook: raises Cancelled when the token is set *)
-		TypeloadCacheHook.check_cancellation := (fun () ->
-			if Atomic.get rq.cancel_token then raise Cancelled
-		);
 		let domain = Domain.spawn (fun () ->
 			let cs = sctx.cs in
 			let rec loop () =
@@ -330,7 +315,9 @@ module WorkerDomain = struct
 						Mutex.unlock rq.mutex;
 						sctx.current_stdin <- request.stdin;
 						Atomic.set rq.cancel_token false;
-						run_request sctx entry request;
+						let request_scope = create_request_scope() in
+						rq.current_request <- Some request_scope;
+						run_request sctx request_scope entry request;
 						request.conn.close();
 						sctx.current_stdin <- None;
 						ServerCache.cleanup();

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -202,17 +202,24 @@ let process sctx entry comm args =
 	let t0 = Extc.time() in
 	ServerMessage.arguments args;
 	ServerCompilationContext.reset sctx;
+	Hashtbl.clear DeprecationCheck.warned_positions;
+
+	let stats = Stats.create () in
+	let after_compilation ctx =
+		ServerCache.after_compilation sctx ctx;
+		Stats.add stats ctx.com.stats;
+	in
 	let api = {
 		on_context_create = (fun () ->
 			sctx.compilation_step <- sctx.compilation_step + 1;
 			sctx.compilation_step;
 		);
-		cache = sctx.cs;
+		sctx;
 		callbacks = {
 			before_anything = ServerCache.before_anything sctx;
 			after_target_init = ServerCache.after_target_init sctx;
 			after_save = ServerCache.after_save sctx;
-			after_compilation = ServerCache.after_compilation sctx;
+			after_compilation = after_compilation;
 		};
 	} in
 	entry api comm args;
@@ -326,7 +333,7 @@ module WorkerDomain = struct
 						run_request sctx entry request;
 						request.conn.close();
 						sctx.current_stdin <- None;
-						ServerCompilationContext.cleanup();
+						ServerCache.cleanup();
 						if sctx.was_compilation then
 							cs#add_task (new Tasks.server_exploration_task cs);
 						RequestQueue.wake_up rq;

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -364,6 +364,8 @@ let wait_loop entry verbose accept =
 				in
 				let stdin_pipe = conn.get_stdin () in
 				let data = Helper.parse_hxml_data hxml in
+				let parsed_args = Args.parse_args_new sctx data in
+				ignore(parsed_args);
 				RequestQueue.add rq data stdin stdin_pipe conn;
 			with Unix.Unix_error _ ->
 				ServerMessage.socket_message "Connection Aborted";

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -231,13 +231,17 @@ module RequestQueue = struct
 		mutex : Mutex.t;
 		semaphore : Semaphore.Counting.t;
 		mutable requests : request list;
+		shutdown_flag : bool Atomic.t;
+		cancel_token : bool Atomic.t;
 	}
 
 	let create () =
 		{
 			mutex = Mutex.create ();
 			semaphore = Semaphore.Counting.make 0;
-			requests = []
+			requests = [];
+			shutdown_flag = Atomic.make false;
+			cancel_token = Atomic.make false;
 		}
 
 	let wake_up rq =
@@ -247,6 +251,11 @@ module RequestQueue = struct
 		Mutex.lock rq.mutex;
 		rq.requests <- { args; stdin; stdin_pipe; conn } :: rq.requests;
 		Mutex.unlock rq.mutex;
+		wake_up rq
+
+	let shutdown rq =
+		Atomic.set rq.cancel_token true;
+		Atomic.set rq.shutdown_flag true;
 		wake_up rq
 end
 
@@ -258,43 +267,71 @@ module WorkerDomain = struct
 		domain : unit Domain.t;
 	}
 
+	let shutdown rq =
+		(* Drain remaining requests by closing their connections, then return
+		   without recursing to exit the loop gracefully. *)
+		Mutex.lock rq.mutex;
+		let pending = rq.requests in
+		rq.requests <- [];
+		Mutex.unlock rq.mutex;
+		List.iter (fun req ->
+			(try req.conn.write "\x02\nServer shutdown\n"; with _ -> ());
+			req.conn.close()
+		) pending
+
+	let run_request sctx entry {conn; stdin; stdin_pipe; args} =
+		try
+			process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write stdin_pipe) args;
+		with
+		| Cancelled ->
+			ServerMessage.uncaught_error "Compilation cancelled";
+			(try conn.write "\x02\nCancelled\n"; with _ -> ());
+		| e ->
+			let estr = Printexc.to_string e in
+			ServerMessage.uncaught_error estr;
+			(try conn.write ("\x02\n" ^ estr); with _ -> ());
+			if Helper.is_debug_run then print_endline (estr ^ "\n" ^ Printexc.get_backtrace());
+			if e = Out_of_memory then begin
+				conn.close();
+				exit (-1);
+			end
+
 	let create sctx entry rq =
+		(* Install cancellation hook: raises Cancelled when the token is set *)
+		TypeloadCacheHook.check_cancellation := (fun () ->
+			if Atomic.get rq.cancel_token then raise Cancelled
+		);
 		let domain = Domain.spawn (fun () ->
 			let cs = sctx.cs in
 			let rec loop () =
 				Semaphore.Counting.acquire rq.semaphore;
-				Mutex.lock rq.mutex;
-				match rq.requests with
-				| [] ->
-					Mutex.unlock rq.mutex;
-					if cs#has_task then begin
-						cs#get_task#run;
-						RequestQueue.wake_up rq;
-					end;
-					loop()
-				| {conn; stdin; stdin_pipe; args} :: l ->
-					rq.requests <- l;
-					Mutex.unlock rq.mutex;
-					sctx.current_stdin <- stdin;
-					begin try
-						process sctx entry (ServerCommunication.Communication.create_pipe sctx conn.write stdin_pipe) args;
-					with e ->
-						let estr = Printexc.to_string e in
-						ServerMessage.uncaught_error estr;
-						(try conn.write ("\x02\n" ^ estr); with _ -> ());
-						if Helper.is_debug_run then print_endline (estr ^ "\n" ^ Printexc.get_backtrace());
-						if e = Out_of_memory then begin
-							conn.close();
-							exit (-1);
+				(* Check for shutdown before doing any work *)
+				if Atomic.get rq.shutdown_flag then begin
+					shutdown rq
+				end else begin
+					Mutex.lock rq.mutex;
+					match rq.requests with
+					| [] ->
+						Mutex.unlock rq.mutex;
+						if cs#has_task then begin
+							cs#get_task#run;
+							RequestQueue.wake_up rq;
 						end;
-					end;
-					conn.close();
-					sctx.current_stdin <- None;
-					ServerCompilationContext.cleanup();
-					if sctx.was_compilation then
-						cs#add_task (new Tasks.server_exploration_task cs);
-					RequestQueue.wake_up rq;
-					loop()
+						loop()
+					| request :: l ->
+						rq.requests <- l;
+						Mutex.unlock rq.mutex;
+						sctx.current_stdin <- request.stdin;
+						Atomic.set rq.cancel_token false;
+						run_request sctx entry request;
+						request.conn.close();
+						sctx.current_stdin <- None;
+						ServerCompilationContext.cleanup();
+						if sctx.was_compilation then
+							cs#add_task (new Tasks.server_exploration_task cs);
+						RequestQueue.wake_up rq;
+						loop()
+				end
 			in
 			loop ()
 		) in
@@ -316,27 +353,32 @@ let wait_loop entry verbose accept =
 	ServerCache.enable_cache_mode sctx;
 	let rq = RequestQueue.create () in
 	let worker = WorkerDomain.create sctx entry rq in
-	(* Main loop: accept connections and enqueue requests for the worker *)
-	while true do
-		let conn = accept() in
-		begin try
-			let s = conn.read () in
-			let stdin,hxml =
-				try
-					let idx = String.index s '\001' in
-					let stdin = (String.sub s (idx + 1) ((String.length s) - idx - 1)) in
-					Some stdin,(String.sub s 0 idx)
-				with Not_found ->
-					None,s
-			in
-			let stdin_pipe = conn.get_stdin () in
-			let data = Helper.parse_hxml_data hxml in
-			RequestQueue.add rq data stdin stdin_pipe conn;
-		with Unix.Unix_error _ ->
-			ServerMessage.socket_message "Connection Aborted";
-			conn.close()
-		end;
-	done;
+	(* Main loop: accept connections and enqueue requests for the worker.
+	   The loop exits if the accept function raises an exception (e.g. socket closed). *)
+	(try
+		while true do
+			let conn = accept() in
+			begin try
+				let s = conn.read () in
+				let stdin,hxml =
+					try
+						let idx = String.index s '\001' in
+						let stdin = (String.sub s (idx + 1) ((String.length s) - idx - 1)) in
+						Some stdin,(String.sub s 0 idx)
+					with Not_found ->
+						None,s
+				in
+				let stdin_pipe = conn.get_stdin () in
+				let data = Helper.parse_hxml_data hxml in
+				RequestQueue.add rq data stdin stdin_pipe conn;
+			with Unix.Unix_error _ ->
+				ServerMessage.socket_message "Connection Aborted";
+				conn.close()
+			end;
+		done
+	with _ -> ());
+	(* Signal the worker to shut down and wait for it to finish *)
+	RequestQueue.shutdown rq;
 	Domain.join worker.domain;
 	0
 

--- a/src/compiler/server/serverCache.ml
+++ b/src/compiler/server/serverCache.ml
@@ -360,7 +360,7 @@ class hxb_reader_api_server
 			(match typing_mode with
 			| FullTyping -> ignore(f_next chunks EOM)
 			| AllowPartialTyping -> delay PConnectField (fun () -> ignore(f_next chunks EOF)));
-			incr com.stats.s_modules_restored;
+			incr com.request_scope.stats.s_modules_restored;
 			m
 		| BadBinaryModule (mc, reason) ->
 			let reader = new HxbReader.hxb_reader path com.hxb_reader_stats (if Common.defined com Define.HxbTimes then Some com.timer_ctx else None) in
@@ -379,7 +379,7 @@ class hxb_reader_api_server
 			(match typing_mode with
 			| FullTyping -> ignore(f_next chunks EOM)
 			| AllowPartialTyping -> delay PConnectField (fun () -> ignore(f_next chunks EOF)));
-			incr com.stats.s_modules_restored;
+			incr com.request_scope.stats.s_modules_restored;
 			m
 		| BadModule reason ->
 			die (Printf.sprintf "Unexpected BadModule %s (%s)" (s_type_path path) (Printer.s_module_skip_reason reason)) __LOC__
@@ -539,7 +539,7 @@ and type_module sctx com delay mpath p =
 					(match typing_mode with
 					| FullTyping -> ignore(f_next chunks EOM)
 					| AllowPartialTyping -> delay PConnectField (fun () -> ignore(f_next chunks EOF)));
-					incr com.stats.s_modules_restored;
+					incr com.request_scope.stats.s_modules_restored;
 					add_modules true m;
 				| Some reason ->
 					skip mpath reason

--- a/src/compiler/server/serverCache.ml
+++ b/src/compiler/server/serverCache.ml
@@ -360,7 +360,7 @@ class hxb_reader_api_server
 			(match typing_mode with
 			| FullTyping -> ignore(f_next chunks EOM)
 			| AllowPartialTyping -> delay PConnectField (fun () -> ignore(f_next chunks EOF)));
-			incr stats.s_modules_restored;
+			incr com.stats.s_modules_restored;
 			m
 		| BadBinaryModule (mc, reason) ->
 			let reader = new HxbReader.hxb_reader path com.hxb_reader_stats (if Common.defined com Define.HxbTimes then Some com.timer_ctx else None) in
@@ -379,7 +379,7 @@ class hxb_reader_api_server
 			(match typing_mode with
 			| FullTyping -> ignore(f_next chunks EOM)
 			| AllowPartialTyping -> delay PConnectField (fun () -> ignore(f_next chunks EOF)));
-			incr stats.s_modules_restored;
+			incr com.stats.s_modules_restored;
 			m
 		| BadModule reason ->
 			die (Printf.sprintf "Unexpected BadModule %s (%s)" (s_type_path path) (Printer.s_module_skip_reason reason)) __LOC__
@@ -539,7 +539,7 @@ and type_module sctx com delay mpath p =
 					(match typing_mode with
 					| FullTyping -> ignore(f_next chunks EOM)
 					| AllowPartialTyping -> delay PConnectField (fun () -> ignore(f_next chunks EOF)));
-					incr stats.s_modules_restored;
+					incr com.stats.s_modules_restored;
 					add_modules true m;
 				| Some reason ->
 					skip mpath reason
@@ -555,6 +555,20 @@ and type_module sctx com delay mpath p =
 	in
 	t();
 	m
+
+let ensure_macro_setup sctx =
+	if not sctx.macro_context_setup then begin
+		sctx.macro_context_setup <- true;
+		MacroContext.setup();
+	end
+
+let cleanup () = match !MacroContext.macro_interp_cache with
+	| Some interp ->
+		(* curapi holds a reference to the typing context which we don't want to persist. Let's unset it so the
+		   context can be collected. *)
+		interp.curapi <- Obj.magic ""
+	| None ->
+		()
 
 let before_anything sctx ctx =
 	ensure_macro_setup sctx
@@ -580,7 +594,7 @@ let after_target_init sctx ctx =
 
 let after_save sctx ctx =
 	if ctx.comm.is_server && not (has_error ctx) then
-		maybe_cache_context sctx ctx.com
+		CommonCache.maybe_cache_context ctx.com
 
 let after_compilation sctx ctx =
 	sctx.cs#clear_temp_cache;
@@ -588,5 +602,5 @@ let after_compilation sctx ctx =
 
 let enable_cache_mode sctx =
 	type_module_hook := type_module sctx;
-	ServerCompilationContext.ensure_macro_setup sctx;
+	ensure_macro_setup sctx;
 	TypeloadParse.parse_hook := parse_file sctx

--- a/src/compiler/server/serverCommunication.ml
+++ b/src/compiler/server/serverCommunication.ml
@@ -36,10 +36,10 @@ let flush_context sctx ctx =
 				);
 				sctx.was_compilation <- ctx.com.display.dms_full_typing;
 				if has_error ctx then begin
-					ctx.timer_ctx.measure_times <- No;
+					ctx.com.timer_ctx.measure_times <- No;
 					write "\x02\n"
 				end else
-					if ctx.timer_ctx.measure_times = Yes then Timer.report_times ctx.timer_ctx (fun s -> write (s ^ "\n"));
+					if ctx.com.timer_ctx.measure_times = Yes then Timer.report_times ctx.com.timer_ctx (fun s -> write (s ^ "\n"));
 
 module Communication = struct
 	let create_stdio () =

--- a/src/compiler/server/serverCompilationContext.ml
+++ b/src/compiler/server/serverCompilationContext.ml
@@ -1,6 +1,9 @@
+open Globals
 open CompilationCache
 
+
 type t = {
+	version : Globals.compiler_version;
 	(* If true, prints some debug information *)
 	verbose : bool;
 	(* The list of changed directories per-signature *)
@@ -21,8 +24,19 @@ type t = {
 	mutable current_stdin : string option;
 }
 
+let create_version () =
+	{
+		version = version;
+		major = version_major;
+		minor = version_minor;
+		revision = version_revision;
+		pre = version_pre;
+		extra = Version.version_extra;
+	}
+
 let create verbose = {
-	verbose = verbose;
+	version = create_version ();
+	verbose;
 	cs = new CompilationCache.cache;
 	class_paths = Hashtbl.create 0;
 	changed_directories = Hashtbl.create 0;

--- a/src/compiler/server/serverCompilationContext.ml
+++ b/src/compiler/server/serverCompilationContext.ml
@@ -1,4 +1,3 @@
-open Common
 open CompilationCache
 
 type t = {
@@ -47,29 +46,4 @@ let reset sctx =
 	Hashtbl.clear sctx.changed_directories;
 	sctx.was_compilation <- false;
 	Parser.reset_state();
-	Parallel.enable := false;
-	Hashtbl.clear DeprecationCheck.warned_positions;
-	stats.s_files_parsed := 0;
-	stats.s_classes_built := 0;
-	stats.s_methods_typed := 0;
-	stats.s_macros_called := 0
-
-let maybe_cache_context sctx com =
-	if com.display.dms_full_typing && com.display.dms_populate_cache then begin
-		Timer.time com.timer_ctx ["server";"cache context"] (CommonCache.cache_context sctx.cs) com;
-		ServerMessage.cached_modules com "" (List.length com.modules);
-	end
-
-let ensure_macro_setup sctx =
-	if not sctx.macro_context_setup then begin
-		sctx.macro_context_setup <- true;
-		MacroContext.setup();
-	end
-
-let cleanup () = match !MacroContext.macro_interp_cache with
-	| Some interp ->
-		(* curapi holds a reference to the typing context which we don't want to persist. Let's unset it so the
-		   context can be collected. *)
-		interp.curapi <- Obj.magic ""
-	| None ->
-		()
+	Parallel.enable := false

--- a/src/compiler/server/serverCompilationContext.ml
+++ b/src/compiler/server/serverCompilationContext.ml
@@ -20,8 +20,6 @@ type t = {
 	mutable macro_context_setup : bool;
 	(* Stdin content for the current display request *)
 	mutable current_stdin : string option;
-	(* Forwarded stdin pipe from the current client connection *)
-	mutable current_stdin_pipe : in_channel option;
 }
 
 let create verbose = {
@@ -34,7 +32,6 @@ let create verbose = {
 	was_compilation = false;
 	macro_context_setup = false;
 	current_stdin = None;
-	current_stdin_pipe = None;
 }
 
 let add_delay sctx f =

--- a/src/compiler/server/serverMessage.ml
+++ b/src/compiler/server/serverMessage.ml
@@ -135,6 +135,7 @@ let display_position com tabs p =
 
 let stats stats time =
 	if config.print_stats then begin
+		let open Common.Stats in
 		print_endline (Printf.sprintf "Stats = %d files, %d classes, %d methods, %d macros" !(stats.s_files_parsed) !(stats.s_classes_built) !(stats.s_methods_typed) !(stats.s_macros_called));
 		print_endline (Printf.sprintf "Time spent : %.3fs" time)
 	end

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -38,14 +38,34 @@ let const_type basic const default =
 	| TBool _ -> basic.tbool
 	| _ -> default
 
-type stats = {
-	s_files_parsed : int ref;
-	s_modules_typed : int ref;
-	s_modules_restored : int ref;
-	s_classes_built : int ref;
-	s_methods_typed : int ref;
-	s_macros_called : int ref;
-}
+module Stats = struct
+	type t = {
+		s_files_parsed : int ref;
+		s_modules_typed : int ref;
+		s_modules_restored : int ref;
+		s_classes_built : int ref;
+		s_methods_typed : int ref;
+		s_macros_called : int ref;
+	}
+
+	let create () =
+		{
+			s_files_parsed = ref 0;
+			s_modules_typed = ref 0;
+			s_modules_restored = ref 0;
+			s_classes_built = ref 0;
+			s_methods_typed = ref 0;
+			s_macros_called = ref 0;
+		}
+
+	let add lhs rhs =
+		lhs.s_files_parsed := !(lhs.s_files_parsed) + !(rhs.s_files_parsed);
+		lhs.s_modules_typed := !(lhs.s_modules_typed) + !(rhs.s_modules_typed);
+		lhs.s_modules_restored := !(lhs.s_modules_restored) + !(rhs.s_modules_restored);
+		lhs.s_classes_built := !(lhs.s_classes_built) + !(rhs.s_classes_built);
+		lhs.s_methods_typed := !(lhs.s_methods_typed) + !(rhs.s_methods_typed);
+		lhs.s_macros_called := !(lhs.s_macros_called) + !(rhs.s_macros_called)
+end
 
 class compiler_callbacks = object(self)
 	val before_typer_create = ref [];
@@ -269,11 +289,13 @@ end
 type context = {
 	compilation_step : int;
 	mutable stage : compiler_stage;
+	sctx : ServerCompilationContext.t;
 	cs : CompilationCache.t;
 	mutable cache : CompilationCache.context_cache option;
 	is_macro_context : bool;
 	mutable json_out : json_api option;
 	timer_ctx : Timer.timer_context;
+	stats : Stats.t;
 	(* config *)
 	version : compiler_version;
 	mutable args : string list;
@@ -478,16 +500,6 @@ let short_platform_name = function
 	| Hl -> "hl"
 	| Eval -> "evl"
 	| CustomTarget n -> "c_" ^ n
-
-let stats =
-	{
-		s_files_parsed = ref 0;
-		s_modules_typed = ref 0;
-		s_modules_restored = ref 0;
-		s_classes_built = ref 0;
-		s_methods_typed = ref 0;
-		s_macros_called = ref 0;
-	}
 
 open PlatformConfig
 
@@ -722,10 +734,11 @@ let get_config com =
 
 let memory_marker = [|Unix.time()|]
 
-let create io timer_ctx compilation_step cs version args display_mode =
+let create io timer_ctx compilation_step sctx version args display_mode =
 	let rec com = {
 		compilation_step = compilation_step;
-		cs = cs;
+		sctx;
+		cs = sctx.cs;
 		cache = None;
 		timer_ctx = timer_ctx;
 		stage = CCreated;
@@ -741,6 +754,7 @@ let create io timer_ctx compilation_step cs version args display_mode =
 			display_module_has_macro_defines = false;
 			module_diagnostics = [];
 		};
+		stats = Stats.create ();
 		debug = false;
 		display = display_mode;
 		verbose = false;
@@ -854,11 +868,13 @@ let clone com is_macro_context =
 	{
 		(* keeps *)
 		compilation_step = com.compilation_step;
+		sctx = com.sctx;
 		cs = com.cs;
 		timer_ctx = com.timer_ctx;
 		version = com.version;
 		args = com.args;
 		shared = com.shared;
+		stats = Stats.create ();
 		debug = com.debug;
 		display = com.display;
 		verbose = com.verbose;

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -57,14 +57,6 @@ module Stats = struct
 			s_methods_typed = ref 0;
 			s_macros_called = ref 0;
 		}
-
-	let add lhs rhs =
-		lhs.s_files_parsed := !(lhs.s_files_parsed) + !(rhs.s_files_parsed);
-		lhs.s_modules_typed := !(lhs.s_modules_typed) + !(rhs.s_modules_typed);
-		lhs.s_modules_restored := !(lhs.s_modules_restored) + !(rhs.s_modules_restored);
-		lhs.s_classes_built := !(lhs.s_classes_built) + !(rhs.s_classes_built);
-		lhs.s_methods_typed := !(lhs.s_methods_typed) + !(rhs.s_methods_typed);
-		lhs.s_macros_called := !(lhs.s_macros_called) + !(rhs.s_macros_called)
 end
 
 class compiler_callbacks = object(self)
@@ -140,19 +132,10 @@ class file_keys = object(self)
 
 end
 
-type shared_display_information = {
-	mutable diagnostics_messages : diagnostic list;
-}
-
 type display_information = {
 	mutable unresolved_identifiers : (string * pos * (string * CompletionItem.t * int) list) list;
 	mutable display_module_has_macro_defines : bool;
 	mutable module_diagnostics : DisplayTypes.module_diagnostics list;
-}
-
-(* This information is shared between normal and macro context. *)
-type shared_context = {
-	shared_display_information : shared_display_information;
 }
 
 type json_api = {
@@ -286,7 +269,21 @@ module LocalWrapper = struct
 	end
 end
 
+type part_scope = {
+	warned_positions : (string * int, string * Globals.pos * warning_option list list) Hashtbl.t;
+	mutable diagnostics_messages : diagnostic list;
+	io : Gctx.compilation_io;
+}
+
+type request_scope = {
+	stats : Stats.t;
+	timer_ctx : Timer.timer_context;
+	mutable cancellation_requested : bool;
+}
+
 type context = {
+	request_scope : request_scope;
+	part_scope : part_scope;
 	compilation_step : int;
 	mutable stage : compiler_stage;
 	sctx : ServerCompilationContext.t;
@@ -295,9 +292,7 @@ type context = {
 	is_macro_context : bool;
 	mutable json_out : json_api option;
 	timer_ctx : Timer.timer_context;
-	stats : Stats.t;
 	(* config *)
-	version : compiler_version;
 	mutable args : string list;
 	mutable display : DisplayTypes.DisplayMode.settings;
 	mutable debug : bool;
@@ -315,7 +310,6 @@ type context = {
 	parser_state : parser_state;
 	dump_config : DumpConfig.t;
 	(* communication *)
-	io : Gctx.compilation_io;
 	mutable error : Gctx.error_function;
 	mutable error_ext : Error.error -> unit;
 	mutable info : ?depth:int -> ?from_macro:bool -> string -> pos -> unit;
@@ -336,7 +330,6 @@ type context = {
 	(* typing state *)
 	mutable std : tclass;
 	mutable global_metadata : (string list * metadata_entry * (bool * bool * bool)) list;
-	shared : shared_context;
 	display_information : display_information;
 	file_keys : file_keys;
 	mutable file_contents : (Path.UniqueKey.t * string option) list;
@@ -381,10 +374,10 @@ let to_gctx com = {
 	run_command_args = com.run_command_args;
 	warning = com.warning;
 	error = com.error;
-	io = com.io;
+	io = com.part_scope.io;
 	debug = com.debug;
 	file = com.file;
-	version = com.version;
+	version = com.sctx.version;
 	features = com.features;
 	modules = com.modules;
 	main = com.main;
@@ -734,27 +727,22 @@ let get_config com =
 
 let memory_marker = [|Unix.time()|]
 
-let create io timer_ctx compilation_step sctx version args display_mode =
+let create sctx request_scope part_scope compilation_step args display_mode =
 	let rec com = {
+		request_scope;
+		part_scope;
 		compilation_step = compilation_step;
 		sctx;
 		cs = sctx.cs;
 		cache = None;
-		timer_ctx = timer_ctx;
+		timer_ctx = request_scope.timer_ctx;
 		stage = CCreated;
-		version = version;
 		args = args;
-		shared = {
-			shared_display_information = {
-				diagnostics_messages = [];
-			}
-		};
 		display_information = {
 			unresolved_identifiers = [];
 			display_module_has_macro_defines = false;
 			module_diagnostics = [];
 		};
-		stats = Stats.create ();
 		debug = false;
 		display = display_mode;
 		verbose = false;
@@ -764,7 +752,6 @@ let create io timer_ctx compilation_step sctx version args display_mode =
 		platform = Cross;
 		config = default_config;
 		custom_ext = None;
-		io;
 		run_command = Sys.command;
 		run_command_args = (fun s args -> com.run_command (Printf.sprintf "%s %s" s (String.concat " " args)));
 		empty_class_path = new ClassPath.directory_class_path "" User;
@@ -862,19 +849,18 @@ let disable_report_mode com =
 	(fun () -> com.report_mode <- old)
 
 let log com str =
-	if com.verbose then com.io.print (str ^ "\n")
+	if com.verbose then com.part_scope.io.print (str ^ "\n")
 
 let clone com is_macro_context =
 	{
 		(* keeps *)
+		request_scope = com.request_scope;
+		part_scope = com.part_scope;
 		compilation_step = com.compilation_step;
 		sctx = com.sctx;
 		cs = com.cs;
 		timer_ctx = com.timer_ctx;
-		version = com.version;
 		args = com.args;
-		shared = com.shared;
-		stats = Stats.create ();
 		debug = com.debug;
 		display = com.display;
 		verbose = com.verbose;
@@ -883,7 +869,6 @@ let clone com is_macro_context =
 		platform = com.platform;
 		config = com.config;
 		custom_ext = com.custom_ext;
-		io = com.io;
 		run_command = com.run_command;
 		run_command_args = com.run_command_args;
 		package_rules = com.package_rules;
@@ -1004,7 +989,7 @@ let init_platform com =
 	end;
 	(* Set the source header, unless the user has set one already or the platform sets a custom one *)
 	if not (defined com Define.SourceHeader) && (com.platform <> Hl) then
-		define_value com Define.SourceHeader ("Generated by Haxe " ^ (s_version_full com.version));
+		define_value com Define.SourceHeader ("Generated by Haxe " ^ (s_version_full com.sctx.version));
 	let forbid acc p = if p = name || PMap.mem p acc then acc else PMap.add p Forbidden acc in
 	com.package_rules <- List.fold_left forbid com.package_rules ("java" :: (List.map platform_name platforms));
 	update_platform_config com;
@@ -1126,7 +1111,7 @@ let hash f =
 
 let add_diagnostics_message ?(depth = 0) ?(code = None) com s p kind sev =
 	if sev = MessageSeverity.Error then com.has_error <- true;
-	let di = com.shared.shared_display_information in
+	let di = com.part_scope in
 	di.diagnostics_messages <- (make_diagnostic ~depth ~code s p kind sev) :: di.diagnostics_messages
 
 let display_error_ext com err =
@@ -1193,3 +1178,6 @@ let make_unforced_lazy t_proc f where =
 				raise (Error.Fatal_error e)
 	);
 	r
+
+let check_cancellation com =
+	if com.request_scope.cancellation_requested then raise Cancelled

--- a/src/context/commonCache.ml
+++ b/src/context/commonCache.ml
@@ -133,3 +133,9 @@ let lock_signature com name =
 	let cs = com.cs in
 	maybe_add_context_sign cs com name;
 	com.cache <- Some (get_cache com)
+
+let maybe_cache_context com =
+	if com.display.dms_full_typing && com.display.dms_populate_cache then begin
+		Timer.time com.timer_ctx ["server";"cache context"] (cache_context com.cs) com;
+		ServerMessage.cached_modules com "" (List.length com.modules);
+	end

--- a/src/context/display/deprecationCheck.ml
+++ b/src/context/display/deprecationCheck.ml
@@ -17,13 +17,11 @@ let create_context com = {
 	curmod = null_module;
 }
 
-let warned_positions = Hashtbl.create 0
-
 let warn_deprecation dctx s p_usage =
 	let pkey p = (p.pfile,p.pmin) in
-	if not (Hashtbl.mem warned_positions (pkey p_usage)) then begin
+	if not (Hashtbl.mem dctx.com.part_scope.warned_positions (pkey p_usage)) then begin
 		let options = Warning.from_meta (dctx.class_meta @ dctx.field_meta) in
-		Hashtbl.add warned_positions (pkey p_usage) (s,p_usage,options);
+		Hashtbl.add dctx.com.part_scope.warned_positions (pkey p_usage) (s,p_usage,options);
 		module_warning dctx.com dctx.curmod WDeprecated options s p_usage;
 	end
 

--- a/src/context/display/diagnostics.ml
+++ b/src/context/display/diagnostics.ml
@@ -147,7 +147,7 @@ let prepare com =
 		unresolved_identifiers = [];
 		missing_fields = PMap.empty;
 	} in
-	if not (List.exists (fun diag -> diag.diag_severity = MessageSeverity.Error) com.shared.shared_display_information.diagnostics_messages) then
+	if not (List.exists (fun diag -> diag.diag_severity = MessageSeverity.Error) com.part_scope.diagnostics_messages) then
 		collect_diagnostics dctx com;
 	let process_modules com =
 		List.iter (fun m ->
@@ -177,7 +177,7 @@ let prepare com =
 	| Some com -> process_modules com
 	end;
 	(* We do this at the end because some of the prepare functions might add information to the common context. *)
-	dctx.diagnostics_messages <- com.shared.shared_display_information.diagnostics_messages;
+	dctx.diagnostics_messages <- com.part_scope.diagnostics_messages;
 	dctx.unresolved_identifiers <- com.display_information.unresolved_identifiers;
 	dctx
 

--- a/src/context/display/diagnosticsPrinter.ml
+++ b/src/context/display/diagnosticsPrinter.ml
@@ -190,7 +190,7 @@ let json_of_diagnostics com dctx =
 				add DKDeprecationWarning p MessageSeverity.Warning (Some wobj.w_name) (JString s);
 			| WMDisable -> ()
 			end
-		) DeprecationCheck.warned_positions;
+		) com.part_scope.warned_positions;
 	| WMDisable ->
 		()
 	end;

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -207,14 +207,15 @@ let handler =
 			let exclude = hctx.jsonrpc#get_opt_param (fun () -> hctx.jsonrpc#get_array_param "exclude") [] in
 			DisplayToplevel.exclude := List.map (fun e -> match e with JString s -> s | _ -> die "" __LOC__) exclude;
 			let methods = Hashtbl.fold (fun k _ acc -> (jstring k) :: acc) h [] in
+			let version = hctx.com.sctx.version in
 			Result (JObject [
 				"methods",jarray methods;
 				"haxeVersion",jobject [
-					"major",jint hctx.com.version.major;
-					"minor",jint hctx.com.version.minor;
-					"patch",jint hctx.com.version.revision;
-					"pre",(match hctx.com.version.pre with None -> jnull | Some pre -> jstring pre);
-					"build",(match hctx.com.version.extra with None -> jnull | Some(_,build) -> jstring build);
+					"major",jint version.major;
+					"minor",jint version.minor;
+					"patch",jint version.revision;
+					"pre",(match version.pre with None -> jnull | Some pre -> jstring pre);
+					"build",(match version.extra with None -> jnull | Some(_,build) -> jstring build);
 				];
 				"protocolVersion",jobject [
 					"major",jint 0;
@@ -580,7 +581,7 @@ type parse_input_result =
 	| Completed
 
 let parse_input com input =
-	let io = com.io in
+	let io = com.part_scope.io in
 	let input = JsonRpc.parse_request input in
 	let jsonrpc = new jsonrpc_handler input in
 
@@ -676,7 +677,7 @@ let parse_input com input =
 
 let parse_input com input =
 	let handle_error json =
-		send_json com.io json;
+		send_json com.part_scope.io json;
 		Completed
 	in
 	JsonRpc.handle_jsonrpc_error (fun () ->

--- a/src/context/nativeLibraryHandler.ml
+++ b/src/context/nativeLibraryHandler.ml
@@ -18,7 +18,7 @@
  *)
 
 open Common
-open CompilationContext
+open ParsedArg
 
 let add_native_lib com lib =
 	let file = lib.lib_file in

--- a/src/core/globals.ml
+++ b/src/core/globals.ml
@@ -185,6 +185,9 @@ let gen_local_prefix = "`"
 (* msg * backtrace *)
 exception Ice of string * string
 
+(* Raised to cooperatively cancel an ongoing compiler operation *)
+exception Cancelled
+
 (**
 	Terminates compiler process and prints user-friendly instructions about filing an issue.
 	Usage: `die message __LOC__`, where `__LOC__` is a built-in ocaml constant

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -1482,7 +1482,7 @@ module StdLog = struct
 					| _ -> [s]
 				in
 				(Printf.sprintf "%s:%i: %s" file_name line_number (String.concat "," l)) ^ lineEnd in
-		((get_ctx()).curapi.MacroApi.get_com()).io.print s;
+		((get_ctx()).curapi.MacroApi.get_com()).part_scope.io.print s;
 		vnull
 	)
 end
@@ -2714,14 +2714,14 @@ module StdSys = struct
 	let print = vfun1 (fun v ->
 		let ctx = get_ctx() in
 		let com = ctx.curapi.get_com() in
-		com.io.print (value_string v);
+		com.part_scope.io.print (value_string v);
 		vnull
 	)
 
 	let println = vfun1 (fun v ->
 		let ctx = get_ctx() in
 		let com = ctx.curapi.get_com() in
-		com.io.print (value_string v ^ lineEnd);
+		com.part_scope.io.print (value_string v ^ lineEnd);
 		vnull
 	)
 
@@ -2763,19 +2763,19 @@ module StdSys = struct
 	let stderr = vfun0 (fun () ->
 		let ctx = get_ctx() in
 		let com = ctx.curapi.get_com() in
-		encode_instance key_sys_io_FileOutput ~kind:(IOutChannel com.io.stderr)
+		encode_instance key_sys_io_FileOutput ~kind:(IOutChannel com.part_scope.io.stderr)
 	)
 
 	let stdin = vfun0 (fun () ->
 		let ctx = get_ctx() in
 		let com = ctx.curapi.get_com() in
-		encode_instance key_sys_io_FileInput ~kind:(IInChannel(com.io.stdin,ref false))
+		encode_instance key_sys_io_FileInput ~kind:(IInChannel(com.part_scope.io.stdin,ref false))
 	)
 
 	let stdout = vfun0 (fun () ->
 		let ctx = get_ctx() in
 		let com = ctx.curapi.get_com() in
-		encode_instance key_sys_io_FileOutput ~kind:(IOutChannel com.io.stdout)
+		encode_instance key_sys_io_FileOutput ~kind:(IOutChannel com.part_scope.io.stdout)
 	)
 
 	let systemName =

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2376,6 +2376,8 @@ let macro_api ccom get_api =
 			vnull
 		);
 		"server_stats", vfun0 (fun () ->
+			let com = ccom() in
+			let stats = com.stats in
 			encode_obj [
 				"filesParsed", vint !(stats.s_files_parsed);
 				"modulesTyped", vint !(stats.s_modules_typed);

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2267,7 +2267,7 @@ let macro_api ccom get_api =
 		"get_configuration", vfun0 (fun() ->
 			let com = ccom() in
 			encode_obj [
-				"version", vint com.version.version;
+				"version", vint com.sctx.version.version;
 				"args", encode_array (List.map encode_string com.args);
 				"debug", vbool com.debug;
 				"verbose", vbool com.verbose;
@@ -2377,7 +2377,7 @@ let macro_api ccom get_api =
 		);
 		"server_stats", vfun0 (fun () ->
 			let com = ccom() in
-			let stats = com.stats in
+			let stats = com.request_scope.stats in
 			encode_obj [
 				"filesParsed", vint !(stats.s_files_parsed);
 				"modulesTyped", vint !(stats.s_modules_typed);

--- a/src/macro/macroApi.ml
+++ b/src/macro/macroApi.ml
@@ -2213,7 +2213,7 @@ let macro_api ccom get_api =
 		"add_native_lib", vfun1 (fun file ->
 			let file = decode_string file in
 			let com = ccom() in
-			let open CompilationContext in
+			let open ParsedArg in
 			let kind = match com.platform with
 				| Jvm -> JavaLib
 				| Flash -> SwfLib

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -819,7 +819,7 @@ let load_macro' ctx display cpath f p =
 
 let do_call_macro com api cpath name args p =
 	if com.verbose then Common.log com ("Calling macro " ^ s_type_path cpath ^ "." ^ name ^ " (" ^ p.pfile ^ ":" ^ string_of_int (Lexer.get_error_line p) ^ ")");
-	incr com.stats.s_macros_called;
+	incr com.request_scope.stats.s_macros_called;
 	let timer_level = Timer.level_from_define com.defines Define.MacroTimes in
 	let f = Interp.call_path (Interp.get_ctx()) ((fst cpath) @ [snd cpath]) name args in
 	let r = macro_timer com.timer_ctx timer_level ["execution";s_type_path cpath ^ "." ^ name] None f api in

--- a/src/typing/macroContext.ml
+++ b/src/typing/macroContext.ml
@@ -819,7 +819,7 @@ let load_macro' ctx display cpath f p =
 
 let do_call_macro com api cpath name args p =
 	if com.verbose then Common.log com ("Calling macro " ^ s_type_path cpath ^ "." ^ name ^ " (" ^ p.pfile ^ ":" ^ string_of_int (Lexer.get_error_line p) ^ ")");
-	incr stats.s_macros_called;
+	incr com.stats.s_macros_called;
 	let timer_level = Timer.level_from_define com.defines Define.MacroTimes in
 	let f = Interp.call_path (Interp.get_ctx()) ((fst cpath) @ [snd cpath]) name args in
 	let r = macro_timer com.timer_ctx timer_level ["execution";s_type_path cpath ^ "." ^ name] None f api in

--- a/src/typing/typeloadCacheHook.ml
+++ b/src/typing/typeloadCacheHook.ml
@@ -13,9 +13,6 @@ type find_module_result =
 
 let type_module_hook : (Common.context -> (typer_pass -> (unit -> unit) -> unit) -> path -> pos -> find_module_result) ref = ref (fun _ _ _ _ -> NoModule)
 
-(* Hook to check for cooperative cancellation. Raises [Cancelled] when set by the server. *)
-let check_cancellation : (unit -> unit) ref = ref (fun () -> ())
-
 let fake_modules = Hashtbl.create 0
 
 let create_fake_module com file =

--- a/src/typing/typeloadCacheHook.ml
+++ b/src/typing/typeloadCacheHook.ml
@@ -13,6 +13,9 @@ type find_module_result =
 
 let type_module_hook : (Common.context -> (typer_pass -> (unit -> unit) -> unit) -> path -> pos -> find_module_result) ref = ref (fun _ _ _ _ -> NoModule)
 
+(* Hook to check for cooperative cancellation. Raises [Cancelled] when set by the server. *)
+let check_cancellation : (unit -> unit) ref = ref (fun () -> ())
+
 let fake_modules = Hashtbl.create 0
 
 let create_fake_module com file =

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -481,7 +481,7 @@ let create_class_context c p =
 	cctx
 
 let create_typer_context_for_class ctx cctx p =
-	incr stats.s_classes_built;
+	incr ctx.com.stats.s_classes_built;
 	let c = cctx.tclass in
 	if cctx.is_lib && not (has_class_flag c CExtern) then ctx.com.error "@:libType can only be used in extern classes" c.cl_pos;
 	TyperManager.clone_for_class ctx c
@@ -835,7 +835,7 @@ module TypeBinding = struct
 		let c = cctx.tclass in
 		let ctx = TyperManager.clone_for_expr ctx_f fmode function_mode in
 		let bind () =
-			incr stats.s_methods_typed;
+			incr ctx_f.com.stats.s_methods_typed;
 			if ctx.com.verbose then Common.log ctx.com ("Typing " ^ (if ctx.com.is_macro_context then "macro " else "") ^ s_type_path c.cl_path ^ "." ^ cf.cf_name);
 			begin match ctx.com.platform with
 				| Jvm when is_java_native_function ctx cf.cf_meta cf.cf_pos ->

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -481,7 +481,7 @@ let create_class_context c p =
 	cctx
 
 let create_typer_context_for_class ctx cctx p =
-	incr ctx.com.stats.s_classes_built;
+	incr ctx.com.request_scope.stats.s_classes_built;
 	let c = cctx.tclass in
 	if cctx.is_lib && not (has_class_flag c CExtern) then ctx.com.error "@:libType can only be used in extern classes" c.cl_pos;
 	TyperManager.clone_for_class ctx c
@@ -835,7 +835,7 @@ module TypeBinding = struct
 		let c = cctx.tclass in
 		let ctx = TyperManager.clone_for_expr ctx_f fmode function_mode in
 		let bind () =
-			incr ctx_f.com.stats.s_methods_typed;
+			incr ctx_f.com.request_scope.stats.s_methods_typed;
 			if ctx.com.verbose then Common.log ctx.com ("Typing " ^ (if ctx.com.is_macro_context then "macro " else "") ^ s_type_path c.cl_path ^ "." ^ cf.cf_name);
 			begin match ctx.com.platform with
 				| Jvm when is_java_native_function ctx cf.cf_meta cf.cf_pos ->

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -796,6 +796,7 @@ let rec load_hxb_module com g path p =
 	loop com.hxb_libs
 
 and load_module' com g m p =
+	!TypeloadCacheHook.check_cancellation ();
 	try
 		(* Check current context *)
 		com.module_lut#find m

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -719,7 +719,7 @@ let type_module com g mpath file ?(dont_check_path=false) ?(is_extern=false) tde
 	let tdecls = ModuleLevel.handle_import_hx com g m tdecls p in
 	let ctx_m = type_types_into_module com g m tdecls p in
 	if is_extern then m.m_extra.m_kind <- MExtern else if not dont_check_path then Naming.check_module_path ctx_m.com m.m_path p;
-	incr com.stats.s_modules_typed;
+	incr com.request_scope.stats.s_modules_typed;
 	m
 
 class hxb_reader_api_typeload
@@ -796,7 +796,7 @@ let rec load_hxb_module com g path p =
 	loop com.hxb_libs
 
 and load_module' com g m p =
-	!TypeloadCacheHook.check_cancellation ();
+	check_cancellation com;
 	try
 		(* Check current context *)
 		com.module_lut#find m

--- a/src/typing/typeloadModule.ml
+++ b/src/typing/typeloadModule.ml
@@ -719,7 +719,7 @@ let type_module com g mpath file ?(dont_check_path=false) ?(is_extern=false) tde
 	let tdecls = ModuleLevel.handle_import_hx com g m tdecls p in
 	let ctx_m = type_types_into_module com g m tdecls p in
 	if is_extern then m.m_extra.m_kind <- MExtern else if not dont_check_path then Naming.check_module_path ctx_m.com m.m_path p;
-	incr stats.s_modules_typed;
+	incr com.stats.s_modules_typed;
 	m
 
 class hxb_reader_api_typeload

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -31,7 +31,7 @@ open Error
 exception DisplayInMacroBlock
 
 let parse_file_from_lexbuf com file p lexbuf =
-	incr stats.s_files_parsed;
+	incr com.stats.s_files_parsed;
 	let parse_result = try
 		ParserEntry.parse (ParserConfig.file_parser_config com file) Grammar.parse_file (Lexer.create_file_ctx file) lexbuf file
 	with

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -31,7 +31,7 @@ open Error
 exception DisplayInMacroBlock
 
 let parse_file_from_lexbuf com file p lexbuf =
-	incr com.stats.s_files_parsed;
+	incr com.request_scope.stats.s_files_parsed;
 	let parse_result = try
 		ParserEntry.parse (ParserConfig.file_parser_config com file) Grammar.parse_file (Lexer.create_file_ctx file) lexbuf file
 	with

--- a/tests/misc/connect_stdin/Main.hx
+++ b/tests/misc/connect_stdin/Main.hx
@@ -58,7 +58,23 @@ class Main {
 			return exitCode == 0;
 		});
 
-		// Test 3: No stdin consumed (just compile) - should not hang
+		// Test 3: Piped stdin through --cmd
+		test("stdin line forwarding to command", () -> {
+			var client = new Process("haxe", ["--connect", Std.string(port), "--cmd", "cat -"]);
+			client.stdin.writeString("hello world\n");
+			client.stdin.close();
+			var stdout = client.stdout.readAll().toString().trim();
+			var exitCode = client.exitCode();
+			client.close();
+			if (stdout != "hello world") {
+				Sys.println('\n    Expected: "hello world"');
+				Sys.println('    Got: "$stdout"');
+				return false;
+			}
+			return exitCode == 0;
+		});
+
+		// Test 4: No stdin consumed (just compile) - should not hang
 		test("no-stdin request completes", () -> {
 			var client = new Process("haxe", ["--connect", Std.string(port), "-cp", ".", "--main", "StdinEcho", "--no-output"]);
 			client.stdin.close();

--- a/tests/misc/projects/Issue10871/Compiler/compile3.hxml
+++ b/tests/misc/projects/Issue10871/Compiler/compile3.hxml
@@ -2,4 +2,4 @@
 --macro Main.MacroClass.start()
 --cpp bin
 --no-output
---no-opt
+-D no-opt

--- a/tests/misc/projects/Issue10871/Compiler/compile3.hxml.stdout
+++ b/tests/misc/projects/Issue10871/Compiler/compile3.hxml.stdout
@@ -1,4 +1,4 @@
-Main.hx:16: [--main,Main,--macro,Main.MacroClass.start(),--cpp,bin,--no-output,--no-opt]
+Main.hx:16: [--main,Main,--macro,Main.MacroClass.start(),--cpp,bin,--no-output,-D,no-opt]
 Main.hx:17: false
 Main.hx:18: false
 Main.hx:19: false

--- a/tests/misc/projects/Issue11087/compile-x.hxml
+++ b/tests/misc/projects/Issue11087/compile-x.hxml
@@ -1,0 +1,2 @@
+-x Main
+-D notanarg

--- a/tests/misc/projects/Issue11087/compile-x.hxml.stdout
+++ b/tests/misc/projects/Issue11087/compile-x.hxml.stdout
@@ -1,0 +1,2 @@
+Main.hx:2: [--main,Main,--interp,-D,notanarg]
+Main.hx:8: []

--- a/tests/misc/projects/Issue11087/compile.hxml.stdout
+++ b/tests/misc/projects/Issue11087/compile.hxml.stdout
@@ -1,2 +1,2 @@
-Main.hx:2: [-x,Main]
+Main.hx:2: [--main,Main,--interp]
 Main.hx:8: [arg]

--- a/tests/misc/projects/Issue11128/compile2-fail.hxml.stderr
+++ b/tests/misc/projects/Issue11128/compile2-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Error: --custom-target cannot use reserved name js.
+Error: --custom-target cannot use reserved name js

--- a/tests/misc/projects/Issue2938/compile.hxml
+++ b/tests/misc/projects/Issue2938/compile.hxml
@@ -1,2 +1,2 @@
---no-inline
+-D no-inline
 --run Main

--- a/tests/misc/projects/Issue3300/test-cwd-fail.hxml.stderr
+++ b/tests/misc/projects/Issue3300/test-cwd-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Error: Invalid directory: unexistant.
+Error: Invalid directory: unexistant

--- a/tests/misc/projects/Issue3542/compile.hxml
+++ b/tests/misc/projects/Issue3542/compile.hxml
@@ -1,4 +1,4 @@
 --main Main
 -js js.js
 --no-output
---no-inline
+-D no-inline

--- a/tests/misc/projects/Issue3864/compile.hxml
+++ b/tests/misc/projects/Issue3864/compile.hxml
@@ -1,2 +1,2 @@
---no-inline
+-D no-inline
 --run Main

--- a/tests/misc/projects/Issue8689/compile1-fail.hxml.stderr
+++ b/tests/misc/projects/Issue8689/compile1-fail.hxml.stderr
@@ -1,1 +1,1 @@
-Error: `js` is a reserved compiler flag and cannot be defined from the command line.
+Error: `js` is a reserved compiler flag and cannot be defined from the command line

--- a/tests/misc/projects/empty_hxml_inclusion/Main.hx
+++ b/tests/misc/projects/empty_hxml_inclusion/Main.hx
@@ -1,0 +1,3 @@
+class Main {
+	static function main() {}
+}

--- a/tests/misc/projects/empty_hxml_inclusion/compile.hxml
+++ b/tests/misc/projects/empty_hxml_inclusion/compile.hxml
@@ -1,0 +1,4 @@
+--interp
+--main Main
+empty.hxml
+empty-actual.hxml

--- a/tests/misc/projects/empty_hxml_inclusion/empty.hxml
+++ b/tests/misc/projects/empty_hxml_inclusion/empty.hxml
@@ -1,0 +1,4 @@
+# This file is intentionally empty (only comments).
+# This simulates what the CI does on macOS/APFS for sys/compile-fs.hxml:
+#   echo "" > sys/compile-fs.hxml
+# Including an empty hxml file should be a no-op, not a "file not found" error.


### PR DESCRIPTION
This spawns a single worker domain to run the actual compilation in. The idea is that the main server threads keeps accepting connections while the worker is working. This will ultimately allow cooperative cancellations and prioritization and all that.

But first we have to get it working properly. There's a `todo_semaphore` at the moment which makes the server thread wait for the worker to finish, so there is no real concurrency yet. This requires redesigning `wait_loop` a little more to do the right thing. At the moment it's still trying to manage server tasks, but I've been thinking that this is something that the worker should be doing instead if there are further requests.

I'd like to do a review pass of this though before I get too deep into the weeds. 