### PR TITLE
[tests] Use auto-compiling hlc templates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -478,12 +478,6 @@ jobs:
           mkdir "$env:HAXELIB_ROOT"
           haxelib setup "$env:HAXELIB_ROOT"
 
-      - name: Add msbuild to PATH (hl/c)
-        uses: microsoft/setup-msbuild@v2
-        if: matrix.target == 'hl'
-        with:
-          msbuild-architecture: x64
-
       - name: Cache Lua environments
         uses: ./.github/actions/cache-lua
         if: matrix.target == 'lua'

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -29,10 +29,6 @@ class Hl {
 
 	static public function getHlDependencies() {
 		Sys.putEnv("HASHLINK", hlInstallDir);
-		if (systemName == "Windows") {
-			Sys.putEnv("HASHLINK_SRC", hlInstallDir);
-			Sys.putEnv("HASHLINK_BIN", hlInstallBinDir);
-		}
 
 		if (FileSystem.exists(hlBinary)) {
 			infoMsg('hl has already been installed at $hlBinary.');
@@ -87,38 +83,13 @@ class Hl {
 	static function buildAndRunHlc(dir:String, filename:String, ?run) {
 		if (run == null) run = runCommand;
 
-		final compiler = if (systemName == "Mac") "clang" else "gcc";
-		final extraCompilerFlags = switch (systemName) {
-			case "Windows": ["-ldbghelp", "-municode"];
-			case "Mac": ["-rpath", hlInstallLibDir];
-			case _: ['-Wl,-rpath,$hlInstallLibDir'];
-		};
-
-		runCommand(compiler, [
-			"-o", '$dir/$filename.exe',
-			'$dir/$filename.c',
-			'-I$dir',
-			'-I$hlInstallDir/include',
-			'-L$hlInstallLibDir',
-			'$hlInstallLibDir/fmt.hdll',
-			'$hlInstallLibDir/ssl.hdll',
-			'$hlInstallLibDir/sqlite.hdll',
-			"-lm",
-			"-lhl"
-		].concat(extraCompilerFlags));
-
-		run('$dir/$filename.exe', []);
+		runCommand("haxelib", ["run", "hashlink", "build", '$dir/$filename.c', "-D", "hlgen.makefile=make"]);
+		run('$dir/$filename', []);
 
 		// Run with MSBuild
 		if (systemName == "Windows") {
-			runCommand("MSBuild.exe", [
-				'$dir/$filename.sln',
-				'-nologo', '-verbosity:minimal',
-				'-t:$filename',
-				'-property:Configuration=Release',
-				'-property:Platform=$msbuildPlatform'
-			]);
-			run('$dir${msbuildPlatform == 'x64' ? '/x64' : ''}/Release/$filename.exe', []);
+			runCommand("haxelib", ["run", "hashlink", "build", '$dir/$filename.c', "-D", "hlgen.makefile=vs2022"]);
+			run('$dir${msbuildPlatform == 'x64' ? '/x64' : ''}/Debug/$filename.exe', []);
 		}
 	}
 
@@ -131,7 +102,7 @@ class Hl {
 		}
 
 		if (withHlcTests) {
-			runCommand("haxe", [hxml, "-hl", '$target/hlc.c', "-D", "hlgen.makefile=ci"].concat(args));
+			runCommand("haxe", [hxml, "-hl", '$target/hlc.c'].concat(args));
 			buildAndRunHlc(target, "hlc");
 		}
 	}
@@ -156,7 +127,7 @@ class Hl {
 			}
 			if (Hl.withHlcTests) {
 				runCommand("haxe", ["compile-hlc.hxml"].concat(extraArgs).concat(haxeArgs));
-				buildAndRunHlc("bin/hlc", "unit", runCommand);
+				buildAndRunHlc("bin/hlc", "main", runCommand);
 			}
 		}
 
@@ -174,11 +145,11 @@ class Hl {
 			buildAndRunHlc("bin/hlc/testArguments", "TestArguments", dontRun);
 			buildAndRunHlc("bin/hlc/exitCode", "ExitCode", dontRun);
 			buildAndRunHlc("bin/hlc/utilityProcess", "UtilityProcess", dontRun);
-			buildAndRunHlc("bin/hlc/sys", "sys", (cmd, ?args) -> runSysTest(FileSystem.fullPath(cmd), args));
+			buildAndRunHlc("bin/hlc/sys", "main", (cmd, ?args) -> runSysTest(FileSystem.fullPath(cmd), args));
 		}
 
 		changeDirectory(getMiscSubDir("cross", "eventLoop"));
-		buildAndRun("build-hl.hxml", "bin/eventLoop");
+		buildAndRun("build-hl.hxml", "bin/eventLoop", haxeArgs);
 
 		// these are generic tests for genhl which shouldn't actually execute the .hl using hl jit,
 		// so they are not skipped with --skip-hl-jit
@@ -189,8 +160,7 @@ class Hl {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "hl"]);
 
 		if (Hl.withHlcTests) {
-			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2022" : "hlgen.makefile=make";
-			runCommand("haxe", ["run-base.hxml", "--run", "Main", "hlc", "-D", hlcTemplateDefine].concat(haxeArgs));
+			runCommand("haxe", ["run-base.hxml", "--run", "Main", "hlc", "-D", "hlgen.makefile"].concat(haxeArgs));
 		}
 	}
 }

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -83,7 +83,8 @@ class Hl {
 	static function buildAndRunHlc(dir:String, filename:String, ?run) {
 		if (run == null) run = runCommand;
 
-		runCommand("haxelib", ["run", "hashlink", "build", '$dir/$filename.c', "-D", "hlgen.makefile=make"]);
+		runCommand("haxelib", ["run", "hashlink", "build", '$dir/$filename.c', "-D", "hlgen.makefile=make"]
+			.concat(systemName == "Windows" ? ["-D", "hlgen.makefile.jumbo"] : []));
 		run('$dir/$filename', []);
 
 		// Run with MSBuild

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -102,7 +102,7 @@ class Hl {
 		}
 
 		if (withHlcTests) {
-			runCommand("haxe", [hxml, "-hl", '$target/hlc.c'].concat(args));
+			runCommand("haxe", [hxml, "-hl", '$target/hlc.c'].concat(args).concat(["--debug"]));
 			buildAndRunHlc(target, "hlc");
 		}
 	}

--- a/tests/sys/compile-hlc.hxml
+++ b/tests/sys/compile-hlc.hxml
@@ -1,22 +1,18 @@
 compile-each.hxml
 --main Main
--hl bin/hlc/sys/sys.c
--D hlgen.makefile=ci
+-hl bin/hlc/sys/main.c
 
 --next
 compile-each.hxml
 --main TestArguments
 -hl bin/hlc/testArguments/TestArguments.c
--D hlgen.makefile=ci
 
 --next
 compile-each.hxml
 --main ExitCode
 -hl bin/hlc/exitCode/ExitCode.c
--D hlgen.makefile=ci
 
 --next
 compile-each.hxml
 --main UtilityProcess
 -hl bin/hlc/utilityProcess/UtilityProcess.c
--D hlgen.makefile=ci

--- a/tests/sys/gen_test_res.py
+++ b/tests/sys/gen_test_res.py
@@ -81,7 +81,7 @@ for data in all_filenames:
         ("../../bin/cpp/UtilityProcess", "bin-cpp"),
         ("../../bin/cppia/UtilityProcess.cppia", "bin-cppia"),
         ("../../bin/hl/UtilityProcess.hl", "bin-hl"),
-        ("../../bin/hlc/utilityProcess/UtilityProcess.exe", "bin-hlc"),
+        ("../../bin/hlc/utilityProcess/UtilityProcess", "bin-hlc"),
         ("../../bin/lua/UtilityProcess.lua", "bin-lua"),
         ("../../bin/java/UtilityProcess-Debug.jar", "bin-java-debug"),
         ("../../bin/java/UtilityProcess.jar", "bin-java"),

--- a/tests/sys/src/ExitCode.hx
+++ b/tests/sys/src/ExitCode.hx
@@ -13,7 +13,7 @@ class ExitCode {
 		"bin/neko/ExitCode.n";
 	#elseif hl
 		#if hlc
-			"bin/hlc/exitCode/ExitCode.exe";
+			"bin/hlc/exitCode/ExitCode";
 		#else
 			"bin/hl/ExitCode.hl";
 		#end

--- a/tests/sys/src/TestArguments.hx
+++ b/tests/sys/src/TestArguments.hx
@@ -73,7 +73,7 @@ class TestArguments extends utest.Test {
 		"bin/neko/TestArguments.n";
 	#elseif hl
 		#if hlc
-			"bin/hlc/testArguments/TestArguments.exe";
+			"bin/hlc/testArguments/TestArguments";
 		#else
 			"bin/hl/TestArguments.hl";
 		#end

--- a/tests/sys/src/TestSys.hx
+++ b/tests/sys/src/TestSys.hx
@@ -125,7 +125,7 @@ class TestSys extends TestCommandBase {
 			"sys.js"
 		#elseif hl
 			#if hlc
-				"sys.exe"
+				"main" + (Sys.systemName() == "Windows" ? ".exe" : "")
 			#else
 				"sys.hl"
 			#end

--- a/tests/sys/src/UtilityProcess.hx
+++ b/tests/sys/src/UtilityProcess.hx
@@ -48,7 +48,7 @@ class UtilityProcess {
 		#end
 #elseif hl
 	#if hlc
-		"UtilityProcess.exe";
+		"UtilityProcess";
 	#else
 		"UtilityProcess.hl";
 	#end

--- a/tests/unit/compile-hlc.hxml
+++ b/tests/unit/compile-hlc.hxml
@@ -1,8 +1,7 @@
 compile-each.hxml
 --main unit.TestMain
--hl bin/hlc/unit.c
+-hl bin/hlc/main.c
 #-D interp
 -D hl-check
 -D hl-ver=1.16.0
--D hlgen.makefile=ci
 -D UTEST-PRINT-TESTS


### PR DESCRIPTION
Uses the auto-compiling hlc templates provided by hashlink, which makes compilation simpler and helps improve coverage for what should be the default build method for users of hlc.

Requires: https://github.com/HaxeFoundation/hashlink/pull/916