### PR TITLE
[hxb] share cached chunk bytes for field expressions instead of copying

### DIFF
--- a/src/compiler/hxb/hxbReader.ml
+++ b/src/compiler/hxb/hxbReader.ml
@@ -1754,8 +1754,8 @@ class hxb_reader
 			self#read_list (fun () ->
 				let cf = self#read_field_ref in
 				let length = read_uleb128 ch in
-				let bytes = read_bytes ch length in
-				let ch_cf = BytesWithPosition.create bytes in
+				let ch_cf = { ch with pos = ch.pos } in
+				ch.pos <- ch.pos + length;
 				let read_expressions () =
 					self#select_class_type_parameters c;
 					field_type_parameters <- (ClassFieldInfos.get class_field_infos cf).type_parameters;


### PR DESCRIPTION
read_exd copied each field's expression blob into a fresh buffer for the sub-reader. The bytes already live in the binary cache, and for deferred (lazy) expressions the copy was duplicated and retained until the lazy was forced. Give the sub-reader its own position over the same cached bytes and advance the main reader past the blob.