### PR TITLE
Fix including haxelib paths with spaces

### DIFF
--- a/src/generators/gencpp.ml
+++ b/src/generators/gencpp.ml
@@ -463,7 +463,7 @@ let generate_source ctx =
 		) common_ctx.defines.values;
 		common_ctx.class_paths#iter (fun path ->
 			let path = path#path in
-			cmd := !cmd @ [Printf.sprintf "-I%s" (escape_command path)]
+			cmd := !cmd @ [Printf.sprintf "-I\"%s\"" (escape_command path)]
 		);
 		CompilerIo.write_out common_ctx.io ("haxelib " ^ (String.concat " " !cmd) ^ "\n");
 		if common_ctx.run_command_args "haxelib" !cmd <> 0 then failwith "Build failed";


### PR DESCRIPTION
The quotes which had originally been here were inadvertently removed in cea8f212cd963d153289673e5452f0cf2f00bfbb.