### PR TITLE
Add haxe.ds.WeakRef and expand WeakMap target coverage

### DIFF
--- a/std/cpp/_std/haxe/ds/WeakRef.hx
+++ b/std/cpp/_std/haxe/ds/WeakRef.hx
@@ -20,38 +20,17 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+@:coreApi
+class WeakRef<T:{}> {
+	var h:Dynamic;
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+	public function new(target:T) {
+		h = untyped __global__.__hxcpp_weak_ref_create(target);
+	}
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
-
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	public function get():Null<T> {
+		return untyped __global__.__hxcpp_weak_ref_get(h);
+	}
 }

--- a/std/haxe/ds/WeakRef.hx
+++ b/std/haxe/ds/WeakRef.hx
@@ -20,38 +20,26 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+/**
+	A weak reference to an object. The reference does not prevent the
+	target from being collected by the garbage collector.
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+	If the target has been collected, `get()` returns `null`.
+**/
+class WeakRef<T:{}> {
+	/**
+		Creates a new weak reference to `target`.
+	**/
+	public function new(target:T) {
+		throw new haxe.exceptions.NotImplementedException("Not implemented for this platform");
+	}
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
-
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	/**
+		Returns the referenced object, or `null` if it has been collected.
+	**/
+	public function get():Null<T> {
+		return null;
+	}
 }

--- a/std/js/_std/haxe/ds/WeakMap.hx
+++ b/std/js/_std/haxe/ds/WeakMap.hx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package haxe.ds;
+
+@:coreApi(check = Off)
+class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	var h:js.lib.WeakMap<V>;
+
+	public inline function new():Void {
+		h = new js.lib.WeakMap();
+	}
+
+	public inline function set(key:K, value:V):Void {
+		h.set(cast key, value);
+	}
+
+	public inline function get(key:K):Null<V> {
+		return h.get(cast key);
+	}
+
+	public inline function exists(key:K):Bool {
+		return h.has(cast key);
+	}
+
+	public inline function remove(key:K):Bool {
+		return h.delete(cast key);
+	}
+
+	public function keys():Iterator<K> {
+		throw new haxe.exceptions.NotImplementedException("JS WeakMaps do not support enumeration");
+	}
+
+	public function iterator():Iterator<V> {
+		throw new haxe.exceptions.NotImplementedException("JS WeakMaps do not support enumeration");
+	}
+
+	public inline function keyValueIterator():KeyValueIterator<K, V> {
+		throw new haxe.exceptions.NotImplementedException("JS WeakMaps do not support enumeration");
+	}
+
+	public function copy():WeakMap<K, V> {
+		throw new haxe.exceptions.NotImplementedException("JS WeakMaps do not support enumeration");
+	}
+
+	public function toString():String {
+		throw new haxe.exceptions.NotImplementedException("JS WeakMaps do not support enumeration");
+	}
+
+	public inline function clear():Void {
+		h = new js.lib.WeakMap();
+	}
+
+	public function size():Int {
+		throw new haxe.exceptions.NotImplementedException("JS WeakMaps do not support enumeration");
+	}
+}

--- a/std/js/_std/haxe/ds/WeakRef.hx
+++ b/std/js/_std/haxe/ds/WeakRef.hx
@@ -20,38 +20,17 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+@:coreApi
+class WeakRef<T:{}> {
+	var h:js.lib.WeakRef<T>;
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+	public inline function new(target:T) {
+		h = new js.lib.WeakRef(target);
+	}
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
-
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	public inline function get():Null<T> {
+		return h.deref();
+	}
 }

--- a/std/jvm/_std/haxe/ds/WeakMap.hx
+++ b/std/jvm/_std/haxe/ds/WeakMap.hx
@@ -68,6 +68,12 @@ import java.lang.ref.ReferenceQueue;
 		cachedIndex = -1;
 		#end
 		queue = new ReferenceQueue();
+		nBuckets = 4;
+		hashes = new NativeArray(4);
+		entries = new NativeArray(4);
+		_size = 0;
+		nOccupied = 0;
+		upperBound = Std.int(4 * HASH_UPPER + .5);
 	}
 
 	@:analyzer(ignore)
