### PR TITLE
[typer] reject non-function constructor fields

### DIFF
--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -1579,6 +1579,8 @@ let init_field (ctx,cctx,fctx) f cf =
 	end;
 	let cf =
 		match f.cff_kind with
+		| (FVar _ | FProp _) when fctx.field_kind = CfrConstructor ->
+			raise_typing_error "A constructor must be a function" p
 		| FVar (t,e) ->
 			create_variable (ctx,cctx,fctx) c f cf t e p
 		| FFun fd ->

--- a/tests/misc/eval/projects/ctor_callable_abstract/Macro.hx
+++ b/tests/misc/eval/projects/ctor_callable_abstract/Macro.hx
@@ -1,0 +1,15 @@
+import haxe.macro.Context;
+import haxe.macro.Expr;
+
+class Macro {
+	macro public static function build():Array<Field> {
+		var fields = Context.getBuildFields();
+		fields.push({
+			name: "new",
+			access: [APublic],
+			kind: FVar(macro :ContextProvider, null),
+			pos: (macro 0).pos
+		});
+		return fields;
+	}
+}

--- a/tests/misc/eval/projects/ctor_callable_abstract/Main.hx
+++ b/tests/misc/eval/projects/ctor_callable_abstract/Main.hx
@@ -1,0 +1,10 @@
+@:callable abstract ContextProvider(Void -> Void) {}
+
+@:build(Macro.build())
+class Base {}
+
+class Child extends Base {}
+
+function main() {
+	new Child();
+}

--- a/tests/misc/eval/projects/ctor_callable_abstract/compile-fail.hxml
+++ b/tests/misc/eval/projects/ctor_callable_abstract/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/eval/projects/ctor_callable_abstract/compile-fail.hxml.stderr
+++ b/tests/misc/eval/projects/ctor_callable_abstract/compile-fail.hxml.stderr
@@ -1,0 +1,2 @@
+Macro.hx:11: characters 16-17 : A constructor must be a function
+Main.hx:9: characters 2-13 : Child does not have a constructor


### PR DESCRIPTION
A field named `new` is always treated as the constructor, but a FVar/FProp `new` (macro-injected) gave the constructor a non-function type, crashing later in add_constructor. Reject it at the field instead.

Alternative could be to reject invalid fields created by macros directly, but that might be a big breaking change?