### PR TITLE
[dce] allow @:dce on fields

### DIFF
--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -181,7 +181,7 @@
 	{
 		"name": "Dce",
 		"metadata": ":dce",
-		"doc": "Forces dead code elimination even when `--dce full` is not specified. On a field, makes that single field eligible for elimination even if its enclosing class is otherwise kept.",
+		"doc": "Forces dead code elimination even when `--dce full` is not specified.",
 		"targets": ["TClass", "TEnum", "TClassField"],
 		"links": ["https://haxe.org/manual/cr-dce.html"]
 	},

--- a/src-json/meta.json
+++ b/src-json/meta.json
@@ -181,8 +181,8 @@
 	{
 		"name": "Dce",
 		"metadata": ":dce",
-		"doc": "Forces dead code elimination even when `--dce full` is not specified.",
-		"targets": ["TClass", "TEnum"],
+		"doc": "Forces dead code elimination even when `--dce full` is not specified. On a field, makes that single field eligible for elimination even if its enclosing class is otherwise kept.",
+		"targets": ["TClass", "TEnum", "TClassField"],
 		"links": ["https://haxe.org/manual/cr-dce.html"]
 	},
 	{

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -364,16 +364,19 @@ let mark_dependent_fields dce csup n kind =
 
 let opt f e = match e with None -> () | Some e -> f e
 
+(* a @:dce toString is not implicitly kept by Std.string/trace/Array.join *)
+let to_string_filter cf = not (field_forces_dce cf)
+
 let rec to_string dce stack t = match t with
 	| TInst(c,tl) ->
-		field dce c "toString" CfrMember;
+		field ~filter:to_string_filter dce c "toString" CfrMember;
 	| TType(tt,tl) ->
 		if not (List.exists (fun t2 -> Type.fast_eq t t2) stack) then begin
 			to_string dce (t :: stack) (apply_typedef tt tl)
 		end
 	| TAbstract({a_impl = Some c} as a,tl) ->
 		if Meta.has Meta.CoreType a.a_meta then
-			field dce c "toString" CfrMember
+			field ~filter:to_string_filter dce c "toString" CfrMember
 		else
 			to_string dce stack (Abstract.get_underlying_type a tl)
 	| TMono r ->
@@ -388,26 +391,31 @@ let rec to_string dce stack t = match t with
 		(* if we to_string these it does not imply that we need all its sub-types *)
 		()
 
-and field dce c n kind =
+(*
+	`filter` is checked against the resolved field before marking it. When it returns false the field is
+	left alone (and the search stops): this is how a @:dce field opts out of being implicitly kept, e.g.
+	`toString` pulled in by `Std.string`/`trace`/`Array.join`.
+*)
+and field ?(filter=(fun _ -> true)) dce c n kind =
 	(try
 		let cf = find_field c n kind in
-		mark_field dce c cf kind;
+		if filter cf then mark_field dce c cf kind;
 	with Not_found -> try
 		if (has_class_flag c CInterface) then begin
 			let rec loop cl = match cl with
 				| [] -> raise Not_found
 				| (c,_) :: cl ->
-					try field dce c n kind with Not_found -> loop cl
+					try field ~filter dce c n kind with Not_found -> loop cl
 			in
 			loop c.cl_implements
-		end else match c.cl_super with Some (csup,_) -> field dce csup n kind | None -> raise Not_found
+		end else match c.cl_super with Some (csup,_) -> field ~filter dce csup n kind | None -> raise Not_found
 	with Not_found -> try
 		match c.cl_kind with
 		| KTypeParameter ttp ->
 			let rec loop tl = match tl with
 				| [] -> raise Not_found
 				| TInst(c,_) :: cl ->
-					(try field dce c n kind with Not_found -> loop cl)
+					(try field ~filter dce c n kind with Not_found -> loop cl)
 				| t :: tl ->
 					loop tl
 			in

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -107,6 +107,15 @@ let keep_whole_enum dce en =
 	Meta.has_one_of keep_metas en.e_meta
 	|| not (dce.full || is_std_file dce (Path.UniqueKey.lazy_path en.e_module.m_extra.m_file) || has_meta Meta.Dce en.e_meta)
 
+(* check if a field carries @:dce, forcing it to be DCE-eligible even if its class is kept *)
+let field_forces_dce cf = has_meta Meta.Dce cf.cf_meta
+
+(* check if a class has any field marked with @:dce *)
+let class_has_dce_field c =
+	List.exists field_forces_dce c.cl_ordered_fields
+	|| List.exists field_forces_dce c.cl_ordered_statics
+	|| (match c.cl_constructor with Some cf -> field_forces_dce cf | None -> false)
+
 let mk_used_meta pos =
 	Meta.Used,[],(mk_zero_range_pos pos)
 
@@ -813,7 +822,8 @@ let collect_entry_points dce types =
 				let cf_if_feature = extract_if_feature cf.cf_meta in
 				check_feature cf_ref (cl_if_feature @ cf_if_feature);
 				(* Have to delay mark_field so that we see all @:ifFeature *)
-				if keep_class || is_struct || keep_field dce cf c kind then delayed := (fun () -> mark_field dce c cf kind) :: !delayed
+				(* a @:dce field is not kept just because its class is: it must be reached like in full DCE *)
+				if (keep_class && not (field_forces_dce cf)) || is_struct || keep_field dce cf c kind then delayed := (fun () -> mark_field dce c cf kind) :: !delayed
 			in
 			List.iter (loop CfrStatic) c.cl_ordered_statics;
 			List.iter (loop CfrMember) c.cl_ordered_fields;
@@ -872,7 +882,7 @@ let mark pool dce =
 let sweep dce types =
 	let rec loop acc types =
 		match types with
-		| (TClassDecl c) as mt :: l when keep_whole_class dce c ->
+		| (TClassDecl c) as mt :: l when keep_whole_class dce c && not (class_has_dce_field c) ->
 			loop (mt :: acc) l
 		| (TClassDecl c) as mt :: l ->
 			let check_property cf stat =
@@ -900,10 +910,14 @@ let sweep dce types =
 					()
 				end;
 			in
+			(* a kept-whole class only reaches this branch because of @:dce fields:
+			   keep all of its fields except the @:dce ones that DCE did not reach *)
+			let class_kept = keep_whole_class dce c in
+			let keep cf kind = (class_kept && not (field_forces_dce cf)) || keep_field dce cf c kind in
 			(* add :keep so subsequent filter calls do not process class fields again *)
 			c.cl_meta <- (mk_keep_meta c.cl_pos) :: c.cl_meta;
  			c.cl_ordered_statics <- List.filter (fun cf ->
-				let b = keep_field dce cf c CfrStatic in
+				let b = keep cf CfrStatic in
 				if not b then begin
 					if dce.debug then print_endline ("[DCE] Removed field " ^ (s_type_path c.cl_path) ^ "." ^ (cf.cf_name));
 					check_property cf true;
@@ -912,7 +926,7 @@ let sweep dce types =
 				b
 			) c.cl_ordered_statics;
 			c.cl_ordered_fields <- List.filter (fun cf ->
-				let b = keep_field dce cf c CfrMember in
+				let b = keep cf CfrMember in
 				if not b then begin
 					if dce.debug then print_endline ("[DCE] Removed field " ^ (s_type_path c.cl_path) ^ "." ^ (cf.cf_name));
 					check_property cf false;
@@ -920,11 +934,11 @@ let sweep dce types =
 				end;
 				b
 			) c.cl_ordered_fields;
-			(match c.cl_constructor with Some cf when not (keep_field dce cf c CfrConstructor) -> c.cl_constructor <- None | _ -> ());
+			(match c.cl_constructor with Some cf when not (keep cf CfrConstructor) -> c.cl_constructor <- None | _ -> ());
 			let inef cf = is_physical_field cf in
 			let has_non_extern_fields = List.exists inef c.cl_ordered_fields || List.exists inef c.cl_ordered_statics in
-			(* we keep a class if it was used or has a used field *)
-			if has_class_flag c CUsed || has_non_extern_fields then loop (mt :: acc) l else begin
+			(* we keep a class if it is kept whole, was used or has a used field *)
+			if class_kept || has_class_flag c CUsed || has_non_extern_fields then loop (mt :: acc) l else begin
 				(match TClass.get_cl_init c with
 				| Some f when Meta.has Meta.KeepInit c.cl_meta ->
 					(* it means that we only need the __init__ block *)

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -364,19 +364,16 @@ let mark_dependent_fields dce csup n kind =
 
 let opt f e = match e with None -> () | Some e -> f e
 
-(* a @:dce toString is not implicitly kept by Std.string/trace/Array.join *)
-let to_string_filter cf = not (field_forces_dce cf)
-
 let rec to_string dce stack t = match t with
 	| TInst(c,tl) ->
-		field ~filter:to_string_filter dce c "toString" CfrMember;
+		keep_to_string dce c;
 	| TType(tt,tl) ->
 		if not (List.exists (fun t2 -> Type.fast_eq t t2) stack) then begin
 			to_string dce (t :: stack) (apply_typedef tt tl)
 		end
 	| TAbstract({a_impl = Some c} as a,tl) ->
 		if Meta.has Meta.CoreType a.a_meta then
-			field ~filter:to_string_filter dce c "toString" CfrMember
+			keep_to_string dce c
 		else
 			to_string dce stack (Abstract.get_underlying_type a tl)
 	| TMono r ->
@@ -391,38 +388,49 @@ let rec to_string dce stack t = match t with
 		(* if we to_string these it does not imply that we need all its sub-types *)
 		()
 
-(*
-	`filter` is checked against the resolved field before marking it. When it returns false the field is
-	left alone (and the search stops): this is how a @:dce field opts out of being implicitly kept, e.g.
-	`toString` pulled in by `Std.string`/`trace`/`Array.join`.
-*)
-and field ?(filter=(fun _ -> true)) dce c n kind =
-	(try
+(* resolve a field by name across the class, its super classes, implemented interfaces and type
+   parameter constraints, returning the class that actually defines it. Raises Not_found if absent. *)
+and resolve_field dce c n kind =
+	try
 		let cf = find_field c n kind in
-		if filter cf then mark_field dce c cf kind;
+		(c,cf)
 	with Not_found -> try
 		if (has_class_flag c CInterface) then begin
 			let rec loop cl = match cl with
 				| [] -> raise Not_found
 				| (c,_) :: cl ->
-					try field ~filter dce c n kind with Not_found -> loop cl
+					try resolve_field dce c n kind with Not_found -> loop cl
 			in
 			loop c.cl_implements
-		end else match c.cl_super with Some (csup,_) -> field ~filter dce csup n kind | None -> raise Not_found
-	with Not_found -> try
+		end else match c.cl_super with Some (csup,_) -> resolve_field dce csup n kind | None -> raise Not_found
+	with Not_found ->
 		match c.cl_kind with
 		| KTypeParameter ttp ->
 			let rec loop tl = match tl with
 				| [] -> raise Not_found
 				| TInst(c,_) :: cl ->
-					(try field ~filter dce c n kind with Not_found -> loop cl)
+					(try resolve_field dce c n kind with Not_found -> loop cl)
 				| t :: tl ->
 					loop tl
 			in
 			loop (get_constraints ttp)
 		| _ -> raise Not_found
+
+and field dce c n kind =
+	try
+		let (c,cf) = resolve_field dce c n kind in
+		mark_field dce c cf kind
 	with Not_found ->
-		if dce.debug then prerr_endline ("[DCE] Field " ^ n ^ " not found on " ^ (s_type_path c.cl_path)) else ())
+		if dce.debug then prerr_endline ("[DCE] Field " ^ n ^ " not found on " ^ (s_type_path c.cl_path))
+
+(* keep a type's toString, unless that field opts out of being implicitly kept with @:dce
+   (it is only pulled in by Std.string/trace/Array.join, never by an explicit call) *)
+and keep_to_string dce c =
+	try
+		let (c,cf) = resolve_field dce c "toString" CfrMember in
+		if not (field_forces_dce cf) then mark_field dce c cf CfrMember
+	with Not_found ->
+		()
 
 and mark_directly_used_class dce c =
 	(* don't add @:directlyUsed if it's used within the class itself. this can happen with extern inline methods *)

--- a/tests/unit/src/unit/TestDCE.hx
+++ b/tests/unit/src/unit/TestDCE.hx
@@ -242,6 +242,14 @@ class TestDCE extends Test {
 		nhsf(c, "staticDceUnused");
 	}
 
+	function testDceToString() {
+		// Std.string normally keeps toString, but @:dce opts the field out of that heuristic
+		var e = new DceToStringElement();
+		var s = Std.string(e);
+		var c = Type.getClass(e);
+		nhf(c, "toString");
+	}
+
 	function testIssue6500() {
 		t(Type.resolveClass("unit.ChildOfGenericKeepSub") != null);
 	}
@@ -270,6 +278,14 @@ class TestDCE extends Test {
 class ClassWithBar {
 	static public function bar()
 		return 'bar';
+}
+
+@:analyzer(no_local_dce)
+class DceToStringElement {
+	public function new() {}
+
+	@:dce public function toString()
+		return "must not be kept by Std.string";
 }
 
 @:keep

--- a/tests/unit/src/unit/TestDCE.hx
+++ b/tests/unit/src/unit/TestDCE.hx
@@ -228,6 +228,20 @@ class TestDCE extends Test {
 		hf(ThrownWithToString, "toString");
 	}
 
+	function testDceField() {
+		// the class is force-kept, but individual @:dce fields still get eliminated when unused
+		var o = new KeepClassWithDceField();
+		o.dceUsed();
+		var c = Type.getClass(o);
+
+		hf(c, "normalUnused"); // kept because the whole class is @:keep
+		hf(c, "dceUsed"); // @:dce but reached -> kept
+		nhf(c, "dceUnused"); // @:dce and unreached -> removed
+
+		hsf(c, "staticNormalUnused");
+		nhsf(c, "staticDceUnused");
+	}
+
 	function testIssue6500() {
 		t(Type.resolveClass("unit.ChildOfGenericKeepSub") != null);
 	}
@@ -256,6 +270,24 @@ class TestDCE extends Test {
 class ClassWithBar {
 	static public function bar()
 		return 'bar';
+}
+
+@:keep
+@:analyzer(no_local_dce)
+class KeepClassWithDceField {
+	public function new() {}
+
+	// no @:dce: kept along with the whole @:keep class even though unused
+	function normalUnused() {}
+
+	static function staticNormalUnused() {}
+
+	// @:dce: eligible for elimination despite the class being kept
+	@:dce public function dceUsed() {}
+
+	@:dce function dceUnused() {}
+
+	@:dce static function staticDceUnused() {}
 }
 
 class UsedConstructed {


### PR DESCRIPTION
I didn't find any strong reason not to support `@:dce` on fields (to mirror `@:keep`), but maybe there's one I missed?

Note: this also gives a solution to #12927, by adding `@:dce` to `Xml.toString` through `addGlobalMetadata`