### PR TITLE
Run (and fix) stdin tests on windows

### DIFF
--- a/libs/extc/extc_stubs.c
+++ b/libs/extc/extc_stubs.c
@@ -28,6 +28,7 @@
 #ifdef _WIN32
 #	include <windows.h>
 #	include <conio.h>
+#	include <io.h>
 #else
 #	include <dlfcn.h>
 #	include <limits.h>
@@ -558,7 +559,25 @@ CAMLprim value sys_timestamp_ms() {
 
 CAMLprim value sys_getch( value b ) {
 #	ifdef _WIN32
-	return Val_int( Bool_val(b)?getche():getch() );
+	/* getch()/getche() from <conio.h> read from the console input buffer,
+	   not from stdin.  When stdin is a pipe or file (e.g. subprocess with
+	   redirected input) they ignore the redirected data entirely.
+	   Detect this and fall back to _read() on the raw file descriptor. */
+	{
+		HANDLE h = GetStdHandle(STD_INPUT_HANDLE);
+		DWORD ft = (h != INVALID_HANDLE_VALUE) ? GetFileType(h) : FILE_TYPE_CHAR;
+		if (ft == FILE_TYPE_CHAR) {
+			return Val_int( Bool_val(b) ? getche() : getch() );
+		} else {
+			unsigned char c;
+			int n = _read(0, &c, 1);
+			if (n <= 0) return Val_int(-1);
+			if (Bool_val(b)) {
+				_write(1, &c, 1);
+			}
+			return Val_int(c);
+		}
+	}
 #	else
 	// took some time to figure out how to do that
 	// without relying on ncurses, which clear the

--- a/src/compiler/pipeThings.ml
+++ b/src/compiler/pipeThings.ml
@@ -187,6 +187,21 @@ let ssend sock str =
 
 let poll sock print =
 	let response_buf = Buffer.create 0 in
+	(* Process all complete lines (up to the last newline) in the buffer,
+	   keeping any partial unflushed line for the next read. *)
+	let flush_complete_lines () =
+		let s = Buffer.contents response_buf in
+		match String.rindex_opt s '\n' with
+		| None -> ()
+		| Some last_nl ->
+			let complete = String.sub s 0 (last_nl + 1) in
+			let remaining = String.sub s (last_nl + 1) (String.length s - last_nl - 1) in
+			let lines = ExtString.String.nsplit complete "\n" in
+			let lines = (match List.rev lines with "" :: l -> List.rev l | _ -> lines) in
+			List.iter print lines;
+			Buffer.reset response_buf;
+			if remaining <> "" then Buffer.add_string response_buf remaining
+	in
 	(* Forward stdin to the server socket in a background thread.
 	   Using a dedicated thread avoids mixing socket and non-socket file
 	   descriptors in Unix.select, which has known issues on Windows. *)
@@ -214,6 +229,8 @@ let poll sock print =
 		Buffer.add_subbytes response_buf sock_buf 0 b;
 		if b <= 0 then
 			sock_open := false
+		else
+			flush_complete_lines ()
 	done;
 	(* Flush any remaining partial line after the server closes the connection *)
 	let s = Buffer.contents response_buf in

--- a/src/compiler/pipeThings.ml
+++ b/src/compiler/pipeThings.ml
@@ -187,45 +187,38 @@ let ssend sock str =
 
 let poll sock print =
 	let response_buf = Buffer.create 0 in
-	let process_response () =
-		let lines = ExtString.String.nsplit (Buffer.contents response_buf) "\n" in
-		let lines = (match List.rev lines with "" :: l -> List.rev l | _ -> lines) in
-		List.iter print lines;
-	in
-	(* Use Unix.select to multiplex reading from both server socket and local stdin,
-	avoiding the need for a separate forwarding thread. *)
-	let stdin_fd = Unix.descr_of_in_channel Stdlib.stdin in
+	(* Forward stdin to the server socket in a background thread.
+	   Using a dedicated thread avoids mixing socket and non-socket file
+	   descriptors in Unix.select, which has known issues on Windows. *)
 	let stdin_buf = Bytes.create 1024 in
-	let sock_buf = Bytes.create 1024 in
-	let stdin_active = ref true in
-	let sock_open = ref true in
-	let rec loop () =
-		let read_fds = (if !sock_open then [sock] else []) @ (if !stdin_active then [stdin_fd] else []) in
-		if read_fds = [] then ()
-		else begin
-			let readable, _, _ = Unix.select read_fds [] [] (-1.0) in
-			List.iter (fun fd ->
-				if fd = stdin_fd then begin
-					let n = Unix.read fd stdin_buf 0 1024 in
-					if n = 0 then begin
-						stdin_active := false;
-						(try Unix.shutdown sock Unix.SHUTDOWN_SEND with _ -> ())
-					end else
-						ssend sock (Bytes.sub stdin_buf 0 n)
-				end else begin
-					let b = Unix.recv sock sock_buf 0 1024 [] in
-					Buffer.add_subbytes response_buf sock_buf 0 b;
-					if b > 0 then begin
-						if Bytes.get sock_buf (b - 1) = '\n' then begin
-							process_response ();
-							Buffer.reset response_buf;
-						end
-					end else
-						sock_open := false
+	let _ = Thread.create (fun () ->
+		(try
+			let rec loop () =
+				let n = Unix.read (Unix.descr_of_in_channel Stdlib.stdin) stdin_buf 0 1024 in
+				if n = 0 then
+					(try Unix.shutdown sock Unix.SHUTDOWN_SEND with _ -> ())
+				else begin
+					ssend sock (Bytes.sub stdin_buf 0 n);
+					loop ()
 				end
-			) readable;
-			if !sock_open then loop ()
-		end
-	in
-	loop ();
-	process_response ()
+			in
+			loop ()
+		with _ -> ())
+	) () in
+	(* Read server output until the connection closes, printing lines immediately
+	   as they arrive rather than waiting for the server to disconnect. *)
+	let sock_buf = Bytes.create 1024 in
+	let sock_open = ref true in
+	while !sock_open do
+		let b = Unix.recv sock sock_buf 0 1024 [] in
+		Buffer.add_subbytes response_buf sock_buf 0 b;
+		if b <= 0 then
+			sock_open := false
+	done;
+	(* Flush any remaining partial line after the server closes the connection *)
+	let s = Buffer.contents response_buf in
+	if s <> "" then begin
+		let lines = ExtString.String.nsplit s "\n" in
+		let lines = (match List.rev lines with "" :: l -> List.rev l | _ -> lines) in
+		List.iter print lines
+	end

--- a/tests/misc/eval/connect_stdin/Main.hx
+++ b/tests/misc/eval/connect_stdin/Main.hx
@@ -163,6 +163,35 @@ class Main {
 			return exitCode == 0;
 		});
 
+		// Test 10: Output is streamed immediately, not buffered until program exit.
+		// StreamOutput traces "before_stdin", then blocks on stdin.
+		// If --connect streaming works, we can read that line before sending stdin.
+		// If output were buffered until exit this test would deadlock because the
+		// program waits for stdin which we only send after reading the first line.
+		test("streaming output not buffered until exit", () -> {
+			var client = new Process("haxe", [
+				"--connect", Std.string(port), "-cp", ".", "--main", "StreamOutput", "--interp"
+			]);
+			// This readLine() returns immediately if streaming works,
+			// because the trace happens before the program reads stdin.
+			var firstLine = client.stdout.readLine();
+			// Unblock the program by sending a stdin byte.
+			client.stdin.writeByte(0);
+			client.stdin.close();
+			var rest = client.stdout.readAll().toString().trim();
+			var exitCode = client.exitCode();
+			client.close();
+			if (!firstLine.contains("before_stdin")) {
+				Sys.println('\n    First line should contain "before_stdin", got: "$firstLine"');
+				return false;
+			}
+			if (!rest.contains("after_stdin")) {
+				Sys.println('\n    Remaining output should contain "after_stdin", got: "$rest"');
+				return false;
+			}
+			return exitCode == 0;
+		});
+
 		// Clean up the server
 		server.kill();
 		server.close();

--- a/tests/misc/eval/connect_stdin/StreamOutput.hx
+++ b/tests/misc/eval/connect_stdin/StreamOutput.hx
@@ -1,0 +1,10 @@
+class StreamOutput {
+	static function main() {
+		// Output something immediately, then block until stdin has a byte.
+		// A test can read this first trace line to confirm streaming works,
+		// then send a byte to let the program continue.
+		trace("before_stdin");
+		Sys.stdin().readByte();
+		trace("after_stdin");
+	}
+}

--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -34,11 +34,11 @@ class Macro {
 			case 'Linux':
 				changeDirectory(getMiscSubDir());
 				runCommand("haxe", ["run-base.hxml", "-D", "timeout=3", "--run", "Main", "eval/compiler_loops"]);
-
-				changeDirectory(getMiscSubDir("eval", "connect_stdin"));
-				runCommand("haxe", ["run.hxml"]);
 			case _: // TODO
 		}
+
+		changeDirectory(getMiscSubDir("eval", "connect_stdin"));
+		runCommand("haxe", ["run.hxml"]);
 
 		changeDirectory(threadsDir);
 		runCommand("haxe", ["build.hxml", "--interp"]);


### PR DESCRIPTION
Still fixing more things... this also makes streaming via `--connect` work - at least on a `--wait server`. The problem with `--server-connect` is that it has a length-prefixed communication protocol which means we really can't send anything until we have everything. Which is stupid...

I'll sit down with Claude and see if we can design a better binary protocol for all this.