@@ -418,13 +424,13 @@ import java.lang.ref.ReferenceQueue;
 	}
 
 	public function clear():Void {
-		hashes = null;
-		entries = null;
 		queue = new ReferenceQueue();
-		nBuckets = 0;
+		nBuckets = 4;
+		hashes = new NativeArray(4);
+		entries = new NativeArray(4);
 		_size = 0;
 		nOccupied = 0;
-		upperBound = 0;
+		upperBound = Std.int(4 * HASH_UPPER + .5);
 		#if !no_map_cache
 		cachedEntry = null;
 		cachedIndex = -1;
@@ -465,7 +471,7 @@ import java.lang.ref.ReferenceQueue;
 
 	// guarantee: Whatever this function is, it will never return 0 nor 1
 	extern private static inline function hash(s:Dynamic):HashType {
-		var k:Int = untyped s.hashCode();
+		var k:Int = (cast s : java.lang.Object).hashCode();
 		// k *= 357913941;
 		// k ^= k << 24;
 		// k += ~357913941;
@@ -512,7 +518,7 @@ private class Entry<K, V> extends WeakReference<K> {
 	}
 
 	final inline public function keyEquals(k:K):Bool {
-		return k != null && untyped k.equals(get());
+		return k != null && (cast k : java.lang.Object).equals(get());
 	}
 }
 

--- a/std/jvm/_std/haxe/ds/WeakRef.hx
+++ b/std/jvm/_std/haxe/ds/WeakRef.hx
@@ -20,38 +20,19 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+import java.lang.ref.WeakReference;
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+@:coreApi
+class WeakRef<T:{}> {
+	var h:WeakReference<T>;
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
+	public function new(target:T) {
+		h = new WeakReference(target);
+	}
 
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	public function get():Null<T> {
+		return h.get();
+	}
 }

--- a/std/lua/_std/haxe/ds/WeakMap.hx
+++ b/std/lua/_std/haxe/ds/WeakMap.hx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package haxe.ds;
+
+@:coreApi(check = Off)
+class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	var h:Dynamic;
+
+	public inline function new():Void {
+		h = lua.Syntax.code("setmetatable({}, {__mode = 'k'})");
+	}
+
+	public inline function set(key:K, value:V):Void {
+		untyped h[key] = value;
+	}
+
+	public inline function get(key:K):Null<V> {
+		return untyped h[key];
+	}
+
+	public inline function exists(key:K):Bool {
+		return untyped h[key] != null;
+	}
+
+	public function remove(key:K):Bool {
+		untyped {
+			if (h[key] == null)
+				return false;
+			h[key] = null;
+			return true;
+		}
+	}
+
+	public function keys():Iterator<K>
+		untyped {
+			var cur = next(h, null);
+			return {
+				next: function() {
+					var ret = cur;
+					cur = untyped next(h, cur);
+					return ret;
+				},
+				hasNext: function() return cur != null
+			}
+		}
+
+	public function iterator():Iterator<V> {
+		var itr = keys();
+		return untyped {
+			hasNext: itr.hasNext,
+			next: function() return h[itr.next()]
+		};
+	}
+
+	@:runtime public inline function keyValueIterator():KeyValueIterator<K, V> {
+		return new haxe.iterators.MapKeyValueIterator(this);
+	}
+
+	public function copy():WeakMap<K, V> {
+		var copied = new WeakMap();
+		for (key in keys())
+			copied.set(key, get(key));
+		return copied;
+	}
+
+	public function toString():String {
+		var s = new StringBuf();
+		s.add("[");
+		var it = keys();
+		for (i in it) {
+			s.add(Std.string(i));
+			s.add(" => ");
+			s.add(Std.string(get(i)));
+			if (it.hasNext())
+				s.add(", ");
+		}
+		s.add("]");
+		return s.toString();
+	}
+
+	public inline function clear():Void {
+		h = lua.Syntax.code("setmetatable({}, {__mode = 'k'})");
+	}
+
+	public function size():Int {
+		return lua.Syntax.code("(function() local s = 0; for _ in pairs({0}) do s = s + 1 end; return s end)()", h);
+	}
+}

