### PR TITLE
[eval] Set SO_REUSEADDR when binding socket to match Neko, HashLink, and hxcpp

### DIFF
--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2199,6 +2199,8 @@ module StdSocket = struct
 		let this = this vthis in
 		let host = decode_i32 host in
 		let port = decode_int port in
+		if not Globals.is_windows then
+			catch_unix_error Unix.setsockopt this SO_REUSEADDR true;
 		catch_unix_error Unix.bind this (ADDR_INET (StdHost.int32_addr host,port));
 		vnull
 	)


### PR DESCRIPTION
In Neko, HashLink, and hxcpp, the `SO_REUSEADDR` flag is set on a socket when calling the socket's `bind()` method on non-Windows targets.

https://github.com/HaxeFoundation/neko/blob/v2-4-1/libs/std/socket.c#L559
https://github.com/HaxeFoundation/hashlink/blob/1.15/src/std/socket.c#L284
https://github.com/HaxeFoundation/hxcpp/blob/v4.3.140/src/hx/libs/std/Socket.cpp#L810

The same is not currently true for the Haxe interpreter, which can result in the following error after exiting without closing the socket (such as when using Ctrl+C in a terminal) and then attempting to bind to the same socket again.

```
Unix.Unix_error(Unix.EADDRINUSE, "bind", "")
```

This PR brings the eval iterpreter in line with the other targets by setting the `SO_REUSEADDR` flag on non-Windows targets too.

See #12880 for a code sample that may be used to reproduce the issue.