### PR TITLE
[hl] plugin do not exclude interface

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -372,7 +372,7 @@ let fake_tnull =
 	}
 
 let is_excluded c =
-	has_class_flag c CExcluded
+	has_class_flag c CExcluded && not (has_class_flag c CInterface)
 
 let get_rec_cache ctx t none_callback not_found_callback =
 	try


### PR DESCRIPTION
https://github.com/HaxeFoundation/hashlink/issues/945#issuecomment-4743720094
> interfaces are compiled as virtuals, not named objects, and since they don't contain any implementation they don't need to be excluded. The haxe compiler should not try to generate runtime type loading for these.