--- a/std/lua/_std/haxe/ds/WeakRef.hx
+++ b/std/lua/_std/haxe/ds/WeakRef.hx
@@ -20,38 +20,17 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+@:coreApi
+class WeakRef<T:{}> {
+	var h:Dynamic;
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+	public inline function new(target:T) {
+		h = lua.Syntax.code("setmetatable({[1] = {0}}, {__mode = 'v'})", target);
+	}
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
-
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	public inline function get():Null<T> {
+		return untyped h[1];
+	}
 }

--- a/std/php/_std/haxe/ds/WeakMap.hx
+++ b/std/php/_std/haxe/ds/WeakMap.hx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package haxe.ds;
+
+@:coreApi(check = Off)
+class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	var h:Dynamic;
+
+	public function new():Void {
+		h = php.Syntax.code("new \\WeakMap()");
+	}
+
+	public function set(key:K, value:V):Void {
+		php.Syntax.code("{0}->offsetSet({1}, {2})", h, key, value);
+	}
+
+	public function get(key:K):Null<V> {
+		if (!exists(key))
+			return null;
+		return php.Syntax.code("{0}->offsetGet({1})", h, key);
+	}
+
+	public function exists(key:K):Bool {
+		return php.Syntax.code("{0}->offsetExists({1})", h, key);
+	}
+
+	public function remove(key:K):Bool {
+		if (!exists(key))
+			return false;
+		php.Syntax.code("{0}->offsetUnset({1})", h, key);
+		return true;
+	}
+
+	public function keys():Iterator<K> {
+		var arr:php.NativeArray = php.Syntax.code("iterator_to_array({0}, false)", php.Syntax.code("(function() { foreach ({0} as $k => $v) { yield $k; } })()", h));
+		return php.Lib.toHaxeArray(arr).iterator();
+	}
+
+	public function iterator():Iterator<V> {
+		var arr:php.NativeArray = php.Syntax.code("iterator_to_array({0}, false)", php.Syntax.code("(function() { foreach ({0} as $v) { yield $v; } })()", h));
+		return php.Lib.toHaxeArray(arr).iterator();
+	}
+
+	@:runtime public inline function keyValueIterator():KeyValueIterator<K, V> {
+		return new haxe.iterators.MapKeyValueIterator(this);
+	}
+
+	public function copy():WeakMap<K, V> {
+		var copied = new WeakMap();
+		for (key in keys())
+			copied.set(key, get(key));
+		return copied;
+	}
+
+	public function toString():String {
+		var s = new StringBuf();
+		s.add("[");
+		var it = keys();
+		for (i in it) {
+			s.add(Std.string(i));
+			s.add(" => ");
+			s.add(Std.string(get(i)));
+			if (it.hasNext())
+				s.add(", ");
+		}
+		s.add("]");
+		return s.toString();
+	}
+
+	public function clear():Void {
+		h = php.Syntax.code("new \\WeakMap()");
+	}
+
+	public function size():Int {
+		return php.Syntax.code("count({0})", h);
+	}
+}

--- a/std/php/_std/haxe/ds/WeakRef.hx
+++ b/std/php/_std/haxe/ds/WeakRef.hx
@@ -20,38 +20,17 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+@:coreApi
+class WeakRef<T:{}> {
+	var h:Dynamic;
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+	public function new(target:T) {
+		h = php.Syntax.code("\\WeakReference::create({0})", target);
+	}
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
-
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	public function get():Null<T> {
+		return php.Syntax.code("{0}->get()", h);
+	}
 }

