### PR TITLE
Fix unbound structInit vars

### DIFF
--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -318,13 +318,17 @@ let rec equal e1 e2 = match e1.eexpr,e2.eexpr with
 
 let e_identity e = e
 
+let copy_var v =
+	let v2 = alloc_var v.v_kind v.v_name v.v_type v.v_pos in
+	v2.v_meta <- v.v_meta;
+	v2.v_extra <- v.v_extra;
+	v2.v_flags <- v.v_flags;
+	v2
+
 let duplicate_tvars f_this e =
 	let vars = Hashtbl.create 0 in
 	let copy_var v =
-		let v2 = alloc_var v.v_kind v.v_name v.v_type v.v_pos in
-		v2.v_meta <- v.v_meta;
-		v2.v_extra <- v.v_extra;
-		v2.v_flags <- v.v_flags;
+		let v2 = copy_var v in
 		Hashtbl.add vars v.v_id v2;
 		v2;
 	in

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -153,18 +153,20 @@ let get_struct_init_super_info ctx c p =
 	match c.cl_super with
 		| Some ({ cl_constructor = Some ctor } as csup, cparams) ->
 			let args = (try get_method_args ctor with Not_found -> []) in
-			let tl_rev,el_rev =
-				List.fold_left (fun (args,exprs) (v,value) ->
+			let args_rev,tl_rev,el_rev =
+				List.fold_left (fun (args,tl,exprs) (v,value) ->
 					let opt = match value with
 						| Some _ -> true
 						| None -> Meta.has Meta.Optional v.v_meta
 					in
 					let t = if opt then ctx.t.tnull v.v_type else v.v_type in
-					(v.v_name,opt,t) :: args,(mk (TLocal v) v.v_type p) :: exprs
-				) ([],[]) args
+					let v' = alloc_var v.v_kind v.v_name v.v_type v.v_pos in
+					v'.v_meta <- v.v_meta;
+					(v',value) :: args,(v.v_name,opt,t) :: tl,(mk (TLocal v') v.v_type p) :: exprs
+				) ([],[],[]) args
 			in
 			let super_expr = mk (TCall (mk (TConst TSuper) (TInst (csup,cparams)) p, List.rev el_rev)) ctx.t.tvoid p in
-			(args,Some super_expr,List.rev tl_rev)
+			(List.rev args_rev,Some super_expr,List.rev tl_rev)
 		| _ ->
 			[],None,[]
 

--- a/src/typing/typeloadFields.ml
+++ b/src/typing/typeloadFields.ml
@@ -160,8 +160,7 @@ let get_struct_init_super_info ctx c p =
 						| None -> Meta.has Meta.Optional v.v_meta
 					in
 					let t = if opt then ctx.t.tnull v.v_type else v.v_type in
-					let v' = alloc_var v.v_kind v.v_name v.v_type v.v_pos in
-					v'.v_meta <- v.v_meta;
+					let v' = copy_var v in
 					(v',value) :: args,(v.v_name,opt,t) :: tl,(mk (TLocal v') v.v_type p) :: exprs
 				) ([],[],[]) args
 			in

--- a/tests/misc/eval/projects/Issue12957/Main.hx
+++ b/tests/misc/eval/projects/Issue12957/Main.hx
@@ -1,0 +1,16 @@
+@:structInit class Base {
+	public var f1 = 0;
+}
+@:structInit class Sub1 extends Base { public var e1 = 1; }
+@:structInit class Sub2 extends Base { public var e2 = 2; }
+@:structInit class Sub3 extends Base { public var e3 = 3; }
+@:structInit class Sub4 extends Base { public var e4 = 4; }
+@:structInit class Sub5 extends Base { public var e5 = 5; }
+@:structInit class Sub6 extends Base { public var e6 = 6; }
+@:structInit class Sub7 extends Base { public var e7 = 7; }
+@:structInit class Sub8 extends Base { public var e8 = 8; }
+@:structInit class Sub9 extends Base { public var e9 = 9; }
+
+class Main {
+	static function main() {}
+}

--- a/tests/misc/eval/projects/Issue12957/compile.hxml
+++ b/tests/misc/eval/projects/Issue12957/compile.hxml
@@ -1,0 +1,2 @@
+-main Main
+--interp


### PR DESCRIPTION
Allocate new args for subclasses instead of using parent ones

Closes https://github.com/HaxeFoundation/haxe/issues/12957