### PR TITLE
add HAXE_HEAP_WORRY_MB to override GC worry thresholds

### DIFF
--- a/src/compiler/haxe.ml
+++ b/src/compiler/haxe.ml
@@ -72,25 +72,43 @@ Sys.catch_break true;
 (try Sys.set_signal 13 Sys.Signal_ignore with _ -> ());
 
 (* Dynamic GC tuning: space_overhead interpolates from max (small heap) down to min
-   (large heap). This runs before argument parsing, so it is overridden via an env
-   var rather than a define: HAXE_SPACE_OVERHEAD="N" sets both bounds to N, "MIN:MAX"
-   sets them independently. *)
+   (large heap) as the major heap grows between the two worry thresholds. This runs
+   before argument parsing, so it is overridden via env vars rather than defines:
+   - HAXE_SPACE_OVERHEAD="N" sets both overhead bounds to N, "MIN:MAX" sets them
+     independently.
+   - HAXE_HEAP_WORRY_MB="N" sets both worry thresholds (in MB) to N, "START:REALLY"
+     sets them independently. *)
 let gc_config =
+	let env name = match (try Some (Sys.getenv name) with Not_found -> None) with
+		| None | Some "" -> None
+		| Some s -> Some s
+	in
+	let parse_pair s = List.map (fun p -> int_of_string (String.trim p)) (String.split_on_char ':' s) in
 	let default = DynamicGc.{
 		min_space_overhead = 80;
 		max_space_overhead = 100;
 		heap_start_worrying_mb = 4_096;
 		heap_really_worry_mb = 8_192;
 	} in
-	match (try Some (Sys.getenv "HAXE_SPACE_OVERHEAD") with Not_found -> None) with
-	| None | Some "" -> default
+	let config = match env "HAXE_SPACE_OVERHEAD" with
+		| None -> default
+		| Some s ->
+			(try
+				match parse_pair s with
+				| [v] -> { default with min_space_overhead = v; max_space_overhead = v }
+				| [mn; mx] -> { default with min_space_overhead = mn; max_space_overhead = mx }
+				| _ -> default
+			with _ -> default)
+	in
+	match env "HAXE_HEAP_WORRY_MB" with
+	| None -> config
 	| Some s ->
 		(try
-			match List.map (fun p -> int_of_string (String.trim p)) (String.split_on_char ':' s) with
-			| [v] -> { default with min_space_overhead = v; max_space_overhead = v }
-			| [mn; mx] -> { default with min_space_overhead = mn; max_space_overhead = mx }
-			| _ -> default
-		with _ -> default)
+			match parse_pair s with
+			| [v] -> { config with heap_start_worrying_mb = v; heap_really_worry_mb = v }
+			| [start; really] -> { config with heap_start_worrying_mb = start; heap_really_worry_mb = really }
+			| _ -> config
+		with _ -> config)
 in
 DynamicGc.setup_dynamic_tuning gc_config;
 


### PR DESCRIPTION
Like HAXE_SPACE_OVERHEAD, the dynamic GC worry thresholds are set up before argument parsing, so a -D define cannot reach them. Read an optional HAXE_HEAP_WORRY_MB env var: "N" sets both heap_start_worrying_mb and heap_really_worry_mb to N, "START:REALLY" sets them independently. Default is unchanged.

See #12961 