### PR TITLE
[ci] Update hardcoded nodejs version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -439,7 +439,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: matrix.target == 'js'
         with:
-          node-version: 18.17.1
+          node-version: 24
 
       # - name: Quick test
       #   shell: pwsh


### PR DESCRIPTION
It was locked to node 18 in #11325 due to some libuv bugs with unicode on windows.

However, those have since been solved in libuv:
- https://github.com/libuv/libuv/pull/4092
- https://github.com/libuv/libuv/pull/5021

Node 24 includes libuv 1.52, which includes both these fixes: https://github.com/nodejs/node/commit/493ac40e1277b2021ad5719e09c13c904c5b027d