### PR TITLE
[cpp] Add missing override specifiers

### DIFF
--- a/src/generators/cpp/gen/cppGen.ml
+++ b/src/generators/cpp/gen/cppGen.ml
@@ -1587,7 +1587,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
       captured |> out;
 
     Printf.sprintf
-      "%s HX_LOCAL_RUN( %s )"
+      "%s HX_LOCAL_RUN( %s ) override "
       (tcpp_to_string closure.close_type)
       (cpp_callable_args closure.close_args "__o_") |> output_i;
 

--- a/src/generators/cpp/gen/cppGenClassHeader.ml
+++ b/src/generators/cpp/gen/cppGenClassHeader.ml
@@ -63,7 +63,7 @@ let gen_member_function ctx class_def is_static func =
     | other ->
       tcpp_to_string other in
 
-  let override_specifier = if func.tcf_is_overriding || (not is_static && func.tcf_name = "toString" && func.tcf_args = []) then
+  let override_specifier = if func.tcf_is_virtual && (func.tcf_is_overriding || (not is_static && func.tcf_name = "toString" && func.tcf_args = [])) then
     " override"
   else
     ""

--- a/src/generators/cpp/gen/cppGenClassHeader.ml
+++ b/src/generators/cpp/gen/cppGenClassHeader.ml
@@ -38,7 +38,7 @@ let gen_member_function ctx class_def is_static func =
 
   let fold_static acc = if is_static then "static" :: acc else acc in
   let fold_virtual acc =
