### PR TITLE
[cpp] Callable comparison handling

### DIFF
--- a/src/generators/cpp/gen/cppGen.ml
+++ b/src/generators/cpp/gen/cppGen.ml
@@ -1610,6 +1610,9 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
     output_i "int __Compare(const ::hx::Object* inRhs) const override {\n";
     output_i (Printf.sprintf "\treturn dynamic_cast<const _hx_Closure_%i*>(inRhs) ? 0 : -1;\n" closure.close_id);
     output_i "}\n";
+    output_i "std::type_index callableId() const override {\n";
+    output_i (Printf.sprintf "\treturn std::type_index{ typeid(_hx_Closure_%i) };\n" closure.close_id);
+    output_i "}\n";
 
     let return =
       match closure.close_type with TCppVoid -> "(void)" | _ -> "return"

--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -1134,7 +1134,10 @@ class texpr_to_jvm
 		| [TObject(path1,_);sig2] when jc#has_typed_function path1 || path1 = haxe_function_path ->
 			code#swap;
 			fun_compare path1 sig2
-		| [(TObject _ | TArray _ | TMethod _) as t1;(TObject _ | TArray _ | TMethod _) as t2] ->
+		| [TMethod _;_] | [_;TMethod _] ->
+			jm#invokestatic haxe_jvm_path "compareFunctions" (method_sig [object_sig;object_sig] (Some TBool));
+			CmpNormal(op,TBool)
+		| [(TObject _ | TArray _) as t1;(TObject _ | TArray _) as t2] ->
 			CmpSpecial ((if op = CmpEq then code#if_acmp_ne else code#if_acmp_eq) t1 t2)
 		| [TDouble;TDouble] ->
 			let op = flip_cmp_op op in

--- a/std/jvm/Jvm.hx
+++ b/std/jvm/Jvm.hx
@@ -71,6 +71,10 @@ class Jvm {
 		return Reflect.compare(v1, v2);
 	}
 
+	static public function compareFunctions(v1:Dynamic, v2:Dynamic):Bool {
+		return Reflect.compareMethods(v1, v2);
+	}
+
 	static public function enumEq(v1:Dynamic, v2:Dynamic) {
 		if (!instanceof(v1, jvm.Enum)) {
 			return false;

--- a/tests/unit/src/unit/issues/Issue12746.hx
+++ b/tests/unit/src/unit/issues/Issue12746.hx
@@ -10,6 +10,7 @@ private class Foo {
 
 class Issue12746 extends Test {
 	function test() {
+#if !neko
 		final obj = new Foo();
 
 		final a:Event->Void = cast obj.onMouseMove;
@@ -17,6 +18,9 @@ class Issue12746 extends Test {
 		t(a == b);
 
 		t(genericCast(obj.onMouseMove, obj.onMouseMove));
+#else
+		utest.Assert.pass(); // See PR 12763 discussion
+#end
 	}
 
 	static function genericCast<T:Event>(a:T->Void, b:T->Void):Bool {

--- a/tests/unit/src/unit/issues/Issue12746.hx
+++ b/tests/unit/src/unit/issues/Issue12746.hx
@@ -12,6 +12,10 @@ class Issue12746 extends Test {
 	function test() {
 		final obj = new Foo();
 
+		final a:Event->Void = cast obj.onMouseMove;
+		final b:Event->Void = cast obj.onMouseMove;
+		t(a == b);
+
 		t(genericCast(obj.onMouseMove, obj.onMouseMove));
 	}
 

--- a/tests/unit/src/unit/issues/Issue12746.hx
+++ b/tests/unit/src/unit/issues/Issue12746.hx
@@ -1,0 +1,23 @@
+package unit.issues;
+
+private class Event {}
+private class MouseEvent extends Event {}
+private class Foo {
+	public function onMouseMove(e:MouseEvent):Void {}
+
+	public function new() {}
+}
+
+class Issue12746 extends Test {
+	function test() {
+		final obj = new Foo();
+
+		t(genericCast(obj.onMouseMove, obj.onMouseMove));
+	}
+
+	static function genericCast<T:Event>(a:T->Void, b:T->Void):Bool {
+		var ca:Event->Void = cast a;
+		var cb:Event->Void = cast b;
+		return ca == cb;
+	}
+}


### PR DESCRIPTION
Closes #12746

Hxcpp side : https://github.com/HaxeFoundation/hxcpp/pull/1313

I've suspected there was some issues around this sort of thing, but the tests didn't throw anything up. Because the new callable handling creates wrapper functions for differing signatures, comparions between closures could start to go wrong.
This introduces a new based class for the callable which exposes a function which returns it's type, which is independent of the callable object itself. The value returned from this is then used for closure comparisons.