### PR TITLE
[eval] free Tls values when the Tls instance dies

### DIFF
--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -22,6 +22,12 @@ open EvalValue
 open EvalHash
 open EvalString
 
+module TlsStorage = Ephemeron.K1.Make(struct
+	type t = value
+	let equal = (==)
+	let hash v = match v with VInstance {ikind = ITls i} -> i | _ -> 0
+end)
+
 type var_info = {
 	vi_name : string;
 	vi_pos : pos;
@@ -122,7 +128,7 @@ and eval = {
 	mutable last_return : value option;
 	(* The debug channel used to synchronize with the debugger. *)
 	debug_channel : unit Event.channel;
-	mutable eval_storage : value IntMap.t;
+	eval_storage : value TlsStorage.t;
 }
 
 and debug_state =

--- a/src/macro/eval/evalStdLib.ml
+++ b/src/macro/eval/evalStdLib.ml
@@ -2959,18 +2959,18 @@ module StdTls = struct
 		| _ -> unexpected_value vthis "Thread"
 
 	let get_value = vifun0 (fun vthis ->
-		let this = this vthis in
+		ignore (this vthis);
 		try
 			let eval = get_eval (get_ctx()) in
-			IntMap.find this eval.eval_storage
+			TlsStorage.find eval.eval_storage vthis
 		with Not_found ->
 			vnull
 	)
 
 	let set_value = vifun1 (fun vthis v ->
-		let this = this vthis in
+		ignore (this vthis);
 		let eval = get_eval (get_ctx()) in
-		eval.eval_storage <- IntMap.add this v eval.eval_storage;
+		TlsStorage.replace eval.eval_storage vthis v;
 		v
 	)
 end

--- a/src/macro/eval/evalThread.ml
+++ b/src/macro/eval/evalThread.ml
@@ -52,7 +52,7 @@ let create_eval tthread =
 		caught_types = IntHashtbl.create 0;
 		last_return = None;
 		caught_exception = vnull;
-		eval_storage = IntMap.empty;
+		eval_storage = TlsStorage.create 0;
 	} in
 	eval
 


### PR DESCRIPTION
eval_storage backing sys.thread.Tls was a non-weak map keyed by Tls instance id, so in the compilation server (where the eval thread is reused across compiles) it retained every Tls value forever, including those of dead instances. Key it weakly on the Tls instance (Ephemeron) so a value lives exactly as long as its instance is reachable.