### PR TITLE
[lua] Default to vanilla JSON parser

### DIFF
--- a/std/lua/_std/haxe/format/JsonParser.hx
+++ b/std/lua/_std/haxe/format/JsonParser.hx
@@ -42,10 +42,10 @@ class JsonParser {
 		If `str` is null, the result is unspecified.
 	**/
 	static public inline function parse(str:String):Dynamic {
-		#if lua_vanilla
-		return new JsonParser(str).doParse();
-		#else
+		#if lua_simdjson
 		return lua.lib.hxluasimdjson.Json.parse(str);
+		#else
+		return new JsonParser(str).doParse();
 		#end
 	}
 


### PR DESCRIPTION
## Summary

- Switch the Lua target's default JSON parser from `hx-lua-simdjson` (requires native C dependency via luarocks) to the pure Haxe implementation
- `hx-lua-simdjson` can still be enabled with `-D lua_simdjson` for users who want the performance
- The `lua_vanilla` define continues to work as before for disabling all native Lua dependencies

## Motivation

`hx-lua-simdjson` requires compiling and installing a C library via luarocks, which adds friction to the default Lua target experience. For most users, the pure Haxe JSON parser is sufficient, and users who need simdjson's performance can opt in explicitly.

This also makes it easier to treat simdjson as a third-party library rather than a compiler dependency.

## Test plan

- [ ] CI passes with default (vanilla) JSON parser
- [ ] Verify `-D lua_simdjson` still works when the luarock is installed