### PR TITLE
--cwd vs -lib

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -592,7 +592,7 @@ let expand_args args =
 			let libs, rest = find_subsequent_libs [name] rest in
 			let ex = {
 				original = List.map (fun name -> AddLib name) libs;
-				state = NotYetExpanded (AddLibs libs)
+				state = NotYetExpanded (AddLibs (libs, Unix.getcwd ()))
 			} in
 			loop (Expand ex :: current) rest
 		| HxmlFile path :: rest ->

--- a/src/compiler/compilationCache.ml
+++ b/src/compiler/compilationCache.ml
@@ -180,7 +180,7 @@ end
 class cache = object(self)
 	val contexts : (string,context_cache) Hashtbl.t = Hashtbl.create 0
 	val mutable context_list = []
-	val haxelib : (string list, string list) Hashtbl.t = Hashtbl.create 0
+	val haxelib : (string list * string option, string list) Hashtbl.t = Hashtbl.create 0
 	val directories : (string, cached_directory list) Hashtbl.t = Hashtbl.create 0
 	val native_libs : (string,cached_native_lib) Hashtbl.t = Hashtbl.create 0
 	val mutable tasks : (server_task PriorityQueue.t) = PriorityQueue.Empty

--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -1,17 +1,11 @@
 open Globals
 open Ast
 open Common
-open DisplayTypes.DisplayMode
 open DisplayTypes.CompletionResultKind
 open CompletionItem
 open DisplayException
-open Type
 open DisplayTypes
 open Genjson
-
-(* New JSON stuff *)
-
-open Json
 
 (* Mode processing *)
 

--- a/src/compiler/highLevel.ml
+++ b/src/compiler/highLevel.ml
@@ -1,13 +1,13 @@
 open Common
 open ParsedArg
 
-let add_libs timer_ctx libs args cs has_display =
+let add_libs timer_ctx (libs,cwd) args cs has_display =
 	let global_repo = List.exists (fun a -> a = "--haxelib-global") args in
 	let fail msg =
 		raise (Arg.Bad msg)
 	in
 	let call_haxelib() =
-		let cmd = "haxelib" ^ (if global_repo then " --global" else "") ^ " path " ^ String.concat " " libs in
+		let cmd = "haxelib" ^ (if global_repo then " --global" else " --cwd " ^ cwd) ^ " path " ^ String.concat " " libs in
 		let pin, pout, perr = Unix.open_process_full cmd (Unix.environment()) in
 		let lines = Std.input_list pin in
 		let err = Std.input_list perr in
@@ -29,10 +29,10 @@ let add_libs timer_ctx libs args cs has_display =
 			try
 				(* if we are compiling, really call haxelib since library path might have changed *)
 				if not has_display then raise Not_found;
-				cs#find_haxelib libs
+				cs#find_haxelib (libs, if global_repo then None else Some cwd)
 			with Not_found -> try
 				let lines = call_haxelib() in
-				cs#cache_haxelib libs lines;
+				cs#cache_haxelib (libs, if global_repo then None else Some cwd) lines;
 				lines
 			with Unix.Unix_error(code,msg,arg) ->
 				fail ((Printf.sprintf "%s (%s)" (Unix.error_message code) arg))

--- a/src/compiler/parsedArg.ml
+++ b/src/compiler/parsedArg.ml
@@ -11,9 +11,8 @@ type native_lib_arg = {
 	lib_extern : bool;
 }
 
-
 type expanding_arg_function =
-	| AddLibs of string list
+	| AddLibs of (string list (* libs *) * string (* cwd *))
 
 type expanding_arg_state =
 	| NotYetExpanded of expanding_arg_function

--- a/src/context/display/displayPath.ml
+++ b/src/context/display/displayPath.ml
@@ -4,7 +4,6 @@ open Type
 open Common
 open CompletionItem
 open ClassFieldOrigin
-open DisplayException
 open Display
 open DisplayEmitter
 open DisplayPosition

--- a/tests/misc/eval/projects/Issue12873/compile-0-setup.hxml
+++ b/tests/misc/eval/projects/Issue12873/compile-0-setup.hxml
@@ -1,0 +1,7 @@
+--cwd dir1
+--cmd haxelib newrepo
+--cmd haxelib dev lib1 ../libs/lib1
+--next
+--cwd dir2
+--cmd haxelib newrepo
+--cmd haxelib dev lib2 ../libs/lib2

--- a/tests/misc/eval/projects/Issue12873/compile-1.hxml
+++ b/tests/misc/eval/projects/Issue12873/compile-1.hxml
@@ -1,0 +1,3 @@
+--cwd dir2
+-lib lib2
+--main Main

--- a/tests/misc/eval/projects/Issue12873/compile-2.hxml
+++ b/tests/misc/eval/projects/Issue12873/compile-2.hxml
@@ -1,0 +1,5 @@
+--cwd dir1
+-lib lib1
+--cwd ../dir2
+-lib lib2
+--main Main

--- a/tests/misc/eval/projects/Issue12873/dir1/Foo.hx
+++ b/tests/misc/eval/projects/Issue12873/dir1/Foo.hx
@@ -1,0 +1,1 @@
+// For current tests, we just need the directory to exist

--- a/tests/misc/eval/projects/Issue12873/dir2/Main.hx
+++ b/tests/misc/eval/projects/Issue12873/dir2/Main.hx
@@ -1,0 +1,6 @@
+#if lib1
+import Type1;
+#end
+import Type2;
+
+function main() {}

--- a/tests/misc/eval/projects/Issue12873/libs/lib1/Type1.hx
+++ b/tests/misc/eval/projects/Issue12873/libs/lib1/Type1.hx
@@ -1,0 +1,1 @@
+class Type1 {}

--- a/tests/misc/eval/projects/Issue12873/libs/lib2/Type2.hx
+++ b/tests/misc/eval/projects/Issue12873/libs/lib2/Type2.hx
@@ -1,0 +1,1 @@
+class Type2 {}


### PR DESCRIPTION
[#12778](https://github.com/HaxeFoundation/haxe/pull/12778) changed the way `--library` behave when using `--cwd`. This PR restores previous behavior, ensuring haxelib calls are using the expected working directory (needed when using local repositories).