### PR TITLE
[std] add haxe.Int64.toFloat()

### DIFF
--- a/std/cpp/_std/haxe/Int64.hx
+++ b/std/cpp/_std/haxe/Int64.hx
@@ -197,6 +197,10 @@ abstract Int64(__Int64) from __Int64 from Int to __Int64 {
 		return Int64Helper.fromFloat(f);
 	}
 
+	public #if !cppia inline #end function toFloat():Float {
+		return Int64Helper.toFloat(abstract);
+	}
+
 	public static function divMod(dividend:Int64, divisor:Int64):{quotient:Int64, modulus:Int64} {
 		var q = dividend / divisor;
 

--- a/std/eval/_std/haxe/Int64.hx
+++ b/std/eval/_std/haxe/Int64.hx
@@ -97,6 +97,9 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return Int64Helper.fromFloat(f);
 	}
 
+	public inline function toFloat():Float
+		return Int64Helper.toFloat(abstract);
+
 	@:op(-A) public static function neg(x:Int64):Int64
 		return -x.val;
 

--- a/std/haxe/Int64.hx
+++ b/std/haxe/Int64.hx
@@ -168,6 +168,15 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 	}
 
 	/**
+		Returns a `Float` with the value of `this` Int64.
+
+		Loss of precision may occur for values whose magnitude exceeds 2^53.
+	**/
+	public inline function toFloat():Float {
+		return Int64Helper.toFloat(abstract);
+	}
+
+	/**
 		Performs signed integer division of `dividend` by `divisor`.
 		Returns `{ quotient : Int64, modulus : Int64 }`.
 	**/

--- a/std/haxe/Int64Helper.hx
+++ b/std/haxe/Int64Helper.hx
@@ -113,4 +113,18 @@ class Int64Helper {
 		}
 		return result;
 	}
+
+	/**
+		Converts an `Int64` to a `Float`.
+
+		Loss of precision may occur for values whose magnitude exceeds 2^53.
+	**/
+	public static function toFloat(x:Int64):Float {
+		var high = x.high;
+		var low = x.low;
+		// `low` is treated as an unsigned 32-bit word; both terms are exactly
+		// representable as Float, so the single addition yields the correctly
+		// rounded result.
+		return high * 4294967296. + (low < 0 ? 4294967296. + low : low);
+	}
 }

--- a/std/hl/_std/haxe/Int64.hx
+++ b/std/hl/_std/haxe/Int64.hx
@@ -132,6 +132,9 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return Int64Helper.fromFloat(f);
 	}
 
+	public inline function toFloat():Float
+		return Int64Helper.toFloat(abstract);
+
 	@:op(-A) public static function neg(x:Int64):Int64
 		return -x.val;
 
@@ -350,6 +353,10 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 
 	public static inline function fromFloat(f:Float):Int64 {
 		return Int64Helper.fromFloat(f);
+	}
+
+	public inline function toFloat():Float {
+		return Int64Helper.toFloat(abstract);
 	}
 
 	public static function divMod(dividend:Int64, divisor:Int64):{quotient:Int64, modulus:Int64} {

--- a/std/jvm/_std/haxe/Int64.hx
+++ b/std/jvm/_std/haxe/Int64.hx
@@ -125,6 +125,9 @@ abstract Int64(__Int64) from __Int64 to __Int64 {
 		return Int64Helper.fromFloat(f);
 	}
 
+	public inline function toFloat():Float
+		return Int64Helper.toFloat(abstract);
+
 	@:op(-A) public static function neg(x:Int64):Int64
 		return -x.val;
 

--- a/tests/unit/src/unit/TestInt64.hx
+++ b/tests/unit/src/unit/TestInt64.hx
@@ -565,6 +565,33 @@ class TestInt64 extends Test {
 		}
 	}
 
+	public function testToFloat() {
+		// exact (within 2^53) round-trips
+		eq(Int64.ofInt(0).toFloat(), 0.0);
+		eq(Int64.ofInt(1).toFloat(), 1.0);
+		eq(Int64.ofInt(-1).toFloat(), -1.0);
+		eq(Int64.ofInt(123456789).toFloat(), 123456789.0);
+		eq(Int64.ofInt(-123456789).toFloat(), -123456789.0);
+
+		// values that need both words
+		eq(Int64.make(0, 0x80000000).toFloat(), 2147483648.0);
+		eq(Int64.make(1, 0).toFloat(), 4294967296.0);
+		eq(Int64.make(1, 1).toFloat(), 4294967297.0);
+		eq(Int64.make(0xFFFFFFFE, 0).toFloat(), -8589934592.0);
+
+		// largest exactly representable magnitudes
+		eq(Int64.fromFloat(9007199254740991).toFloat(), 9007199254740991.0);
+		eq(Int64.fromFloat(-9007199254740991).toFloat(), -9007199254740991.0);
+
+		// extremes (precision loss expected, but the rounded double is well defined)
+		eq(Int64.make(0x7FFFFFFF, 0xFFFFFFFF).toFloat(), 9223372036854775807.0);
+		eq(Int64.make(0x80000000, 0).toFloat(), -9223372036854775808.0);
+
+		// matches the static `using` form
+		var a:Int64 = Int64.make(0x12345678, 0x9ABCDEF0);
+		eq(a.toFloat(), 1311768467463790320.0);
+	}
+
 	static function toHex(v:haxe.Int64) {
 		return "0x" + (v.high == 0 ? StringTools.hex(v.low) : StringTools.hex(v.high) + StringTools.hex(v.low, 8));
 	}


### PR DESCRIPTION
Adds an instance method `toFloat():Float` to haxe.Int64 across all target-specific implementations. The shared conversion lives in Int64Helper.toFloat, computing `high * 2^32 + lowUnsigned` where both terms are exactly representable as Float, so the single addition yields the correctly-rounded result.