### PR TITLE
[jvm] do not add std/java/_std as std classpath anymore

### DIFF
--- a/src/compiler/compiler.ml
+++ b/src/compiler/compiler.ml
@@ -135,7 +135,6 @@ module Setup = struct
 			| Jvm ->
 				add_std "jvm";
 				com.package_rules <- PMap.remove "java" com.package_rules;
-				add_std "java";
 				"java"
 			| Python ->
 				add_std "python";

--- a/tests/misc/jvm/projects/classpath/compile.hxml
+++ b/tests/misc/jvm/projects/classpath/compile.hxml
@@ -1,0 +1,3 @@
+-cp src
+--jvm bin/out.jar
+--macro Macro.run()

--- a/tests/misc/jvm/projects/classpath/src/Macro.hx
+++ b/tests/misc/jvm/projects/classpath/src/Macro.hx
@@ -1,0 +1,9 @@
+import haxe.macro.Context;
+import sys.FileSystem;
+
+function run() {
+	for (cp in Context.getClassPath()) {
+		if (cp == "") continue;
+		Sys.println(FileSystem.fullPath(cp));
+	}
+}


### PR DESCRIPTION
`std/java/_std` has been removed in #11829, and is still being added as std classpath by jvm target