### PR TITLE
[hxb] reuse the scratch buffer in SimnBuffer.reset

### DIFF
--- a/src/compiler/hxb/hxbWriter.ml
+++ b/src/compiler/hxb/hxbWriter.ml
@@ -180,8 +180,7 @@ module SimnBuffer = struct
 	}
 
 	let reset sb =
-		sb.buffer <- Bytes.create sb.buffer_size;
-		sb.buffers <- Queue.create ();
+		Queue.clear sb.buffers;
 		sb.offset <- 0
 
 	let promote_buffer sb =


### PR DESCRIPTION
reset allocated a fresh buffer on every call, which defeated the reuse of the scratch chunk that serializes type instances (its only caller, invoked once per type-instance write). Keep the buffer and overwrite it in place — writes restart at offset 0 and contents reads only up to offset, so stale bytes are never seen; just clear any overflow buffers and rewind. Output is byte-identical.