### PR TITLE
[cpp] Fully qualify std in std::type_index

### DIFF
--- a/src/generators/cpp/gen/cppGen.ml
+++ b/src/generators/cpp/gen/cppGen.ml
@@ -1610,8 +1610,8 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
     output_i "int __Compare(const ::hx::Object* inRhs) const override {\n";
     output_i (Printf.sprintf "\treturn dynamic_cast<const _hx_Closure_%i*>(inRhs) ? 0 : -1;\n" closure.close_id);
     output_i "}\n";
-    output_i "std::type_index callableId() const override {\n";
-    output_i (Printf.sprintf "\treturn std::type_index{ typeid(_hx_Closure_%i) };\n" closure.close_id);
+    output_i "::std::type_index callableId() const override {\n";
+    output_i (Printf.sprintf "\treturn ::std::type_index{ typeid(_hx_Closure_%i) };\n" closure.close_id);
     output_i "}\n";
 
     let return =


### PR DESCRIPTION
This avoids `std` clashing with a user defined `foo.std.bar` package.

See: #12829

This is a regression from f5087fe2b34aa87ce630a6b9d77ae38aeed1ca93