### PR TITLE
[display] don't serialize the full declaring type into completion item origins

### DIFF
--- a/src/compiler/displayOutput.ml
+++ b/src/compiler/displayOutput.ml
@@ -42,14 +42,17 @@ let handle_syntax_completion com kind subj =
 	| _ ->
 		let l = List.map make_ci_keyword l in
 		let rh = com.Common.request_scope.result_handler in
-		let ctx = Genjson.create_context GMFull in
+		let ctx = Genjson.create_full_config () in
 		CompilerOutput.send_result_raise rh (fields_to_json ctx l kind subj)
 
 let handle_display_exception_json com dex rh =
 	match dex with
 	| DisplayHover _ | DisplayFields _ ->
 		DisplayPosition.display_position#reset;
-		let ctx = DisplayJson.create_json_context (match dex with DisplayFields _ -> true | _ -> false) in
+		let ctx = match dex with
+			| DisplayFields _ when !DisplayJson.supports_resolve -> Genjson.create_minimal_config ()
+			| _ -> Genjson.create_full_config ()
+		in
 		CompilerOutput.send_result_raise rh (DisplayException.to_json ctx dex)
 
 let handle_display_exception com dex =
@@ -73,7 +76,7 @@ let handle_type_path_exception com p c is_import pos =
 	| None ->
 		()
 	| Some fields ->
-		let ctx = DisplayJson.create_json_context false in
+		let ctx = Genjson.create_full_config () in
 		let path = match List.rev p with
 			| name :: pack -> List.rev pack,name
 			| [] -> [],""

--- a/src/context/display/diagnosticsPrinter.ml
+++ b/src/context/display/diagnosticsPrinter.ml
@@ -53,7 +53,7 @@ open CompletionModuleType
     position, handles cross-entry field deduplication, and wraps
     them in the final "entries" array. *)
 let make_missing_fields_message mf =
-	let jctx = create_context GMMinimum in
+	let jctx = create_minimal_config () in
 	let scope cf =
 		if has_class_field_flag cf CfStatic then CFSStatic else CFSMember
 	in
@@ -101,7 +101,7 @@ let make_missing_fields_message mf =
 		]
 	] in
 	let j = jobject [
-		"moduleType",generate_module_type { jctx with generate_minimal = true } mf.mf_on;
+		"moduleType",generate_module_type { jctx with generate_member_bodies = false } mf.mf_on;
 		"moduleFile",jstring (Path.UniqueKey.lazy_path (t_infos mf.mf_on).mt_module.m_extra.m_file);
 		"entry",entry
 	] in

--- a/src/context/display/diagnosticsPrinter.ml
+++ b/src/context/display/diagnosticsPrinter.ml
@@ -101,7 +101,7 @@ let make_missing_fields_message mf =
 		]
 	] in
 	let j = jobject [
-		"moduleType",generate_module_type jctx mf.mf_on;
+		"moduleType",generate_module_type { jctx with generate_minimal = true } mf.mf_on;
 		"moduleFile",jstring (Path.UniqueKey.lazy_path (t_infos mf.mf_on).mt_module.m_extra.m_file);
 		"entry",entry
 	] in

--- a/src/context/display/displayException.ml
+++ b/src/context/display/displayException.ml
@@ -163,7 +163,7 @@ let to_json ctx de =
 			| LocalVariable name -> (2, name)
 			| ImplicitReturn -> die "" __LOC__
 		in
