### PR TITLE
Add GC configuration env vars

### DIFF
--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -77,8 +77,8 @@ Sys.catch_break true;
    sets them independently. *)
 let gc_config =
 	let default = DynamicGc.{
-		min_space_overhead = 100;
-		max_space_overhead = 120;
+		min_space_overhead = 80;
+		max_space_overhead = 100;
 		heap_start_worrying_mb = 4_096;
 		heap_really_worry_mb = 8_192;
 	} in

--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -71,13 +71,28 @@ Sys.catch_break true;
    Sys.sigpipe may not map to the real signal number, so use 13 directly. *)
 (try Sys.set_signal 13 Sys.Signal_ignore with _ -> ());
 
-DynamicGc.(setup_dynamic_tuning
-  {
-    min_space_overhead = 100;
-    max_space_overhead = 120;
-    heap_start_worrying_mb = 4_096;
-    heap_really_worry_mb = 8_192;
-  });
+(* Dynamic GC tuning: space_overhead interpolates from max (small heap) down to min
+   (large heap). This runs before argument parsing, so it is overridden via an env
+   var rather than a define: HAXE_SPACE_OVERHEAD="N" sets both bounds to N, "MIN:MAX"
+   sets them independently. *)
+let gc_config =
+	let default = DynamicGc.{
+		min_space_overhead = 100;
+		max_space_overhead = 120;
+		heap_start_worrying_mb = 4_096;
+		heap_really_worry_mb = 8_192;
+	} in
+	match (try Some (Sys.getenv "HAXE_SPACE_OVERHEAD") with Not_found -> None) with
+	| None | Some "" -> default
+	| Some s ->
+		(try
+			match List.map (fun p -> int_of_string (String.trim p)) (String.split_on_char ':' s) with
+			| [v] -> { default with min_space_overhead = v; max_space_overhead = v }
+			| [mn; mx] -> { default with min_space_overhead = mn; max_space_overhead = mx }
+			| _ -> default
+		with _ -> default)
+in
+DynamicGc.setup_dynamic_tuning gc_config;
 
 let args = List.tl (Array.to_list Sys.argv) in
 set_binary_mode_out stdout true;

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -284,6 +284,16 @@ module WorkerDomain = struct
 
 	let create sctx rq =
 		let domain = Domain.spawn (fun () ->
+			(* Enlarge the minor heap of the compilation domain only — the domain that runs
+			   typing/macro/hxb, the source of most short-lived allocation that otherwise gets
+			   promoted to the major heap. A per-domain Gc.set does not change the default
+			   inherited by the parallel pool's worker domains, so it costs the minor heap size
+			   in RSS once, not once per domain. Set via HAXE_MAIN_MINOR_MB (in MB; 0 disables). *)
+			(try
+				let mb = int_of_string (Sys.getenv "HAXE_MAIN_MINOR_MB") in
+				if mb > 0 then
+					Gc.set { (Gc.get ()) with Gc.minor_heap_size = mb * 1024 * 1024 / (Sys.word_size / 8) }
+			with _ -> ());
 			let cs = sctx.cs in
 			let rec loop () =
 				Semaphore.Counting.acquire rq.semaphore;

--- a/src/compiler/server/server.ml
+++ b/src/compiler/server/server.ml
@@ -288,12 +288,15 @@ module WorkerDomain = struct
 			   typing/macro/hxb, the source of most short-lived allocation that otherwise gets
 			   promoted to the major heap. A per-domain Gc.set does not change the default
 			   inherited by the parallel pool's worker domains, so it costs the minor heap size
-			   in RSS once, not once per domain. Set via HAXE_MAIN_MINOR_MB (in MB; 0 disables). *)
-			(try
-				let mb = int_of_string (Sys.getenv "HAXE_MAIN_MINOR_MB") in
-				if mb > 0 then
-					Gc.set { (Gc.get ()) with Gc.minor_heap_size = mb * 1024 * 1024 / (Sys.word_size / 8) }
-			with _ -> ());
+			   in RSS once, not once per domain. Default 32MB; HAXE_MAIN_MINOR_MB overrides
+			   (in MB; 0 disables). *)
+			let mb =
+				match (try Some (Sys.getenv "HAXE_MAIN_MINOR_MB") with Not_found -> None) with
+				| Some s -> (try int_of_string s with _ -> 32)
+				| None -> 32
+			in
+			if mb > 0 then
+				Gc.set { (Gc.get ()) with Gc.minor_heap_size = mb * 1024 * 1024 / (Sys.word_size / 8) };
 			let cs = sctx.cs in
 			let rec loop () =
 				Semaphore.Counting.acquire rq.semaphore;


### PR DESCRIPTION
* Space overhead: `HAXE_SPACE_OVERHEAD=N` sets both bounds to `N`, `HAXE_SPACE_OVERHEAD=MIN:MAX` sets independently (new default 80:100 instead of 100:120)
* Minor heap size: `HAXE_MAIN_MINOR_MB` to customize (new default value 32MB, previously using OCAML default 2MB); only impacts server's compilation domain