### PR TITLE
[cpp] Typed semaphore + haxe lock and dequeue

### DIFF
--- a/std/cpp/_std/sys/thread/Deque.hx
+++ b/std/cpp/_std/sys/thread/Deque.hx
@@ -24,21 +24,51 @@ package sys.thread;
 
 @:coreApi
 class Deque<T> {
-	var q:Dynamic;
+	final storage:Array<T>;
+	final condition:Condition;
 
 	public function new() {
-		q = untyped __global__.__hxcpp_deque_create();
+		storage   = [];
+		condition = new Condition();
 	}
 
 	public function add(i:T):Void {
-		untyped __global__.__hxcpp_deque_add(q, i);
+		condition.acquire();
+		storage.push(i);
+		condition.signal();
+		condition.release();
 	}
 
 	public function push(i:T):Void {
-		untyped __global__.__hxcpp_deque_push(q, i);
+		condition.acquire();
+		storage.insert(0, i);
+		condition.signal();
+		condition.release();
 	}
 
 	public function pop(block:Bool):Null<T> {
-		return untyped __global__.__hxcpp_deque_pop(q, block);
+		if (block)
+		{
+			condition.acquire();
+
+			var result = storage.shift();
+			while (null == result) {
+				condition.wait();
+
+				result = storage.shift();
+			}
+
+			condition.release();
+
+			return result;
+		}
+		else
+		{
+			condition.acquire();
+			final result = storage.shift();
+			condition.release();
+			
+			return result;
+		}
 	}
 }

--- a/std/cpp/_std/sys/thread/Lock.hx
+++ b/std/cpp/_std/sys/thread/Lock.hx
@@ -24,17 +24,17 @@ package sys.thread;
 
 @:coreApi
 class Lock {
-	var l:Dynamic;
+	final s:Semaphore;
 
 	public function new() {
-		l = untyped __global__.__hxcpp_lock_create();
+		s = new Semaphore(0);
 	}
 
 	public function wait(?timeout:Float = -1):Bool {
-		return untyped __global__.__hxcpp_lock_wait(l, timeout);
+		return s.tryAcquire(timeout);
 	}
 
 	public function release():Void {
-		untyped __global__.__hxcpp_lock_release(l);
+		s.release();
 	}
 }

--- a/std/cpp/_std/sys/thread/Semaphore.hx
+++ b/std/cpp/_std/sys/thread/Semaphore.hx
@@ -19,7 +19,7 @@ class Semaphore {
 	}
 
 	public function acquire():Void {
-		s.release();
+		s.acquire();
 	}
 
 	public function tryAcquire(?timeout:Float):Bool {

--- a/std/cpp/_std/sys/thread/Semaphore.hx
+++ b/std/cpp/_std/sys/thread/Semaphore.hx
@@ -1,22 +1,32 @@
 package sys.thread;
 
+@:include("hx/thread/CountingSemaphore.hpp")
+@:cpp.ManagedType({ namespace : [ "hx", "thread" ], flags : [ StandardNaming ] })
+private extern class CountingSemaphore {
+	function new(value:Int):Void;
+
+	public function acquire():Void;
+	public function release():Void;
+	public function tryAcquire(timeout:Null<Float>):Bool;
+}
+
 @:coreApi
 class Semaphore {
-	var m:Dynamic;
+	final s:CountingSemaphore;
 
 	public function new(value:Int) {
-		m = untyped __global__.__hxcpp_semaphore_create(value);
+		s = new CountingSemaphore(value);
 	}
 
 	public function acquire():Void {
-		untyped __global__.__hxcpp_semaphore_acquire(m);
+		s.release();
 	}
 
 	public function tryAcquire(?timeout:Float):Bool {
-		return untyped __global__.__hxcpp_semaphore_try_acquire(m, timeout == null ? 0 : (timeout:Float));
+		return s.tryAcquire(timeout);
 	}
 
 	public function release():Void {
-		untyped __global__.__hxcpp_semaphore_release(m);
+		s.release();
 	}
 }


### PR DESCRIPTION
Now that the typed semaphore is in (and finally working) the haxe side can directly call it instead of going through the dynamic handle.
I've also moved the the lock and dequeue implementations into haxe, there was nothing special going on with the C++ implementation (I've just transcribed it from C++ to haxe) so I don't think we've lost anything here. Less C++ is always good in my books.