### PR TITLE
[hl/std] ssl socket accept use typed error blocked

### DIFF
--- a/std/hl/_std/sys/ssl/Socket.hx
+++ b/std/hl/_std/sys/ssl/Socket.hx
@@ -208,7 +208,7 @@ class Socket extends sys.net.Socket {
 	public override function accept():Socket {
 		var c = sys.net.Socket.socket_accept(__s);
 		if(c == null)
-			throw "Blocking";
+			throw haxe.io.Error.Blocked;
 		var cssl = new Context(conf);
 		cssl.setSocket(c);
 


### PR DESCRIPTION
On linux hl, CPU profiling can generate EINTER and cause `socket_accept` to return `null`, then ssl.Socket.accept `throw "Blocking"` which is just a String and not ideal for catch. This PR replace it with `throw haxe.io.Error.Blocked`.