### PR TITLE
[typer] allow non-constant default argument values

### DIFF
--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -41,7 +41,7 @@ let iter f e =
 	| TVar (v,eo) ->
 		(match eo with None -> () | Some e -> f e)
 	| TFunction fu ->
-		List.iter (fun (_,eo) -> match eo with None -> () | Some e -> f e) fu.tf_args;
+		List.iter (fun (_,eo) -> match eo with None | Some {eexpr = TConst TNull} -> () | Some e -> f e) fu.tf_args;
 		f fu.tf_expr
 	| TIf (e,e1,e2) ->
 		f e;
@@ -80,8 +80,7 @@ let check_expr predicate e =
 		| TVar (_,eo) | TReturn eo ->
 			(match eo with None -> false | Some e -> predicate e)
 		| TFunction fu ->
-			List.exists (fun (_,eo) -> match eo with None -> false | Some e -> predicate e) fu.tf_args
-			|| predicate fu.tf_expr
+			List.exists (fun (_,eo) -> match eo with None | Some {eexpr = TConst TNull} -> false | Some e -> predicate e) fu.tf_args || predicate fu.tf_expr
 		| TIf (e,e1,e2) ->
 			predicate e || predicate e1 || (match e2 with None -> false | Some e -> predicate e)
 		| TSwitch switch ->
@@ -135,7 +134,11 @@ let map_expr f e =
 	| TVar (v,eo) ->
 		{ e with eexpr = TVar (v, match eo with None -> None | Some e -> Some (f e)) }
 	| TFunction fu ->
-		{ e with eexpr = TFunction { fu with tf_args = List.map (fun (v,eo) -> v,Option.map f eo) fu.tf_args; tf_expr = f fu.tf_expr } }
+		let map_arg (v,eo) = match eo with
+			| None | Some {eexpr = TConst TNull} -> v,eo
+			| Some e -> v,Some (f e)
+		in
+		{ e with eexpr = TFunction { fu with tf_args = List.map map_arg fu.tf_args; tf_expr = f fu.tf_expr } }
 	| TIf (ec,e1,e2) ->
 		let ec = f ec in
 		let e1 = f e1 in
@@ -440,8 +443,9 @@ let foldmap f acc e =
 		acc,{ e with eexpr = TVar (v, eo) }
 	| TFunction fu ->
 		let acc,tf_args = List.fold_left (fun (acc,args) (v,eo) ->
-			let acc,eo = foldmap_opt f acc eo in
-			acc,((v,eo) :: args)
+			match eo with
+			| None | Some {eexpr = TConst TNull} -> acc,((v,eo) :: args)
+			| _ -> let acc,eo = foldmap_opt f acc eo in acc,((v,eo) :: args)
 		) (acc,[]) fu.tf_args in
 		let tf_args = List.rev tf_args in
 		let acc,e1 = f acc fu.tf_expr in

--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -41,7 +41,7 @@ let iter f e =
 	| TVar (v,eo) ->
 		(match eo with None -> () | Some e -> f e)
 	| TFunction fu ->
-		List.iter (fun (_,eo) -> match eo with None | Some {eexpr = TConst TNull} -> () | Some e -> f e) fu.tf_args;
+		List.iter (fun (_,eo) -> match eo with None -> () | Some e -> f e) fu.tf_args;
 		f fu.tf_expr
 	| TIf (e,e1,e2) ->
 		f e;
@@ -80,7 +80,7 @@ let check_expr predicate e =
 		| TVar (_,eo) | TReturn eo ->
 			(match eo with None -> false | Some e -> predicate e)
 		| TFunction fu ->
-			List.exists (fun (_,eo) -> match eo with None | Some {eexpr = TConst TNull} -> false | Some e -> predicate e) fu.tf_args || predicate fu.tf_expr
+			List.exists (fun (_,eo) -> match eo with None -> false | Some e -> predicate e) fu.tf_args || predicate fu.tf_expr
 		| TIf (e,e1,e2) ->
 			predicate e || predicate e1 || (match e2 with None -> false | Some e -> predicate e)
 		| TSwitch switch ->
@@ -135,7 +135,7 @@ let map_expr f e =
 		{ e with eexpr = TVar (v, match eo with None -> None | Some e -> Some (f e)) }
 	| TFunction fu ->
 		let map_arg (v,eo) = match eo with
-			| None | Some {eexpr = TConst TNull} -> v,eo
+			| None -> v,eo
 			| Some e -> v,Some (f e)
 		in
 		{ e with eexpr = TFunction { fu with tf_args = List.map map_arg fu.tf_args; tf_expr = f fu.tf_expr } }
@@ -443,9 +443,8 @@ let foldmap f acc e =
 		acc,{ e with eexpr = TVar (v, eo) }
 	| TFunction fu ->
 		let acc,tf_args = List.fold_left (fun (acc,args) (v,eo) ->
-			match eo with
-			| None | Some {eexpr = TConst TNull} -> acc,((v,eo) :: args)
-			| _ -> let acc,eo = foldmap_opt f acc eo in acc,((v,eo) :: args)
+			let acc,eo = foldmap_opt f acc eo in
+			acc,((v,eo) :: args)
 		) (acc,[]) fu.tf_args in
 		let tf_args = List.rev tf_args in
 		let acc,e1 = f acc fu.tf_expr in

--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -41,6 +41,7 @@ let iter f e =
 	| TVar (v,eo) ->
 		(match eo with None -> () | Some e -> f e)
 	| TFunction fu ->
+		List.iter (fun (_,eo) -> match eo with None -> () | Some e -> f e) fu.tf_args;
 		f fu.tf_expr
 	| TIf (e,e1,e2) ->
 		f e;
@@ -79,7 +80,8 @@ let check_expr predicate e =
 		| TVar (_,eo) | TReturn eo ->
 			(match eo with None -> false | Some e -> predicate e)
 		| TFunction fu ->
-			predicate fu.tf_expr
+			List.exists (fun (_,eo) -> match eo with None -> false | Some e -> predicate e) fu.tf_args
+			|| predicate fu.tf_expr
 		| TIf (e,e1,e2) ->
 			predicate e || predicate e1 || (match e2 with None -> false | Some e -> predicate e)
 		| TSwitch switch ->
@@ -133,7 +135,7 @@ let map_expr f e =
 	| TVar (v,eo) ->
 		{ e with eexpr = TVar (v, match eo with None -> None | Some e -> Some (f e)) }
 	| TFunction fu ->
