### PR TITLE
[syntax] lex via a custom UTF-8 refill instead of a per-char generator

### DIFF
--- a/src/syntax/lexer.ml
+++ b/src/syntax/lexer.ml
@@ -34,6 +34,23 @@ type error_msg =
 
 exception Error of error_msg * pos
 
+(* Feed sedlex a refill that decodes UTF-8 on demand into its buffer, instead of
+   Utf8.from_string's per-character generator (the allocation source). Lazy and
+   single-pass: only the consumed prefix is decoded. *)
+let lexbuf_from_utf8_string s =
+	let n = String.length s in
+	let pos = ref 0 in
+	Sedlexing.create (fun buf start len ->
+		let count = ref 0 in
+		while !count < len && !pos < n do
+			let d = String.get_utf_8_uchar s !pos in
+			if not (Uchar.utf_decode_is_valid d) then raise Sedlexing.MalFormed;
+			Array.unsafe_set buf (start + !count) (Uchar.utf_decode_uchar d);
+			pos := !pos + Uchar.utf_decode_length d;
+			incr count
+		done;
+		!count)
+
 type lexer_file = {
 	lfile : string;
 	mutable lline : int;

--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -383,7 +383,7 @@ let parse_string config entry s p error inlined =
 		config
 	in
 	let result = try
-		parse config entry lctx (Sedlexing.Utf8.from_string s) p.pfile
+		parse config entry lctx (Lexer.lexbuf_from_utf8_string s) p.pfile
 	with Error (e,pe) ->
 		restore();
 		error (error_msg e) (if inlined then pe else p)

--- a/src/typing/typeloadParse.ml
+++ b/src/typing/typeloadParse.ml
@@ -59,7 +59,7 @@ let parse_file_from_lexbuf com file p lexbuf =
 	Timer.time com.timer_ctx ["parsing"] (parse_file_from_lexbuf com file p) lexbuf
 
 let parse_file_from_string com file p string =
-	parse_file_from_lexbuf com file p (Sedlexing.Utf8.from_string string)
+	parse_file_from_lexbuf com file p (Lexer.lexbuf_from_utf8_string string)
 
 let parse_file com rfile p =
 	let file_key = com.part_scope.file_keys#get rfile.ClassPaths.file in
@@ -82,7 +82,8 @@ let parse_file com rfile p =
 		| FFile ->
 			let file = rfile.file in
 			let ch = try open_in_bin file with _ -> raise_typing_error ("Could not open " ^ file) p in
-			Std.finally (fun() -> close_in ch) (parse_file_from_lexbuf com file p) (Sedlexing.Utf8.from_channel ch)
+			let s = Std.finally (fun() -> close_in ch) (fun ch -> really_input_string ch (in_channel_length ch)) ch in
+			parse_file_from_string com file p s
 
 let parse_hook = ref parse_file
 


### PR DESCRIPTION
Sedlexing.Utf8.from_string/from_channel wrap the input in a per-character generator (a closure + an option box per code point), which dominated allocation during lexing. Build the lexbuf with Sedlexing.create and a refill that decodes UTF-8 on demand straight into sedlex's buffer: no per-char allocation, still lazy (only the consumed prefix is decoded) and single-pass. Used for both file parsing and macro string parsing; MalFormed is raised lazily when the bad byte is reached, as before.