### PR TITLE
[lua] Implement Sys.getEnv and Timer.stamp for lua-vanilla mode

### DIFF
--- a/std/haxe/Timer.hx
+++ b/std/haxe/Timer.hx
@@ -173,6 +173,8 @@ class Timer {
 		return untyped __global__.__time_stamp();
 		#elseif python
 		return Sys.cpuTime();
+		#elseif lua
+		return lua.Os.clock();
 		#elseif sys
 		return Sys.time();
 		#else

--- a/std/lua/_std/Sys.hx
+++ b/std/lua/_std/Sys.hx
@@ -46,7 +46,7 @@ class Sys {
 	public static inline function programPath():String return haxe.io.Path.join([getCwd(), Lua.arg[0]]);
 	public static function getCwd():String return notImplemented();
 	public static function setCwd(s:String):Void notImplemented();
-	public static function getEnv(s:String):Null<String> return notImplemented();
+	public static inline function getEnv(s:String):Null<String> return lua.Os.getenv(s);
 	public static function putEnv(s:String, v:Null<String>):Void notImplemented();
 	public static inline function setTimeLocale(loc:String):Bool return lua.Os.setlocale(loc) != null;
 	public static function sleep(seconds:Float):Void notImplemented();


### PR DESCRIPTION
## Summary

- **`Sys.time()`** — use `os.time()` instead of throwing. Note: integer-second precision only (vs microsecond precision with luv). Open question: should we emit a compiler warning here?
- **`Sys.getEnv()`** — use `os.getenv()` instead of throwing
- **`Timer.stamp()`** — use `os.clock()` directly on all Lua targets (subsecond precision, avoids the `Sys.time()` path entirely)

These are the remaining Haxe-side changes needed for #12843 (hxcoro with `-D lua-vanilla`). The bit ops part was already resolved by #12599.

## Open question

`os.time()` only returns integer seconds. Should we warn at compile time when `Sys.time()` is used in `lua-vanilla` mode, since users might expect subsecond precision? Or is it fine as-is since the docs don't guarantee precision?

## Test plan

- [ ] CI passes on all targets
- [ ] Verify `Timer.stamp()` returns subsecond values on Lua
- [ ] Verify `Sys.getEnv()` works in lua-vanilla mode