### PR TITLE
[cpp] Typed Thread and TLS

### DIFF
--- a/std/cpp/Scratch.hx
+++ b/std/cpp/Scratch.hx
@@ -1,0 +1,10 @@
+package cpp;
+
+@:include("hx/thread/Scratch.hpp")
+@:semantics(value)
+@:cpp.ValueType({ namespace : [ "hx", "thread" ], flags : [ StackOnly ] })
+private extern class Scratch {
+	final view : cpp.marshal.View<cpp.UInt8>;
+
+	static function alloc(bytes:Int):Scratch;
+}

--- a/std/cpp/_std/sys/thread/ThreadImpl.hx
+++ b/std/cpp/_std/sys/thread/ThreadImpl.hx
@@ -22,27 +22,32 @@
 
 package sys.thread;
 
-@:callable
-@:coreType
-private abstract NativeThreadHandle {}
+@:include("hx/thread/Thread.hpp")
+@:cpp.ManagedType({ namespace : [ "hx", "thread" ], type : "Thread", flags : [ StandardNaming ] })
+private extern class NativeThread {
+	static function create(job:()->Void):NativeThread;
+	static function current():NativeThread;
 
-private typedef ThreadHandle = NativeThreadHandle;
+	function getName():String;
+	function setName(name:String):Void;
+}
 
-abstract ThreadImpl(ThreadHandle) {
+abstract ThreadImpl(NativeThread) {
 
 	public static #if !scriptable inline #end function current():ThreadImpl {
-		return untyped __global__.__hxcpp_thread_current();
+		return cast NativeThread.current();
 	}
 
 	public static #if !scriptable inline #end function create(job:Void->Void):ThreadImpl {
-		return untyped __global__.__hxcpp_thread_create(job);
+		return cast NativeThread.create(job);
 	}
 
 	public static function setName( t : ThreadImpl, name : String ) {
+		(cast t : NativeThread).setName(name);
 	}
 
 	public static function getName( t : ThreadImpl ) {
-		return null;
+		return (cast t : NativeThread).getName();
 	}
 
 }

--- a/std/cpp/_std/sys/thread/Tls.hx
+++ b/std/cpp/_std/sys/thread/Tls.hx
@@ -22,28 +22,32 @@
 
 package sys.thread;
 
+@:include("hx/thread/ThreadLocal.hpp")
+@:cpp.ManagedType({ namespace : [ "hx", "thread" ], flags : [ StandardNaming ] })
+private extern class ThreadLocal {
+	function new():Void;
+	
+	function get():Dynamic;
+	function set(obj:Dynamic):Void;
+}
+
 @:coreApi
 class Tls<T> {
-	static var sFreeSlot:Int;
-
-	var mTLSID:Int;
+	final tls:ThreadLocal;
 
 	public var value(get, set):Null<T>;
 
 	public function new() {
-		mTLSID = sFreeSlot++;
+		tls = new ThreadLocal();
 	}
 
 	function get_value():Null<T> {
-		return untyped __global__.__hxcpp_tls_get(mTLSID);
+		return tls.get();
 	}
 
 	function set_value(v:Null<T>):Null<T> {
-		untyped __global__.__hxcpp_tls_set(mTLSID, v);
-		return v;
-	}
+		tls.set(v);
 
-	static function __init__ ():Void {
-		sFreeSlot = 0;
+		return v;
 	}
 }


### PR DESCRIPTION
https://github.com/HaxeFoundation/hxcpp/pull/1336

This is much the same as my other threading related updates, adding a typed api for threads and thread local storage on the cpp side and exposing them in haxe. The main changes are.

- Typed `hx::thread::Thread` api for spawning, current thread, etc. This now supports the thread name setting which was recently added, although this is only implemented on Windows.

Important note on the Windows implementation, it uses the modern `GetThreadDescription` and `SetThreadDescription` Win32 api which was added in Windows 10. So this does add a Windows 10 hard dependency to hxcpp. I'm not fussed about this but it's probably worth mentioning in case anyone is.
There is also an implementation difference here which is also worth noting. In the old implementation hxcpp would immediately detach the thread, but we keep the thread attached now until the haxe object is finalised since you can't set the description of a detached thread. This was fine on Windows, but the hxcpp "haxe" tests (not haxe repo tests) on 32bit Linux were failing due to a "lack of resources" (creating too many threads). One of the tests spins up a bunch of threads and seems to be hitting a OS limit now that threads aren't detached until finalisation, since only name setting is implemented on Windows I've made it eagerly detach threads on other OS'.

- Typed `hx::thread::ThreadLocal` api for thread local storage.

This implementation has changed slightly, instead of using an ever growing counter, TLS objects return their slot ID when finalised so they can be recycled. This should hopefully help reduce the TLS array from constantly growing in long lived programs.

- New `Scratch` api

Something I've wanted for a while is to be able to create short lived (tied to the current scope) non GC memory for various introp cases (e.g. encoding haxe strings or arrays before passing to native code). Normally you would do this with c arrays or `std::array` but the constant / compile time size requirement makes this a pain in haxe.
The scratch api provides this sort of functionality, each thread contains a buffer which the scratch api simply bump allocates out of. Since this uses the `cpp.Marshal.View` type and stack only flags these scratch allocations can't escape the current thread so are safe to be reference counted.

For example the following is a code snipped which parses a date out of a string with zero GC allocations (and without needing to do all the manual string indexing you'd need to do).

```haxe
class DateConverter {
	public static inline function toDate(string:String) {
		final view   = string.asCharView();
		final buffer = Scratch.alloc(Range.sizeof() * 3).view.reinterpret();

		switch view.length {
			case 8:
				if (3 != view.split(':'.code, buffer)) {
					throw new Exception("");
				}

				final hh = view.slice(buffer[0].start, buffer[0].end - buffer[0].start).parseInt(None);
				final mm = view.slice(buffer[1].start, buffer[1].end - buffer[1].start).parseInt(None);
				final ss = view.slice(buffer[2].start, buffer[2].end - buffer[2].start).parseInt(None);

				return
					Date.fromTime(
						hh * 3_600_000f64 + mm + 60_000f64 + ss * 1000f64);
			default:
				throw new NotImplementedException();
		}
	}
}
```

Like the others the hxcpp side needs to be merged before the cpp tests on the haxe side will pass.