### PR TITLE
[tests] Improve windows hl tests with preinstalled hl

### DIFF
--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -11,14 +11,15 @@ class RunCi {
 	static function main():Void {
 		Sys.putEnv("OCAMLRUNPARAM", "b");
 
-		function argToTarget(arg:Null<String>) {
-			if (arg == null || arg.startsWith("-"))
+		function parseTargetArg(args:Array<String>) {
+			if (args[0] == null || args[0].startsWith("-")) {
 				return null;
-			return arg;
+			}
+			return args.shift();
 		}
 
 		final testArgs = Sys.args();
-		final tests:Array<TestTarget> = switch (argToTarget(testArgs.shift()) ?? Sys.getEnv("TEST")) {
+		final tests:Array<TestTarget> = switch (parseTargetArg(testArgs) ?? Sys.getEnv("TEST")) {
 			case null:
 				[Macro];
 			case env:

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -11,8 +11,14 @@ class RunCi {
 	static function main():Void {
 		Sys.putEnv("OCAMLRUNPARAM", "b");
 
+		function argToTarget(arg:Null<String>) {
+			if (arg == null || arg.startsWith("-"))
+				return null;
+			return arg;
+		}
+
 		final testArgs = Sys.args();
-		final tests:Array<TestTarget> = switch (testArgs.shift() ?? Sys.getEnv("TEST")) {
+		final tests:Array<TestTarget> = switch (argToTarget(testArgs.shift()) ?? Sys.getEnv("TEST")) {
 			case null:
 				[Macro];
 			case env:

--- a/tests/RunCi.hx
+++ b/tests/RunCi.hx
@@ -11,13 +11,13 @@ class RunCi {
 	static function main():Void {
 		Sys.putEnv("OCAMLRUNPARAM", "b");
 
-		var args = Sys.args();
-		var tests:Array<TestTarget> = switch (args.length >= 1 ? args[0] : Sys.getEnv("TEST")) {
+		final testArgs = Sys.args();
+		final tests:Array<TestTarget> = switch (testArgs.shift() ?? Sys.getEnv("TEST")) {
 			case null:
 				[Macro];
 			case env:
 				[for (v in env.split(",")) v.trim().toLowerCase()];
-		}
+		};
 
 		infoMsg('Going to test: $tests');
 
@@ -68,9 +68,7 @@ class RunCi {
 					case Flash:
 						runci.targets.Flash.run(args);
 					case Hl:
-						final withJitTests = !Sys.args().contains("--skip-hl-jit");
-						final withHlcTests = !Sys.args().contains("--skip-hlc");
-						runci.targets.Hl.run(args, withJitTests, withHlcTests);
+						runci.targets.Hl.run(testArgs, args);
 					case t:
 						throw new Exception("unknown target: " + t);
 				}

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -30,7 +30,7 @@ class Hl {
 	static public function getHlDependencies() {
 		Sys.putEnv("HASHLINK", hlInstallDir);
 		if (systemName == "Windows") {
-			Sys.putEnv("HASHLINK_SRC", hlSrc);
+			Sys.putEnv("HASHLINK_SRC", hlInstallDir);
 			Sys.putEnv("HASHLINK_BIN", hlInstallBinDir);
 		}
 

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -25,6 +25,8 @@ class Hl {
 	static var withJitTests = true;
 	static var withHlcTests = true;
 
+	static var msbuildPlatform:String = 'x64';
+
 	static public function getHlDependencies() {
 		Sys.putEnv("HASHLINK", hlInstallDir);
 		if (systemName == "Windows") {
@@ -114,9 +116,9 @@ class Hl {
 				'-nologo', '-verbosity:minimal',
 				'-t:$filename',
 				'-property:Configuration=Release',
-				'-property:Platform=x64'
+				'-property:Platform=$msbuildPlatform'
 			]);
-			run('$dir/x64/Release/$filename.exe', []);
+			run('$dir${msbuildPlatform == 'x64' ? '/x64' : ''}/Release/$filename.exe', []);
 		}
 	}
 
@@ -134,19 +136,24 @@ class Hl {
 		}
 	}
 
-	static public function run(args:Array<String>, withJitTests:Bool, withHlcTests:Bool) {
-		Hl.withJitTests = withJitTests;
-		Hl.withHlcTests = withHlcTests;
+	static public function run(testArgs:Array<String>, haxeArgs:Array<String>) {
+		final msbuildPlatformArgIndex = testArgs.lastIndexOf("--msbuild-platform");
+		if (msbuildPlatformArgIndex != -1) {
+			msbuildPlatform = testArgs[msbuildPlatformArgIndex + 1] ?? throw "--msbuild-platform needs an argument";
+			testArgs.splice(msbuildPlatformArgIndex, 2);
+		}
+		withJitTests = !testArgs.remove("--skip-hl-jit");
+		withHlcTests = !testArgs.remove("--skip-hlc");
 
 		getHlDependencies();
 
 		for (extraArgs in [[], ["--undefine", "analyzer-optimize"]]) {
 			if (Hl.withJitTests) {
-				runCommand("haxe", ["compile-hl.hxml"].concat(extraArgs).concat(args));
+				runCommand("haxe", ["compile-hl.hxml"].concat(extraArgs).concat(haxeArgs));
 				runCommand(hlBinary, ['bin/unit.hl']);
 			}
 			if (Hl.withHlcTests) {
-				runCommand("haxe", ["compile-hlc.hxml"].concat(extraArgs).concat(args));
+				runCommand("haxe", ["compile-hlc.hxml"].concat(extraArgs).concat(haxeArgs));
 				buildAndRunHlc("bin/hlc", "unit", runCommand);
 			}
 		}
@@ -156,11 +163,11 @@ class Hl {
 
 		changeDirectory(sysDir);
 		if (Hl.withJitTests) {
-			runCommand("haxe", ["compile-hl.hxml"].concat(args));
+			runCommand("haxe", ["compile-hl.hxml"].concat(haxeArgs));
 			runSysTest(hlBinary, ["bin/hl/sys.hl"]);
 		}
 		if (Hl.withHlcTests) {
-			runCommand("haxe", ["compile-hlc.hxml"].concat(args));
+			runCommand("haxe", ["compile-hlc.hxml"].concat(haxeArgs));
 			function dontRun(cmd,?args) {}
 			buildAndRunHlc("bin/hlc/testArguments", "TestArguments", dontRun);
 			buildAndRunHlc("bin/hlc/exitCode", "ExitCode", dontRun);

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -26,6 +26,12 @@ class Hl {
 	static var withHlcTests = true;
 
 	static public function getHlDependencies() {
+		Sys.putEnv("HASHLINK", hlInstallDir);
+		if (systemName == "Windows") {
+			Sys.putEnv("HASHLINK_SRC", hlSrc);
+			Sys.putEnv("HASHLINK_BIN", hlInstallBinDir);
+		}
+
 		if (FileSystem.exists(hlBinary)) {
 			infoMsg('hl has already been installed at $hlBinary.');
 			return;
@@ -74,12 +80,6 @@ class Hl {
 		}
 
 		haxelibDev("hashlink", '$hlSrc/other/haxelib/');
-
-		Sys.putEnv("HASHLINK", hlInstallDir);
-		if (systemName == "Windows") {
-			Sys.putEnv("HASHLINK_SRC", hlSrc);
-			Sys.putEnv("HASHLINK_BIN", hlInstallBinDir);
-		}
 	}
 
 	static function buildAndRunHlc(dir:String, filename:String, ?run) {


### PR DESCRIPTION
Follow up to #12689 with some windows fixes.

We need the `HASHLINK` environment variables to be set, and I've also added a `--msbuild-platform` flag to choose the msbuild platform.

I also need to figure out some way to configure the platform hardcoded here: https://github.com/HaxeFoundation/hashlink/blob/19c4c225f811075c05d55ff973f6a2362f49d7e9/other/haxelib/Run.hx#L55