### PR TITLE
[jvm] fix compiler hang on recursive abstract

### DIFF
--- a/src/generators/genjvm.ml
+++ b/src/generators/genjvm.ml
@@ -3221,31 +3221,37 @@ module Preprocessor = struct
 	   it; scanning non-extern code only keeps classpath noise out. *)
 	let collect_used_functional_interfaces gctx =
 		let used = Hashtbl.create 0 in
-		let rec note_fi_in_type depth t =
-			if depth < 32 then match follow t with
+		(* `seen` guards against recursive types (e.g. a recursive abstract whose
+		   underlying references itself through several fields): without it the walk
+		   branches exponentially and the compiler hangs. depth is a coarse backstop. *)
+		let rec note_fi_in_type seen depth t =
+			if depth < 32 && not (List.exists (fast_eq t) seen) then begin
+			let seen = t :: seen in
+			match follow t with
 			| TInst(c,tl) ->
 				if has_class_flag c CFunctionalInterface then Hashtbl.replace used c.cl_path ();
-				List.iter (note_fi_in_type (depth + 1)) tl
+				List.iter (note_fi_in_type seen (depth + 1)) tl
 			| TFun(args,ret) ->
-				List.iter (fun (_,_,t) -> note_fi_in_type (depth + 1) t) args;
-				note_fi_in_type (depth + 1) ret
+				List.iter (fun (_,_,t) -> note_fi_in_type seen (depth + 1) t) args;
+				note_fi_in_type seen (depth + 1) ret
 			| TAbstract(_,tl) | TEnum(_,tl) | TType(_,tl) ->
-				List.iter (note_fi_in_type (depth + 1)) tl
+				List.iter (note_fi_in_type seen (depth + 1)) tl
 			| TAnon an ->
-				PMap.iter (fun _ cf -> note_fi_in_type (depth + 1) cf.cf_type) an.a_fields
+				PMap.iter (fun _ cf -> note_fi_in_type seen (depth + 1) cf.cf_type) an.a_fields
 			| TDynamic (Some t) ->
-				note_fi_in_type (depth + 1) t
+				note_fi_in_type seen (depth + 1) t
 			| _ ->
 				()
+			end
 		in
 		let rec note_fi_in_expr e =
-			note_fi_in_type 0 e.etype;
+			note_fi_in_type [] 0 e.etype;
 			Type.iter note_fi_in_expr e
 		in
 		let scan_class c =
 			if not (has_class_flag c CExtern) then begin
 				let rec scan cf =
-					note_fi_in_type 0 cf.cf_type;
+					note_fi_in_type [] 0 cf.cf_type;
 					Option.may note_fi_in_expr cf.cf_expr;
 					List.iter scan cf.cf_overloads
 				in

--- a/tests/unit/src/unit/issues/Issue12239.hx
+++ b/tests/unit/src/unit/issues/Issue12239.hx
@@ -1,0 +1,27 @@
+package unit.issues;
+
+// hl wil fail with Out of memory here (see #12955)
+#if !hl
+private typedef BinaryTreeDef<T> = {
+	public final ?l:Null<BinaryTree<T>>;
+	public final ?r:Null<BinaryTree<T>>;
+}
+
+@:forward private abstract BinaryTree<T>(BinaryTreeDef<T>) {
+	public function new(self:BinaryTreeDef<T>) this = self;
+
+	@:noUsing static public function lift<T>(self:BinaryTreeDef<T>):BinaryTree<T>
+		return new BinaryTree(self);
+}
+#end
+
+class Issue12239 extends Test {
+	function test() {
+		#if hl
+		noAssert();
+		#else
+		var tree = BinaryTree.lift({});
+		t(tree != null);
+		#end
+	}
+}


### PR DESCRIPTION
`collect_used_functional_interfaces.note_fi_in_type` walks types following abstracts to find referenced functional interfaces. On a recursive abstract whose underlying references itself through several fields (e.g. a binary tree `{ ?l:Null<T>, ?r:Null<T> }`), the walk branched exponentially: each field led back to the same abstract, so the recursion doubled at every level and the `depth < 32` cap let it reach ~2^32 calls before stopping. The compiler hung.

Guard the walk with a `seen` set (fast_eq) so a type already being processed is not descended into again, cutting the recursion to linear. Regression from #12901, which introduced this scan.