-		let ctx = Genjson.create_context GMFull in
+		let ctx = Genjson.create_full_config () in
 		let generate_name kind =
 			let i,si = named_source_kind kind in
 			jobject [
@@ -207,12 +207,12 @@ let send_module_symbols_raise com s =
 
 let send_hover_raise com item expected p =
 	DisplayPosition.display_position#reset;
-	let ctx = Genjson.create_context GMFull in
+	let ctx = Genjson.create_full_config () in
 	send_json_result_raise com (to_json ctx (DisplayHover({hitem = item;hpos = p;hexpected = expected})))
 
 let send_signatures_raise com sigs isig iarg kind =
 	DisplayPosition.display_position#reset;
-	let ctx = Genjson.create_context GMFull in
+	let ctx = Genjson.create_full_config () in
 	let fsig ((_,signature),doc) =
 		let fl = CompletionType.generate_function' ctx signature in
 		let fl = (match doc with None -> fl | Some d -> ("documentation",jstring (gen_doc_text d)) :: fl) in

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -35,9 +35,6 @@ let json_of_times root =
 
 let supports_resolve = ref false
 
-let create_json_context  may_resolve =
-	Genjson.create_context (if may_resolve && !supports_resolve then GMMinimum else GMFull)
-
 let send_string io j =
 	CompilerIo.write_result io j
 
@@ -229,7 +226,7 @@ let handler =
 			let i = hctx.jsonrpc#get_int_param "index" in
 			begin try
 				let item = (!DisplayException.last_completion_result).(i) in
-				let ctx = Genjson.create_context GMFull in
+				let ctx = Genjson.create_full_config () in
 				Result (jobject ["item",CompletionItem.to_json ctx None item])
 			with Invalid_argument _ ->
 				Error (jstring (Printf.sprintf "Invalid index: %i" i))
@@ -470,7 +467,7 @@ let handler =
 						end;
 						let infos = t_infos mt in
 						if snd infos.mt_path = typeName then begin
-							let ctx = Genjson.create_context GMFull in
+							let ctx = Genjson.create_full_config () in
 							Result (Genjson.generate_module_type ctx mt)
 						end else
 							loop mtl
@@ -571,7 +568,7 @@ let handler =
 		);
 		"typer/compiledTypes", (fun hctx ->
 			defer AfterFilters (fun () ->
-				let ctx = create_context GMFull in
+				let ctx = create_full_config () in
 				let l = List.map (generate_module_type ctx) hctx.com.types in
 				Result (jarray l)
 			)

--- a/src/context/display/displayJson.ml
+++ b/src/context/display/displayJson.ml
@@ -470,7 +470,7 @@ let handler =
 						end;
 						let infos = t_infos mt in
 						if snd infos.mt_path = typeName then begin
-							let ctx = Genjson.create_context GMMinimum in
+							let ctx = Genjson.create_context GMFull in
 							Result (Genjson.generate_module_type ctx mt)
 						end else
 							loop mtl

--- a/src/core/display/completionItem.ml
+++ b/src/core/display/completionItem.ml
@@ -246,16 +246,13 @@ module CompletionModuleType = struct
 				("importStatus",jint (ImportStatus.to_int is));
 			]) ::
 			("kind",jint (to_int cm.kind)) ::
-			(match ctx.generation_mode with
-			| GMFull | GMWithoutDoc | GMMinimum ->
-				("meta",generate_metadata ctx cm.meta) ::
-				("pos",generate_pos ctx cm.pos) ::
-				("params",jlist (generate_ast_type_param ctx) cm.params) ::
-				("isExtern",jbool cm.is_extern) ::
-				("isFinal",jbool cm.is_final) ::
-				("isAbstract",jbool cm.is_abstract) ::
-				(if ctx.generation_mode = GMFull then ["doc",jopt jstring (gen_doc_text_opt cm.doc)] else [])
-			)
+			("meta",generate_metadata ctx cm.meta) ::
+			("pos",generate_pos ctx cm.pos) ::
+			("params",jlist (generate_ast_type_param ctx) cm.params) ::
+			("isExtern",jbool cm.is_extern) ::
+			("isFinal",jbool cm.is_final) ::
+			("isAbstract",jbool cm.is_abstract) ::
+			(if ctx.generate_docs then ["doc",jopt jstring (gen_doc_text_opt cm.doc)] else [])
 		in
 		jobject fields
 end
@@ -271,14 +268,14 @@ module ClassFieldOrigin = struct
 		| Unknown
 
 	let to_json ctx cfo =
-		let octx = { ctx with generate_minimal = true } in
+		let octx = { ctx with generate_member_bodies = false } in
 		let generate_module_type mt = generate_module_type octx mt in
 		let i,args = match cfo with
