### PR TITLE
[eval] memoize anonymous-object prototype name

### DIFF
--- a/src/macro/eval/evalContext.ml
+++ b/src/macro/eval/evalContext.ml
@@ -285,6 +285,7 @@ and context = {
 	mutable static_prototypes : static_prototypes;
 	mutable constructors : value AtomicLazy.t IntMap.t;
 	file_keys : Common.file_keys;
+	object_name_cache : (int list,int) Hashtbl.t;
 	get_object_prototype : 'a . context -> (int * 'a) list -> vprototype * (int * 'a) list;
 	(* eval *)
 	mutable next_thread_id : int Atomic.t;

--- a/src/macro/eval/evalMain.ml
+++ b/src/macro/eval/evalMain.ml
@@ -114,6 +114,7 @@ let create com api is_macro args =
 		instance_prototypes = IntMap.empty;
 		constructors = IntMap.empty;
 		file_keys = com.part_scope.file_keys;
+		object_name_cache = Hashtbl.create 0;
 		get_object_prototype = get_object_prototype;
 		(* eval *)
 		next_thread_id;

--- a/src/macro/eval/evalPrototype.ml
+++ b/src/macro/eval/evalPrototype.ml
@@ -289,9 +289,17 @@ let create_instance_prototype ctx c =
 
 let get_object_prototype ctx l =
 	let l = List.sort (fun (i1,_) (i2,_) -> if i1 = i2 then 0 else if i1 < i2 then -1 else 1) l in
+	let name =
+		let ids = List.map fst l in
+		try
+			Hashtbl.find ctx.object_name_cache ids
+		with Not_found ->
+			let sfields = String.concat "," (List.map (fun i -> Printf.sprintf ":%s" (rev_hash i)) ids) in
+			let name = hash (Printf.sprintf "eval.object.Object[%s]" sfields) in
+			Hashtbl.replace ctx.object_name_cache ids name;
+			name
+	in
 	let proto =
-		let sfields = String.concat "," (List.map (fun (i,_) -> (Printf.sprintf ":%s" (rev_hash i))) l) in
-		let name = hash (Printf.sprintf "eval.object.Object[%s]" sfields) in
 		try
 			IntMap.find name ctx.instance_prototypes
 		with Not_found ->


### PR DESCRIPTION
get_object_prototype built a string cache key (reverse-hashing each field, then formatting and hashing) for every anonymous object created in macro code, including on cache hits, before looking it up in instance_prototypes. Memoize the sorted-field-ids to interned-name mapping on the eval context, so it is reset with the interpreter; the resulting name is identical, so behavior is unchanged.