### PR TITLE
Drop dead var init

### DIFF
--- a/src/optimization/analyzerTexpr.ml
+++ b/src/optimization/analyzerTexpr.ml
@@ -828,8 +828,12 @@ module Fusion = struct
 			end;
 			b
 		in
+		let can_fuse_var_init v init e_assign = match init with
+			| None -> true
+			| Some e -> config.local_dce && not (has_var_flag v VCaptured) && not (has_side_effect e) && not (has_var_read (InterferenceReport.from_texpr e_assign) v)
+		in
 		let rec fuse acc el = match el with
-			| ({eexpr = TVar(v1,None)} as e1) :: {eexpr = TBinop(OpAssign,{eexpr = TLocal v2},e2)} :: el when v1 == v2 ->
+			| ({eexpr = TVar(v1,init)} as e1) :: {eexpr = TBinop(OpAssign,{eexpr = TLocal v2},e2)} :: el when v1 == v2 && can_fuse_var_init v1 init e2 ->
 				state#changed;
 				let e1 = {e1 with eexpr = TVar(v1,Some e2)} in
 				state#dec_writes v1;

--- a/tests/optimization/src/TestInlineConstructors.hx
+++ b/tests/optimization/src/TestInlineConstructors.hx
@@ -166,4 +166,16 @@ class TestInlineConstructors extends TestBase {
 		var p2 = {v: new PA(5)};
 		return [p2.v.x];
 	}
+
+	@:js('
+		var x = Std.random(0);
+		if(x == null) {x = 0;}
+		TestInlineConstructors.sink.x = x;
+	')
+	static function testDeadFieldInitFusion() {
+		var p = new P(Std.random(0));
+		sink.x = p.x;
+	}
+
+	static var sink:P = new P();
 }


### PR DESCRIPTION
Closes https://github.com/HaxeFoundation/haxe/issues/8815

This removes `foo2_start` for such case:
```haxe
var foo2_start = 0;
foo2_start = start;
Test.foo.start = foo2_start;
```
For inlining without generated null checks, there is separate issue at https://github.com/HaxeFoundation/haxe/issues/8905