### PR TITLE
Update haxe test suite to VS2026

### DIFF
--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -189,7 +189,7 @@ class Hl {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "hl"]);
 
 		if (Hl.withHlcTests) {
-			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2022" : "hlgen.makefile=make";
+			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2026" : "hlgen.makefile=make";
 			runCommand("haxe", ["run-base.hxml", "--run", "Main", "hlc", "-D", hlcTemplateDefine].concat(haxeArgs));
 		}
 	}


### PR DESCRIPTION
This PR aims to allow compiling hashlink with VS2026 to benefit from optimisation updates in the latest version of MSVC, see https://github.com/HaxeFoundation/hashlink/pull/933