-		| Self mt -> 0,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
-		| StaticImport mt -> 1,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
-		| Parent mt -> 2,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
-		| StaticExtension mt -> 3,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
-		| AnonymousStructure an -> 4,if ctx.generation_mode = GMMinimum then None else Some (generate_anon ctx an)
+		| Self mt -> 0,if ctx.generate_origins then Some (generate_module_type mt) else None
+		| StaticImport mt -> 1,if ctx.generate_origins then Some (generate_module_type mt) else None
+		| Parent mt -> 2,if ctx.generate_origins then Some (generate_module_type mt) else None
+		| StaticExtension mt -> 3,if ctx.generate_origins then Some (generate_module_type mt) else None
+		| AnonymousStructure an -> 4,if ctx.generate_origins then Some (generate_anon ctx an) else None
 		| BuiltIn -> 5,None
 		| Unknown -> 6,None
 		in

--- a/src/core/display/completionItem.ml
+++ b/src/core/display/completionItem.ml
@@ -271,11 +271,13 @@ module ClassFieldOrigin = struct
 		| Unknown
 
 	let to_json ctx cfo =
+		let octx = { ctx with generate_minimal = true } in
+		let generate_module_type mt = generate_module_type octx mt in
 		let i,args = match cfo with
-		| Self mt -> 0,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type ctx mt)
-		| StaticImport mt -> 1,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type ctx mt)
-		| Parent mt -> 2,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type ctx mt)
-		| StaticExtension mt -> 3,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type ctx mt)
+		| Self mt -> 0,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
+		| StaticImport mt -> 1,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
+		| Parent mt -> 2,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
+		| StaticExtension mt -> 3,if ctx.generation_mode = GMMinimum then None else Some (generate_module_type mt)
 		| AnonymousStructure an -> 4,if ctx.generation_mode = GMMinimum then None else Some (generate_anon ctx an)
 		| BuiltIn -> 5,None
 		| Unknown -> 6,None

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -3,15 +3,12 @@ open Globals
 open Type
 open Meta
 
-type generation_mode =
-	| GMFull
-	| GMWithoutDoc
-	| GMMinimum
-
 type context = {
-	generation_mode : generation_mode;
 	generate_abstract_impl : bool;
-	generate_minimal : bool;
+	generate_member_bodies : bool;
+	generate_docs : bool;
+	generate_exprs : bool;
+	generate_origins : bool;
 }
 
 let jnull = Json.JNull
@@ -91,9 +88,8 @@ let generate_pos ctx p =
 let generate_expr_pos ctx p =
 	jtodo
 
-let generate_doc ctx d = match ctx.generation_mode with
-	| GMFull -> jopt jstring (gen_doc_text_opt d)
-	| GMWithoutDoc | GMMinimum -> jnull
+let generate_doc ctx d =
+	if ctx.generate_docs then jopt jstring (gen_doc_text_opt d) else jnull
 
 (** return a range JSON structure for given position
     positions are 0-based and the result object looks like this:
@@ -504,8 +500,8 @@ and generate_class_field' ctx cfs cf =
 		in
 		generate_adt ctx None name args
 	in
-	let expr = match ctx.generation_mode with
-		| GMFull | GMWithoutDoc ->
+	let expr =
+		if ctx.generate_exprs then begin
 			let value = match cf.cf_kind with
 				| Method _ -> None
 				| Var _ ->
@@ -526,7 +522,7 @@ and generate_class_field' ctx cfs cf =
 						jnull
 				| Some e -> jobject ["string",jstring (Ast.Printer.s_expr e)]
 			end
-		| GMMinimum ->
+		end else
 			jnull
 	in
 	[
@@ -599,11 +595,11 @@ let generate_class ctx c =
 		"isInterface",jbool (has_class_flag c CInterface);
 		"superClass",jopt generate_class_relation c.cl_super;
 		"interfaces",jlist generate_class_relation c.cl_implements;
-		"fields",if ctx.generate_minimal then jarray [] else jlist (generate_class_field ctx CFSMember) c.cl_ordered_fields;
-		"statics",if ctx.generate_minimal then jarray [] else jlist (generate_class_field ctx CFSStatic) c.cl_ordered_statics;
-		"constructor",if ctx.generate_minimal then jnull else jopt (generate_class_field ctx CFSConstructor) c.cl_constructor;
-		"init",if ctx.generate_minimal then jnull else jopt (generate_texpr ctx) (TClass.get_cl_init c);
-		"overrides",if ctx.generate_minimal then jarray [] else jlist (classfield_ref ctx) (List.filter (fun cf -> has_class_field_flag cf CfOverride) c.cl_ordered_fields);
+		"fields",if ctx.generate_member_bodies then jlist (generate_class_field ctx CFSMember) c.cl_ordered_fields else jarray [];
+		"statics",if ctx.generate_member_bodies then jlist (generate_class_field ctx CFSStatic) c.cl_ordered_statics else jarray [];
+		"constructor",if ctx.generate_member_bodies then jopt (generate_class_field ctx CFSConstructor) c.cl_constructor else jnull;
+		"init",if ctx.generate_member_bodies then jopt (generate_texpr ctx) (TClass.get_cl_init c) else jnull;
+		"overrides",if ctx.generate_member_bodies then jlist (classfield_ref ctx) (List.filter (fun cf -> has_class_field_flag cf CfOverride) c.cl_ordered_fields) else jarray [];
 		"isExtern",jbool (has_class_flag c CExtern);
 		"isFinal",jbool (has_class_flag c CFinal);
 		"isAbstract",jbool (has_class_flag c CAbstract);
@@ -617,7 +613,7 @@ let generate_enum ctx e =
 		) e.e_names)
 	in
 	[
-		"constructors",if ctx.generate_minimal then jarray [] else generate_enum_constructors ();
+		"constructors",if ctx.generate_member_bodies then generate_enum_constructors () else jarray [];
 		"isExtern",jbool (has_enum_flag e EnExtern)
 	]
 