-		{ e with eexpr = TFunction { fu with tf_expr = f fu.tf_expr } }
+		{ e with eexpr = TFunction { fu with tf_args = List.map (fun (v,eo) -> v,Option.map f eo) fu.tf_args; tf_expr = f fu.tf_expr } }
 	| TIf (ec,e1,e2) ->
 		let ec = f ec in
 		let e1 = f e1 in
@@ -335,7 +337,7 @@ let duplicate_tvars f_this e =
 			) cl in
 			{e with eexpr = TTry(build_expr e1, cl)}
 		| TFunction f ->
-			let args = List.map (fun (v,c) -> copy_var v, c) f.tf_args in
+			let args = List.map (fun (v,c) -> let v = copy_var v in v, Option.map build_expr c) f.tf_args in
 			let f = {
 				tf_args = args;
 				tf_type = f.tf_type;
@@ -437,8 +439,13 @@ let foldmap f acc e =
 		let acc,eo = foldmap_opt f acc eo in
 		acc,{ e with eexpr = TVar (v, eo) }
 	| TFunction fu ->
+		let acc,tf_args = List.fold_left (fun (acc,args) (v,eo) ->
+			let acc,eo = foldmap_opt f acc eo in
+			acc,((v,eo) :: args)
+		) (acc,[]) fu.tf_args in
+		let tf_args = List.rev tf_args in
 		let acc,e1 = f acc fu.tf_expr in
-		acc,{ e with eexpr = TFunction { fu with tf_expr = e1 } }
+		acc,{ e with eexpr = TFunction { fu with tf_args; tf_expr = e1 } }
 	| TIf (ec,e1,eo) ->
 		let acc,ec = f acc ec in
 		let acc,e1 = f acc e1 in

--- a/src/filters/renameVars.ml
+++ b/src/filters/renameVars.ml
@@ -303,6 +303,7 @@ let rec collect_vars ?(in_block=false) rc scope e =
 		let scope = create_scope (Some scope) in
 		List.iter (fun (v,_) -> declare_var rc scope v) fn.tf_args;
 		List.iter (fun (v,_) -> use_var rc scope v) fn.tf_args;
+		List.iter (fun (_,eo) -> Option.may (collect_vars scope) eo) fn.tf_args;
 		(match fn.tf_expr.eexpr with
 		| TBlock exprs -> List.iter (collect_vars scope) exprs
 		| _ -> collect_vars scope fn.tf_expr

--- a/src/generators/cpp/gen/cppCppia.ml
+++ b/src/generators/cpp/gen/cppCppia.ml
@@ -756,7 +756,7 @@ class script_writer ctx filename asciiOut basic =
         match fieldExpression with
         | Some ({ eexpr = TFunction function_def } as e) ->
             if cppiaAst then (
-              let args = List.map (fun (v, e) -> (CppRetyper.retype_tvar basic v), e) function_def.tf_args in
+              let args = List.map this#retype_default_arg function_def.tf_args in
               let cppExpr =
                 CppRetyper.expression ctx TCppVoid args (cpp_type_of basic function_def.tf_type)
                   function_def.tf_expr false
@@ -884,6 +884,16 @@ class script_writer ctx filename asciiOut basic =
            this#writeOpLine op);
         this#gen_expression expr)
 
+    method private retype_default_arg (v, e) =
+      let v =
+        match e with
+        | Some { eexpr = TConst _ } | None -> v
+        | Some _ when is_cpp_scalar (cpp_type_of basic v.v_type) ->
+            { v with v_type = basic.tnull v.v_type }
+        | Some _ -> v
+      in
+      (CppRetyper.retype_tvar basic v, e)
+
     method gen_func_args args =
       let gen_inits = ref [] in
       List.iter
@@ -959,7 +969,7 @@ class script_writer ctx filename asciiOut basic =
             ^ this#typeText function_def.tf_type
             ^ string_of_int (List.length function_def.tf_args)
             ^ "\n");
-          let close = this#gen_func_args (List.map (fun (v, e) -> CppRetyper.retype_tvar basic v, e) function_def.tf_args) in
+          let close = this#gen_func_args (List.map this#retype_default_arg function_def.tf_args) in
           let pop = this#pushReturn function_def.tf_type in
           this#gen_expression function_def.tf_expr;
           pop ();

--- a/src/generators/cpp/gen/cppCppia.ml
+++ b/src/generators/cpp/gen/cppCppia.ml
@@ -7,7 +7,7 @@ open CppAst
 open CppAstTools
 open CppContext
 
-type script_type = 
+type script_type =
   | ScriptBool
   | ScriptInt
   | ScriptFloat
@@ -892,7 +892,7 @@ class script_writer ctx filename asciiOut basic =
           this#writeVar arg.tcppv_var;
           match init with
           | Some { eexpr = TConst TNull } -> this#write "0\n"
-          | Some const ->
+          | Some ({ eexpr = TConst _ } as const) ->
               let argType = cpp_type_of basic const.etype in
               if is_cpp_scalar argType || argType == TCppString then (
                 this#write "1 ";
@@ -901,6 +901,9 @@ class script_writer ctx filename asciiOut basic =
               else (
                 gen_inits := (arg, const) :: !gen_inits;
                 this#write "0\n")
+          | Some init ->
+              gen_inits := (arg, init) :: !gen_inits;
+              this#write "0\n"
           | _ -> this#write "0\n")
         args;
 

--- a/src/generators/cpp/gen/cppCppia.ml
+++ b/src/generators/cpp/gen/cppCppia.ml
@@ -907,11 +907,12 @@ class script_writer ctx filename asciiOut basic =
           | _ -> this#write "0\n")
         args;
 
-      if List.length !gen_inits == 0 then fun () -> ()
+      let gen_inits = List.rev !gen_inits in
+      if List.length gen_inits == 0 then fun () -> ()
       else (
         this#begin_expr;
-        this#writePos (snd (List.hd !gen_inits));
-        this#writeList (this#op IaBlock) (List.length !gen_inits + 1);
+        this#writePos (snd (List.hd gen_inits));
+        this#writeList (this#op IaBlock) (List.length gen_inits + 1);
         List.iter
           (fun (arg, const) ->
             let start_expr () =
@@ -939,7 +940,7 @@ class script_writer ctx filename asciiOut basic =
             this#gen_expression const;
             this#end_expr;
             this#begin_expr)
-          !gen_inits;
+          gen_inits;
         fun () -> this#end_expr)
 
     method gen_expression expr =

--- a/src/generators/cpp/gen/cppGen.ml
+++ b/src/generators/cpp/gen/cppGen.ml
@@ -185,49 +185,6 @@ let default_value_string ctx value =
       string_of_path enum.e_path ^ "::" ^ cpp_enum_name_of field ^ "_dyn()"
   | _ -> "/* Hmmm " ^ s_expr_kind value ^ " */"
 
-let gen_default_value_expr_ref :
-    (context -> string -> string -> tcpp -> string -> texpr -> unit) ref =
-  ref (fun _ _ _ _ _ _ -> die "" __LOC__)
-
-let cpp_gen_default_values ctx dot_name func_name args prefix =
-  List.iter
-    (fun (var, o) ->
-      let not_null =
-        type_has_meta_key Meta.NotNull var.tcppv_var.v_type || is_cpp_scalar var.tcppv_type
-      in
-      let spacer = if ctx.ctx_debug_level > 0 then "            \t" else "" in
-      let pname = prefix ^ var.tcppv_name in
-      let vname = var.tcppv_name in
-      let tname = tcpp_to_string var.tcppv_type in
-      match o with
-      | Some { eexpr = TConst TNull } -> ()
-      | Some const when is_renderable_constant const ->
-          ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ " = " ^ pname);
-          ctx.ctx_output
-            (if not_null then
-               ".Default(" ^ default_value_string ctx.ctx_common const ^ ");\n"
-             else
-               ";\n" ^ spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) " ^ vname
-               ^ " = "
-               ^ default_value_string ctx.ctx_common const
-               ^ ";\n")
-      | Some const ->
-          let gen_assign () =
-            !gen_default_value_expr_ref ctx dot_name func_name var.tcppv_type (vname ^ " = ") const
-          in
-          if not_null then begin
-            ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ ";\n");
-            ctx.ctx_output (spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) ");
-            gen_assign ();
-            ctx.ctx_output (spacer ^ "\telse " ^ vname ^ " = " ^ pname ^ ";\n")
-          end else begin
-            ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ " = " ^ pname ^ ";\n");
-            ctx.ctx_output (spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) ");
-            gen_assign ()
-          end
-      | _ -> ())
-    args
-
 let cpp_class_hash interface =
   gen_hash 0 (join_class_path interface.cl_path "::")
 
@@ -464,7 +421,7 @@ let needed_interface_functions implemented_instance_fields native_implementation
   |> List.fold_left iface_folder (have, [])
   |> snd
 
-let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_type injection tree =
+let rec gen_cpp_ast_expression_tree ctx class_name func_name function_args function_type injection tree =
   let writer = ctx.ctx_writer in
   let out = ctx.ctx_output in
   let lastLine = ref (-1) in
@@ -1647,11 +1604,48 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
 
   gen_with_injection injection cppTree true
 
-let () =
-  gen_default_value_expr_ref :=
-    (fun ctx dot_name func_name ftype lhs expr ->
-      let injection = mk_injection (fun _ -> ()) lhs "" in
-      gen_cpp_ast_expression_tree ctx dot_name func_name [] ftype injection (mk_block expr))
+and cpp_gen_default_values ctx dot_name func_name args prefix =
+  List.iter
+    (fun (var, o) ->
+      let not_null =
+        type_has_meta_key Meta.NotNull var.tcppv_var.v_type || is_cpp_scalar var.tcppv_type
+      in
+      let spacer = if ctx.ctx_debug_level > 0 then "            \t" else "" in
+      let pname = prefix ^ var.tcppv_name in
+      let vname = var.tcppv_name in
+      let tname = tcpp_to_string var.tcppv_type in
+      match o with
+      | Some { eexpr = TConst TNull } -> ()
+      | Some const when is_renderable_constant const ->
+          ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ " = " ^ pname);
+          ctx.ctx_output
+            (if not_null then
+               ".Default(" ^ default_value_string ctx.ctx_common const ^ ");\n"
+             else
+               ";\n" ^ spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) " ^ vname
+               ^ " = "
+               ^ default_value_string ctx.ctx_common const
+               ^ ";\n")
+      | Some const ->
+          let gen_assign () =
+            gen_default_value_expr ctx dot_name func_name var.tcppv_type (vname ^ " = ") const
+          in
+          if not_null then begin
+            ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ ";\n");
+            ctx.ctx_output (spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) ");
+            gen_assign ();
+            ctx.ctx_output (spacer ^ "\telse " ^ vname ^ " = " ^ pname ^ ";\n")
+          end else begin
+            ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ " = " ^ pname ^ ";\n");
+            ctx.ctx_output (spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) ");
+            gen_assign ()
+          end
+      | _ -> ())
+    args
+
+and gen_default_value_expr ctx dot_name func_name ftype lhs expr =
+  let injection = mk_injection (fun _ -> ()) lhs "" in
+  gen_cpp_ast_expression_tree ctx dot_name func_name [] ftype injection (mk_block expr)
 
 let gen_cpp_init ctx dot_name func_name var_name expr =
   let output = ctx.ctx_output in

