### PR TITLE
Fix redundant dependency invalidations

### DIFF
--- a/src/typing/typeloadCacheHook.ml
+++ b/src/typing/typeloadCacheHook.ml
@@ -13,12 +13,10 @@ type find_module_result =
 
 let type_module_hook : (Common.context -> (typer_pass -> (unit -> unit) -> unit) -> path -> pos -> find_module_result) ref = ref (fun _ _ _ _ -> NoModule)
 
-let fake_modules = Hashtbl.create 0
-
 let create_fake_module com file =
 	let key = com.part_scope.file_keys#get file in
 	let file = Path.get_full_path file in
-	let mdep = (try Hashtbl.find fake_modules key with Not_found ->
+	let mdep = (try Hashtbl.find com.fake_modules key with Not_found ->
 		let mdep = {
 			m_id = alloc_mid();
 			m_path = (["$DEP"],file);
@@ -26,7 +24,7 @@ let create_fake_module com file =
 			m_statics = None;
 			m_extra = module_extra file (Define.get_signature com.defines) (file_time file) MFake com.part_scope.compilation_step [];
 		} in
-		Hashtbl.add fake_modules key mdep;
+		Hashtbl.add com.fake_modules key mdep;
 		mdep
 	) in
 	com.module_lut#add mdep.m_path mdep;

--- a/tests/server/src/cases/issues/Issue12846.hx
+++ b/tests/server/src/cases/issues/Issue12846.hx
@@ -1,0 +1,46 @@
+package cases.issues;
+
+import utest.Assert;
+
+class Issue12846 extends TestCase {
+	function test(_) {
+		vfs.putContent("App.hx", "
+			@:build(Macro.build())
+			class App {
+				static function main() {}
+			}
+		");
+		vfs.putContent("Macro.hx", "
+			import haxe.macro.Context;
+			class Macro {
+				static function build() {
+					trace('building_macro');
+					Context.registerModuleDependency(Context.getLocalModule(), 'dependency.txt');
+					return Context.getBuildFields();
+				}
+			}
+		");
+		vfs.putContent("dependency.txt", "initial");
+
+		var args = ["-main", "App.hx", "--no-output", "-js", "no.js", "-v"];
+
+		runHaxe(args);
+		assertSuccess();
+		Assert.isTrue(hasMessage("building_macro"));
+
+		// wait to ensure timestamp difference
+		Sys.sleep(1);
+
+		// change file
+		vfs.overwriteContent("dependency.txt", "changed");
+		runHaxe(args);
+		assertSuccess();
+		Assert.isTrue(hasMessage("building_macro"));
+
+		// no change, should reuse App
+		runHaxe(args);
+		assertSuccess();
+		assertReuse("App");
+		Assert.isFalse(hasMessage("building_macro"));
+	}
+}


### PR DESCRIPTION
Now after i update dependency file, build macro will not be called on every other module focus/save, only on actual dependency updates or macro module updates.

This `let fake_modules` seems like another leftover from https://github.com/HaxeFoundation/haxe/pull/11482#issuecomment-1910186378

Also, i wonder if fake modules can be added with `~skip_postprocess:true` there?
https://github.com/HaxeFoundation/haxe/blob/d800964208265926aa2869648d87204be719b0d2/src/typing/macroContext.ml#L529

Closes https://github.com/HaxeFoundation/haxe/issues/12846