### PR TITLE
[jvm] lost overload resolution during inlining 

### DIFF
--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -5,7 +5,7 @@ open OptimizerTexpr
 open Typecore
 open Error
 
-let maybe_reapply_overload_call_ref = ref (fun _ _ -> assert false)
+let maybe_reapply_overload_call_ref = ref (fun (_ : typer option) (_ : texpr) -> assert false)
 
 let mk_untyped_call name p params =
 	{
@@ -610,12 +610,7 @@ object(self)
 			| _ -> unify_func());
 		end;
 		let vars = Hashtbl.create 0 in
-		let maybe_reapply_overload_call = match ictx.typer with
-			| Some ctx ->
-				(!maybe_reapply_overload_call_ref) ctx
-			| None ->
-				(fun e -> e)
-		in
+		let maybe_reapply_overload_call = !maybe_reapply_overload_call_ref ictx.typer in
 		let rec map_var map_type v =
 			if not (Hashtbl.mem vars v.v_id) then begin
 				Hashtbl.add vars v.v_id ();

--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -708,24 +708,64 @@ object(self)
 			end
 end
 
-let maybe_reapply_overload_call ctx e =
+(*
+	After inlining, [Type.map_expr_type] has re-resolved TField nodes by name
+	through [quick_field], which collapses an overloaded method to its first
+	declared overload while leaving the field's applied type untouched. This
+	restores the correct overload on such call nodes (other nodes are returned
+	unchanged - hence [maybe_]).
+
+	With a typer available we re-type the call precisely through
+	[unify_field_call]. Without one (e.g. the optimizer's self-calling-closure
+	inlining) we re-select the matching overload structurally from the (already
+	mapped) argument types and restore just the field reference, which is what
+	code generation relies on.
+*)
+let maybe_reapply_overload_call ctxo e =
 	match e.eexpr with
 		| TCall({eexpr = TField(e1,fa)} as ef,el) ->
-			let recall fh cf =
-				let fa = FieldAccess.create e1 cf fh false ef.epos in
-				let fcc = unify_field_call ctx fa el [] e.epos false in
-				let e1 = fcc.fc_data() in
-				(try Type.unify e1.etype e.etype
-				with Unify_error _ -> die ~p:e.epos "Failed to reapply overload call" __LOC__);
-				e1
-			in
-			begin match fa with
-			| FStatic(c,cf) when has_class_field_flag cf CfOverload ->
-				recall (FHStatic c) cf
-			| FInstance(c,tl,cf) when has_class_field_flag cf CfOverload ->
-				recall (FHInstance(c,tl)) cf
-			| _ ->
-				e
+			begin match ctxo with
+			| Some ctx ->
+				let recall fh cf =
+					let fa = FieldAccess.create e1 cf fh false ef.epos in
+					let fcc = unify_field_call ctx fa el [] e.epos false in
+					let e1 = fcc.fc_data() in
+					(try Type.unify e1.etype e.etype
+					with Unify_error _ -> die ~p:e.epos "Failed to reapply overload call" __LOC__);
+					e1
+				in
+				begin match fa with
+				| FStatic(c,cf) when has_class_field_flag cf CfOverload ->
+					recall (FHStatic c) cf
+				| FInstance(c,tl,cf) when has_class_field_flag cf CfOverload ->
+					recall (FHInstance(c,tl)) cf
+				| _ ->
+					e
+				end
+			| None ->
+				let rebuild cf' =
+					let fa = match fa with
+						| FInstance(c,tl,_) -> FInstance(c,tl,cf')
+						| FStatic(c,_) -> FStatic(c,cf')
+						| _ -> fa
+					in
+					{e with eexpr = TCall({ef with eexpr = TField(e1,fa)},el)}
+				in
+				begin match fa with
+				| FStatic(c,cf) when has_class_field_flag cf CfOverload ->
+					begin match OverloadResolution.filter_overloads (OverloadResolution.find_overload (fun t -> t) c cf el) with
+					| Some(_,cf',_) -> rebuild cf'
+					| None -> e
+					end
+				| FInstance(c,tl,cf) when has_class_field_flag cf CfOverload ->
+					let map_type = apply_params c.cl_params tl in
+					begin match OverloadResolution.resolve_instance_overload false map_type c cf.cf_name el with
+					| Some(_,cf',_) -> rebuild cf'
+					| None -> e
+					end
+				| _ ->
+					e
+				end
 			end
 		| _ ->
 			e

--- a/src/typing/generic.ml
+++ b/src/typing/generic.ml
@@ -160,7 +160,7 @@ let generic_substitute_expr gctx e =
 		| _ ->
 			map_expr_type build_expr (generic_substitute_type gctx) build_var e
 		in
-		CallUnification.maybe_reapply_overload_call gctx.ctx e
+		CallUnification.maybe_reapply_overload_call (Some gctx.ctx) e
 	in
 	build_expr e
 

--- a/tests/unit/src/unit/issues/Issue12921.hx
+++ b/tests/unit/src/unit/issues/Issue12921.hx
@@ -1,0 +1,42 @@
+package unit.issues;
+
+class Issue12921 extends Test {
+#if jvm
+	function test() {
+		var c = new Issue12921_Canvas();
+		var paint = new Issue12921_Paint();
+		var left:Float = 1, top:Float = 2, right:Float = 3, bottom:Float = 4;
+		var calls = 0;
+		// The @:overload'd drawRect (Single overload) is called inside a closure
+		// passed to an *inline* higher-order function. The leading Float (double)
+		// arguments need a D2F conversion for the float overload. This used to emit
+		// invalid bytecode (boxing the doubles to java.lang.Double instead of D2F),
+		// producing a VerifyError at class load.
+		withClip(() -> {
+			c.drawRect(left, top, right, bottom, paint);
+			calls++;
+		});
+		eq(1, calls);
+	}
+
+	static inline function withClip(body:Void->Void):Void {
+		body();
+	}
+#end
+}
+
+#if jvm
+private class Issue12921_Rect {
+	public function new() {}
+}
+
+private class Issue12921_Paint {
+	public function new() {}
+}
+
+private class Issue12921_Canvas {
+	public function new() {}
+	@:overload public function drawRect(rect:Issue12921_Rect, paint:Issue12921_Paint):Void {}
+	@:overload public function drawRect(left:Single, top:Single, right:Single, bottom:Single, paint:Issue12921_Paint):Void {}
+}
+#end


### PR DESCRIPTION
`Type.map_expr_type` re-resolves `TField` nodes by name via `quick_field`, which collapses an overloaded method to its first declared overload. The typer repairs this afterwards with `maybe_reapply_overload_call`, but the optimizer's self-calling-closure inlining runs without a typer, so the wrong overload survived into code generation (e.g. an `@:overload`'d call inside a closure passed to an inline higher-order function, producing invalid JVM bytecode).

Runtime crash found on jvm target, but likely also applies to `extern @:overload` on other static targets.