### PR TITLE
[jvm] strip backticks from generated var names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,6 +226,12 @@ jobs:
         with:
           key-prefix: lua-env-linux-${{ matrix.arch }}
 
+      - name: Setup Android SDK (for d8)
+        if: matrix.target == 'jvm'
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'build-tools;34.0.0'
+
       - name: Test
         run: haxe --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}
         working-directory: ${{github.workspace}}/tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,11 +226,16 @@ jobs:
         with:
           key-prefix: lua-env-linux-${{ matrix.arch }}
 
-      - name: Setup Android SDK (for d8)
+      - name: Download d8 (Android build-tools)
         if: matrix.target == 'jvm'
-        uses: android-actions/setup-android@v3
-        with:
-          packages: 'build-tools;34.0.0'
+        run: |
+          set -ex
+          curl -fsSLo /tmp/build-tools.zip https://dl.google.com/android/repository/build-tools_r34-linux.zip
+          mkdir -p "$HOME/d8"
+          unzip -q /tmp/build-tools.zip -d "$HOME/d8"
+          d8=$(find "$HOME/d8" -name d8 -type f -executable | head -n1)
+          test -x "$d8"
+          echo "D8=$d8" >> "$GITHUB_ENV"
 
       - name: Test
         run: haxe --run RunCi ${{ matrix.target }} ${{ matrix.runci-args }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: repolevedavaj/install-nsis@v1.1.0
+      - uses: repolevedavaj/install-nsis@v1.2.0
         with:
           nsis-version: '3.10'
 

--- a/src/filters/filters.ml
+++ b/src/filters/filters.ml
@@ -448,7 +448,6 @@ let run_safe_filters ectx com (scom : SafeCom.t) all_types_array new_types_array
 		"add_final_return",(fun _ -> if scom.platform_config.pf_add_final_return then AddFinalReturn.add_final_return else (fun e -> e));
 		"RenameVars",(match scom.platform with
 			| Eval -> (fun _ e -> e)
-			| Jvm -> (fun _ e -> e)
 			| _ -> (fun scom e -> RenameVars.run scom.curclass.cl_path rename_locals_config e)
 		);
 		"mark_switch_break_loops",SafeFilters.mark_switch_break_loops;

--- a/tests/misc/jvm/projects/Issue12893/Check.hx
+++ b/tests/misc/jvm/projects/Issue12893/Check.hx
@@ -1,0 +1,75 @@
+import haxe.io.Bytes;
+import haxe.io.BytesInput;
+import haxe.zip.Reader;
+import sys.FileSystem;
+import sys.io.File;
+
+class Check {
+	static final BACKTICK_THIS = Bytes.ofString("`this");
+
+	static function main() {
+		final d8 = locateD8();
+		if (d8 != null) {
+			FileSystem.createDirectory("bin/dex-out");
+			final code = Sys.command(d8, ["--min-api", "21", "--output", "bin/dex-out", "bin/run.jar"]);
+			if (code != 0) {
+				Sys.println("FAIL: d8 rejected the jar (exit " + code + ")");
+				Sys.exit(1);
+			}
+		}
+
+		final entries = Reader.readZip(new BytesInput(File.getBytes("bin/run.jar")));
+		final offenders = [];
+		for (e in entries) {
+			if (!StringTools.endsWith(e.fileName, ".class")) continue;
+			final data = Reader.unzip(e);
+			if (indexOfBytes(data, BACKTICK_THIS) >= 0) offenders.push(e.fileName);
+		}
+
+		if (offenders.length > 0) {
+			Sys.println("FAIL: --jvm emitted a synthetic field named `this on:");
+			for (n in offenders) Sys.println("  " + n);
+			Sys.println("d8/r8 rejects this; genjvm should pick a dex-safe name (e.g. _hx_this).");
+			Sys.exit(1);
+		}
+	}
+
+	static function locateD8():Null<String> {
+		final explicit = Sys.getEnv("D8");
+		if (explicit != null) return FileSystem.exists(explicit) ? explicit : null;
+
+		// Try ANDROID_SDK first, then the standard SDK env vars exposed by
+		// the GitHub-hosted runners and android-actions/setup-android.
+		for (envName in ["ANDROID_SDK", "ANDROID_SDK_ROOT", "ANDROID_HOME"]) {
+			final sdk = Sys.getEnv(envName);
+			if (sdk == null) continue;
+
+			final buildTools = '$sdk/build-tools';
+			if (!FileSystem.exists(buildTools) || !FileSystem.isDirectory(buildTools)) continue;
+
+			// Pick the highest-versioned build-tools directory that ships d8.
+			final versions = FileSystem.readDirectory(buildTools);
+			versions.sort((a, b) -> Reflect.compare(b, a));
+			for (v in versions) {
+				final candidate = '$buildTools/$v/d8';
+				if (FileSystem.exists(candidate)) return candidate;
+			}
+		}
+		return null;
+	}
+
+	static function indexOfBytes(haystack:Bytes, needle:Bytes):Int {
+		if (needle.length == 0 || needle.length > haystack.length) return -1;
+		final first = needle.get(0);
+		var i = 0;
+		while (i <= haystack.length - needle.length) {
+			if (haystack.get(i) == first) {
+				var j = 1;
+				while (j < needle.length && haystack.get(i + j) == needle.get(j)) j++;
+				if (j == needle.length) return i;
+			}
+			i++;
+		}
+		return -1;
+	}
+}

--- a/tests/misc/jvm/projects/Issue12893/Main.hx
+++ b/tests/misc/jvm/projects/Issue12893/Main.hx
@@ -1,0 +1,11 @@
+class Main {
+	var x:Int = 0;
+	public function new() {}
+	public function run(r:java.lang.Runnable) r.run();
+	public function test() {
+		run(() -> { x = 1; }); // captures `this`, triggers the bug
+	}
+	static public function main() {
+		new Main().test();
+	}
+}

--- a/tests/misc/jvm/projects/Issue12893/compile.hxml
+++ b/tests/misc/jvm/projects/Issue12893/compile.hxml
@@ -1,0 +1,7 @@
+--main Main
+--jvm bin/run.jar
+
+--next
+
+--main Check
+--interp


### PR DESCRIPTION
While jvm itself doesn't care much, when targeting android we use stricter tools which don't allow backticks (see [Dalvik executable format - identifiers](https://source.android.com/docs/core/runtime/dex-format/#simplename)). The situation happens easily with closures generating `` `this `` variables.

Note about CI:
- Installing d8 through android sdk would require bumping jdk to version 17+; not sure we want to do that.
- Actually installing d8 is not really required; the raw bytes check is technically enough by itself. I can remove the workflow change if it's too hacky.