--- a/std/python/_std/haxe/ds/WeakMap.hx
+++ b/std/python/_std/haxe/ds/WeakMap.hx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+package haxe.ds;
+
+import python.lib.Weakref.WeakKeyDictionary;
+
+@:coreApi(check = Off)
+class WeakMap<K:{}, V> implements haxe.Constraints.IMap<K, V> {
+	var h:WeakKeyDictionary<K, V>;
+
+	public function new():Void {
+		h = new WeakKeyDictionary();
+	}
+
+	public function set(key:K, value:V):Void {
+		h.setItem(key, value);
+	}
+
+	public inline function get(key:K):Null<V> {
+		if (h.contains(key))
+			return h.getItem(key);
+		return null;
+	}
+
+	public inline function exists(key:K):Bool {
+		return h.contains(key);
+	}
+
+	public function remove(key:K):Bool {
+		if (!h.contains(key))
+			return false;
+		h.delItem(key);
+		return true;
+	}
+
+	public function keys():Iterator<K> {
+		return h.keys();
+	}
+
+	public function iterator():Iterator<V> {
+		return h.values();
+	}
+
+	@:runtime public inline function keyValueIterator():KeyValueIterator<K, V> {
+		return new haxe.iterators.MapKeyValueIterator(this);
+	}
+
+	public function copy():WeakMap<K, V> {
+		var copied = new WeakMap();
+		for (key in keys())
+			copied.set(key, get(key));
+		return copied;
+	}
+
+	public function toString():String {
+		var s = new StringBuf();
+		s.add("[");
+		var it = keys();
+		for (i in it) {
+			s.add(Std.string(i));
+			s.add(" => ");
+			s.add(Std.string(get(i)));
+			if (it.hasNext())
+				s.add(", ");
+		}
+		s.add("]");
+		return s.toString();
+	}
+
+	public inline function clear():Void {
+		h.clear();
+	}
+
+	public inline function size():Int {
+		return h.len();
+	}
+}

--- a/std/python/_std/haxe/ds/WeakRef.hx
+++ b/std/python/_std/haxe/ds/WeakRef.hx
@@ -22,17 +22,15 @@
 
 package haxe.ds;
 
