### PR TITLE
[typer] snapshot only unbound monomorphs in monomorph_transaction

### DIFF
--- a/src/context/typecore.ml
+++ b/src/context/typecore.ml
@@ -392,11 +392,14 @@ let spawn_monomorph ctx p =
 	TMono (spawn_monomorph' ctx p)
 
 let monomorph_transaction ctx =
-	let known = List.map (fun (m,_) -> m,m.tm_type,m.tm_down_constraints) ctx.e.monomorphs in
 	let current = ctx.e.monomorphs in
+	let known = List.fold_left (fun acc (m,_) -> match m.tm_type with
+		| None -> (m,m.tm_down_constraints) :: acc
+		| Some _ -> acc
+	) [] current in
 	(fun () ->
-		List.iter (fun (m,t,constr) ->
-			if t != m.tm_type then m.tm_type <- t;
+		List.iter (fun (m,constr) ->
+			(match m.tm_type with Some _ -> m.tm_type <- None | None -> ());
 			if constr != m.tm_down_constraints then m.tm_down_constraints <- constr;
 		) known;
 		ctx.e.monomorphs <- current


### PR DESCRIPTION
`monomorph_transaction` allocated a snapshot tuple for every entry in `ctx.e.monomorphs`, which accumulates every monomorph created while typing a field body. The vast majority are already bound, and a bound monomorph is single-assignment (`do_bind` asserts `tm_type = None` and clears constraints; unification follows through it rather than rebinding it), so restoring it is always a no-op. Snapshot only the unbound monomorphs.

Fixes the typing-time regression from #12945