--- a/src/generators/cpp/gen/cppGen.ml
+++ b/src/generators/cpp/gen/cppGen.ml
@@ -168,6 +168,11 @@ let cpp_enum_name_of field =
 
 let string_of_path path = "::" ^ join_class_path_remap path "::" ^ "_obj"
 
+let is_renderable_constant value =
+  match value.eexpr with
+  | TConst _ | TField (_, FEnum _) -> true
+  | _ -> false
+
 let default_value_string ctx value =
   match value.eexpr with
   | TConst (TInt i) -> Printf.sprintf "%ld" i
@@ -180,27 +185,46 @@ let default_value_string ctx value =
       string_of_path enum.e_path ^ "::" ^ cpp_enum_name_of field ^ "_dyn()"
   | _ -> "/* Hmmm " ^ s_expr_kind value ^ " */"
 
-let cpp_gen_default_values ctx args prefix =
+let gen_default_value_expr_ref :
+    (context -> string -> string -> tcpp -> string -> texpr -> unit) ref =
+  ref (fun _ _ _ _ _ _ -> die "" __LOC__)
+
+let cpp_gen_default_values ctx dot_name func_name args prefix =
   List.iter
     (fun (var, o) ->
       let not_null =
         type_has_meta_key Meta.NotNull var.tcppv_var.v_type || is_cpp_scalar var.tcppv_type
       in
+      let spacer = if ctx.ctx_debug_level > 0 then "            \t" else "" in
+      let pname = prefix ^ var.tcppv_name in
+      let vname = var.tcppv_name in
+      let tname = tcpp_to_string var.tcppv_type in
       match o with
       | Some { eexpr = TConst TNull } -> ()
-      | Some const ->
-          let spacer = if ctx.ctx_debug_level > 0 then "            \t" else "" in
-          let pname = prefix ^ var.tcppv_name in
-          ctx.ctx_output
-            (spacer ^ "\t" ^ tcpp_to_string var.tcppv_type ^ " " ^ var.tcppv_name ^ " = " ^ pname);
+      | Some const when is_renderable_constant const ->
+          ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ " = " ^ pname);
           ctx.ctx_output
             (if not_null then
                ".Default(" ^ default_value_string ctx.ctx_common const ^ ");\n"
              else
-               ";\n" ^ spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) " ^ var.tcppv_name
+               ";\n" ^ spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) " ^ vname
                ^ " = "
                ^ default_value_string ctx.ctx_common const
                ^ ";\n")
