### PR TITLE
[cpp] More func comparisons

### DIFF
--- a/src/generators/cpp/gen/cppGenClassImplementation.ml
+++ b/src/generators/cpp/gen/cppGenClassImplementation.ml
@@ -20,12 +20,18 @@ let write_callable_header callable_name captures func return_type_str prefix out
   | None ->
     Printf.sprintf "\t%s() {} \n" callable_name |> output);
   
+  (* Override __Compare *)
   output "\tint __Compare(const ::hx::Object* inRhs) const override {\n";
   Printf.sprintf "\t\tauto casted = dynamic_cast<const %s*>(inRhs);\n" callable_name |> output;
   output "\t\tif (!casted) { return -1; }\n";
   if Option.is_some captures then
     output "\t\tif (__this != casted->__this) return 1;\n";
   output "\t\treturn 0;\n";
+  output "\t}\n";
+
+  (* Override callableId, Haxe function closures are only compared based on name, not signature *)
+  output "\tstd::type_index callableId() const override {\n";
+  Printf.sprintf "\t\treturn std::type_index{ typeid(%s) };\n" callable_name |> output;
   output "\t}\n";
 
   Printf.sprintf "\t%s HX_LOCAL_RUN(%s) override {\n" return_type_str (cpp_callable_args func.tcf_args prefix) |> output

--- a/tests/unit/src/unit/issues/Issue12872.hx
+++ b/tests/unit/src/unit/issues/Issue12872.hx
@@ -1,0 +1,40 @@
+package unit.issues;
+
+private class GenericHolder<T> {
+    public var value:T;
+    public function new() {}
+}
+
+private class ClassA {
+    public function new() {}
+    public function doSomething(x:Int) {}
+}
+
+private class ClassB {
+    public function new() {}
+    public function doSomethingElse(x:Int) {}
+}
+
+class Issue12872 extends Test {
+	function test() {
+		final a = new ClassA();
+        final b = new ClassB();
+
+        final fnA:Int->Void = a.doSomething;
+        final fnB:Int->Void = b.doSomethingElse;
+
+        f(fnA == fnB);
+        f(Reflect.compareMethods(fnA, fnB));
+
+        final castA:Dynamic->Void = cast fnA;
+        final castB:Dynamic->Void = cast fnB;
+
+        f(castA == castB);
+        f(Reflect.compareMethods(castA, castB));
+
+        var holder = new GenericHolder<Dynamic->Void>();
+        holder.value = castA;
+
+        f(holder.value == castB);
+	}
+}


### PR DESCRIPTION
Fixes #12872

There were two problems.

1. Class function closures should not be compared based on their signature, but they were. These closures now override `callableId` which means they no longer return an Id representing the signature.
2. On the hxcpp side when callables are "wrapped" due to the signature changing I forgot to have these wrapped callables override `callableId` which meant they weren't returning the Id of the underlying callable.

The hxcpp side will need to be merged in before the new tests pass for cpp.

https://github.com/HaxeFoundation/hxcpp/pull/1337