@@ -708,15 +704,24 @@ let generate_module modules find_module m =
 		) modules []));
 	]
 
-let create_context gm = {
-	generation_mode = gm;
+let create_full_config () = {
 	generate_abstract_impl = false;
-	generate_minimal = false;
+	generate_member_bodies = true;
+	generate_docs = true;
+	generate_exprs = true;
+	generate_origins = true;
+}
+
+let create_minimal_config () = {
+	(create_full_config ()) with
+	generate_docs = false;
+	generate_exprs = false;
+	generate_origins = false;
 }
 
 let generate timer_ctx types file =
 	let json = Timer.time timer_ctx ["generate";"json";"construct"] (fun () ->
-		let ctx = create_context GMFull in
+		let ctx = create_full_config () in
 		jarray (List.map (generate_module_type ctx) types)
 	) () in
 	Timer.time timer_ctx ["generate";"json";"write"] (fun () ->

--- a/src/core/json/genjson.ml
+++ b/src/core/json/genjson.ml
@@ -11,6 +11,7 @@ type generation_mode =
 type context = {
 	generation_mode : generation_mode;
 	generate_abstract_impl : bool;
+	generate_minimal : bool;
 }
 
 let jnull = Json.JNull
@@ -598,11 +599,11 @@ let generate_class ctx c =
 		"isInterface",jbool (has_class_flag c CInterface);
 		"superClass",jopt generate_class_relation c.cl_super;
 		"interfaces",jlist generate_class_relation c.cl_implements;
-		"fields",jlist (generate_class_field ctx CFSMember) c.cl_ordered_fields;
-		"statics",jlist (generate_class_field ctx CFSStatic) c.cl_ordered_statics;
-		"constructor",jopt (generate_class_field ctx CFSConstructor) c.cl_constructor;
-		"init",jopt (generate_texpr ctx) (TClass.get_cl_init c);
-		"overrides",jlist (classfield_ref ctx) (List.filter (fun cf -> has_class_field_flag cf CfOverride) c.cl_ordered_fields);
+		"fields",if ctx.generate_minimal then jarray [] else jlist (generate_class_field ctx CFSMember) c.cl_ordered_fields;
+		"statics",if ctx.generate_minimal then jarray [] else jlist (generate_class_field ctx CFSStatic) c.cl_ordered_statics;
+		"constructor",if ctx.generate_minimal then jnull else jopt (generate_class_field ctx CFSConstructor) c.cl_constructor;
+		"init",if ctx.generate_minimal then jnull else jopt (generate_texpr ctx) (TClass.get_cl_init c);
+		"overrides",if ctx.generate_minimal then jarray [] else jlist (classfield_ref ctx) (List.filter (fun cf -> has_class_field_flag cf CfOverride) c.cl_ordered_fields);
 		"isExtern",jbool (has_class_flag c CExtern);
 		"isFinal",jbool (has_class_flag c CFinal);
 		"isAbstract",jbool (has_class_flag c CAbstract);
@@ -616,7 +617,7 @@ let generate_enum ctx e =
 		) e.e_names)
 	in
 	[
-		"constructors",generate_enum_constructors ();
+		"constructors",if ctx.generate_minimal then jarray [] else generate_enum_constructors ();
 		"isExtern",jbool (has_enum_flag e EnExtern)
 	]
 