+      | Some const ->
+          let gen_assign () =
+            !gen_default_value_expr_ref ctx dot_name func_name var.tcppv_type (vname ^ " = ") const
+          in
+          if not_null then begin
+            ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ ";\n");
+            ctx.ctx_output (spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) ");
+            gen_assign ();
+            ctx.ctx_output (spacer ^ "\telse " ^ vname ^ " = " ^ pname ^ ";\n")
+          end else begin
+            ctx.ctx_output (spacer ^ "\t" ^ tname ^ " " ^ vname ^ " = " ^ pname ^ ";\n");
+            ctx.ctx_output (spacer ^ "\tif (::hx::IsNull(" ^ pname ^ ")) ");
+            gen_assign ()
+          end
       | _ -> ())
     args
 
@@ -412,7 +436,7 @@ let find_class_implementation func tcpp_class =
   in
 
   match find tcpp_class with
-  | Some func -> 
+  | Some func ->
     print_arg_list func.tcf_args ""
   | _ ->
     ""
@@ -1593,7 +1617,7 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
 
     let prologue = function
       | gc_stack ->
-          cpp_gen_default_values ctx closure.close_args "__o_";
+          cpp_gen_default_values ctx class_name func_name closure.close_args "__o_";
 
           hx_stack_push ctx output_i class_name func_name
             closure.close_expr.cpppos gc_stack;
@@ -1622,6 +1646,12 @@ let gen_cpp_ast_expression_tree ctx class_name func_name function_args function_
   in
 
   gen_with_injection injection cppTree true
+
+let () =
+  gen_default_value_expr_ref :=
+    (fun ctx dot_name func_name ftype lhs expr ->
+      let injection = mk_injection (fun _ -> ()) lhs "" in
+      gen_cpp_ast_expression_tree ctx dot_name func_name [] ftype injection (mk_block expr))
 
 let gen_cpp_init ctx dot_name func_name var_name expr =
   let output = ctx.ctx_output in
@@ -1719,8 +1749,6 @@ let generate_boot ctx boot_enums boot_classes nonboot_classes init_classes (slot
   let newScriptable = Gctx.defined common_ctx Define.Scriptable in
   if newScriptable then (
     output_boot "#include <hx/Scriptable.h>\n";
-
-    
 
     let funcs = StringMap.bindings slots.hash in
     let sorted = List.sort (fun (_, id1) (_, id2) -> id1 - id2) funcs in
@@ -1839,7 +1867,7 @@ let gen_cpp_function_body ctx clazz is_static func_name function_def head_code t
     | gc_stack ->
         let spacer = if no_debug then "\t" else "            \t" in
         let output_i s = output (spacer ^ s) in
-        cpp_gen_default_values ctx function_def.tcf_args "__o_";
+        cpp_gen_default_values ctx dot_name func_name function_def.tcf_args "__o_";
         hx_stack_push ctx output_i dot_name func_name function_def.tcf_func.tf_expr.epos
           gc_stack;
         if ctx.ctx_debug_level >= 2 then (
@@ -1922,7 +1950,7 @@ let generate_constructor ctx out tcpp_class isHeader =
     if isHeader then
       match tcpp_class.tcl_constructor with
       | Some constructor ->
-        let cb no_debug = 
+        let cb no_debug =
           ctx.ctx_real_this_ptr <- false;
           gen_cpp_function_body ctx tcpp_class.tcl_class false "new" constructor "" "" no_debug;
           out "\n";

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -3372,18 +3372,18 @@ and make_fun ?gen_content ctx name fidx f cthis cparent =
 				(match c.eexpr with
 				| TConst (TInt i) -> op ctx (OInt (t,alloc_i32 ctx i))
 				| TConst (TFloat s) -> op ctx (OInt (t,alloc_i32 ctx  (Int32.of_float (float_of_string s))))
-				| _ -> die "" __LOC__)
+				| _ -> op ctx (OMov (t,eval_to ctx c vt)))
 			| GFloat ->
 				(match c.eexpr with
 				| TConst (TInt i) -> op ctx (OFloat (t,alloc_float ctx (Int32.to_float i)))
 				| TConst (TFloat s) -> op ctx (OFloat (t,alloc_float ctx  (float_of_string s)))
-				| _ -> die "" __LOC__)
+				| _ -> op ctx (OMov (t,eval_to ctx c vt)))
 			| GBool ->
 				(match c.eexpr with
 				| TConst (TBool b) -> op ctx (OBool (t,b))
-				| _ -> die "" __LOC__)
+				| _ -> op ctx (OMov (t,eval_to ctx c vt)))
 			| _ ->
-				die "" __LOC__);
+				op ctx (OMov (t,eval_to ctx c vt)));
 			if capt = None then add_assign ctx v;
 			let jend = jump ctx (fun n -> OJAlways n) in
 			j();

--- a/src/generators/genjs.ml
+++ b/src/generators/genjs.ml
@@ -210,11 +210,11 @@ let declare_rest_args_legacy com offset rest_arg =
 	]
 
 let fun_block ctx f p =
-	let e = List.fold_left (fun e (a,c) ->
+	let e = List.fold_right (fun (a,c) e ->
 		match c with
 		| None | Some {eexpr = TConst TNull} -> e
 		| Some c -> Type.concat (Texpr.set_default ctx.com.basic a c p) e
-	) f.tf_expr f.tf_args in
+	) f.tf_args f.tf_expr in
 	e
 
 let open_block ctx =

