### PR TITLE
[server] allow disabling stale context cleanup

### DIFF
--- a/src/compiler/server/serverCache.ml
+++ b/src/compiler/server/serverCache.ml
@@ -570,9 +570,11 @@ let cleanup sctx =
 	(* Remove context caches that haven't been accessed within the max age window.
 	   This prevents unbounded accumulation of stale contexts when compilation defines
 	   change between requests, generating new cache signatures each time. *)
-	let removed = sctx.cs#remove_stale_contexts !ServerConfig.stale_context_max_age_seconds in
-	if removed > 0 then
-		ServerMessage.message (Printf.sprintf "Removed %d stale context cache(s)" removed)
+	if !ServerConfig.stale_context_max_age_seconds > -1 then begin
+		let removed = sctx.cs#remove_stale_contexts !ServerConfig.stale_context_max_age_seconds in
+		if removed > 0 then
+			ServerMessage.message (Printf.sprintf "Removed %d stale context cache(s)" removed)
+	end
 
 let before_anything sctx ctx =
 	ensure_macro_setup sctx

--- a/src/compiler/server/serverConfig.ml
+++ b/src/compiler/server/serverConfig.ml
@@ -4,7 +4,8 @@ let max_completion_items = ref 0
 
 (* Maximum age in seconds for unused context caches before they are removed.
    10 minutes is long enough to survive bursts of display requests with
-   varying defines, while still cleaning up contexts that are truly abandoned. *)
+   varying defines, while still cleaning up contexts that are truly abandoned.
+   If set to -1, the feature is disabled. *)
 let default_stale_context_max_age = 600
 let stale_context_max_age_seconds = ref default_stale_context_max_age
 


### PR DESCRIPTION
This allows users to opt out of the feature (which can lead to problematic behavior) by setting `staleContextMaxAge` to `-1` in `initialize` request.