@@ -710,6 +711,7 @@ let generate_module modules find_module m =
 let create_context gm = {
 	generation_mode = gm;
 	generate_abstract_impl = false;
+	generate_minimal = false;
 }
 
 let generate timer_ctx types file =

--- a/tests/server/src/cases/display/issues/CompletionOriginMinimal.hx
+++ b/tests/server/src/cases/display/issues/CompletionOriginMinimal.hx
@@ -1,0 +1,61 @@
+package cases.display.issues;
+
+import haxe.display.JsonModuleTypes;
+
+class CompletionOriginMinimal extends DisplayTestCase {
+	/**
+		class Base {
+			public var a:Int;
+			public var b:String;
+			public var c:Float;
+			public function new() {}
+			public function foo() {}
+			public function bar() {}
+		}
+
+		class Child extends Base {
+			public function new() super();
+		}
+
+		class Main {
+			static function main() {
+				var child = new Child();
+				child.{-1-}
+			}
+		}
+	**/
+	function test(_) {
+		var result = runHaxeJson([], DisplayMethods.Completion, {file: file, offset: offset(1), wasAutoTriggered: false});
+		// A field inherited from Base carries an origin pointing at Base. That origin
+		// must only identify the declaring type, not drag Base's whole field list into
+		// the item (the bloat fix). Assert the origin's class args carry no fields/statics.
+		var sawInherited = false;
+		for (item in result.items) {
+			switch item.kind {
+				case ClassField:
+					var occurrence:{origin:ClassFieldOrigin<Dynamic>} = cast item.args;
+					var origin = occurrence.origin;
+					if (origin == null || origin.args == null) continue;
+					switch origin.kind {
+						case Parent:
+							sawInherited = true;
+							var mt:JsonModuleType<Dynamic> = origin.args;
+							// path/name must still be present so the client can render "from Base"
+							Assert.equals("Base", mt.name);
+							switch mt.kind {
+								case Class:
+									var cl:JsonClass = mt.args;
+									Assert.equals(0, cl.fields.length);
+									Assert.equals(0, cl.statics.length);
+									Assert.isNull(cl.constructor);
+								case _:
+									Assert.fail("expected Class origin");
+							}
+						case _:
+					}
+				case _:
+			}
+		}
+		Assert.isTrue(sawInherited);
+	}
+}


### PR DESCRIPTION
Each completion item carries an `origin` identifying where the field comes from (Self/StaticImport/Parent/StaticExtension). For a ClassField, the origin was serialized as the entire declaring module type with all fields fully expanded via generate_module_type. A field inherited from a big class dragged that whole class's field list into every item that came from it, so completion responses ballooned (one real project: ~27 MB for ~340 items, ~83 KB/item), which clients then spent seconds parsing.

Add a `generate_minimal` flag to the genjson context. When set, generate_class emits empty fields/statics/overrides and null constructor/init, and generate_enum emits empty constructors; the type's identifying data (pack/name/moduleName/pos/meta/params/kind, class kind+isInterface, typedef type) is kept. ClassFieldOrigin.to_json now serializes origins through such a context, so an origin only identifies its declaring type instead of inlining its members. Scoped to completion origins; the completionItem/resolve path and full type listings are unaffected.

Same project now returns ~0.73 MB (~2.1 KB/item).
Ran haxe LSP tests with this, no failure.