### PR TITLE
Set up the project and document how to debug the compiler using `ocamldebug`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 
 /src/version.ml
 /haxe
+/haxe.debug
 /haxelib*
 /haxedoc*
 /lib

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ haxe:
 	dune build --profile release src/haxe.exe
 	cp -f _build/default/src/haxe.exe ./"$(HAXE_OUTPUT)"
 
+haxe.debug:
+	dune build src/haxe.bc
+	cp -f _build/default/src/haxe.bc ./"$(HAXE_OUTPUT).debug"
+
 plugin: haxe
 	$(DUNE_COMMAND) build --profile release plugins/$(PLUGIN)/$(PLUGIN).cmxs
 	mkdir -p plugins/$(PLUGIN)/cmxs/$(SYSTEM_NAME)
@@ -238,10 +242,10 @@ package_installer_mac: $(INSTALLER_TMP_DIR)/neko-osx.tar.gz package_unix
 clean: clean_haxe clean_tools clean_package
 
 clean_haxe:
-	rm -f -r _build $(HAXE_OUTPUT) $(PREBUILD_OUTPUT)
+	rm -f -r _build $(HAXE_OUTPUT) $(HAXE_OUTPUT).debug $(PREBUILD_OUTPUT)
 
 clean_tools:
-	rm -f $(HAXE_OUTPUT) $(PREBUILD_OUTPUT) $(HAXELIB_OUTPUT)
+	rm -f $(HAXE_OUTPUT) $(PREBUILD_OUTPUT) $(HAXE_OUTPUT).debug $(HAXELIB_OUTPUT)
 
 clean_package:
 	rm -rf $(PACKAGE_OUT_DIR)
@@ -256,7 +260,7 @@ FORCE:
 .ml.cmo:
 	$(CC_CMD)
 
-.PHONY: haxe haxelib
+.PHONY: haxe haxe.debug haxelib
 
 # our "all:" target doens't work in parallel mode
 .NOTPARALLEL:

--- a/extra/DEBUG.md
+++ b/extra/DEBUG.md
@@ -1,0 +1,36 @@
+Run
+```
+make haxe.debug
+```
+
+Set the following environment variables before calling `ocamldebug`.
+```
+export LD_PRELOAD=$(pkg-config --variable=libdir libuv)/libuv.so
+export HAXE_STD_PATH=/path/to/haxe/std
+export CAML_LD_LIBRARY_PATH=/path/to/haxe/_build/default/libs/pcre2:/path/to/haxe/_build/default/libs/mbedtls:/path/to/haxe/_build/default/libs/extc:/path/to/haxe/_build/default/libs/extc:/path/to/haxe/_build/default/libs/objsize:$CAML_LD_LIBRARY_PATH
+```
+
+If the last one doesn't take, add it as a prefix to `ocamldebug`.
+Add the following commands to your `.ocamldebug`, or run them first when starting it.
+```
+directory /path/to/haxe/_build/default/
+directory /path/to/haxe/_build/default/src/.haxe.eobjs/byte
+directory /path/to/haxe/_build/default/src/.haxe.objs/byte
+directory /path/to/haxe/_build/default/libs/extc/.extc.objs/byte
+directory /path/to/haxe/_build/default/libs/extc/.extproc.objs/byte
+directory /path/to/haxe/_build/default/libs/extlib-leftovers/.extlib_leftovers.objs/byte
+directory /path/to/haxe/_build/default/libs/ilib/.ilib.objs/byte
+directory /path/to/haxe/_build/default/libs/javalib/.javalib.objs/byte
+directory /path/to/haxe/_build/default/libs/json/.json.objs/byte
+directory /path/to/haxe/_build/default/libs/mbedtls/.mbedtls.objs/byte
+directory /path/to/haxe/_build/default/libs/neko/.neko.objs/byte
+directory /path/to/haxe/_build/default/libs/objsize/.objsize.objs/byte
+directory /path/to/haxe/_build/default/libs/pcre2/.pcre2.objs/byte
+directory /path/to/haxe/_build/default/libs/swflib/.swflib.objs/byte
+directory /path/to/haxe/_build/default/libs/ttflib/.ttflib.objs/byte
+directory /path/to/haxe/_build/default/libs/ziplib/.ziplib.objs/byte
+```
+
+
+Tips:
+On Unix use `rlwrap ocamldebug /path/to/haxe.debug <base.hxml>` for sensible QOL.

--- a/libs/extc/dune
+++ b/libs/extc/dune
@@ -6,6 +6,7 @@
 	(foreign_stubs
 		(language c)
 		(names extc_stubs))
+        (c_library_flags -lz)
 	(modules extc)
 	(wrapped false)
 )

--- a/libs/mbedtls/dune
+++ b/libs/mbedtls/dune
@@ -5,5 +5,6 @@
 	(foreign_stubs
 		(language c)
 		(names mbedtls_stubs))
+        (c_library_flags -lmbedtls -lmbedx509 -lmbedcrypto)
 	(wrapped false)
 )

--- a/libs/pcre2/dune
+++ b/libs/pcre2/dune
@@ -5,5 +5,6 @@
 	(foreign_stubs
 		(language c)
 		(names pcre2_stubs))
+        (c_library_flags -lpcre2-8)
 	(wrapped false)
 )

--- a/src/context/abstractCast.ml
+++ b/src/context/abstractCast.ml
@@ -1,5 +1,4 @@
 open Globals
-open Common
 open Ast
 open Type
 open Typecore

--- a/src/dune
+++ b/src/dune
@@ -52,6 +52,5 @@
 	(libraries haxe)
 	(modules haxe)
 	(link_flags (:include libs.sexp))
-	; Uncomment to enable bytecode output for ocamldebug support
-	; (modes byte)
+	(modes byte native)
 )


### PR DESCRIPTION
Since `ocamldebug` doesn't support domains (yet?), this PR is not as useful as I originally thought it was going to be.
I was however able to use it very successfully when investigating a bug in 4.3.7.

I just figured I should share it and let you guys decide whether you want it or not.