### PR TITLE
[tests] Enable ipc tests in CI

### DIFF
--- a/tests/runci/targets/Cpp.hx
+++ b/tests/runci/targets/Cpp.hx
@@ -80,7 +80,7 @@ class Cpp {
 			runCpp("bin/cpp/TestMain-debug", []);
 
 			changeDirectory(sysDir);
-			runCommand("haxe", ["--each", "compile-cpp.hxml"].concat(args));
+			runCommand("haxe", args.concat(["compile-cpp.hxml"]));
 			runSysTest(FileSystem.fullPath("bin/cpp/Main-debug"));
 
 			changeDirectory(threadsDir);
@@ -110,7 +110,7 @@ class Cpp {
 			runCppia("bin/unit.cppia", FileSystem.fullPath("bin/cppia/Host-debug"));
 
 			changeDirectory(sysDir);
-			runCommand("haxe", ["compile-cppia.hxml"].concat(args));
+			runCommand("haxe", args.concat(["compile-cppia.hxml"]));
 			runCppia("bin/cppia/Main.cppia", runSysTest);
 		}
 	}

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -39,7 +39,7 @@ class Hl {
 			return;
 		}
 		if (!FileSystem.exists(hlSrc))
-			runCommand("git", ["clone", "--depth=1", "https://github.com/HaxeFoundation/hashlink.git", hlSrc]);
+			runCommand("git", ["clone", "--depth=1", "https://github.com/tobil4sk/hashlink.git", hlSrc, "--branch", "fix/stdout-stderr-unicode"]);
 		else
 			infoMsg("Reusing hashlink repository");
 

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -165,11 +165,11 @@ class Hl {
 
 		changeDirectory(sysDir);
 		if (Hl.withJitTests) {
-			runCommand("haxe", ["compile-hl.hxml"].concat(haxeArgs));
+			runCommand("haxe", haxeArgs.concat(["compile-hl.hxml"]));
 			runSysTest(hlBinary, ["bin/hl/sys.hl"]);
 		}
 		if (Hl.withHlcTests) {
-			runCommand("haxe", ["compile-hlc.hxml"].concat(haxeArgs));
+			runCommand("haxe", haxeArgs.concat(["compile-hlc.hxml"]));
 			function dontRun(cmd,?args) {}
 			buildAndRunHlc("bin/hlc/testArguments", "TestArguments", dontRun);
 			buildAndRunHlc("bin/hlc/exitCode", "ExitCode", dontRun);

--- a/tests/runci/targets/Js.hx
+++ b/tests/runci/targets/Js.hx
@@ -137,7 +137,7 @@ class Js {
 
 		changeDirectory(sysDir);
 		installNpmPackages(["deasync"]);
-		runCommand("haxe", ["compile-js.hxml"].concat(args));
+		runCommand("haxe", args.concat(["compile-js.hxml"]));
 		runSysTest("node", ["bin/js/sys.js"]);
 
 		changeDirectory(getMiscSubDir(""));

--- a/tests/runci/targets/Jvm.hx
+++ b/tests/runci/targets/Jvm.hx
@@ -35,7 +35,7 @@ class Jvm {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "jvm"]);
 
 		changeDirectory(sysDir);
-		runCommand("haxe", ["compile-jvm.hxml"].concat(args));
+		runCommand("haxe", args.concat(["compile-jvm.hxml"]));
 		runSysTest("java", ["-jar", "bin/jvm/sys.jar"]);
 
 		changeDirectory(threadsDir);

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -154,7 +154,7 @@ class Lua {
 			}
 
 			changeDirectory(sysDir);
-			runCommand("haxe", ["compile-lua.hxml"].concat(args));
+			runCommand("haxe", args.concat(["compile-lua.hxml"]));
 			runSysTest("lua", ["bin/lua/sys.lua"]);
 
 			changeDirectory(getMiscSubDir("lua", "luaDeadCode", "stringReflection"));

--- a/tests/runci/targets/Macro.hx
+++ b/tests/runci/targets/Macro.hx
@@ -27,7 +27,7 @@ class Macro {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "eval/resolution"]);
 
 		changeDirectory(sysDir);
-		runCommand("haxe", args.concat(["--each", "compile-eval-hxb.hxml"]));
+		runCommand("haxe", args.concat(["compile-eval-hxb.hxml"]));
 		runSysTest("haxe", ["--hxb-lib", "bin/eval/sys.hxb", "--run", "Main"]);
 
 		switch Sys.systemName() {

--- a/tests/runci/targets/Neko.hx
+++ b/tests/runci/targets/Neko.hx
@@ -12,7 +12,7 @@ class Neko {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "neko"]);
 
 		changeDirectory(sysDir);
-		runCommand("haxe", ["compile-neko.hxml"].concat(args));
+		runCommand("haxe", args.concat(["compile-neko.hxml"]));
 		runSysTest("neko", ["bin/neko/sys.n"]);
 
 		changeDirectory(threadsDir);

--- a/tests/runci/targets/Php.hx
+++ b/tests/runci/targets/Php.hx
@@ -95,7 +95,7 @@ class Php {
 			if(isCi())
 				deleteDirectoryRecursively(binDir);
 
-			runCommand("haxe", ["compile-php.hxml"].concat(prefix).concat(args));
+			runCommand("haxe", prefix.concat(args).concat(["compile-php.hxml"]));
 			runSysTest("php", generateArgs(binDir + "/Main/index.php"));
 		}
 	}

--- a/tests/runci/targets/Python.hx
+++ b/tests/runci/targets/Python.hx
@@ -68,7 +68,7 @@ class Python {
 		}
 
 		changeDirectory(sysDir);
-		runCommand("haxe", ["compile-python.hxml"].concat(args));
+		runCommand("haxe", args.concat(["compile-python.hxml"]));
 		for (py in pys) {
 			runSysTest(py, ["bin/python/sys.py"]);
 		}

