### PR TITLE
[hl] Fix Out of Memory failures

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -26,6 +26,21 @@ open Type
 open Error
 open Gctx
 open Hlcode
+open Tanon_identification
+
+(* Unification context for identifying anonymous structures in [anons_cache] (see
+   #12718). Using tanon_identification (which unifies via recursion-guarded stacks)
+   instead of a structural compare avoids looping forever on cyclic recursive anons.
+   - strict already implies null_follow_mode = NeverFollow, so Null<T> and T stay
+     distinct (HL uses a different field type for each)
+   - allow_optional_mismatch: { ?node:T } and { node:T } yield the same virtual
+   - opaque_field_params: treat cf_params as opaque so two uses of the same generic
+     method are equal rather than instantiated against concrete types *)
+let anon_id_uctx = {
+	AnonIdMode.strict with
+	allow_optional_mismatch = true;
+	opaque_field_params = true;
+}
 
 (* compiler *)
 
@@ -105,7 +120,8 @@ type context = {
 	defined_funs : (int,unit) Hashtbl.t;
 	mutable cached_types : (string list, ttype) PMap.t;
 	mutable m : method_context;
-	mutable anons_cache : (tanon, ttype) PMap.t;
+	anon_id : ttype tanon_identification;
+	anons_cache : (path, ttype) Hashtbl.t;
 	mutable method_wrappers : ((ttype * ttype), int) PMap.t;
 	mutable rec_cache : (Type.t * ttype option ref) list;
 	mutable cached_tuples : (ttype list, ttype) PMap.t;
@@ -374,100 +390,6 @@ let fake_tnull =
 let is_excluded c =
 	has_class_flag c CExcluded && not (has_class_flag c CInterface)
 
-(*
-	Cycle-safe structural total order on tanon, used as the [anons_cache] PMap key
-	comparator instead of OCaml's polymorphic compare.
-
-	Recursive anonymous structures (e.g. `typedef T = { var node : T; }`) produce
-	tanons that are cyclic in memory. Comparing two *distinct* such cyclic tanons with
-	polymorphic compare loops forever, growing the compare stack until Out_of_memory.
-	We break the cycle at repeated TAnon nodes via De Bruijn levels.
-
-	The comparison only inspects what actually determines the generated HVirtual (see
-	[cfield_type]): each field's name, its type, and whether it is a method (HFun is
-	turned into HMethod). It therefore reports two anons equal exactly when they yield
-	the same virtual, so a wrong cache hit is impossible; at worst a missed match
-	produces a harmless duplicate virtual. The `t1 == t2` fast path mirrors polymorphic
-	compare on physically shared types (interned protos, a reused recursive anon), so
-	non-cyclic inputs keep the same dedup behaviour as before.
-*)
-let tanon_compare a1 a2 =
-	let seen1 = ref [] and seen2 = ref [] and depth = ref 0 in
-	let level seen an =
-		let rec loop = function
-			| [] -> None
-			| (an',d) :: l -> if an' == an then Some d else loop l
-		in
-		loop !seen
-	in
-	let tag = function
-		| TMono _ -> 0 | TEnum _ -> 1 | TInst _ -> 2 | TType _ -> 3 | TFun _ -> 4
-		| TAnon _ -> 5 | TDynamic _ -> 6 | TLazy _ -> 7 | TAbstract _ -> 8
-	in
-	let is_method cf = match cf.cf_kind with Method (MethNormal | MethInline) -> true | _ -> false in
-	(* mirror to_type: see through bound monomorphs and lazy types so that types
-	   to_type would generate identically compare equal (and, crucially, two
-	   distinct lazy/mono types are never wrongly merged). *)
-	let rec reduce t = match t with
-		| TMono { tm_type = Some t } -> reduce t
-		| TLazy f -> reduce (lazy_type f)
-		| _ -> t
-	in
-	let rec cmp_t t1 t2 =
-		let t1 = reduce t1 and t2 = reduce t2 in
-		if t1 == t2 then 0 else
-		match t1, t2 with
-		| TAnon an1, TAnon an2 -> cmp_anon an1 an2
-		| TMono _, TMono _ -> 0 (* both unbound -> to_type maps both to HDyn *)
-		| TInst (c1,tl1), TInst (c2,tl2) -> let c = compare c1.cl_path c2.cl_path in if c <> 0 then c else cmp_tl tl1 tl2
-		| TEnum (e1,tl1), TEnum (e2,tl2) -> let c = compare e1.e_path e2.e_path in if c <> 0 then c else cmp_tl tl1 tl2
-		| TType (d1,tl1), TType (d2,tl2) -> let c = compare d1.t_path d2.t_path in if c <> 0 then c else cmp_tl tl1 tl2
-		| TAbstract (a1,tl1), TAbstract (a2,tl2) -> let c = compare a1.a_path a2.a_path in if c <> 0 then c else cmp_tl tl1 tl2
-		| TFun (args1,ret1), TFun (args2,ret2) -> let c = cmp_args args1 args2 in if c <> 0 then c else cmp_t ret1 ret2
-		| TDynamic d1, TDynamic d2 ->
-			(match d1, d2 with
-			| None, None -> 0
-			| None, _ -> -1
-			| _, None -> 1
-			| Some t1, Some t2 -> cmp_t t1 t2)
-		| _ -> compare (tag t1) (tag t2)
-	and cmp_tl l1 l2 = match l1, l2 with
-		| [], [] -> 0
-		| [], _ -> -1
-		| _, [] -> 1
-		| t1 :: l1, t2 :: l2 -> let c = cmp_t t1 t2 in if c <> 0 then c else cmp_tl l1 l2
-	and cmp_args l1 l2 = match l1, l2 with
-		| [], [] -> 0
-		| [], _ -> -1
-		| _, [] -> 1
-		| (n1,o1,t1) :: l1, (n2,o2,t2) :: l2 ->
-			let c = compare (n1 : string) n2 in if c <> 0 then c else
-			let c = compare (o1 : bool) o2 in if c <> 0 then c else
-			let c = cmp_t t1 t2 in if c <> 0 then c else cmp_args l1 l2
-	and cmp_anon an1 an2 =
-		match level seen1 an1, level seen2 an2 with
-		| Some d1, Some d2 -> compare d1 d2
-		| Some _, None -> -1
-		| None, Some _ -> 1
-		| None, None ->
-			let d = !depth in
-			seen1 := (an1,d) :: !seen1;
-			seen2 := (an2,d) :: !seen2;
-			incr depth;
-			let fields an = List.sort (fun (n1,_) (n2,_) -> compare (n1 : string) n2) (PMap.foldi (fun n cf acc -> (n,cf) :: acc) an.a_fields []) in
-			let rec loop l1 l2 = match l1, l2 with
-				| [], [] -> 0
-				| [], _ -> -1
-				| _, [] -> 1
-				| (n1,cf1) :: l1, (n2,cf2) :: l2 ->
-					let c = compare (n1 : string) n2 in if c <> 0 then c else
-					let c = compare (is_method cf1) (is_method cf2) in if c <> 0 then c else
-					let c = cmp_t cf1.cf_type cf2.cf_type in if c <> 0 then c else loop l1 l2
-			in
-			loop (fields an1) (fields an2)
-	in
-	cmp_anon a1 a2
-
 (* Cycle-safe comparators for the other ttype-keyed genhl caches (see ttype_compare). *)
 let rec ttype_list_compare l1 l2 = match l1, l2 with
 	| [], [] -> 0
@@ -521,10 +443,9 @@ let rec to_type ?tref ctx t =
 		| _ -> die "" __LOC__)
 	| TAnon a ->
 		if PMap.is_empty a.a_fields then HDyn else
+		let pfm = ctx.anon_id#identify_anon anon_id_uctx a in
 		(try
-			(* can't use physical comparison in PMap since addresses might change in GC compact,
-				maybe add an uid to tanon if too slow ? *)
-			PMap.find a ctx.anons_cache
+			Hashtbl.find ctx.anons_cache pfm.pfm_path
 		with Not_found ->
 			let vp = {
 				vfields = [||];
@@ -534,7 +455,7 @@ let rec to_type ?tref ctx t =
 			(match tref with
 			| None -> ()
 			| Some r -> r := Some t);
-			ctx.anons_cache <- PMap.add a t ctx.anons_cache;
+			Hashtbl.add ctx.anons_cache pfm.pfm_path t;
 			let fields = PMap.fold (fun cf acc -> cfield_type ctx cf :: acc) a.a_fields [] in
 			let fields = List.sort (fun (n1,_,_) (n2,_,_) -> compare n1 n2) fields in
 			vp.vfields <- Array.of_list fields;
@@ -4339,7 +4260,8 @@ let create_context com =
 		core_type = get_class "CoreType";
 		core_enum = get_class "CoreEnum";
 		ref_abstract = get_abstract "Ref";
-		anons_cache = PMap.create tanon_compare;
+		anon_id = new tanon_identification;
+		anons_cache = Hashtbl.create 0;
 		rec_cache = [];
 		method_wrappers = PMap.create ttype_pair_compare;
 		cdebug_files = new_lookup();

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -468,6 +468,16 @@ let tanon_compare a1 a2 =
 	in
 	cmp_anon a1 a2
 
+(* Cycle-safe comparators for the other ttype-keyed genhl caches (see ttype_compare). *)
+let rec ttype_list_compare l1 l2 = match l1, l2 with
+	| [], [] -> 0
+	| [], _ -> -1
+	| _, [] -> 1
+	| t1 :: l1, t2 :: l2 -> let c = ttype_compare t1 t2 in if c <> 0 then c else ttype_list_compare l1 l2
+
+let ttype_pair_compare (a1,b1) (a2,b2) =
+	let c = ttype_compare a1 a2 in if c <> 0 then c else ttype_compare b1 b2
+
 let get_rec_cache ctx t none_callback not_found_callback =
 	try
 		match !(snd (List.find (fun (t',_) -> fast_eq t' t) ctx.rec_cache)) with
@@ -4294,7 +4304,7 @@ let create_context com =
 		cfunctions = DynArray.create();
 		overrides = Hashtbl.create 0;
 		cached_types = PMap.empty;
-		cached_tuples = PMap.empty;
+		cached_tuples = PMap.create ttype_list_compare;
 		cfids = new_lookup();
 		defined_funs = Hashtbl.create 0;
 		tstring = HVoid;
@@ -4331,7 +4341,7 @@ let create_context com =
 		ref_abstract = get_abstract "Ref";
 		anons_cache = PMap.create tanon_compare;
 		rec_cache = [];
-		method_wrappers = PMap.empty;
+		method_wrappers = PMap.create ttype_pair_compare;
 		cdebug_files = new_lookup();
 		macro_typedefs = Hashtbl.create 0;
 		ct_delayed = [];

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -390,16 +390,6 @@ let fake_tnull =
 let is_excluded c =
 	has_class_flag c CExcluded && not (has_class_flag c CInterface)
 
-(* Cycle-safe comparators for the other ttype-keyed genhl caches (see ttype_compare). *)
-let rec ttype_list_compare l1 l2 = match l1, l2 with
-	| [], [] -> 0
-	| [], _ -> -1
-	| _, [] -> 1
-	| t1 :: l1, t2 :: l2 -> let c = ttype_compare t1 t2 in if c <> 0 then c else ttype_list_compare l1 l2
-
-let ttype_pair_compare (a1,b1) (a2,b2) =
-	let c = ttype_compare a1 a2 in if c <> 0 then c else ttype_compare b1 b2
-
 let get_rec_cache ctx t none_callback not_found_callback =
 	try
 		match !(snd (List.find (fun (t',_) -> fast_eq t' t) ctx.rec_cache)) with

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -241,7 +241,7 @@ let method_context id t captured hasthis =
 		mregs = new_lookup();
 		mops = DynArray.create();
 		mvars = Hashtbl.create 0;
-		mallocs = PMap.empty;
+		mallocs = PMap.create ttype_compare;
 		mret = t;
 		mbreaks = [];
 		mdeclared = [];
@@ -373,6 +373,100 @@ let fake_tnull =
 
 let is_excluded c =
 	has_class_flag c CExcluded && not (has_class_flag c CInterface)
+
+(*
+	Cycle-safe structural total order on tanon, used as the [anons_cache] PMap key
+	comparator instead of OCaml's polymorphic compare.
+
+	Recursive anonymous structures (e.g. `typedef T = { var node : T; }`) produce
+	tanons that are cyclic in memory. Comparing two *distinct* such cyclic tanons with
+	polymorphic compare loops forever, growing the compare stack until Out_of_memory.
+	We break the cycle at repeated TAnon nodes via De Bruijn levels.
+
+	The comparison only inspects what actually determines the generated HVirtual (see
+	[cfield_type]): each field's name, its type, and whether it is a method (HFun is
+	turned into HMethod). It therefore reports two anons equal exactly when they yield
+	the same virtual, so a wrong cache hit is impossible; at worst a missed match
+	produces a harmless duplicate virtual. The `t1 == t2` fast path mirrors polymorphic
+	compare on physically shared types (interned protos, a reused recursive anon), so
+	non-cyclic inputs keep the same dedup behaviour as before.
+*)
+let tanon_compare a1 a2 =
+	let seen1 = ref [] and seen2 = ref [] and depth = ref 0 in
+	let level seen an =
+		let rec loop = function
+			| [] -> None
+			| (an',d) :: l -> if an' == an then Some d else loop l
+		in
+		loop !seen
+	in
+	let tag = function
+		| TMono _ -> 0 | TEnum _ -> 1 | TInst _ -> 2 | TType _ -> 3 | TFun _ -> 4
+		| TAnon _ -> 5 | TDynamic _ -> 6 | TLazy _ -> 7 | TAbstract _ -> 8
+	in
+	let is_method cf = match cf.cf_kind with Method (MethNormal | MethInline) -> true | _ -> false in
+	(* mirror to_type: see through bound monomorphs and lazy types so that types
+	   to_type would generate identically compare equal (and, crucially, two
+	   distinct lazy/mono types are never wrongly merged). *)
+	let rec reduce t = match t with
+		| TMono { tm_type = Some t } -> reduce t
+		| TLazy f -> reduce (lazy_type f)
+		| _ -> t
+	in
+	let rec cmp_t t1 t2 =
+		let t1 = reduce t1 and t2 = reduce t2 in
+		if t1 == t2 then 0 else
+		match t1, t2 with
+		| TAnon an1, TAnon an2 -> cmp_anon an1 an2
+		| TMono _, TMono _ -> 0 (* both unbound -> to_type maps both to HDyn *)
+		| TInst (c1,tl1), TInst (c2,tl2) -> let c = compare c1.cl_path c2.cl_path in if c <> 0 then c else cmp_tl tl1 tl2
+		| TEnum (e1,tl1), TEnum (e2,tl2) -> let c = compare e1.e_path e2.e_path in if c <> 0 then c else cmp_tl tl1 tl2
+		| TType (d1,tl1), TType (d2,tl2) -> let c = compare d1.t_path d2.t_path in if c <> 0 then c else cmp_tl tl1 tl2
+		| TAbstract (a1,tl1), TAbstract (a2,tl2) -> let c = compare a1.a_path a2.a_path in if c <> 0 then c else cmp_tl tl1 tl2
+		| TFun (args1,ret1), TFun (args2,ret2) -> let c = cmp_args args1 args2 in if c <> 0 then c else cmp_t ret1 ret2
+		| TDynamic d1, TDynamic d2 ->
+			(match d1, d2 with
+			| None, None -> 0
+			| None, _ -> -1
+			| _, None -> 1
+			| Some t1, Some t2 -> cmp_t t1 t2)
+		| _ -> compare (tag t1) (tag t2)
+	and cmp_tl l1 l2 = match l1, l2 with
+		| [], [] -> 0
+		| [], _ -> -1
+		| _, [] -> 1
+		| t1 :: l1, t2 :: l2 -> let c = cmp_t t1 t2 in if c <> 0 then c else cmp_tl l1 l2
+	and cmp_args l1 l2 = match l1, l2 with
+		| [], [] -> 0
+		| [], _ -> -1
+		| _, [] -> 1
+		| (n1,o1,t1) :: l1, (n2,o2,t2) :: l2 ->
+			let c = compare (n1 : string) n2 in if c <> 0 then c else
+			let c = compare (o1 : bool) o2 in if c <> 0 then c else
+			let c = cmp_t t1 t2 in if c <> 0 then c else cmp_args l1 l2
+	and cmp_anon an1 an2 =
+		match level seen1 an1, level seen2 an2 with
+		| Some d1, Some d2 -> compare d1 d2
+		| Some _, None -> -1
+		| None, Some _ -> 1
+		| None, None ->
+			let d = !depth in
+			seen1 := (an1,d) :: !seen1;
+			seen2 := (an2,d) :: !seen2;
+			incr depth;
+			let fields an = List.sort (fun (n1,_) (n2,_) -> compare (n1 : string) n2) (PMap.foldi (fun n cf acc -> (n,cf) :: acc) an.a_fields []) in
+			let rec loop l1 l2 = match l1, l2 with
+				| [], [] -> 0
+				| [], _ -> -1
+				| _, [] -> 1
+				| (n1,cf1) :: l1, (n2,cf2) :: l2 ->
+					let c = compare (n1 : string) n2 in if c <> 0 then c else
+					let c = compare (is_method cf1) (is_method cf2) in if c <> 0 then c else
+					let c = cmp_t cf1.cf_type cf2.cf_type in if c <> 0 then c else loop l1 l2
+			in
+			loop (fields an1) (fields an2)
+	in
+	cmp_anon a1 a2
 
 let get_rec_cache ctx t none_callback not_found_callback =
 	try
@@ -4235,7 +4329,7 @@ let create_context com =
 		core_type = get_class "CoreType";
 		core_enum = get_class "CoreEnum";
 		ref_abstract = get_abstract "Ref";
-		anons_cache = PMap.empty;
+		anons_cache = PMap.create tanon_compare;
 		rec_cache = [];
 		method_wrappers = PMap.empty;
 		cdebug_files = new_lookup();

--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -28,14 +28,6 @@ open Gctx
 open Hlcode
 open Tanon_identification
 
-(* Unification context for identifying anonymous structures in [anons_cache] (see
-   #12718). Using tanon_identification (which unifies via recursion-guarded stacks)
-   instead of a structural compare avoids looping forever on cyclic recursive anons.
-   - strict already implies null_follow_mode = NeverFollow, so Null<T> and T stay
-     distinct (HL uses a different field type for each)
-   - allow_optional_mismatch: { ?node:T } and { node:T } yield the same virtual
-   - opaque_field_params: treat cf_params as opaque so two uses of the same generic
-     method are equal rather than instantiated against concrete types *)
 let anon_id_uctx = {
 	AnonIdMode.strict with
 	allow_optional_mismatch = true;
@@ -434,9 +426,7 @@ let rec to_type ?tref ctx t =
 	| TAnon a ->
 		if PMap.is_empty a.a_fields then HDyn else
 		let pfm = ctx.anon_id#identify_anon anon_id_uctx a in
-		(try
-			Hashtbl.find ctx.anons_cache pfm.pfm_path
-		with Not_found ->
+		(try Hashtbl.find ctx.anons_cache pfm.pfm_path with Not_found ->
 			let vp = {
 				vfields = [||];
 				vindex = PMap.empty;

--- a/src/generators/hl2c.ml
+++ b/src/generators/hl2c.ml
@@ -339,7 +339,7 @@ let close_file ctx =
 	let content = (match defines with [] -> out | l -> String.concat "\n" l ^ "\n\n" ^ out) in
 	let str = if ctx.curfile = "hlc.json" then content else bom ^ content in
 	ctx.defines <- [];
-	ctx.defined_types <- PMap.empty;
+	ctx.defined_types <- PMap.create ttype_compare;
 	Hashtbl.clear ctx.hdefines;
 	Hashtbl.clear ctx.defined_funs;
 	Buffer.reset ctx.out;
@@ -382,7 +382,7 @@ let create_file_context dir file =
 		defines = [];
 		hdefines = Hashtbl.create 0;
 		defined_funs = Hashtbl.create 0;
-		defined_types = PMap.empty;
+		defined_types = PMap.create ttype_compare;
 		fun_index = 0;
 		file_prefix = (short_digest file) ^ "_";
 	} in
@@ -1173,7 +1173,7 @@ let native_name str =
 	if str.[0] = '?' then String.sub str 1 (String.length str - 1) else str
 
 let make_types_idents htypes =
-	let types_descs = ref PMap.empty in
+	let types_descs = ref (PMap.create (fun a b -> ttype_compare (HVirtual a) (HVirtual b))) in
 	let rec make_desc t =
 		match t with
 		| HVoid | HUI8 | HUI16 | HI32 | HI64 | HF32 | HF64 | HBool | HBytes | HDyn | HArray _ | HType | HRef _ | HDynObj | HNull _ | HGUID ->
@@ -1395,7 +1395,7 @@ let make_modules ctx all_types =
 		in
 		m.m_functions <- get_deps [] m.m_functions
 	) !all_modules;
-	let contexts = ref PMap.empty in
+	let contexts = ref (PMap.create ttype_compare) in
 	Array.iter (fun f ->
 		if f.fe_module = None && ExtString.String.starts_with f.fe_name "fun$" then f.fe_name <- "wrap" ^ type_name ctx (match f.fe_decl with None -> Globals.die "" __LOC__ | Some f -> f.ftype);
 		(* assign context to function module *)
@@ -1511,7 +1511,7 @@ let write_c com file (code:code) gnames num_domains =
 		htypes = types_ids;
 		gnames = gnames;
 		bytes_names = bnames;
-		type_module = PMap.empty;
+		type_module = PMap.create ttype_compare;
 		gcon = com;
 	} in
 	let modules = make_modules gctx all_types in

--- a/src/generators/hlcode.ml
+++ b/src/generators/hlcode.ml
@@ -436,6 +436,16 @@ let ttype_compare t1 t2 =
 	in
 	cmp t1 t2
 
+(* Cycle-safe comparators derived from ttype_compare, for ttype-list / ttype-pair keyed caches. *)
+let rec ttype_list_compare l1 l2 = match l1, l2 with
+	| [], [] -> 0
+	| [], _ -> -1
+	| _, [] -> 1
+	| t1 :: l1, t2 :: l2 -> let c = ttype_compare t1 t2 in if c <> 0 then c else ttype_list_compare l1 l2
+
+let ttype_pair_compare (a1,b1) (a2,b2) =
+	let c = ttype_compare a1 a2 in if c <> 0 then c else ttype_compare b1 b2
+
 let compatible_element_types t1 t2 =
 	if t1 == t2 then
 		true (* equal types are always compatible *)

--- a/src/generators/hlcode.ml
+++ b/src/generators/hlcode.ml
@@ -335,12 +335,6 @@ let is_dynamic t =
 	| HDyn | HFun _ | HObj _ | HArray _ | HVirtual _ | HDynObj | HNull _ | HEnum _ -> true
 	| _ -> false
 
-(*
-	Structural type equality. Virtuals can be cyclic (recursive anonymous structures),
-	so we carry the set of virtual pairs currently being compared and treat a
-	re-encountered pair as equal (coinductive equality / bisimulation): without this,
-	comparing two distinct cyclic virtuals would recurse forever.
-*)
 let tsame t1 t2 =
 	let rec tsame seen t1 t2 =
 		if t1 == t2 then true else
@@ -369,24 +363,6 @@ let tsame t1 t2 =
 	in
 	tsame [] t1 t2
 
-(*
-	Total order on ttype, cycle-safe, suitable as a PMap key comparator.
-
-	The only ttype constructor that can be cyclic in memory is HVirtual (a virtual
-	whose fields reference itself, generated for recursive anonymous structures).
-	OCaml's polymorphic compare loops forever (growing its compare stack until
-	Out_of_memory) when comparing two *distinct* such cyclic virtuals. We intercept
-	HVirtual (and the transparent wrappers that can hold one) and break the cycle by
-	remembering, per side, the virtuals currently being compared, ordering a back-edge
-	by the depth at which it was first seen (De Bruijn level).
-
-	Every other constructor is delegated to polymorphic compare, which is exactly the
-	behaviour the previous `PMap.empty` maps relied on (class/enum/struct/abstract
-	protos are interned, so it short-circuits on physical equality and never recurses
-	into a cyclic field). This keeps the same equality classes for all non-virtual
-	types -- comparing protos by their name id instead is *not* equivalent, since
-	distinct protos can share a name id.
-*)
 let ttype_compare t1 t2 =
 	let seen1 = ref [] and seen2 = ref [] and depth = ref 0 in
 	let level seen v =
@@ -436,7 +412,6 @@ let ttype_compare t1 t2 =
 	in
 	cmp t1 t2
 
-(* Cycle-safe comparators derived from ttype_compare, for ttype-list / ttype-pair keyed caches. *)
 let rec ttype_list_compare l1 l2 = match l1, l2 with
 	| [], [] -> 0
 	| [], _ -> -1

--- a/src/generators/hlcode.ml
+++ b/src/generators/hlcode.ml
@@ -335,28 +335,106 @@ let is_dynamic t =
 	| HDyn | HFun _ | HObj _ | HArray _ | HVirtual _ | HDynObj | HNull _ | HEnum _ -> true
 	| _ -> false
 
-let rec tsame t1 t2 =
-	if t1 == t2 then true else
-	match t1, t2 with
-	| HFun (args1,ret1), HFun (args2,ret2) when List.length args1 = List.length args2 -> List.for_all2 tsame args1 args2 && tsame ret2 ret1
-	| HMethod (args1,ret1), HMethod (args2,ret2) when List.length args1 = List.length args2 -> List.for_all2 tsame args1 args2 && tsame ret2 ret1
-	| HObj p1, HObj p2 -> p1 == p2
-	| HEnum e1, HEnum e2 -> e1 == e2
-	| HStruct p1, HStruct p2 -> p1 == p2
-	| HAbstract (_,a1), HAbstract (_,a2) -> a1 == a2
-	| HVirtual v1, HVirtual v2 ->
-		if v1 == v2 then true else
-		if Array.length v1.vfields <> Array.length v2.vfields then false else
+(*
+	Structural type equality. Virtuals can be cyclic (recursive anonymous structures),
+	so we carry the set of virtual pairs currently being compared and treat a
+	re-encountered pair as equal (coinductive equality / bisimulation): without this,
+	comparing two distinct cyclic virtuals would recurse forever.
+*)
+let tsame t1 t2 =
+	let rec tsame seen t1 t2 =
+		if t1 == t2 then true else
+		match t1, t2 with
+		| HFun (args1,ret1), HFun (args2,ret2) when List.length args1 = List.length args2 -> List.for_all2 (tsame seen) args1 args2 && tsame seen ret2 ret1
+		| HMethod (args1,ret1), HMethod (args2,ret2) when List.length args1 = List.length args2 -> List.for_all2 (tsame seen) args1 args2 && tsame seen ret2 ret1
+		| HObj p1, HObj p2 -> p1 == p2
+		| HEnum e1, HEnum e2 -> e1 == e2
+		| HStruct p1, HStruct p2 -> p1 == p2
+		| HAbstract (_,a1), HAbstract (_,a2) -> a1 == a2
+		| HVirtual v1, HVirtual v2 ->
+			if v1 == v2 then true else
+			if List.exists (fun (a,b) -> a == v1 && b == v2) seen then true else
+			if Array.length v1.vfields <> Array.length v2.vfields then false else
+			let seen = (v1,v2) :: seen in
+			let rec loop i =
+				if i = Array.length v1.vfields then true else
+				let _, i1, t1 = v1.vfields.(i) in
+				let _, i2, t2 = v2.vfields.(i) in
+				if i1 = i2 && tsame seen t1 t2 then loop (i + 1) else false
+			in
+			loop 0
+		| HNull t1, HNull t2 -> tsame seen t1 t2
+		| HRef t1, HRef t2 -> tsame seen t1 t2
+		| _ -> false
+	in
+	tsame [] t1 t2
+
+(*
+	Total order on ttype, cycle-safe, suitable as a PMap key comparator.
+
+	The only ttype constructor that can be cyclic in memory is HVirtual (a virtual
+	whose fields reference itself, generated for recursive anonymous structures).
+	OCaml's polymorphic compare loops forever (growing its compare stack until
+	Out_of_memory) when comparing two *distinct* such cyclic virtuals. We intercept
+	HVirtual (and the transparent wrappers that can hold one) and break the cycle by
+	remembering, per side, the virtuals currently being compared, ordering a back-edge
+	by the depth at which it was first seen (De Bruijn level).
+
+	Every other constructor is delegated to polymorphic compare, which is exactly the
+	behaviour the previous `PMap.empty` maps relied on (class/enum/struct/abstract
+	protos are interned, so it short-circuits on physical equality and never recurses
+	into a cyclic field). This keeps the same equality classes for all non-virtual
+	types -- comparing protos by their name id instead is *not* equivalent, since
+	distinct protos can share a name id.
+*)
+let ttype_compare t1 t2 =
+	let seen1 = ref [] and seen2 = ref [] and depth = ref 0 in
+	let level seen v =
+		let rec loop = function
+			| [] -> None
+			| (v',d) :: l -> if v' == v then Some d else loop l
+		in
+		loop !seen
+	in
+	let rec cmp t1 t2 =
+		if t1 == t2 then 0 else
+		match t1, t2 with
+		| HVirtual v1, HVirtual v2 ->
+			(match level seen1 v1, level seen2 v2 with
+			| Some d1, Some d2 -> compare d1 d2
+			| Some _, None -> -1
+			| None, Some _ -> 1
+			| None, None ->
+				let d = !depth in
+				seen1 := (v1,d) :: !seen1;
+				seen2 := (v2,d) :: !seen2;
+				incr depth;
+				cmp_vfields v1.vfields v2.vfields)
+		| HFun (args1,ret1), HFun (args2,ret2)
+		| HMethod (args1,ret1), HMethod (args2,ret2) ->
+			let c = cmp_list args1 args2 in
+			if c <> 0 then c else cmp ret1 ret2
+		| (HArray a, HArray b) | (HRef a, HRef b) | (HNull a, HNull b) | (HPacked a, HPacked b) -> cmp a b
+		| _ -> compare t1 t2
+	and cmp_list l1 l2 = match l1, l2 with
+		| [], [] -> 0
+		| [], _ -> -1
+		| _, [] -> 1
+		| x :: l1, y :: l2 -> let c = cmp x y in if c <> 0 then c else cmp_list l1 l2
+	and cmp_vfields a b =
+		let c = compare (Array.length a) (Array.length b) in
+		if c <> 0 then c else
 		let rec loop i =
-			if i = Array.length v1.vfields then true else
-			let _, i1, t1 = v1.vfields.(i) in
-			let _, i2, t2 = v2.vfields.(i) in
-			if i1 = i2 && tsame t1 t2 then loop (i + 1) else false
+			if i = Array.length a then 0 else
+			let (n1,i1,t1) = a.(i) and (n2,i2,t2) = b.(i) in
+			let c = compare (n1 : string) n2 in if c <> 0 then c else
+			let c = compare (i1 : int) i2 in if c <> 0 then c else
+			let c = cmp t1 t2 in if c <> 0 then c else
+			loop (i + 1)
 		in
 		loop 0
-	| HNull t1, HNull t2 -> tsame t1 t2
-	| HRef t1, HRef t2 -> tsame t1 t2
-	| _ -> false
+	in
+	cmp t1 t2
 
 let compatible_element_types t1 t2 =
 	if t1 == t2 then
@@ -448,7 +526,7 @@ let resolve_field p fid =
 	loop [] p
 
 let gather_types (code:code) =
-	let types = ref PMap.empty in
+	let types = ref (PMap.create ttype_compare) in
 	let arr = DynArray.create() in
 	let rec get_type t =
 		(match t with

--- a/tests/hlcode/src/cases/HlCodeTests.hx
+++ b/tests/hlcode/src/cases/HlCodeTests.hx
@@ -78,7 +78,7 @@ class HlCodeTests {
 	@:hl(<>
 		fun@367(16Fh) ():virtual(node:...)
 		; src/cases/HlCodeTests.hx:82 (cases.HlCodeTests.testTreeA)
-			r0 virtual(node:virtual(node:...))
+			r0 virtual(node:...)
 			r1 virtual(node:...)
 			.82    @0 new 0
 			.82    @1 null 1

--- a/tests/hlcode/src/cases/HlCodeTests.hx
+++ b/tests/hlcode/src/cases/HlCodeTests.hx
@@ -22,6 +22,24 @@ private class ChoiceWheel {
 	}
 }
 
+private interface IDrawable {
+	public function render( engine : Engine ) : Void;
+}
+
+private class App implements IDrawable {
+	public function new() {}
+	public function render( e : Engine ) {}
+}
+
+private class Engine {
+	public function new() {}
+	public function render( obj : { function render( engine : Engine ) : Void; } ) {}
+}
+
+private typedef MiniRef<T> = {
+	public function get():T;
+}
+
 /**
 	Tests that verify correct HL code generation for basic patterns.
 **/
@@ -88,5 +106,51 @@ class HlCodeTests {
 	static public function testTreeA() {
 		var a : TreeA = { node : null };
 		return a;
+	}
+
+	// Passing a class instance where a structural `{ render : ... }` is expected
+	// goes through the same virtual as a plain anonymous structure.
+	@:hl(<>
+		fun@372(174h) ():void
+		; src/cases/HlCodeTests.hx:114 (cases.HlCodeTests.testInterfaceToStructural)
+			r0 void
+			r1 cases._HlCodeTests.Engine
+			r2 cases._HlCodeTests.App
+			r3 virtual(render:method:(cases._HlCodeTests.Engine):void)
+			.114   @0 new 1
+			.114   @1 call 0, cases._HlCodeTests.Engine.new(1)
+			.114   @2 new 2
+			.114   @3 call 0, cases._HlCodeTests.App.new(2)
+			.114   @4 jnotnull 2,2
+			.114   @5 null 3
+			.114   @6 jalways 4
+			.114   @7 field 3,2[0]
+			.114   @8 jnotnull 3,2
+			.114   @9 tovirtual 3,2
+			.114   @A setfield 2[0],3
+			.114   @B call 0, cases._HlCodeTests.Engine.render(1,3)
+			.114   @C ret 0
+	</>)
+	static public function testInterfaceToStructural() {
+		new Engine().render(new App());
+	}
+
+	// An object literal whose field holds a function (`get` is a Var) used where
+	// a method field is expected (`MiniRef.get` is a Method) must NOT be conflated
+	// with the method-bearing virtual: the field stays a plain function value.
+	@:hl(<>
+		fun@373(175h) ():virtual(get:method:():i32)
+		; src/cases/HlCodeTests.hx:121 (cases.HlCodeTests.testVarFieldVsMethod)
+			r0 dynobj
+			r1 ():i32
+			r2 virtual(get:method:():i32)
+			.121   @0 new 0
+			.121   @1 staticclosure 1, fun$374
+			.121   @2 dynset 0[@174],1
+			.121   @3 tovirtual 2,0
+			.121   @4 ret 2
+	</>)
+	static public function testVarFieldVsMethod():MiniRef<Int> {
+		return { get: function() return 1 };
 	}
 }

--- a/tests/hlcode/src/cases/RecursiveAnonCaches.hx
+++ b/tests/hlcode/src/cases/RecursiveAnonCaches.hx
@@ -1,0 +1,30 @@
+package cases;
+
+// Recursive anonymous structures produce cyclic HVirtual types. Besides
+// `anons_cache`/`gather_types`, genhl keys other caches on `ttype`; if those use
+// polymorphic compare they loop forever on two distinct-but-parallel cyclic
+// virtuals. These are compile-only regression tests: if a cache loops, HL
+// generation never finishes (Out of memory), so merely compiling this file
+// exercises the fix.
+
+private typedef Foo1 = {
+	function make<T>(v:T):Foo1;
+}
+
+private typedef Foo2 = {
+	function make<T>(v:T):Foo2;
+}
+
+class RecursiveAnonCaches {
+	// Closures capturing a recursive-anon variable (plus one more captured var)
+	// pack their captures into a tuple -> genhl `cached_tuples`.
+	static public function captureTuples() {
+		var a:Foo1 = null;
+		var b:Foo2 = null;
+		var n = 1;
+		var f = function() return a != null && n > 0;
+		var g = function() return b != null && n > 0;
+		f();
+		g();
+	}
+}

--- a/tests/unit/src/unit/issues/Issue12239.hx
+++ b/tests/unit/src/unit/issues/Issue12239.hx
@@ -1,7 +1,5 @@
 package unit.issues;
 
-// hl wil fail with Out of memory here (see #12955)
-#if !hl
 private typedef BinaryTreeDef<T> = {
 	public final ?l:Null<BinaryTree<T>>;
 	public final ?r:Null<BinaryTree<T>>;
@@ -13,15 +11,10 @@ private typedef BinaryTreeDef<T> = {
 	@:noUsing static public function lift<T>(self:BinaryTreeDef<T>):BinaryTree<T>
 		return new BinaryTree(self);
 }
-#end
 
 class Issue12239 extends Test {
 	function test() {
-		#if hl
-		noAssert();
-		#else
 		var tree = BinaryTree.lift({});
 		t(tree != null);
-		#end
 	}
 }

--- a/tests/unit/src/unit/issues/Issue12256.hx
+++ b/tests/unit/src/unit/issues/Issue12256.hx
@@ -1,0 +1,16 @@
+package unit.issues;
+
+// Recursive typedef used through a generic function. On the hl target the
+// recursive structure made `Hlcode.tsame` recurse forever (compiler hang).
+private typedef Tree<T> = {
+	var left:Tree<T>;
+}
+
+class Issue12256 extends Test {
+	function test() {
+		function iterTree<T>(tree:Tree<T>):Null<T> {
+			return null;
+		}
+		t(iterTree(null) == null);
+	}
+}

--- a/tests/unit/src/unit/issues/Issue9662.hx
+++ b/tests/unit/src/unit/issues/Issue9662.hx
@@ -1,0 +1,31 @@
+package unit.issues;
+
+// Two structurally identical, self-referential anonymous structures. On the hl
+// target these produced distinct cyclic virtuals whose comparison made the
+// genhl type caches loop forever in polymorphic compare ("Out of memory").
+private typedef Foo1 = {
+	function make<T>(v:T):Foo1;
+}
+
+private class FooLike1 {
+	public function new() {}
+	public function make<T>(v:T):FooLike1 return this;
+}
+
+private typedef Foo2 = {
+	function make<T>(v:T):Foo2;
+}
+
+private class FooLike2 {
+	public function new() {}
+	public function make<T>(v:T):FooLike2 return this;
+}
+
+class Issue9662 extends Test {
+	function test() {
+		var f1:Foo1 = new FooLike1();
+		var f2:Foo2 = new FooLike2();
+		t(f1.make(0) != null);
+		t(f2.make(0) != null);
+	}
+}


### PR DESCRIPTION
Recursive anonymous structures (e.g. `typedef T = { next : T }` or `{ make<S>(v:S):T }`) produce tanon/HVirtual values that are cyclic in memory. Several genhl/hlcode lookups compared these with OCaml's polymorphic compare, which loops forever when comparing two *distinct* cyclic values (growing the compare stack until Out_of_memory):

- anons_cache  (tanon-keyed PMap, genhl)
- mallocs      (ttype-keyed PMap, genhl)
- gather_types type table (ttype-keyed PMap, hlcode)
- tsame / safe_cast (unguarded structural recursion into HVirtual)

Add cycle-safe comparators that break the cycle at the recursive node via De Bruijn levels (ttype_compare, tanon_compare), and a coinductive cycle guard to tsame. Behaviour is unchanged for non-cyclic types: ttype_compare delegates every non-virtual constructor to polymorphic compare, and tanon_compare keeps the `==` fast path, so dedup is preserved.

Closes #9662 
Closes #12256
Closes #12239
Fixes hl unit test **re**compilation through server