### PR TITLE
[coro] fail harder for @:coroutine vs constructor

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1243,7 +1243,7 @@ let create_method (ctx,cctx,fctx) c f cf fd p =
 			if fctx.is_inline && (has_class_flag c CInterface) then invalid_modifier ctx.com fctx "inline" "method of interface" p;
 		| false,CfrConstructor ->
 			if fctx.is_static then invalid_modifier ctx.com fctx "static" "constructor" p;
-			if Meta.has Meta.Coroutine f.cff_meta then invalid_modifier ctx.com fctx "@:coroutine" "constructor" p;
+			if Meta.has Meta.Coroutine f.cff_meta then raise_typing_error "Invalid modifier: @:coroutine on constructor" p;
 			begin match fd.f_type with
 				| None -> ()
 				| Some (CTPath ({ path = {tpackage = []; tname = "Void" } as tp}),p) ->

--- a/tests/misc/eval/projects/coro_ctor/Main.hx
+++ b/tests/misc/eval/projects/coro_ctor/Main.hx
@@ -1,0 +1,9 @@
+extern class Base {
+	@:coroutine public function new():Void;
+}
+
+class Child extends Base {}
+
+function main() {
+	new Child();
+}

--- a/tests/misc/eval/projects/coro_ctor/compile-fail.hxml
+++ b/tests/misc/eval/projects/coro_ctor/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/eval/projects/coro_ctor/compile-fail.hxml.stderr
+++ b/tests/misc/eval/projects/coro_ctor/compile-fail.hxml.stderr
@@ -1,12 +1,2 @@
-[ERROR] Main.hx:2: characters 14-41
-
- 2 |  @:coroutine public function new():Void;
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | Invalid modifier: @:coroutine on constructor
-
-[ERROR] Main.hx:8: characters 2-13
-
- 8 |  new Child();
-   |  ^^^^^^^^^^^
-   | Child does not have a constructor
-
+Main.hx:2: characters 14-41 : Invalid modifier: @:coroutine on constructor
+Main.hx:8: characters 2-13 : Child does not have a constructor

--- a/tests/misc/eval/projects/coro_ctor/compile-fail.hxml.stderr
+++ b/tests/misc/eval/projects/coro_ctor/compile-fail.hxml.stderr
@@ -1,0 +1,12 @@
+[ERROR] Main.hx:2: characters 14-41
+
+ 2 |  @:coroutine public function new():Void;
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | Invalid modifier: @:coroutine on constructor
+
+[ERROR] Main.hx:8: characters 2-13
+
+ 8 |  new Child();
+   |  ^^^^^^^^^^^
+   | Child does not have a constructor
+


### PR DESCRIPTION
This used to be a compiler failure:
```
Compiler failure
Please submit an issue at 
Attach the following information:
Haxe: 5.0.0-preview.1+3aed86e98; OS type: windows;
File "src/typing/typeloadFunction.ml", line 236, characters 19-26
Called from TypeloadFunction.add_constructor.(fun) in file "src/typing/typeloadFunction.ml", line 236, characters 12-26
Called from Common.make_unforced_lazy.(fun) in file "src/context/common.ml", line 1168, characters 11-15
Called from TFunctions.follow in file "src/core/tFunctions.ml", line 590, characters 16-29
Called from TFunctions.follow_with_coro in file "src/core/tFunctions.ml", line 656, characters 31-39
Called from CallUnification.unify_field_call.attempt_call in file "src/typing/callUnification.ml", line 307, characters 8-26
Called from CallUnification.unify_field_call in file "src/typing/callUnification.ml", line 389, characters 26-49
Called from Typer.type_new.unify_constructor_call in file "src/typing/typer.ml", line 861, characters 13-57
Called from Typer.type_new in file "src/typing/typer.ml", line 945, characters 12-48
Called from Typer.type_block.loop in file "src/typing/typer.ml", line 646, characters 27-94
Called from Typer.type_block in file "src/typing/typer.ml", line 649, characters 9-19
Called from Typer.type_expr in file "src/typing/typer.ml", line 1826, characters 10-38
Called from Case.make in file "src/typing/matcher/case.ml", line 59, characters 11-55
Called from Matcher.Match.match_expr.(fun) in file "src/typing/matcher.ml", line 56, characters 27-77
```

But 62d94f9fa9215024dd44fb2145ec391483853d72 made it fail with this instead, which is a lot nicer:
```
[ERROR] Main.hx:2: characters 14-41

 2 |  @:coroutine public function new():Void;
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   | Invalid modifier: @:coroutine on constructor

[ERROR] Main.hx:2: characters 30-33

 2 |  @:coroutine public function new():Void;
   |                              ^^^
   | Unexpected constructor type: TAbstract(haxe.coro.Coroutine, [TFun([], TAbstract(Void, []))])
```

This PR adds a test, and makes @:coroutine on constructor fail harder to avoid the `die` in the first place. I reverted `62d94f9` which is no longer necessary for this case, but maybe we want to keep it anyway?