### PR TITLE
Process args at execution entry point

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -557,13 +557,17 @@ let expand_args args =
 		| [] ->
 			add_part (List.rev current) []
 		| Next :: rest when current = [] ->
+			(* reset hxml_stack so the same hxml can be included in a subsequent section *)
+			hxml_stack := [];
 			loop [] rest
 		| Next :: rest ->
 			add_part (List.rev current) [];
+			(* reset hxml_stack so the same hxml can be included in a subsequent section *)
+			hxml_stack := [];
 			loop [] rest
 		| Each :: rest ->
 			each := List.rev current;
-			loop []  rest
+			loop [] rest
 		| Cwd dir :: rest ->
 			(try Unix.chdir dir with _ -> ());
 			loop (Cwd dir :: current) rest
@@ -607,9 +611,9 @@ let expand_args args =
 			loop current (expanded @ rest)
 		| SetDisplayArg s :: rest ->
 			display_arg := Some s;
-			loop current rest
-		| _ ->
-			assert false
+			loop (SetDisplayArg s :: current) rest
+		| arg :: rest ->
+			loop (arg :: current) rest
 	in
 	loop [] args;
 	{

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -2,6 +2,11 @@ open Globals
 open Common
 open ParsedArg
 
+type server_mode =
+	| SMNone
+	| SMListen of string
+	| SMConnect of string
+
 let columns = AtomicLazy.from_fun (fun () -> match Terminal_size.get_columns () with None -> 80 | Some c -> c)
 
 let limit_string s offset =
@@ -99,7 +104,7 @@ let adv_args_descriptions = [
     The translation is mostly 1-to-1: one CLI flag group → one [parsed_arg].
     Compound expansions (e.g. adding [php.Boot] for [--php], setting
     [actx.interp] for [--interp]) are deferred to [process_args]. *)
-let parse_args (_sctx : ServerCompilationContext.t) args =
+let parse_args args =
 	let parsed = DynArray.create () in
 	let add a = DynArray.add parsed a in
 	let rec loop = function
@@ -396,7 +401,7 @@ let process_args (com : Common.context) (parsed_args : parsed_arg list) =
 		| HxmlFile _ ->
 			(* hxml files should have been expanded before reaching process_args *)
 			()
-		| Next | Each ->
+		| Next | Each | Expand _ ->
 			(* batch directives handled at process_params level *)
 			()
 		| ServerListen _ | ServerConnect _ | Connect _ ->
@@ -460,7 +465,7 @@ let to_raw_args (parsed_args : parsed_arg list) =
 		| CustomTarget name -> name
 	in
 	let s_path (p, n) = String.concat "." (p @ [n]) in
-	List.concat_map (fun arg -> match arg with
+	let rec to_raw arg = match arg with
 		| SetPlatform (platform, file) -> ["--" ^ s_platform platform; file]
 		| SetCppiaTarget file -> ["--cppia"; file]
 		| SetCustomTarget (name, path) ->
@@ -505,6 +510,7 @@ let to_raw_args (parsed_args : parsed_arg list) =
 		| SetPrompt -> ["--prompt"]
 		| Next -> ["--next"]
 		| Each -> ["--each"]
+		| Expand ex -> List.concat_map to_raw ex.original
 		| ServerListen hp -> ["--wait"; hp]
 		| ServerConnect hp -> ["--server-connect"; hp]
 		| Connect hp -> ["--connect"; hp]
@@ -516,5 +522,99 @@ let to_raw_args (parsed_args : parsed_arg list) =
 		| ShowHelpMetas -> ["--help-metas"]
 		| ShowHelpUserDefines -> ["--help-user-defines"]
 		| ShowHelpUserMetas -> ["--help-user-metas"]
-	) parsed_args
+	in
+	List.concat_map to_raw parsed_args
 
+type part_args = {
+	args : parsed_arg list;
+	runtime_args : string list;
+}
+
+type request_args = {
+	parts : part_args list;
+	server_mode : server_mode;
+	connect_arg : string option;
+	display_arg : string option;
+}
+
+let expand_args args =
+	let each = ref [] in
+	let parts = DynArray.create () in
+	let server_mode = ref SMNone in
+	let connect_arg = ref None in
+	let display_arg = ref None in
+	let hxml_stack = ref [] in
+	let add_part args runtime_args =
+		DynArray.add parts {args = !each @ args;runtime_args}
+	in
+	let rec find_subsequent_libs acc args = match args with
+		| AddLib name :: args ->
+			find_subsequent_libs (name :: acc) args
+		| _ ->
+			List.rev acc, args
+	in
+	let rec loop current = function
+		| [] ->
+			add_part (List.rev current) []
+		| Next :: rest when current = [] ->
+			loop [] rest
+		| Next :: rest ->
+			add_part (List.rev current) [];
+			loop [] rest
+		| Each :: rest ->
+			each := List.rev current;
+			loop []  rest
+		| Cwd dir :: rest ->
+			(try Unix.chdir dir with _ -> ());
+			loop (Cwd dir :: current) rest
+		| Connect hp :: rest ->
+			connect_arg := Some hp;
+			loop current rest
+		| ServerConnect hp :: rest ->
+			server_mode := SMConnect hp;
+			loop current rest
+		| ServerListen hp :: rest ->
+			server_mode := SMListen hp;
+			loop current rest
+		| Run (cl, runtime_args) :: rest ->
+			let cpath = Path.parse_type_path cl in
+			let acc = Interp :: SetMain cpath :: current in
+			let runtime_args = runtime_args @ (to_raw_args rest) in
+			add_part (List.rev acc) runtime_args;
+		| RunX cl :: rest ->
+			let cpath = Path.parse_type_path cl in
+			loop (Interp :: SetMain cpath :: current) rest
+		| AddLib name :: rest ->
+			let libs, rest = find_subsequent_libs [name] rest in
+			let ex = {
+				original = List.map (fun name -> AddLib name) libs;
+				state = NotYetExpanded (AddLibs libs)
+			} in
+			loop (Expand ex :: current) rest
+		| HxmlFile path :: rest ->
+			let full_path = try Extc.get_full_path path with Failure(_) -> raise (Arg.Bad (Printf.sprintf "File not found: %s" path)) in
+			if List.mem full_path !hxml_stack then
+				raise (Arg.Bad (Printf.sprintf "Duplicate hxml inclusion: %s" full_path))
+			else
+				hxml_stack := full_path :: !hxml_stack;
+			let expanded =
+				try
+					let raw = Helper.parse_hxml path in
+					parse_args raw
+				with Not_found ->
+					[IncludeModule (path ^ " (file not found)")]
+			in
+			loop current (expanded @ rest)
+		| SetDisplayArg s :: rest ->
+			display_arg := Some s;
+			loop current rest
+		| _ ->
+			assert false
+	in
+	loop [] args;
+	{
+		parts = DynArray.to_list parts;
+		server_mode = !server_mode;
+		connect_arg = !connect_arg;
+		display_arg = !display_arg;
+	}

--- a/src/compiler/compilationContext.ml
+++ b/src/compiler/compilationContext.ml
@@ -3,11 +3,6 @@ open ParsedArg
 
 exception Abort
 
-type server_mode =
-	| SMNone
-	| SMListen of string
-	| SMConnect of string
-
 type communication = {
 	write_out : string -> unit;
 	write_err : string -> unit;

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -605,182 +605,54 @@ module HighLevel = struct
 			) [] (List.rev lines) in
 			lines
 
-	(* Returns a list of contexts, but doesn't do anything yet *)
-	let process_params (sctx : ServerCompilationContext.t) (request_scope : request_scope) timer_ctx create each_args has_display is_server (args : parsed_arg list) =
-		(* We want the loop below to actually see all the --each params, so let's prepend them *)
-		let args = !each_args @ args in
-		let added_libs = Hashtbl.create 0 in
-		let server_mode = ref Args.SMNone in
-		let hxml_stack = ref [] in
-		let create_context parsed =
-			sctx.compilation_step <- sctx.compilation_step + 1;
-			let ctx = create sctx.compilation_step parsed in
-			ctx
-		in
-		let rec find_subsequent_libs acc args = match args with
-		| AddLib name :: args ->
-			find_subsequent_libs (name :: acc) args
-		| _ ->
-			List.rev acc, args
-		in
-		let expand_libs libs rest =
-			let libs = List.filter (fun l -> not (Hashtbl.mem added_libs l)) libs in
-			List.iter (fun l -> Hashtbl.add added_libs l ()) libs;
-			let global_repo = List.exists (fun a -> a = HaxelibGlobal) args in
-			let raw_lines = add_libs timer_ctx libs (if global_repo then ["--haxelib-global"] else []) sctx.cs has_display in
-			(Args.parse_args raw_lines) @ rest
-		in
-		let rec loop acc = function
-			| [] ->
-				[], Some (create_context (List.rev acc))
-			| Next :: l when acc = [] -> (* skip empty --next *)
-				loop [] l
-			| Next :: l ->
-				let ctx = create_context (List.rev acc) in
-				ctx.has_next <- true;
-				l, Some ctx
-			| Each :: l ->
-				each_args := List.rev acc;
-				loop acc l
-			| Cwd dir :: l ->
-				(* Apply cwd eagerly for hxml file resolution *)
-				(try Unix.chdir dir with _ -> ());
-				loop (Cwd dir :: acc) l
-			| Connect hp :: l ->
-				if is_server then
-					(* If we are already connected, ignore (issue #10813) *)
-					loop acc l
-				else begin
-					let host, port = Helper.parse_host_port hp in
-					(* Forward accumulated + remaining args to the remote server *)
-					ignore(Server.Connect.do_connect host port ((List.rev acc) @ l));
-					[], None
-				end
-			| ServerConnect hp :: l ->
-				server_mode := SMConnect hp;
-				loop acc l
-			| ServerListen hp :: l ->
-				server_mode := SMListen hp;
-				loop acc l
-			| Run (cl, runtime_args) :: l ->
-				(* --run: expand into SetMain + Interp, then create context.
-				   This is terminal: remaining args become runtime_args (already in tuple).
-				   Normalise com.args to the -x form, matching old parse_args behaviour. *)
-				let cpath = Path.parse_type_path cl in
-				let acc = Interp :: SetMain cpath :: acc in
-				let ctx = create_context (List.rev acc) in
-				ctx.runtime_args <- runtime_args @ (Args.to_raw_args l);
-				[], Some ctx
-			| RunX cl :: l ->
-				(* -x: non-terminal shorthand for SetMain + Interp; subsequent args are still build args *)
-				let cpath = Path.parse_type_path cl in
-				loop (Interp :: SetMain cpath :: acc) l
-			| AddLib name :: args ->
-				let libs, args = find_subsequent_libs [name] args in
-				loop acc (expand_libs libs args)
-			| HxmlFile path :: l ->
-				let full_path = try Extc.get_full_path path with Failure(_) -> raise (Arg.Bad (Printf.sprintf "File not found: %s" path)) in
-				if List.mem full_path !hxml_stack then
-					raise (Arg.Bad (Printf.sprintf "Duplicate hxml inclusion: %s" full_path))
-				else
-					hxml_stack := full_path :: !hxml_stack;
-				(* Separate "file not found" from "file exists but is empty/all-comments":
-				   an empty hxml (e.g. cleared by CI for platform reasons) is a no-op,
-				   not an error. *)
-				let hxml_raw, expanded =
-					try
-						let raw = Helper.parse_hxml path in
-						raw, Args.parse_args raw
-					with Not_found ->
-						[], [IncludeModule (path ^ " (file not found)")]
-				in
-				loop acc (expanded @ l)
-			| arg :: l ->
-				loop (arg :: acc) l
-		in
-		let args, ctx = loop [] args in
-		args, !server_mode, ctx
-
-	let rec execute_ctx (sctx : ServerCompilationContext.t) ctx server_mode =
-		begin match server_mode with
-		| Args.SMListen hp ->
-			(* Apply args to get com.verbose before starting the wait loop *)
-			ignore(Args.process_args ctx.com ctx.parsed_args);
-			let accept =
-				let host, port = Helper.parse_host_port hp in
-				Server.init_wait_socket host port
+	let create_context_from_part (sctx : ServerCompilationContext.t) comm request_scope timer_ctx has_display part =
+		(* Expand Expand markers by calling haxelib, caching the result in the marker state *)
+		let expand_part_libs has_global (part_args : parsed_arg list) =
+			let expand_one arg = match arg with
+				| Expand ex ->
+					(match ex.state with
+					| AlreadyExpanded expanded ->
+						expanded
+					| NotYetExpanded (AddLibs libs) ->
+						let raw_lines = add_libs timer_ctx libs (if has_global then ["--haxelib-global"] else []) sctx.cs has_display in
+						let expanded = Args.parse_args raw_lines in
+						ex.state <- AlreadyExpanded expanded;
+						expanded)
+				| arg -> [arg]
 			in
-			Server.wait_loop entry ctx.com.verbose accept
-		| SMConnect hp ->
-			ignore(Args.process_args ctx.com ctx.parsed_args);
-			let host, port = Helper.parse_host_port hp in
-			let accept = Server.init_wait_connect host port in
-			Server.wait_loop entry ctx.com.verbose accept
-		| SMNone ->
-			compile_ctx sctx ctx
-		end
+			List.concat_map expand_one part_args
+		in
+		let has_global = List.exists (fun a -> a = HaxelibGlobal) part.Args.args in
+		let expanded_args = expand_part_libs has_global part.Args.args in
+		sctx.compilation_step <- sctx.compilation_step + 1;
+		create_context comm sctx request_scope timer_ctx sctx.compilation_step expanded_args
 
-	and entry sctx request_scope comm (args : parsed_arg list) =
+	let entry sctx request_scope comm (args : parsed_arg list) =
 		let timer_ctx = Timer.make_context (Timer.make ["other"]) in
-		let create = create_context comm sctx request_scope timer_ctx in
 		let curdir = Unix.getcwd () in
-		let has_display = List.exists (fun a -> match a with SetDisplayArg _ -> true | _ -> false) args in
 		let code =
 			try
 				let request_args = Args.expand_args args in
-				(* expand_args applies --cwd eagerly; restore original dir before compilation *)
-				Unix.chdir curdir;
-				(* Expand Expand markers by calling haxelib, caching the result in the marker state *)
-				let expand_part_libs has_global (part_args : parsed_arg list) =
-					let expand_one arg = match arg with
-						| Expand ex ->
-							(match ex.state with
-							| AlreadyExpanded expanded ->
-								expanded
-							| NotYetExpanded (AddLibs libs) ->
-								let raw_lines = add_libs timer_ctx libs (if has_global then ["--haxelib-global"] else []) sctx.cs has_display in
-								let expanded = Args.parse_args raw_lines in
-								ex.state <- AlreadyExpanded expanded;
-								expanded)
-						| arg -> [arg]
-					in
-					List.concat_map expand_one part_args
+				let has_display = request_args.display_arg <> None in
+				let rec loop = function
+					| [] -> 0
+					| part :: rest ->
+						(* Re-apply original dir in case --cwd was used in a previous part *)
+						Unix.chdir curdir;
+						let ctx = create_context_from_part sctx comm request_scope timer_ctx has_display part in
+						if rest <> [] then ctx.has_next <- true;
+						ctx.runtime_args <- part.Args.runtime_args;
+						let code = compile_ctx sctx ctx in
+						if code = 0 && rest <> [] && not has_display then
+							loop rest
+						else
+							code
 				in
-				(* Handle --connect: forward all args to a remote compilation server *)
-				match request_args.connect_arg with
-				| Some hp when not comm.is_server ->
-					let host, port = Helper.parse_host_port hp in
-					let rec interleave_next = function
-						| [] -> []
-						| [p] -> p.Args.args
-						| p :: rest -> p.Args.args @ [Next] @ interleave_next rest
-					in
-					ignore(Server.Connect.do_connect host port (interleave_next request_args.parts));
-					0
-				| _ ->
-					let rec loop = function
-						| [] -> 0
-						| part :: rest ->
-							(* Re-apply original dir in case --cwd was used in a previous part *)
-							Unix.chdir curdir;
-							let has_global = List.exists (fun a -> a = HaxelibGlobal) part.Args.args in
-							let expanded_args = expand_part_libs has_global part.Args.args in
-							sctx.compilation_step <- sctx.compilation_step + 1;
-							let ctx = create sctx.compilation_step expanded_args in
-							if rest <> [] then ctx.has_next <- true;
-							ctx.runtime_args <- part.Args.runtime_args;
-							(* server_mode only applies to the last part in the sequence *)
-							let server_mode = if rest = [] then request_args.server_mode else Args.SMNone in
-							let code = execute_ctx sctx ctx server_mode in
-							if code = 0 && rest <> [] && not has_display then
-								loop rest
-							else
-								code
-					in
-					loop request_args.parts
+				loop request_args.parts
 			with Arg.Bad msg ->
 				Unix.chdir curdir;
-				let ctx = create 0 args in
+				(* TODO: this is silly *)
+				let ctx = create_context comm sctx request_scope timer_ctx 0 args in
 				error ctx ("Error: " ^ msg) null_pos;
 				compile_ctx sctx ctx
 		in

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -610,7 +610,7 @@ module HighLevel = struct
 		(* We want the loop below to actually see all the --each params, so let's prepend them *)
 		let args = !each_args @ args in
 		let added_libs = Hashtbl.create 0 in
-		let server_mode = ref SMNone in
+		let server_mode = ref Args.SMNone in
 		let hxml_stack = ref [] in
 		let create_context parsed =
 			sctx.compilation_step <- sctx.compilation_step + 1;
@@ -628,7 +628,7 @@ module HighLevel = struct
 			List.iter (fun l -> Hashtbl.add added_libs l ()) libs;
 			let global_repo = List.exists (fun a -> a = HaxelibGlobal) args in
 			let raw_lines = add_libs timer_ctx libs (if global_repo then ["--haxelib-global"] else []) sctx.cs has_display in
-			(Args.parse_args sctx raw_lines) @ rest
+			(Args.parse_args raw_lines) @ rest
 		in
 		let rec loop acc = function
 			| [] ->
@@ -690,7 +690,7 @@ module HighLevel = struct
 				let hxml_raw, expanded =
 					try
 						let raw = Helper.parse_hxml path in
-						raw, Args.parse_args sctx raw
+						raw, Args.parse_args raw
 					with Not_found ->
 						[], [IncludeModule (path ^ " (file not found)")]
 				in
@@ -703,7 +703,7 @@ module HighLevel = struct
 
 	let rec execute_ctx (sctx : ServerCompilationContext.t) ctx server_mode =
 		begin match server_mode with
-		| SMListen hp ->
+		| Args.SMListen hp ->
 			(* Apply args to get com.verbose before starting the wait loop *)
 			ignore(Args.process_args ctx.com ctx.parsed_args);
 			let accept =

--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -723,33 +723,66 @@ module HighLevel = struct
 	and entry sctx request_scope comm (args : parsed_arg list) =
 		let timer_ctx = Timer.make_context (Timer.make ["other"]) in
 		let create = create_context comm sctx request_scope timer_ctx in
-		let each_args = ref [] in
 		let curdir = Unix.getcwd () in
-		let has_display = ref (List.exists (fun a -> match a with SetDisplayArg _ -> true | _ -> false) args) in
-		let rec loop args =
-			let args,server_mode,ctx = try
-				process_params sctx request_scope timer_ctx create each_args !has_display comm.is_server args
+		let has_display = List.exists (fun a -> match a with SetDisplayArg _ -> true | _ -> false) args in
+		let code =
+			try
+				let request_args = Args.expand_args args in
+				(* expand_args applies --cwd eagerly; restore original dir before compilation *)
+				Unix.chdir curdir;
+				(* Expand Expand markers by calling haxelib, caching the result in the marker state *)
+				let expand_part_libs has_global (part_args : parsed_arg list) =
+					let expand_one arg = match arg with
+						| Expand ex ->
+							(match ex.state with
+							| AlreadyExpanded expanded ->
+								expanded
+							| NotYetExpanded (AddLibs libs) ->
+								let raw_lines = add_libs timer_ctx libs (if has_global then ["--haxelib-global"] else []) sctx.cs has_display in
+								let expanded = Args.parse_args raw_lines in
+								ex.state <- AlreadyExpanded expanded;
+								expanded)
+						| arg -> [arg]
+					in
+					List.concat_map expand_one part_args
+				in
+				(* Handle --connect: forward all args to a remote compilation server *)
+				match request_args.connect_arg with
+				| Some hp when not comm.is_server ->
+					let host, port = Helper.parse_host_port hp in
+					let rec interleave_next = function
+						| [] -> []
+						| [p] -> p.Args.args
+						| p :: rest -> p.Args.args @ [Next] @ interleave_next rest
+					in
+					ignore(Server.Connect.do_connect host port (interleave_next request_args.parts));
+					0
+				| _ ->
+					let rec loop = function
+						| [] -> 0
+						| part :: rest ->
+							(* Re-apply original dir in case --cwd was used in a previous part *)
+							Unix.chdir curdir;
+							let has_global = List.exists (fun a -> a = HaxelibGlobal) part.Args.args in
+							let expanded_args = expand_part_libs has_global part.Args.args in
+							sctx.compilation_step <- sctx.compilation_step + 1;
+							let ctx = create sctx.compilation_step expanded_args in
+							if rest <> [] then ctx.has_next <- true;
+							ctx.runtime_args <- part.Args.runtime_args;
+							(* server_mode only applies to the last part in the sequence *)
+							let server_mode = if rest = [] then request_args.server_mode else Args.SMNone in
+							let code = execute_ctx sctx ctx server_mode in
+							if code = 0 && rest <> [] && not has_display then
+								loop rest
+							else
+								code
+					in
+					loop request_args.parts
 			with Arg.Bad msg ->
+				Unix.chdir curdir;
 				let ctx = create 0 args in
 				error ctx ("Error: " ^ msg) null_pos;
-				[],SMNone,Some ctx
-			in
-			let code = match ctx with
-				| Some ctx ->
-					(* Need chdir here because --cwd is eagerly applied in process_params *)
-					Unix.chdir curdir;
-					execute_ctx sctx ctx server_mode
-				| None ->
-					(* caused by --connect *)
-					0
-			in
-			if code = 0 && args <> [] && not !has_display then begin
-				(* We have to chdir here again because any --cwd also takes effect in execute_ctx *)
-				Unix.chdir curdir;
-				loop args
-			end else
-				code
+				compile_ctx sctx ctx
 		in
-		let code = loop args in
 		comm.exit timer_ctx code
 end

--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -59,7 +59,7 @@ set_binary_mode_out stdout true;
 set_binary_mode_out stderr true;
 
 let sctx = Server.setup_server_context false in
-let parsed_args = Args.parse_args sctx args in
+let parsed_args = Args.parse_args args in
 let comm = ServerCommunication.Communication.create_stdio () in
 let request_scope = create_request_scope() in
 Compiler.HighLevel.entry sctx request_scope comm parsed_args;

--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -42,6 +42,7 @@
 	semantic suffixes may be used freely (e.g. e1, e_if, e')
 *)
 open Server
+open ParsedArg
 
 ;;
 Sys.catch_break true;
@@ -58,8 +59,54 @@ let args = List.tl (Array.to_list Sys.argv) in
 set_binary_mode_out stdout true;
 set_binary_mode_out stderr true;
 
-let sctx = Server.setup_server_context false in
 let parsed_args = Args.parse_args args in
+let curdir = Unix.getcwd () in
+let request_args = Args.expand_args parsed_args in
+Unix.chdir curdir;
+
+(* Are we a client? *)
+
+begin match request_args.connect_arg with
+	| Some hp ->
+		let host, port = Helper.parse_host_port hp in
+		(* Pass the entire args again, the server can take that apart. *)
+		let code = Server.Connect.do_connect host port parsed_args in
+		exit code
+	| None ->
+		()
+end;
+
+let entry = Compiler.HighLevel.entry in
+
+let is_verbose () = match request_args.parts with
+	| [] ->
+		false
+	| part :: _ ->
+		List.mem SetVerbose part.args
+in
+
+(* Are we a server? *)
+
+begin match request_args.server_mode with
+	| SMListen hp ->
+		let accept =
+			let host, port = Helper.parse_host_port hp in
+			Server.init_wait_socket host port
+		in
+		let code = Server.wait_loop entry (is_verbose()) accept in
+		exit code
+	| SMConnect hp ->
+		let host, port = Helper.parse_host_port hp in
+		let accept = Server.init_wait_connect host port in
+		let code = Server.wait_loop entry (is_verbose()) accept in
+		exit code
+	| SMNone ->
+		()
+end;
+
+(* We are a normal non-server compilation. *)
+
+let sctx = Server.setup_server_context false in
 let comm = ServerCommunication.Communication.create_stdio () in
 let request_scope = create_request_scope() in
 Compiler.HighLevel.entry sctx request_scope comm parsed_args;

--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -47,6 +47,10 @@ open ParsedArg
 ;;
 Sys.catch_break true;
 
+(* Ignore SIGPIPE to prevent process termination when stdin pipe is closed.
+   Sys.sigpipe may not map to the real signal number, so use 13 directly. *)
+(try Sys.set_signal 13 Sys.Signal_ignore with _ -> ());
+
 DynamicGc.(setup_dynamic_tuning
   {
     min_space_overhead = 100;

--- a/src/compiler/parsedArg.ml
+++ b/src/compiler/parsedArg.ml
@@ -12,7 +12,20 @@ type native_lib_arg = {
 	lib_extern : bool;
 }
 
-type parsed_arg =
+
+type expanding_arg_function =
+	| AddLibs of string list
+
+type expanding_arg_state =
+	| NotYetExpanded of expanding_arg_function
+	| AlreadyExpanded of parsed_arg list
+
+and expanding_arg = {
+	original : parsed_arg list;
+	mutable state : expanding_arg_state;
+}
+
+and parsed_arg =
 	(* Targets *)
 	| SetPlatform of platform * string
 	| SetCustomTarget of string * string
@@ -54,6 +67,7 @@ type parsed_arg =
 	(* Batch *)
 	| Next
 	| Each
+	| Expand of expanding_arg
 	(* Server *)
 	| ServerListen of string
 	| ServerConnect of string

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -64,7 +64,7 @@ module Connect = struct
 				prerr_endline line;
 		in
 		PipeThings.poll sock print;
-		if !has_error then exit 1 else exit 0
+		if !has_error then 1 else 0
 end
 
 module SocketRequest = struct

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -315,7 +315,7 @@ let wait_loop entry verbose accept =
 						None,s
 				in
 				let data = Helper.parse_hxml_data hxml in
-				let parsed_args = Args.parse_args sctx data in
+				let parsed_args = Args.parse_args data in
 				let comm () = ServerCommunication.Communication.create_pipe sctx conn in
 				RequestQueue.add rq parsed_args stdin comm;
 			with Unix.Unix_error _ ->

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -285,9 +285,6 @@ end
 let setup_server_context verbose =
 	if verbose then ServerMessage.enable_all ();
 	Sys.catch_break false; (* Sys can never catch a break *)
-	(* Ignore SIGPIPE to prevent process termination when stdin pipe is closed.
-	   Sys.sigpipe may not map to the real signal number, so use 13 directly. *)
-	(try Sys.set_signal 13 Sys.Signal_ignore with _ -> ());
 	(* Create server context and set up hooks for parsing and typing *)
 	let sctx = ServerCompilationContext.create verbose in
 	ServerCache.enable_cache_mode sctx;


### PR DESCRIPTION
This moves the entire client/server/normal part to haxe.ml itself by pre-processing the arguments and detecting early what we're doing, which avoids meandering into the normal architecture. I don't know if this is going to do anything for our current stalled process issues but it's a much cleaner approach.