### PR TITLE
[eval] cache fake_proto per path

### DIFF
--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -284,6 +284,7 @@ and context = {
 	mutable instance_prototypes : vprototype IntMap.t;
 	mutable static_prototypes : static_prototypes;
 	mutable constructors : value AtomicLazy.t IntMap.t;
+	fake_proto_cache : (int,vprototype) Hashtbl.t;
 	file_keys : Common.file_keys;
 	get_object_prototype : 'a . context -> (int * 'a) list -> vprototype * (int * 'a) list;
 	(* eval *)

--- a/src/macro/eval/evalEncode.ml
+++ b/src/macro/eval/evalEncode.ml
@@ -256,45 +256,48 @@ let encode_string_map convert m =
 	PMap.iter (fun key value -> RuntimeStringHashtbl.add h (create_ascii key) (convert value)) m;
 	encode_string_map_direct h
 
-let fake_proto path =
-	let proto = {
-		ppath = path;
-		pfields = [||];
-		pnames = IntMap.empty;
-		pinstance_names = IntMap.empty;
-		pinstance_fields = [||];
-		pparent = None;
-		pkind = PInstance;
-		pvalue = vnull;
-	} in
-	proto.pvalue <- vprototype proto;
-	proto
+let fake_proto cache path =
+	try Hashtbl.find cache path
+	with Not_found ->
+		let proto = {
+			ppath = path;
+			pfields = [||];
+			pnames = IntMap.empty;
+			pinstance_names = IntMap.empty;
+			pinstance_fields = [||];
+			pparent = None;
+			pkind = PInstance;
+			pvalue = vnull;
+		} in
+		proto.pvalue <- vprototype proto;
+		Hashtbl.replace cache path proto;
+		proto
 
 let encode_unsafe o =
 	vinstance {
 		ifields = [||];
-		iproto = fake_proto key_haxe_macro_Unsafe;
+		iproto = fake_proto (get_ctx()).fake_proto_cache key_haxe_macro_Unsafe;
 		ikind = IRef (Obj.repr o);
 	}
 
 let encode_pos p =
 	vinstance {
 		ifields = [||];
-		iproto = fake_proto key_haxe_macro_Position;
+		iproto = fake_proto (get_ctx()).fake_proto_cache key_haxe_macro_Position;
 		ikind = IPos p;
 	}
 
 let encode_lazytype t f =
 	vinstance {
 		ifields = [||];
-		iproto = fake_proto key_haxe_macro_LazyType;
+		iproto = fake_proto (get_ctx()).fake_proto_cache key_haxe_macro_LazyType;
 		ikind = ILazyType(t,f);
 	}
 
 let encode_tdecl t =
 	vinstance {
 		ifields = [||];
-		iproto = fake_proto key_haxe_macro_TypeDecl;
+		iproto = fake_proto (get_ctx()).fake_proto_cache key_haxe_macro_TypeDecl;
 		ikind = ITypeDecl t;
 	}
 

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -95,6 +95,7 @@ let create com api is_macro args =
 	let eval = EvalThread.create_eval thread in
 	let evals = ThreadSafeHashtbl.create 1 in
 	ThreadSafeHashtbl.add evals 0 eval;
+	let fake_proto_cache = Hashtbl.create 0 in
 	let ctx = {
 		ctx_id = !GlobalState.sid;
 		is_macro = is_macro;
@@ -107,19 +108,20 @@ let create com api is_macro args =
 		had_error = false;
 		args;
 		(* prototypes *)
-		string_prototype = fake_proto key_String;
-		array_prototype = fake_proto key_Array;
-		vector_prototype = fake_proto key_eval_Vector;
+		string_prototype = fake_proto fake_proto_cache key_String;
+		array_prototype = fake_proto fake_proto_cache key_Array;
+		vector_prototype = fake_proto fake_proto_cache key_eval_Vector;
 		static_prototypes = new static_prototypes;
 		instance_prototypes = IntMap.empty;
 		constructors = IntMap.empty;
+		fake_proto_cache = fake_proto_cache;
 		file_keys = com.part_scope.file_keys;
 		get_object_prototype = get_object_prototype;
 		(* eval *)
 		next_thread_id;
 		toplevel = 	vobject {
 			ofields = [||];
-			oproto = OProto (fake_proto key_eval_toplevel);
+			oproto = OProto (fake_proto fake_proto_cache key_eval_toplevel);
 		};
 		eval = Thread_local_storage.create ();
 		evals = evals;


### PR DESCRIPTION
The empty prototype used as the iproto of opaque wrapper instances (positions, lazy types, refs, ...) depends only on the path and is never mutated, but a fresh one was built on every use (encode_pos alone built one per encoded position). Cache one per path.