--- a/src/generators/genlua.ml
+++ b/src/generators/genlua.ml
@@ -243,11 +243,11 @@ let inject_rest_args ctx args e =
 
 let fun_block ctx f p =
     let fn_body = inject_rest_args ctx f.tf_args f.tf_expr in
-    List.fold_left (fun e (a,c) ->
+    List.fold_right (fun (a,c) e ->
         match c with
         | None | Some {eexpr = TConst TNull} -> e
         | Some c -> Type.concat (Texpr.set_default ctx.com.basic a c p) e
-    ) fn_body f.tf_args
+    ) f.tf_args fn_body
 
 let open_block ctx =
     let oldt = ctx.tabs in

--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -767,7 +767,7 @@ let begin_fun ctx args tret el stat p =
 			| TConst (TFloat s) -> HVFloat (float_of_string s)
 			| TConst (TBool b) -> HVBool b
 			| TConst TNull -> abort ("In Flash9, null can't be used as basic type " ^ s_type (print_context()) t) p
-			| _ -> die "" __LOC__)
+			| _ -> abort ("Non-constant default argument values are not supported on the flash target for basic type " ^ s_type (print_context()) t) p)
 		| _, Some {eexpr = TConst TNull} -> HVNone
 		| k, Some c ->
 			write ctx (HReg r.rid);

--- a/src/macro/eval/evalJit.ml
+++ b/src/macro/eval/evalJit.ml
@@ -670,11 +670,10 @@ and jit_tfunction jit static pos tf =
 		| Local slot -> execute_set_local slot
 	) tf.tf_args in
 	let fl = if static then fl else (execute_set_local 0) :: fl in
-	(* Add conditionals for default values. *)
-	let e = List.fold_left (fun e (v,cto) -> match cto with
+	let e = List.fold_right (fun (v,cto) e -> match cto with
 		| None -> e
 		| Some ct -> concat (Texpr.set_default (ctx.curapi.MacroApi.get_com()).Common.basic v ct e.epos) e
-	) tf.tf_expr tf.tf_args in
+	) tf.tf_args tf.tf_expr in
 	let has_final_return el = match List.rev el with
 		| {eexpr = TReturn _} :: _ -> true
 		| _ -> false

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -758,9 +758,6 @@ and expr dce e =
 			Type.iter loop e
 		in
 		loop e
-	| TFunction tf ->
-		List.iter (fun (_,eo) -> match eo with None -> () | Some e -> expr dce e) tf.tf_args;
-		expr dce tf.tf_expr
 	| _ ->
 		Type.iter (expr dce) e
 

--- a/src/optimization/dce.ml
+++ b/src/optimization/dce.ml
@@ -758,6 +758,9 @@ and expr dce e =
 			Type.iter loop e
 		in
 		loop e
+	| TFunction tf ->
+		List.iter (fun (_,eo) -> match eo with None -> () | Some e -> expr dce e) tf.tf_args;
+		expr dce tf.tf_expr
 	| _ ->
 		Type.iter (expr dce) e
 

--- a/src/optimization/inline.ml
+++ b/src/optimization/inline.ml
@@ -583,7 +583,7 @@ object(self)
 					add (mk (TVar (v,eo)) scom.basic.tvoid e.epos);
 				) vl;
 				List.iter (fun (l,e) -> match l.i_default_value with
-					| Some e when l.i_read > 0 -> add (Texpr.set_default scom.basic l.i_subst e e.epos)
+					| Some e when l.i_read > 0 -> add (Texpr.set_default scom.basic l.i_subst (Texpr.duplicate_tvars e_identity e) e.epos)
 					| _ -> ()
 				) _inlined_vars;
 				begin match e.eexpr with

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -26,16 +26,23 @@ let type_function_arg_value ctx t c do_display =
 			let e = type_expr ctx e (WithType.with_type t) in
 			let e = AbstractCast.cast_or_unify ctx t e p in
 			let e = Optimizer.reduce_expression (SafeCom.of_typer ctx) e in
+			let run_analyzer e = !analyzer_run_on_expr_ref ctx.com (Printf.sprintf "%s.%s" (s_type_path ctx.c.curclass.cl_path) ctx.f.curfield.cf_name) e in
+			let rec check_this e = match e.eexpr with
+				| TConst TThis ->
+					raise_typing_error "Cannot access this in a default argument value" e.epos
+				| TLocal v when (match ctx.f.vthis with Some v2 -> v == v2 | None -> false) ->
+					raise_typing_error "Cannot access this in a default argument value" e.epos
+				| _ ->
+					Type.iter check_this e
+			in
+			check_this e;
 			let rec loop analyzered e = match e.eexpr with
 				| TConst _ -> Some e
 				| TField({eexpr = TTypeExpr _},FEnum _) -> Some e
 				| TField({eexpr = TTypeExpr _},FStatic({cl_kind = KAbstractImpl a},cf)) when a.a_enum && has_class_field_flag cf CfEnum -> Some e
 				| TCast(e,None) -> loop analyzered e
-				| _ when not analyzered -> loop true (!analyzer_run_on_expr_ref ctx.com (Printf.sprintf "%s.%s" (s_type_path ctx.c.curclass.cl_path) ctx.f.curfield.cf_name) e)
-				| _ ->
-					if ctx.com.display.dms_kind = DMNone || Common.is_diagnostics ctx.com then
-						Common.display_error ctx.com "Default argument value should be constant" p;
-					None
+				| _ when not analyzered -> loop true (run_analyzer e)
+				| _ -> Some e
 			in
 			loop false e
 

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -4,6 +4,14 @@ open Type
 open Typecore
 open Error
 
