### PR TITLE
[macro] add wildcard support to addGlobalMetadata

### DIFF
--- a/src/core/ast.ml
+++ b/src/core/ast.ml
@@ -1068,6 +1068,13 @@ let expr_of_type_path (sl,s) p =
 
 let match_path recursive sl sl_pattern =
 	let rec loop top sl1 sl2 = match sl1,sl2 with
+		(* trailing ** matches any remainder, at any depth *)
+		| _,["**"] ->
+			true
+		(* ** matches zero segments here, or one or more by consuming sl1 *)
+		| _,("**" :: sl2') ->
+			loop false sl1 sl2'
+			|| (match sl1 with [] -> false | _ :: sl1 -> loop false sl1 sl2)
 		| [],[] ->
 			true
 		(* always recurse into types of package paths *)
@@ -1079,8 +1086,9 @@ let match_path recursive sl sl_pattern =
 			recursive
 		| [],_ ->
 			false
+		(* * matches exactly one segment *)
 		| (s1 :: sl1),(s2 :: sl2) ->
-			s1 = s2 && loop false sl1 sl2
+			(s2 = "*" || s1 = s2) && loop false sl1 sl2
 	in
 	loop true sl sl_pattern
 

--- a/std/haxe/macro/Compiler.hx
+++ b/std/haxe/macro/Compiler.hx
@@ -334,6 +334,8 @@ class Compiler {
 
 		If `pathFilter` is the empty String `""` it matches everything (if
 		`recursive = true`) or only top-level types (if `recursive = false`).
+		`pathFilter` may contain wildcard segments: `*` matches exactly one
+		path segment, while `**` matches any depth.
 
 		This operation has no effect if the type has already been loaded, e.g.
 		through `Context.getType`.

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/Macro.hx
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/Macro.hx
@@ -1,0 +1,15 @@
+#if macro
+import haxe.macro.Compiler;
+
+class Macro {
+	public static function initMacro() {
+		// `*` matches exactly one segment: only types directly in `pack`
+		Compiler.addGlobalMetadata("pack.*", "@onestar", false, true, false);
+		// `**` matches any depth: every type under `pack`
+		Compiler.addGlobalMetadata("pack.**", "@twostar", false, true, false);
+		// same, but for the `foo` field
+		Compiler.addGlobalMetadata("pack.*.foo", "@fonestar", false, false, true);
+		Compiler.addGlobalMetadata("pack.**.foo", "@ftwostar", false, false, true);
+	}
+}
+#end

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/Main.hx
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/Main.hx
@@ -1,0 +1,35 @@
+import haxe.rtti.Meta;
+import pack.A;
+import pack.M;
+import pack.M.B;
+import pack.sub.C;
+
+class Main {
+	static function hasType(c:Class<Dynamic>, name:String):Bool {
+		var m = Meta.getType(c);
+		return m != null && Reflect.hasField(m, name);
+	}
+
+	static function hasField(c:Class<Dynamic>, field:String, name:String):Bool {
+		var m = Meta.getFields(c);
+		if (m == null)
+			return false;
+		var fm = Reflect.field(m, field);
+		return fm != null && Reflect.hasField(fm, name);
+	}
+
+	static function report(name:String, c:Class<Dynamic>) {
+		Sys.println(name
+			+ " onestar=" + hasType(c, "onestar")
+			+ " twostar=" + hasType(c, "twostar")
+			+ " foo.fonestar=" + hasField(c, "foo", "fonestar")
+			+ " foo.ftwostar=" + hasField(c, "foo", "ftwostar"));
+	}
+
+	static function main() {
+		report("A", A);
+		report("M", M);
+		report("B", B);
+		report("C", C);
+	}
+}

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/compile.hxml
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/compile.hxml
@@ -1,0 +1,2 @@
+--macro Macro.initMacro()
+--run Main

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/compile.hxml.stdout
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/compile.hxml.stdout
@@ -1,0 +1,4 @@
+A onestar=true twostar=true foo.fonestar=true foo.ftwostar=true
+M onestar=true twostar=true foo.fonestar=true foo.ftwostar=true
+B onestar=false twostar=true foo.fonestar=false foo.ftwostar=true
+C onestar=false twostar=true foo.fonestar=false foo.ftwostar=true

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/pack/A.hx
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/pack/A.hx
@@ -1,0 +1,7 @@
+package pack;
+
+class A {
+	public function new() {}
+
+	public function foo() {}
+}

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/pack/M.hx
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/pack/M.hx
@@ -1,0 +1,14 @@
+package pack;
+
+class M {
+	public function new() {}
+
+	public function foo() {}
+}
+
+// sub-module type: dot-path is pack.M.B
+class B {
+	public function new() {}
+
+	public function foo() {}
+}

--- a/tests/misc/eval/projects/GlobalMetadataWildcard/pack/sub/C.hx
+++ b/tests/misc/eval/projects/GlobalMetadataWildcard/pack/sub/C.hx
@@ -1,0 +1,7 @@
+package pack.sub;
+
+class C {
+	public function new() {}
+
+	public function foo() {}
+}

--- a/tests/misc/eval/projects/HxbWildcardExclude/compile.hxml
+++ b/tests/misc/eval/projects/HxbWildcardExclude/compile.hxml
@@ -1,0 +1,12 @@
+# Step 1: compile to an hxb archive, excluding the `pack` package via wildcard
+-cp src
+-main Main
+-js bin/out.js
+--hxb config.json
+
+--next
+
+# Step 2: inspect the archive to confirm the wildcard exclude was honored
+-cp src
+-main Check
+--interp

--- a/tests/misc/eval/projects/HxbWildcardExclude/compile.hxml.stdout
+++ b/tests/misc/eval/projects/HxbWildcardExclude/compile.hxml.stdout
@@ -1,0 +1,4 @@
+Main present: true
+pack.A present: false
+pack.sub.B present: false
+other.C present: true

--- a/tests/misc/eval/projects/HxbWildcardExclude/config.json
+++ b/tests/misc/eval/projects/HxbWildcardExclude/config.json
@@ -1,0 +1,6 @@
+{
+	"archivePath": "bin/hxb.zip",
+	"targetConfig": {
+		"exclude": ["pack.**"]
+	}
+}

--- a/tests/misc/eval/projects/HxbWildcardExclude/src/Check.hx
+++ b/tests/misc/eval/projects/HxbWildcardExclude/src/Check.hx
@@ -1,0 +1,39 @@
+// Reports which modules made it into the hxb archive produced by the previous
+// compilation step. With `exclude: ["pack.**"]`, everything under the `pack`
+// package (at any depth) must be absent, while `Main` and `other.C` remain. A
+// literal (non-wildcard) match of `pack.**` would exclude nothing, so this also
+// guards that the wildcard is actually interpreted.
+//
+// Entry names are stored as plain ASCII in the zip headers, so a raw byte
+// search over the archive is enough (and avoids depending on the exact zip
+// features the writer uses).
+import haxe.io.Bytes;
+
+class Check {
+	static function contains(haystack:Bytes, needle:Bytes):Bool {
+		var max = haystack.length - needle.length;
+		for (i in 0...max + 1) {
+			var found = true;
+			for (j in 0...needle.length) {
+				if (haystack.get(i + j) != needle.get(j)) {
+					found = false;
+					break;
+				}
+			}
+			if (found)
+				return true;
+		}
+		return false;
+	}
+
+	static function main() {
+		var data = sys.io.File.getBytes("bin/hxb.zip");
+		function present(entry:String):Bool {
+			return contains(data, Bytes.ofString(entry));
+		}
+		Sys.println("Main present: " + present("/Main.hxb"));
+		Sys.println("pack.A present: " + present("/pack/A.hxb"));
+		Sys.println("pack.sub.B present: " + present("/pack/sub/B.hxb"));
+		Sys.println("other.C present: " + present("/other/C.hxb"));
+	}
+}

--- a/tests/misc/eval/projects/HxbWildcardExclude/src/Main.hx
+++ b/tests/misc/eval/projects/HxbWildcardExclude/src/Main.hx
@@ -1,0 +1,11 @@
+import pack.A;
+import pack.sub.B;
+import other.C;
+
+class Main {
+	static function main() {
+		new A();
+		new B();
+		new C();
+	}
+}

--- a/tests/misc/eval/projects/HxbWildcardExclude/src/other/C.hx
+++ b/tests/misc/eval/projects/HxbWildcardExclude/src/other/C.hx
@@ -1,0 +1,5 @@
+package other;
+
+class C {
+	public function new() {}
+}

--- a/tests/misc/eval/projects/HxbWildcardExclude/src/pack/A.hx
+++ b/tests/misc/eval/projects/HxbWildcardExclude/src/pack/A.hx
@@ -1,0 +1,5 @@
+package pack;
+
+class A {
+	public function new() {}
+}

--- a/tests/misc/eval/projects/HxbWildcardExclude/src/pack/sub/B.hx
+++ b/tests/misc/eval/projects/HxbWildcardExclude/src/pack/sub/B.hx
@@ -1,0 +1,5 @@
+package pack.sub;
+
+class B {
+	public function new() {}
+}


### PR DESCRIPTION
One use case could be for example to add `@:keep` to all `toString` fields in a package.

Notes: 
- `module_check_policy` also technically had the wildcard support added, but I didn't document/test it because I'm still not sure what we'll be doing with that API
- the hxb test is weird but eh.. does the job