### PR TITLE
Speed up large XML parses

### DIFF
--- a/std/Xml.hx
+++ b/std/Xml.hx
@@ -396,8 +396,8 @@ class Xml {
 
 	function new(nodeType:XmlType) {
 		this.nodeType = nodeType;
-		children = [];
-		attributeMap = new Map();
+		if (nodeType == Element || nodeType == Document) children = [];
+		if (nodeType == Element) attributeMap = new Map();
 	}
 
 	inline function ensureElementType() {


### PR DESCRIPTION
Creating the children array and attribute map for nodes that will never use it (text nodes, etc) is both wasteful in terms of RAM and in terms of time. Parsing a 400MB XML file this small change saves me a full second of time in benchmarks.