### PR TITLE
[dce] apply @:keepSub on interfaces too

### DIFF
--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -64,7 +64,7 @@ let resolve_class_field_ref dce cfr =
 
 (* check for @:keepSub metadata, which forces @:keep on child classes *)
 let rec super_forces_keep c =
-	Meta.has Meta.KeepSub c.cl_meta || match c.cl_super with
+	Meta.has Meta.KeepSub c.cl_meta || (List.exists (fun (c,_) -> super_forces_keep c) c.cl_implements) || match c.cl_super with
 	| Some (csup,_) -> super_forces_keep csup
 	| _ -> false
 

--- a/tests/unit/src/unit/TestDCE.hx
+++ b/tests/unit/src/unit/TestDCE.hx
@@ -27,6 +27,21 @@ class GenericKeepSub<T> {}
 
 class ChildOfGenericKeepSub extends GenericKeepSub<String> {}
 
+@:keepSub
+interface KeepSubInterface {}
+
+// never referenced/constructed, kept only via @:keepSub on the interface
+class ImplementsKeepSubInterface implements KeepSubInterface {}
+class ExtendsImplementsKeepSubInterface extends ImplementsKeepSubInterface {}
+
+@:keepSub
+interface KeepSubBaseInterface {}
+
+interface KeepSubChildInterface extends KeepSubBaseInterface {}
+
+// kept via @:keepSub on a transitively extended interface
+class ImplementsKeepSubChildInterface implements KeepSubChildInterface {}
+
 @:analyzer(no_local_dce)
 class DCEClass {
 	// used statics
@@ -215,6 +230,12 @@ class TestDCE extends Test {
 
 	function testIssue6500() {
 		t(Type.resolveClass("unit.ChildOfGenericKeepSub") != null);
+	}
+
+	function testKeepSubInterface() {
+		t(Type.resolveClass("unit.ImplementsKeepSubInterface") != null);
+		t(Type.resolveClass("unit.ImplementsKeepSubChildInterface") != null);
+		t(Type.resolveClass("unit.ExtendsImplementsKeepSubInterface") != null);
 	}
 
 	public function testIssue7259() {


### PR DESCRIPTION
(as per documentation: "Extends `@:keep` metadata to all implementing and extending classes.")