--- a/tests/sys/compile-jvm.hxml
+++ b/tests/sys/compile-jvm.hxml
@@ -1,6 +1,7 @@
 compile-each.hxml
 
 --main Main
+-D std-encoding-utf8
 --jvm bin/jvm/sys.jar
 
 --next
@@ -13,4 +14,5 @@ compile-each.hxml
 
 --next
 --main UtilityProcess
+-D std-encoding-utf8
 --jvm bin/jvm/UtilityProcess.jar

--- a/tests/sys/compile-python.hxml
+++ b/tests/sys/compile-python.hxml
@@ -1,6 +1,7 @@
 compile-each.hxml
 
 --main Main
+-D std-encoding-utf8
 -python bin/python/sys.py
 
 --next
@@ -13,4 +14,5 @@ compile-each.hxml
 
 --next
 --main UtilityProcess
+-D std-encoding-utf8
 -python bin/python/UtilityProcess.py

--- a/tests/sys/run.hxml
+++ b/tests/sys/run.hxml
@@ -18,7 +18,7 @@ compile.hxml
 --cmd echo Php    && export EXISTS=1 && php bin/php/Main/index.php
 --cmd echo Hl     && export EXISTS=1 && hl bin/hl/sys.hl
 --cmd echo Js     && export EXISTS=1 && node bin/js/sys.js
---cmd echo Lua    && export EXISTS=1 && lua bin/sys.lua
+--cmd echo Lua    && export EXISTS=1 && lua bin/lua/sys.lua
 --cmd echo Eval   && export EXISTS=1 && haxe --hxb-lib bin/eval/sys.hxb --run Main
 
 # Windows

--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -270,6 +270,7 @@ class TestUnicode extends utest.Test {
 			});
 	}
 
+	#if !js // See #10436
 	// Temporary disabled for local run because of https://github.com/HaxeFoundation/haxe/issues/8380
 	#if github
 	function testIPC() {
@@ -318,6 +319,7 @@ class TestUnicode extends utest.Test {
 				});
 		}
 	}
+	#end
 	#end
 
 	function testIO() {

--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -304,17 +304,17 @@ class TestUnicode extends utest.Test {
 				// trace
 				assertUEnds(runUtility(["trace", '$i', mode]).stdout, str + endLine);
 				#if !jvm
-#if (hl || cpp) if (Sys.systemName() != "Windows") { #end // HL and C++ temporarily disabled (#8379)
+#if (hl || cpp || lua) if (Sys.systemName() != "Windows") { #end // HL and C++ temporarily disabled (#8379)
 				// putEnv + getEnv
 				assertUEquals(runUtility(["putEnv", "HAXE_TEST", '$i', mode, "getEnv", "HAXE_TEST"]).stdout, str + endLine);
 				// putEnv + environment
 				assertUEquals(runUtility(["putEnv", "HAXE_TEST", '$i', mode, "environment", "HAXE_TEST"]).stdout, str + endLine);
-#if (hl || cpp) } #end // HL and C++ temporarily disabled (#8379)
+#if (hl || cpp || lua) } #end // HL and C++ temporarily disabled (#8379)
 				#end
 			});
 
 		// args
-		if (#if (jvm || eval || hl || cpp) Sys.systemName() != "Windows" #else true #end) {
+		if (#if (jvm || eval || hl || cpp || lua) Sys.systemName() != "Windows" #else true #end) {
 			// https://stackoverflow.com/questions/7660651/passing-command-line-unicode-argument-to-java-code
 			UnicodeSequences.normalBoth(str -> {
 					assertUEquals(runUtility(["args", str]).stdout, str + endLine);

--- a/tests/sys/src/TestUnicode.hx
+++ b/tests/sys/src/TestUnicode.hx
@@ -304,15 +304,17 @@ class TestUnicode extends utest.Test {
 				// trace
 				assertUEnds(runUtility(["trace", '$i', mode]).stdout, str + endLine);
 				#if !jvm
+#if (hl || cpp) if (Sys.systemName() != "Windows") { #end // HL and C++ temporarily disabled (#8379)
 				// putEnv + getEnv
 				assertUEquals(runUtility(["putEnv", "HAXE_TEST", '$i', mode, "getEnv", "HAXE_TEST"]).stdout, str + endLine);
 				// putEnv + environment
 				assertUEquals(runUtility(["putEnv", "HAXE_TEST", '$i', mode, "environment", "HAXE_TEST"]).stdout, str + endLine);
+#if (hl || cpp) } #end // HL and C++ temporarily disabled (#8379)
 				#end
 			});
 
 		// args
-		if (#if (jvm || eval || cpp) Sys.systemName() != "Windows" #else true #end) {
+		if (#if (jvm || eval || hl || cpp) Sys.systemName() != "Windows" #else true #end) {
 			// https://stackoverflow.com/questions/7660651/passing-command-line-unicode-argument-to-java-code
 			UnicodeSequences.normalBoth(str -> {
 					assertUEquals(runUtility(["args", str]).stdout, str + endLine);


### PR DESCRIPTION
These tests were behind a `-D github` flag, but that was added like this: `haxe compile-*.hxml -D github`. This doesn't work because the sys test hxmls have 4 different builds, so the `github` define was only set for the final build.

Renabling them shows some failures:
- The tests cannot run currently for nodejs, because they require the process api: #10436.
- HL has regressed: https://github.com/HaxeFoundation/hashlink/pull/917
- JVM and Python also regressed, but this is due to #8586. We can avoid this by adding `-D std-encoding-utf8`
- Some failing tests related to #8379 were enabled since they were inactive and the failures weren't noticed. Similarly lua needs these to be disabled. 