### PR TITLE
[jvm] Fix Reflect.fields behavior

### DIFF
--- a/std/jvm/_std/Reflect.hx
+++ b/std/jvm/_std/Reflect.hx
@@ -78,6 +78,10 @@ class Reflect {
 	}
 
 	public static function fields(o:Dynamic):Array<String> {
+		if (o == null) {
+			return [];
+		}
+		
 		if (!Jvm.instanceof(o, jvm.DynamicObject)) {
 			if (Jvm.instanceof(o, java.lang.Class)) {
 				return Type.getClassFields(o);

--- a/tests/unit/src/unit/TestReflect.hx
+++ b/tests/unit/src/unit/TestReflect.hx
@@ -344,7 +344,6 @@ class TestReflect extends Test {
 	}
 
 	function testNullFields() {
-		var fields:Array<String> = Reflect.fields(null);
-		typeof(fields, TClass(Array));
+		typeof(Reflect.fields(null), TClass(Array));
 	}
 }

--- a/tests/unit/src/unit/TestReflect.hx
+++ b/tests/unit/src/unit/TestReflect.hx
@@ -342,4 +342,9 @@ class TestReflect extends Test {
 		var None:haxe.ds.Option<Dynamic> = Reflect.getProperty(haxe.ds.Option, "None");
 		utest.Assert.same(None, None);
 	}
+
+	function testNullFields() {
+		var fields:Array<String> = Reflect.fields(null);
+		typeof(fields, TClass(Array));
+	}
 }


### PR DESCRIPTION
While all other targets return an empty array using `Reflect.fields(null)`, the lua and JVM target throws an exception.

https://github.com/HaxeFoundation/haxe/pull/12912