### PR TITLE
[CI/hlc] use vs2026 runner until available in windows-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -414,7 +414,7 @@ jobs:
 
   windows64-test:
     needs: windows64-build
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     env:
       PLATFORM: windows64
       TEST: ${{matrix.target}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -490,7 +490,7 @@ jobs:
           haxelib setup "$env:HAXELIB_ROOT"
 
       - name: Add msbuild to PATH (hl/c)
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         if: matrix.target == 'hl'
         with:
           msbuild-architecture: x64

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -189,7 +189,7 @@ class Hl {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "hl"]);
 
 		if (Hl.withHlcTests) {
-			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2022" : "hlgen.makefile=make";
+			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2026" : "hlgen.makefile=make";
 			runCommand("haxe", ["run-base.hxml", "--run", "Main", "hlc", "-D", hlcTemplateDefine].concat(haxeArgs));
 		}
 	}

--- a/tests/runci/targets/Hl.hx
+++ b/tests/runci/targets/Hl.hx
@@ -189,7 +189,7 @@ class Hl {
 		runCommand("haxe", ["run-base.hxml", "--run", "Main", "hl"]);
 
 		if (Hl.withHlcTests) {
-			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2026" : "hlgen.makefile=make";
+			final hlcTemplateDefine = systemName == "Windows" ? "hlgen.makefile=vs2022" : "hlgen.makefile=make";
 			runCommand("haxe", ["run-base.hxml", "--run", "Main", "hlc", "-D", hlcTemplateDefine].concat(haxeArgs));
 		}
 	}


### PR DESCRIPTION
VS2026 isn't yet available in windows-latest runner

Related:
- Changed to vs2026 but actually didn't test auto-compilation anymore: https://github.com/HaxeFoundation/haxe/pull/12894
- Support for auto-compilation on vs2026: https://github.com/HaxeFoundation/hashlink/pull/933