### PR TITLE
[hl] generate cache slots for inherited interfaces

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -686,15 +686,24 @@ and class_type ?(tref=None) ctx c pl statics =
 		) (if statics then c.cl_ordered_statics else c.cl_ordered_fields);
 		if not statics then begin
 			(* add interfaces *)
-			List.iter (fun (i,pl) ->
-				if not (has_class_flag i CExtern) then begin
+			let seen = ref PMap.empty in
+			let rec add_interface i pl =
+				if not (has_class_flag i CExtern) && not (PMap.mem i.cl_path !seen) then begin
+					seen := PMap.add i.cl_path () !seen;
 					let rid = ref (-1) in
 					rid := add_field "" (fun() ->
 						let t = to_type ctx (TInst (i,pl)) in
 						p.pinterfaces <- PMap.add t !rid p.pinterfaces;
 						t
 					);
+					List.iter (fun (si,spl) ->
+						let spl = List.map (apply_params i.cl_params pl) spl in
+						add_interface si spl
+					) i.cl_implements;
 				end;
+			in
+			List.iter (fun (i,pl) ->
+				add_interface i pl
 			) c.cl_implements;
 			(* check toString *)
 			(try

--- a/tests/hlcode/src/cases/HlInterfaceCastTests.hx
+++ b/tests/hlcode/src/cases/HlInterfaceCastTests.hx
@@ -1,0 +1,55 @@
+package cases;
+
+private interface IBase {
+	function base():Int;
+}
+
+private interface IChild extends IBase {
+	function child():Int;
+}
+
+private class Impl implements IChild {
+	public function new() {}
+	public function base():Int return 1;
+	public function child():Int return 2;
+}
+
+class HlInterfaceCastTests {
+	@:hl(<>
+		fun@N(Nh) ():i32
+		r0 cases._HlInterfaceCastTests.Impl
+		r1 void
+		r2 virtual(base:method:():i32)
+		r3 virtual(base:method:():i32,child:method:():i32)
+		r4 i32
+		r5 i32
+		.22    @0 new 0
+		.22    @1 call 1, cases._HlInterfaceCastTests.Impl.new(0)
+		.23    @2 jnotnull 0,2
+		.23    @3 null 2
+		.23    @4 jalways 4
+		.23    @5 field 2,0[1]
+		.23    @6 jnotnull 2,2
+		.23    @7 tovirtual 2,0
+		.23    @8 setfield 0[1],2
+		.24    @9 jnotnull 0,2
+		.24    @A null 3
+		.24    @B jalways 4
+		.24    @C field 3,0[0]
+		.24    @D jnotnull 3,2
+		.24    @E tovirtual 3,0
+		.24    @F setfield 0[0],3
+		.25    @10 nullcheck 2
+		.25    @11 callmethod 4, 2[0]()
+		.25    @12 nullcheck 3
+		.25    @13 callmethod 5, 3[1]()
+		.25    @14 add 4,4,5
+		.25    @15 ret 4
+	</>)
+	static public function testParentAndChildVirtualSlots() {
+		var obj = new Impl();
+		var base:IBase = obj;
+		var child:IChild = obj;
+		return base.base() + child.child();
+	}
+}


### PR DESCRIPTION
Previously, HL only generated cache fields for interfaces directly implemented by a class or its superclasses. This PR also generates cache fields for inherited interfaces (dedup with `i.cl_path`).

https://github.com/HaxeFoundation/haxe/blob/17ff4c50cff84a010e19621af843a335b9542b7c/src/generators/genhl.ml#L1198-L1207

- Fixes #12926 