### PR TITLE
[ci] Fix cygwin root for setup-ocaml 3.5

### DIFF
--- a/.github/actions/cache-lua/action.yml
+++ b/.github/actions/cache-lua/action.yml
@@ -1,4 +1,5 @@
 name: Cache Lua environments
+description: Cache lua environments used in haxe tests
 inputs:
   key-prefix:
     description: 'Platform/arch-specific cache key prefix (e.g., lua-env-linux-arm64, lua-env-mac-x86_64)'

--- a/.github/actions/setup-neko/action.yml
+++ b/.github/actions/setup-neko/action.yml
@@ -1,4 +1,5 @@
 name: Setup neko
+description: Install latest neko from build.haxe.org
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-ocaml-windows/action.yml
+++ b/.github/actions/setup-ocaml-windows/action.yml
@@ -16,7 +16,7 @@ runs:
     run: |
       curl.exe -fsSL -o "libmbedtls.tar.xz" --retry 3 `
         https://github.com/Simn/mingw64-mbedtls/releases/download/${{ env.MBEDTLS_VERSION }}/mingw64-${{ env.MINGW_ARCH }}-mbedtls-${{ env.MBEDTLS_VERSION }}-1-noarch.tar.xz
-      ${{ env.CYG_ROOT }}\bin\tar.exe -C ${{ env.CYG_ROOT }} -xvf libmbedtls.tar.xz
+      opam exec -- tar -C / -xvf libmbedtls.tar.xz
 
   - name: Install OCaml libraries
     uses: nick-fields/retry@v3

--- a/.github/actions/setup-ocaml-windows/action.yml
+++ b/.github/actions/setup-ocaml-windows/action.yml
@@ -1,4 +1,5 @@
 name: Setup Ocaml Windows
+description: Sets up ocaml on Windows
 runs:
   using: composite
   steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       PLATFORM: windows64
       ARCH: 64
       MINGW_ARCH: x86_64
-      CYG_ROOT: C:\cygwin
+      CYG_ROOT: C:\.opam\.cygwin\root
     steps:
       - uses: actions/checkout@main
         with:


### PR DESCRIPTION
The cygwin root path changed in setup-ocaml 3.5.0: https://github.com/ocaml/setup-ocaml/pull/1067

This is causing builds to fail