### PR TITLE
Update `@:using` meta documentation

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -1137,7 +1137,7 @@
 		"name": "Using",
 		"metadata": ":using",
 		"doc": "Automatically uses the argument types as static extensions for the annotated type.",
-		"targets": ["TClass", "TEnum", "TAbstract"],
+		"targets": ["TClass", "TEnum", "TTypedef", "TAbstract"],
 		"links": ["https://haxe.org/manual/lf-static-extension-metadata.html"]
 	},
 	{


### PR DESCRIPTION
This PR completes the list of types `@:using` can be used with.