-    if not is_static && func.tcf_is_virtual then (
+    if not is_static && func.tcf_is_virtual && not func.tcf_is_overriding then (
       if func.tcf_is_external && not func.tcf_is_scriptable then
         let key = Printf.sprintf "%s.%s" (join_class_path class_def.cl_path ".") func.tcf_field.cf_name in
         match StringMap.find_opt key ctx.ctx_class_member_types with
@@ -63,7 +63,13 @@ let gen_member_function ctx class_def is_static func =
     | other ->
       tcpp_to_string other in
 
-  Printf.sprintf "\t\t%s %s %s(%s);\n" attributes return_type_str func.tcf_name (print_arg_list func.tcf_args "") |> output;
+  let override_specifier = if func.tcf_is_overriding || (not is_static && func.tcf_name = "toString" && func.tcf_args = []) then
+    " override"
+  else
+    ""
+  in
+
+  Printf.sprintf "\t\t%s %s %s(%s)%s;\n" attributes return_type_str func.tcf_name (print_arg_list func.tcf_args "") override_specifier |> output;
 
   if (not func.tcf_is_virtual || not func.tcf_is_overriding) && func.tcf_is_reflective then
     let prefix    = if is_static then "static " else "" in
@@ -283,19 +289,19 @@ let generate_managed_header base_ctx tcpp_class =
   output_h "\t\tHX_DO_RTTI_ALL;\n";
   if has_tcpp_class_flag tcpp_class MemberGet then
     output_h
-      "\t\t::hx::Val __Field(const ::String &inString, ::hx::PropertyAccess inCallProp);\n";
+      "\t\t::hx::Val __Field(const ::String &inString, ::hx::PropertyAccess inCallProp) override;\n";
   if has_tcpp_class_flag tcpp_class StaticGet then
     output_h
       "\t\tstatic bool __GetStatic(const ::String &inString, ::Dynamic &outValue, ::hx::PropertyAccess inCallProp);\n";
   if has_tcpp_class_flag tcpp_class MemberSet then
     output_h
-      "\t\t::hx::Val __SetField(const ::String &inString,const ::hx::Val &inValue, ::hx::PropertyAccess inCallProp);\n";
+      "\t\t::hx::Val __SetField(const ::String &inString, const ::hx::Val &inValue, ::hx::PropertyAccess inCallProp) override;\n";
   if has_tcpp_class_flag tcpp_class StaticSet then
     output_h
       "\t\tstatic bool __SetStatic(const ::String &inString, ::Dynamic &ioValue, ::hx::PropertyAccess inCallProp);\n";
   if has_tcpp_class_flag tcpp_class GetFields then
     output_h
-      "\t\tvoid __GetFields(::Array< ::String> &outFields);\n";
+      "\t\tvoid __GetFields(::Array< ::String> &outFields) override;\n";
   if has_tcpp_class_flag tcpp_class Compare then
     output_h
       ("\t\tint __Compare(const ::hx::Object *inRHS) const { "
@@ -304,8 +310,8 @@ let generate_managed_header base_ctx tcpp_class =
 
   output_h "\t\tstatic void __register();\n";
   if tcpp_class.tcl_container = Some Current then (
-    output_h "\t\tvoid __Mark(HX_MARK_PARAMS);\n";
-    output_h "\t\tvoid __Visit(HX_VISIT_PARAMS);\n");
+    output_h "\t\tvoid __Mark(HX_MARK_PARAMS) override;\n";
+    output_h "\t\tvoid __Visit(HX_VISIT_PARAMS) override;\n");
 
   if List.length tcpp_class.tcl_native_interfaces > 0 then (
     output_h "\n\t\tHX_NATIVE_IMPLEMENTATION\n";
@@ -323,9 +329,9 @@ let generate_managed_header base_ctx tcpp_class =
 
     output_h "\n");
 
-  output_h "\t\tbool _hx_isInstanceOf(int inClassId);\n";
+  output_h "\t\tbool _hx_isInstanceOf(int inClassId) override;\n";
   if List.length tcpp_class.tcl_haxe_interfaces > 0 then (
-    output_h "\t\tvoid *_hx_getInterface(int inHash);\n";
+    output_h "\t\tvoid *_hx_getInterface(int inHash) override;\n";
     (* generate header glue *)
     let alreadyGlued = Hashtbl.create 0 in
     List.iter
@@ -366,7 +372,7 @@ let generate_managed_header base_ctx tcpp_class =
 
   if Option.is_some tcpp_class.tcl_init then output_h "\t\tstatic void __init__();\n\n";
   output_h
-    ("\t\t::String __ToString() const { return " ^ strq smart_class_name ^ "; }\n\n");
+    ("\t\t::String __ToString() const override { return " ^ strq smart_class_name ^ "; }\n\n");
 
   if has_tcpp_class_flag tcpp_class Boot then output_h "\t\tstatic void __boot();\n";
 

--- a/src/generators/cpp/gen/cppGenEnum.ml
+++ b/src/generators/cpp/gen/cppGenEnum.ml
@@ -170,9 +170,9 @@ let generate base_ctx tcpp_enum =
   output_h ("\t\tstatic void __boot();\n");
   output_h ("\t\tstatic void __register();\n");
   output_h ("\t\tstatic bool __GetStatic(const ::String &inName, ::Dynamic &outValue, ::hx::PropertyAccess inCallProp);\n");
-  output_h ("\t\t::String GetEnumName( ) const { return " ^ (strq (join_class_path class_path "."))  ^ "; }\n" );
-  output_h ("\t\t::String __ToString() const { return " ^ (strq (just_class_name ^ ".") )^ " + _hx_tag; }\n");
-  output_h ("\t\tbool _hx_isInstanceOf(int inClassId);\n\n");
+  output_h ("\t\t::String GetEnumName() const override { return " ^ (strq (join_class_path class_path "."))  ^ "; }\n" );
+  output_h ("\t\t::String __ToString() const override { return " ^ (strq (just_class_name ^ ".") )^ " + _hx_tag; }\n");
+  output_h ("\t\tbool _hx_isInstanceOf(int inClassId) override;\n\n");
 
   List.iter
     (fun constructor ->

--- a/tests/unit/src/unit/issues/Issue10830.hx
+++ b/tests/unit/src/unit/issues/Issue10830.hx
@@ -29,8 +29,8 @@ namespace customnamespace {
 
 		static bool __GetStatic(const String&, Dynamic&, hx::PropertyAccess);
 
-		String GetEnumName() const { return HX_CSTRING("MyExternEnum"); }
-		String __ToString() const { return HX_CSTRING("MyExternEnum.") + _hx_tag; }
+		String GetEnumName() const override { return HX_CSTRING("MyExternEnum"); }
+		String __ToString() const override { return HX_CSTRING("MyExternEnum.") + _hx_tag; }
 
 		static MyExternEnum First();
 		static Dynamic First_dyn();

--- a/tests/unit/src/unit/issues/Issue9516.hx
+++ b/tests/unit/src/unit/issues/Issue9516.hx
@@ -32,10 +32,10 @@ class Issue9516 extends unit.Test {
     var starBaz: Star<Baz> = new Baz(5, 4);
     var referenceBaz: Reference<Baz> = starBaz;
 
-    eq(7, justBaz.fun());
-    eq(8, structBaz.fun());
-    eq(9, starBaz.fun());
-    eq(9, referenceBaz.fun());
+    eq(7, justBaz.funBaz());
+    eq(8, structBaz.funBaz());
+    eq(9, starBaz.funBaz());
+    eq(9, referenceBaz.funBaz());
 
     Pointer.fromStar(starFoo).destroy();
     Pointer.fromStar(starBar).destroy();
@@ -73,7 +73,7 @@ private class Baz extends Bar {
     super(value);
   }
 
-  public override function fun() return super.fun() + delta;
+  public function funBaz() return super.fun() + delta;
 }
 
 #else


### PR DESCRIPTION
Together with https://github.com/HaxeFoundation/hxcpp/pull/1319, this fixes warnings about missing overrides that show up when compiling a hxcpp program.

These were already present in a few places, and it is fine to add them because the minimum c++ version for haxe 5 is already c++11. It is good practice to have these to help catch issues like #11666, where a method is overloaded instead of overridden.

I had to modify the test for #9516, because adding these revealed a possible bug. Despite `override` in haxe code, `Baz.fun` was never actually overriding `Bar.fun`, because `Foo` is marked as `@:nativeGen`. This happens even with haxe 4.3.7, but is only revealed when these `override` specifiers are added.