### PR TITLE
[tests] Add test for toString with function field

### DIFF
--- a/tests/unit/src/unit/issues/Issue12876.hx
+++ b/tests/unit/src/unit/issues/Issue12876.hx
@@ -1,0 +1,11 @@
+package unit.issues;
+
+class Issue12876 extends Test {
+    function test() {
+        final tv = {
+            fun : () -> "foo",
+        };
+        final v = Std.string(tv);
+        t(v != null);
+    }
+}


### PR DESCRIPTION
This adds a test for a regression in https://github.com/HaxeFoundation/hashlink/pull/917 that was fixed in https://github.com/HaxeFoundation/hashlink/pull/919