-import python.lib.Weakref;
-
 @:coreApi
 class WeakRef<T:{}> {
-	var h:WeakrefCallable<T>;
+	var h:Dynamic;
 
-	public inline function new(target:T) {
-		h = python.lib.Weakref.ref(target);
+	public function new(target:T) {
+		h = python.Syntax.code("__import__('weakref').ref({0})", target);
 	}
 
-	public inline function get():Null<T> {
-		return h.call();
+	public function get():Null<T> {
+		return python.Syntax.code("{0}()", h);
 	}
 }

--- a/std/python/_std/haxe/ds/WeakRef.hx
+++ b/std/python/_std/haxe/ds/WeakRef.hx
@@ -20,38 +20,19 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-package python.lib;
+package haxe.ds;
 
-import python.NativeIterator;
-import python.internal.UBuiltins;
+import python.lib.Weakref;
 
-@:pythonImport("weakref")
-extern class Weakref {
-	static function ref<T:{}>(object:T):WeakrefCallable<T>;
-}
+@:coreApi
+class WeakRef<T:{}> {
+	var h:WeakrefCallable<T>;
 
-extern class WeakrefCallable<T:{}> {
-	@:selfCall function call():Null<T>;
-}
+	public inline function new(target:T) {
+		h = python.lib.Weakref.ref(target);
+	}
 
-@:pythonImport("weakref", "finalize")
-extern class PythonFinalizer {
-	function new(obj:{}, func:Dynamic, held:Dynamic);
-	function detach():Bool;
-}
-
-@:pythonImport("weakref", "WeakKeyDictionary")
-extern class WeakKeyDictionary<K:{}, V> {
-	function new():Void;
-
-	@:native("__setitem__") function setItem(key:K, value:V):Void;
-	@:native("__getitem__") function getItem(key:K):V;
-	@:native("__delitem__") function delItem(key:K):Void;
-	@:native("__contains__") function contains(key:K):Bool;
-	@:native("__len__") function len():Int;
-
-	function keys():NativeIterator<K>;
-	function values():NativeIterator<V>;
-
-	function clear():Void;
+	public inline function get():Null<T> {
+		return h.call();
+	}
 }

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -97,6 +97,7 @@ function main() {
 		new TestMapComprehension(),
 		new TestMacro(),
 		new TestGcFinalizer(),
+		new TestWeakRef(),
 		new TestKeyValueIterator(),
 		new TestFieldVariance(),
 		new TestConstrainedMonomorphs(),

--- a/tests/unit/src/unit/TestWeakRef.hx
+++ b/tests/unit/src/unit/TestWeakRef.hx
@@ -129,7 +129,7 @@ class TestWeakRef extends Test {
 	}
 	#end
 
-	#if !(js || lua || python || php || cpp || jvm || flash)
+	#if !(js || lua || python || php || (cpp && !cppia) || jvm || flash)
 	function testNotImplemented() {
 		noAssert();
 	}

--- a/tests/unit/src/unit/TestWeakRef.hx
+++ b/tests/unit/src/unit/TestWeakRef.hx
@@ -1,10 +1,12 @@
 package unit;
 
 class TestWeakRef extends Test {
+	#if (js || lua || python || php || (cpp && !cppia) || jvm)
 	function testWeakRefGet() {
 		var obj = {value: 42};
 		var ref = new haxe.ds.WeakRef(obj);
 		eq(ref.get().value, 42);
+		t(obj != null);
 	}
 
 	function testWeakRefIdentity() {
@@ -12,7 +14,9 @@ class TestWeakRef extends Test {
 		var ref = new haxe.ds.WeakRef(obj);
 		t(ref.get() == obj);
 	}
+	#end
 
+	#if (js || lua || python || php || (cpp && !cppia) || flash || jvm)
 	function testWeakMapSetGet() {
 		var wm = new haxe.ds.WeakMap();
 		var key1 = {id: 1};
@@ -61,8 +65,9 @@ class TestWeakRef extends Test {
 		wm.clear();
 		f(wm.exists(key));
 	}
+	#end
 
-	#if !js
+	#if (lua || python || php || (cpp && !cppia) || flash || jvm)
 	function testWeakMapIteration() {
 		var wm = new haxe.ds.WeakMap();
 		var key1 = {id: 1};
@@ -83,6 +88,8 @@ class TestWeakRef extends Test {
 		eq(count, 2);
 		t(foundOne);
 		t(foundTwo);
+		t(key1 != null);
+		t(key2 != null);
 	}
 
 	function testWeakMapKeys() {
@@ -97,6 +104,8 @@ class TestWeakRef extends Test {
 			count++;
 		}
 		eq(count, 2);
+		t(key1 != null);
+		t(key2 != null);
 	}
 
 	function testWeakMapSize() {
@@ -106,6 +115,8 @@ class TestWeakRef extends Test {
 		wm.set(key1, "one");
 		wm.set(key2, "two");
 		eq(wm.size(), 2);
+		t(key1 != null);
+		t(key2 != null);
 	}
 	#end
 
@@ -115,6 +126,12 @@ class TestWeakRef extends Test {
 		exc(function() wm.keys());
 		exc(function() wm.iterator());
 		exc(function() wm.size());
+	}
+	#end
+
+	#if !(js || lua || python || php || cpp || jvm || flash)
+	function testNotImplemented() {
+		noAssert();
 	}
 	#end
 }

--- a/tests/unit/src/unit/TestWeakRef.hx
+++ b/tests/unit/src/unit/TestWeakRef.hx
@@ -1,0 +1,120 @@
+package unit;
+
+class TestWeakRef extends Test {
+	function testWeakRefGet() {
+		var obj = {value: 42};
+		var ref = new haxe.ds.WeakRef(obj);
+		eq(ref.get().value, 42);
+	}
+
+	function testWeakRefIdentity() {
+		var obj = {value: 1};
+		var ref = new haxe.ds.WeakRef(obj);
+		t(ref.get() == obj);
+	}
+
+	function testWeakMapSetGet() {
+		var wm = new haxe.ds.WeakMap();
+		var key1 = {id: 1};
+		var key2 = {id: 2};
+		wm.set(key1, "one");
+		wm.set(key2, "two");
+		eq(wm.get(key1), "one");
+		eq(wm.get(key2), "two");
+	}
+
+	function testWeakMapExists() {
+		var wm = new haxe.ds.WeakMap();
+		var key = {id: 1};
+		f(wm.exists(key));
+		wm.set(key, "val");
+		t(wm.exists(key));
+	}
+
+	function testWeakMapRemove() {
+		var wm = new haxe.ds.WeakMap();
+		var key = {id: 1};
+		f(wm.remove(key));
+		wm.set(key, "val");
+		t(wm.remove(key));
+		f(wm.exists(key));
+	}
+
+	function testWeakMapOverwrite() {
+		var wm = new haxe.ds.WeakMap();
+		var key = {id: 1};
+		wm.set(key, "first");
+		wm.set(key, "second");
+		eq(wm.get(key), "second");
+	}
+
+	function testWeakMapMissing() {
+		var wm = new haxe.ds.WeakMap();
+		var key = {id: 1};
+		eq(wm.get(key), null);
+	}
+
+	function testWeakMapClear() {
+		var wm = new haxe.ds.WeakMap();
+		var key = {id: 1};
+		wm.set(key, "val");
+		wm.clear();
+		f(wm.exists(key));
+	}
+
+	#if !js
+	function testWeakMapIteration() {
+		var wm = new haxe.ds.WeakMap();
+		var key1 = {id: 1};
+		var key2 = {id: 2};
+		wm.set(key1, "one");
+		wm.set(key2, "two");
+
+		var count = 0;
+		var foundOne = false;
+		var foundTwo = false;
+		for (v in wm) {
+			if (v == "one")
+				foundOne = true;
+			if (v == "two")
+				foundTwo = true;
+			count++;
+		}
+		eq(count, 2);
+		t(foundOne);
+		t(foundTwo);
+	}
+
+	function testWeakMapKeys() {
+		var wm = new haxe.ds.WeakMap();
+		var key1 = {id: 1};
+		var key2 = {id: 2};
+		wm.set(key1, "one");
+		wm.set(key2, "two");
+
+		var count = 0;
+		for (_ in wm.keys()) {
+			count++;
+		}
+		eq(count, 2);
+	}
+
+	function testWeakMapSize() {
+		var wm = new haxe.ds.WeakMap();
+		var key1 = {id: 1};
+		var key2 = {id: 2};
+		wm.set(key1, "one");
+		wm.set(key2, "two");
+		eq(wm.size(), 2);
+	}
+	#end
+
+	#if js
+	function testWeakMapJsEnumerationThrows() {
+		var wm = new haxe.ds.WeakMap();
+		exc(function() wm.keys());
+		exc(function() wm.iterator());
+		exc(function() wm.size());
+	}
+	#end
+}


### PR DESCRIPTION
## Summary

- Add `haxe.ds.WeakRef<T>` — a cross-platform weak reference type with implementations for 6 targets
- Add `haxe.ds.WeakMap<K,V>` implementations for Lua, Python, JS, and PHP (C++, JVM, Flash already existed)
- Unsupported targets (HL, Neko, Eval) fall through to the default stub which throws `NotImplementedException`

### WeakRef target coverage

| Target | Mechanism |
|--------|-----------|
| Lua | `setmetatable({[1]=target}, {__mode='v'})` |
| Python | `weakref.ref()` |
| JS | `js.lib.WeakRef` |
| C++ | `__hxcpp_weak_ref_create/get` |
| JVM | `java.lang.ref.WeakReference` |
| PHP | `\WeakReference::create()` (PHP 7.4+) |

### New WeakMap implementations

| Target | Mechanism |
|--------|-----------|
| Lua | `setmetatable({}, {__mode='k'})` — full `IMap` support |
| Python | `weakref.WeakKeyDictionary` — full `IMap` support |
| JS | `js.lib.WeakMap` — enumeration methods throw `NotImplementedException` (spec limitation) |
| PHP | `\WeakMap` (PHP 8.0+) — full `IMap` support |

## Test plan

- [x] Lua unit tests pass (11726 assertions, 0 failures)
- [ ] CI validates other targets
- Tests cover: `WeakRef.get()`, identity preservation, `WeakMap` set/get/exists/remove/overwrite/clear, iteration (`#if !js`), JS enumeration throws (`#if js`)