+let rec is_flash_native_basic t = match follow t with
+	| TAbstract({a_path=([],("Int"|"Float"|"Bool"))},_) -> true
+	| TAbstract({a_path=(["haxe"],("Int32"|"UInt32"))},_) -> true
+	| TInst({cl_path=([],("Int"|"Float"))},_) -> true
+	| TInst({cl_path=(["haxe"],"Int32")},_) -> true
+	| TEnum({e_path=([],"Bool")},_) -> true
+	| _ -> false
+
 let type_function_arg com t e opt p =
 	(* TODO https://github.com/HaxeFoundation/haxe/issues/8461 *)
 	(* delay ctx PTypeField (fun() ->
@@ -52,7 +60,7 @@ let type_function_arg_value ctx t c do_display =
 				| TField({eexpr = TTypeExpr _},FStatic({cl_kind = KAbstractImpl a},cf)) when a.a_enum && has_class_field_flag cf CfEnum -> Some e
 				| TCast(e,None) -> loop analyzered e
 				| _ when not analyzered && not (references_arg e) -> loop true (run_analyzer e)
-				| _ when ctx.com.platform = Flash && not (is_nullable t) ->
+				| _ when ctx.com.platform = Flash && is_flash_native_basic t ->
 					raise_typing_error ("Non-constant default argument values are not supported on the flash target for basic type " ^ s_type (print_context()) t) p
 				| _ -> Some e
 			in

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -35,7 +35,7 @@ let type_function_arg_value ctx t c do_display =
 			let e = AbstractCast.cast_or_unify ctx t e p in
 			let e = Optimizer.reduce_expression (SafeCom.of_typer ctx) e in
 			let run_analyzer e = !analyzer_run_on_expr_ref ctx.com (Printf.sprintf "%s.%s" (s_type_path ctx.c.curclass.cl_path) ctx.f.curfield.cf_name) e in
-			if ctx.f.curfield.cf_name = "new" then begin
+			if ctx.e.curfun = FunConstructor then begin
 				let rec check_this e = match e.eexpr with
 					| TConst TThis ->
 						raise_typing_error "Cannot access this in a constructor's default argument value" e.epos

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -27,15 +27,17 @@ let type_function_arg_value ctx t c do_display =
 			let e = AbstractCast.cast_or_unify ctx t e p in
 			let e = Optimizer.reduce_expression (SafeCom.of_typer ctx) e in
 			let run_analyzer e = !analyzer_run_on_expr_ref ctx.com (Printf.sprintf "%s.%s" (s_type_path ctx.c.curclass.cl_path) ctx.f.curfield.cf_name) e in
-			let rec check_this e = match e.eexpr with
-				| TConst TThis ->
-					raise_typing_error "Cannot access this in a default argument value" e.epos
-				| TLocal v when (match ctx.f.vthis with Some v2 -> v == v2 | None -> false) ->
-					raise_typing_error "Cannot access this in a default argument value" e.epos
-				| _ ->
-					Type.iter check_this e
-			in
-			check_this e;
+			if ctx.f.curfield.cf_name = "new" then begin
+				let rec check_this e = match e.eexpr with
+					| TConst TThis ->
+						raise_typing_error "Cannot access this in a constructor's default argument value" e.epos
+					| TLocal v when (match ctx.f.vthis with Some v2 -> v == v2 | None -> false) ->
+						raise_typing_error "Cannot access this in a constructor's default argument value" e.epos
+					| _ ->
+						Type.iter check_this e
+				in
+				check_this e
+			end;
 			let references_arg e =
 				let rec loop e = match e.eexpr with
 					| TLocal v when (try PMap.find v.v_name ctx.f.locals == v with Not_found -> false) -> raise Exit

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -36,12 +36,20 @@ let type_function_arg_value ctx t c do_display =
 					Type.iter check_this e
 			in
 			check_this e;
+			let references_arg e =
+				let rec loop e = match e.eexpr with
+					| TLocal v when (try PMap.find v.v_name ctx.f.locals == v with Not_found -> false) -> raise Exit
+					| _ -> Type.iter loop e
+				in
+				try loop e; false with Exit -> true
+			in
 			let rec loop analyzered e = match e.eexpr with
 				| TConst _ -> Some e
+				| TLocal _ -> Some e
 				| TField({eexpr = TTypeExpr _},FEnum _) -> Some e
 				| TField({eexpr = TTypeExpr _},FStatic({cl_kind = KAbstractImpl a},cf)) when a.a_enum && has_class_field_flag cf CfEnum -> Some e
 				| TCast(e,None) -> loop analyzered e
-				| _ when not analyzered -> loop true (run_analyzer e)
+				| _ when not analyzered && not (references_arg e) -> loop true (run_analyzer e)
 				| _ -> Some e
 			in
 			loop false e
@@ -131,6 +139,7 @@ object(self)
 					if do_display && DisplayPosition.display_position#enclosed_in pn then
 						DisplayEmitter.display_variable ctx v pn;
 					if acc = [] && TyperManager.is_coroutine_context ctx then check_coroutine_scope v;
+					if name <> "_" then ctx.f.locals <- PMap.add v.v_name v ctx.f.locals;
 					loop ((v,eo) :: acc) false syntax typed
 				| [],[] ->
 					List.rev acc

--- a/src/typing/functionArguments.ml
+++ b/src/typing/functionArguments.ml
@@ -52,6 +52,8 @@ let type_function_arg_value ctx t c do_display =
 				| TField({eexpr = TTypeExpr _},FStatic({cl_kind = KAbstractImpl a},cf)) when a.a_enum && has_class_field_flag cf CfEnum -> Some e
 				| TCast(e,None) -> loop analyzered e
 				| _ when not analyzered && not (references_arg e) -> loop true (run_analyzer e)
+				| _ when ctx.com.platform = Flash && not (is_nullable t) ->
+					raise_typing_error ("Non-constant default argument values are not supported on the flash target for basic type " ^ s_type (print_context()) t) p
 				| _ -> Some e
 			in
 			loop false e

--- a/src/typing/typeloadFunction.ml
+++ b/src/typing/typeloadFunction.ml
@@ -210,12 +210,12 @@ let add_constructor ctx_c c force_constructor p =
 					let's optimize a bit the output by not always copying the default value
 					into the inherited constructor when it's not necessary for the platform
 				*)
-				let null () = Some (Texpr.Builder.make_null v.v_type v.v_pos) in
+				let null v = Some (Texpr.Builder.make_null v.v_type v.v_pos) in
 				match ctx.com.platform, def with
-				| _, Some _ when not ctx.com.config.pf_static -> v, null()
-				| Flash, Some ({eexpr = TConst (TString _)}) when not (has_class_flag csup CExtern) -> v, null()
+				| _, Some _ when not ctx.com.config.pf_static -> v, null v
+				| Flash, Some ({eexpr = TConst (TString _)}) when not (has_class_flag csup CExtern) -> v, null v
 				| Cpp, Some ({eexpr = TConst (TString _)}) -> v, def
-				| Cpp, Some _ -> { v with v_type = ctx.t.tnull v.v_type }, null()
+				| Cpp, Some _ -> let v = { v with v_type = ctx.t.tnull v.v_type } in v, null v
 				| _ -> v, def
 			in
 			let args = (match cfsup.cf_expr with

--- a/tests/misc/eval/projects/defaultArgConstructorThis/Main.hx
+++ b/tests/misc/eval/projects/defaultArgConstructorThis/Main.hx
@@ -1,0 +1,10 @@
+class C {
+	public var f = 5;
+	public function new(x:Int = this.f) {}
+}
+
+class Main {
+	static function main() {
+		new C();
+	}
+}

--- a/tests/misc/eval/projects/defaultArgConstructorThis/compile-fail.hxml
+++ b/tests/misc/eval/projects/defaultArgConstructorThis/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+--interp

--- a/tests/misc/eval/projects/defaultArgConstructorThis/compile-fail.hxml.stderr
+++ b/tests/misc/eval/projects/defaultArgConstructorThis/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:3: characters 30-34 : Cannot access this in a constructor's default argument value

--- a/tests/misc/flash/projects/defaultArgBasicValueType/Main.hx
+++ b/tests/misc/flash/projects/defaultArgBasicValueType/Main.hx
@@ -1,0 +1,12 @@
+class Helper {
+	public static var seven = 7;
+}
+
+class Main {
+	// non-constant default for a basic value type: unsupported on flash
+	static function f(x:Int = Helper.seven):Int return x;
+
+	static function main() {
+		f();
+	}
+}

--- a/tests/misc/flash/projects/defaultArgBasicValueType/compile-fail.hxml
+++ b/tests/misc/flash/projects/defaultArgBasicValueType/compile-fail.hxml
@@ -1,0 +1,3 @@
+--main Main
+-swf swf.swf
+--no-output

--- a/tests/misc/flash/projects/defaultArgBasicValueType/compile-fail.hxml.stderr
+++ b/tests/misc/flash/projects/defaultArgBasicValueType/compile-fail.hxml.stderr
@@ -1,0 +1,1 @@
+Main.hx:7: characters 28-40 : Non-constant default argument values are not supported on the flash target for basic type Int

--- a/tests/unit/src/unit/TestDefaultArgs.hx
+++ b/tests/unit/src/unit/TestDefaultArgs.hx
@@ -4,7 +4,9 @@ import haxe.Int64;
 
 private class Helper {
 	public static var counter = 0;
-	public static inline final CONST = 7;
+	// non-inline so a default referencing it is genuinely non-constant (and must
+	// survive DCE)
+	public static var seven = 7;
 
 	public static function make():Int {
 		counter++;
@@ -17,8 +19,7 @@ private class Helper {
 }
 
 class TestDefaultArgs extends Test {
-	// --- Non-value-type, non-constant defaults (work everywhere but cpp) ---
-	#if !cpp
+	// --- Non-constant defaults of object/string types (work on every target) ---
 	static function fArr(a:Array<Int> = [1, 2, 3]):Int
 		return a.length;
 
@@ -28,8 +29,10 @@ class TestDefaultArgs extends Test {
 	static function fStr(s:String = "a" + "b"):String
 		return s;
 
+	static function defArr(a:Array<Int> = []):Array<Int>
+		return a;
+
 	public function testNonConstReference() {
-		// array/object/string defaults
 		eq(3, fArr());
 		eq(0, fArr([]));
 		eq(9, fObj());
@@ -44,15 +47,27 @@ class TestDefaultArgs extends Test {
 		eq(0, a2.length);
 	}
 
-	static function defArr(a:Array<Int> = []):Array<Int>
-		return a;
-	#end
+	// --- haxe.Int64 defaults (the original motivation; Int64 is never a TConst) ---
+	static function fI64(v:Int64 = 5):String
+		return Int64.toStr(v);
 
-	// --- Value-type, non-constant defaults. Not supported on cpp (can't
-	//     render the default) nor flash (basic types can't hold the null
-	//     "not passed" sentinel). ---
-	#if (!cpp && !flash)
-	static function fStatic(x:Int = Helper.CONST):Int
+	static function fI64Lit(v:Int64 = 0x7FFFFFFFFFFFFFFFi64):String
+		return Int64.toStr(v);
+
+	static function fI64Neg(v:Int64 = -5i64):String
+		return Int64.toStr(v);
+
+	public function testInt64Default() {
+		eq("5", fI64());
+		eq("42", fI64(42i64));
+		eq("9223372036854775807", fI64Lit());
+		eq("-5", fI64Neg());
+	}
+
+	// --- Non-constant defaults of basic value types. Not supported on flash,
+	//     where a basic type can't hold the `null` "not-passed" sentinel. ---
+	#if !flash
+	static function fStatic(x:Int = Helper.seven):Int
 		return x;
 
 	static function fCall(x:Int = Helper.make()):Int
@@ -74,26 +89,6 @@ class TestDefaultArgs extends Test {
 		// ...and not evaluated at all when the argument is passed
 		eq(100, fCall(100));
 		eq(2, Helper.counter);
-	}
-	#end
-
-	// --- haxe.Int64 defaults (the original motivation). Int64 is a boxed
-	//     value on flash, so only cpp is excluded. ---
-	#if !cpp
-	static function fI64(v:Int64 = 5):String
-		return Int64.toStr(v);
-
-	static function fI64Lit(v:Int64 = 0x7FFFFFFFFFFFFFFFi64):String
-		return Int64.toStr(v);
-
-	static function fI64Neg(v:Int64 = -5i64):String
-		return Int64.toStr(v);
-
-	public function testInt64Default() {
-		eq("5", fI64());
-		eq("42", fI64(42i64));
-		eq("9223372036854775807", fI64Lit());
-		eq("-5", fI64Neg());
 	}
 	#end
 }

--- a/tests/unit/src/unit/TestDefaultArgs.hx
+++ b/tests/unit/src/unit/TestDefaultArgs.hx
@@ -1,0 +1,99 @@
+package unit;
+
+import haxe.Int64;
+
+private class Helper {
+	public static var counter = 0;
+	public static inline final CONST = 7;
+
+	public static function make():Int {
+		counter++;
+		return 40 + counter;
+	}
+
+	public static function reset() {
+		counter = 0;
+	}
+}
+
+class TestDefaultArgs extends Test {
+	// --- Non-value-type, non-constant defaults (work everywhere but cpp) ---
+	#if !cpp
+	static function fArr(a:Array<Int> = [1, 2, 3]):Int
+		return a.length;
+
+	static function fObj(o:{x:Int} = {x: 9}):Int
+		return o.x;
+
+	static function fStr(s:String = "a" + "b"):String
+		return s;
+
+	public function testNonConstReference() {
+		// array/object/string defaults
+		eq(3, fArr());
+		eq(0, fArr([]));
+		eq(9, fObj());
+		eq(5, fObj({x: 5}));
+		eq("ab", fStr());
+		eq("z", fStr("z"));
+
+		// a fresh instance is created on each defaulted call (not shared)
+		var a1 = defArr();
+		var a2 = defArr();
+		a1.push(99);
+		eq(0, a2.length);
+	}
+
+	static function defArr(a:Array<Int> = []):Array<Int>
+		return a;
+	#end
+
+	// --- Value-type, non-constant defaults. Not supported on cpp (can't
+	//     render the default) nor flash (basic types can't hold the null
+	//     "not passed" sentinel). ---
+	#if (!cpp && !flash)
+	static function fStatic(x:Int = Helper.CONST):Int
+		return x;
+
+	static function fCall(x:Int = Helper.make()):Int
+		return x;
+
+	public function testValueTypeDefault() {
+		eq(7, fStatic());
+		eq(3, fStatic(3));
+		// explicit falsy value must win over the default
+		eq(0, fStatic(0));
+	}
+
+	public function testEvaluationTiming() {
+		Helper.reset();
+		// default expression is evaluated on each defaulted call...
+		eq(41, fCall());
+		eq(42, fCall());
+		eq(2, Helper.counter);
+		// ...and not evaluated at all when the argument is passed
+		eq(100, fCall(100));
+		eq(2, Helper.counter);
+	}
+	#end
+
+	// --- haxe.Int64 defaults (the original motivation). Int64 is a boxed
+	//     value on flash, so only cpp is excluded. ---
+	#if !cpp
+	static function fI64(v:Int64 = 5):String
+		return Int64.toStr(v);
+
+	static function fI64Lit(v:Int64 = 0x7FFFFFFFFFFFFFFFi64):String
+		return Int64.toStr(v);
+
+	static function fI64Neg(v:Int64 = -5i64):String
+		return Int64.toStr(v);
+
+	public function testInt64Default() {
+		eq("5", fI64());
+		eq("42", fI64(42i64));
+		eq("9223372036854775807", fI64Lit());
+		eq("-5", fI64Neg());
+	}
+	#end
+}

--- a/tests/unit/src/unit/TestDefaultArgs.hx
+++ b/tests/unit/src/unit/TestDefaultArgs.hx
@@ -90,5 +90,22 @@ class TestDefaultArgs extends Test {
 		eq(100, fCall(100));
 		eq(2, Helper.counter);
 	}
+
+	// --- A default value may reference a preceding argument ---
+	static function fSibling(a:Int, b:Int = a):Int
+		return a + b;
+
+	static function fChain(a:Int = 1, b:Int = a, c:Int = b):String
+		return '$a,$b,$c';
+
+	public function testSiblingArg() {
+		eq(10, fSibling(5));
+		eq(8, fSibling(5, 3));
+		// chained defaults are injected in argument order
+		eq("1,1,1", fChain());
+		eq("2,2,2", fChain(2));
+		eq("2,3,3", fChain(2, 3));
+		eq("2,3,4", fChain(2, 3, 4));
+	}
 	#end
 }

--- a/tests/unit/src/unit/TestDefaultArgs.hx
+++ b/tests/unit/src/unit/TestDefaultArgs.hx
@@ -107,5 +107,20 @@ class TestDefaultArgs extends Test {
 		eq("2,3,3", fChain(2, 3));
 		eq("2,3,4", fChain(2, 3, 4));
 	}
+
+	// --- A (non-constructor) method default may reference `this` ---
+	var instanceField = 10;
+
+	function mThis(x:Int = this.instanceField):Int
+		return x;
+
+	public function testThisInDefault() {
+		instanceField = 10;
+		eq(10, mThis());
+		eq(3, mThis(3));
+		// evaluated at call time
+		instanceField = 99;
+		eq(99, mThis());
+	}
 	#end
 }

--- a/tests/unit/src/unit/TestInt64.hx
+++ b/tests/unit/src/unit/TestInt64.hx
@@ -655,8 +655,6 @@ class TestInt64 extends Test {
 		f(x < x);
 	}
 
-	#if !cpp
-	// Default argument values for haxe.Int64 (int and i64 literals), not yet supported on cpp
 	static function defI64(i:Int64 = 0i64):Int64 return i;
 	static function defInt(i:Int64 = 7):Int64 return i;
 	static function defNeg(i:Int64 = -5i64):Int64 return i;
@@ -672,5 +670,4 @@ class TestInt64 extends Test {
 		// passed value must win over the default
 		eq("9223372036854775807", defI64(0x7FFFFFFFFFFFFFFFi64).toStr());
 	}
-	#end
 }

--- a/tests/unit/src/unit/TestInt64.hx
+++ b/tests/unit/src/unit/TestInt64.hx
@@ -654,4 +654,23 @@ class TestInt64 extends Test {
 		t(x - 1 < x);
 		f(x < x);
 	}
+
+	#if !cpp
+	// Default argument values for haxe.Int64 (int and i64 literals), not yet supported on cpp
+	static function defI64(i:Int64 = 0i64):Int64 return i;
+	static function defInt(i:Int64 = 7):Int64 return i;
+	static function defNeg(i:Int64 = -5i64):Int64 return i;
+	static function defOpt(?i:Int64 = 100):Int64 return i;
+
+	public function testDefaultArg() {
+		eq("0", defI64().toStr());
+		eq("42", defI64(42i64).toStr());
+		eq("7", defInt().toStr());
+		eq("-5", defNeg().toStr());
+		eq("100", defOpt().toStr());
+		eq("3", defOpt(3i64).toStr());
+		// passed value must win over the default
+		eq("9223372036854775807", defI64(0x7FFFFFFFFFFFFFFFi64).toStr());
+	}
+	#end
 }

--- a/tests/unit/src/unit/TestMain.hx
+++ b/tests/unit/src/unit/TestMain.hx
@@ -46,6 +46,7 @@ function main() {
 		new TestJson(),
 		new TestResource(),
 		new TestInt64(),
+		new TestDefaultArgs(),
 		new TestReflect(),
 		new TestSerialize(),
 		new TestSerializerCrossTarget(),


### PR DESCRIPTION
Previously a default argument value had to reduce to a compile-time constant. Drop that restriction: any analyzed expression is kept and each generator materializes it on the not-passed path via the existing if-null injection.

Notes:
- flash only supports this for object types; basic value types can't hold the null "not-passed" sentinel
- A constructor argument default value cannot reference 'this' (same restriction as member variable initializers)

Closes #12923 