### PR TITLE
[lua] Fix Reflect.fields behavior

### DIFF
--- a/std/lua/_std/Reflect.hx
+++ b/std/lua/_std/Reflect.hx
@@ -84,6 +84,7 @@ import lua.TableTools;
 	}
 
 	public static function fields(o:Dynamic):Array<String> {
+		if (o == null) return [];
 		if (lua.Lua.type(o) == "string") {
 			return Reflect.fields(untyped String.prototype);
 		} else {


### PR DESCRIPTION
While all other targets return an empty array using Reflect.fields(null), the lua and JVM target throws an exception.

https://github.com/HaxeFoundation/haxe/pull/12912

https://github.com/HaxeFoundation/haxe/blob/52e31acb3c979734b6ead568cb914d27d6a3e223/std/cpp/_std/Reflect.hx#L62-L64
https://github.com/HaxeFoundation/haxe/blob/08e39f64b695b9b3410c997c94aa0e762fe33c3c/std/hl/_std/Reflect.hx#L90-L93
https://github.com/HaxeFoundation/haxe/blob/08e39f64b695b9b3410c997c94aa0e762fe33c3c/std/flash/_std/Reflect.hx#L58-L60
https://github.com/HaxeFoundation/haxe/blob/08e39f64b695b9b3410c997c94aa0e762fe33c3c/std/neko/_std/Reflect.hx#L65-L67