### PR TITLE
[std/js] Prevent EntryPoint timeout warning on js

### DIFF
--- a/std/haxe/EntryPoint.hx
+++ b/std/haxe/EntryPoint.hx
@@ -11,7 +11,9 @@ class EntryPoint {
 		#if js
 			var nextTick = haxe.EventLoop.main.getNextTick();
 			inline function setTimeoutNextTick() {
-				(untyped setTimeout)(run, (nextTick < 0 ? 0 : nextTick * 1000));
+				var time = nextTick < 0 ? 0 : nextTick * 1000;
+				if( time > 0x7FFFFFFF ) time = 0x7FFFFFFF;
+				(untyped setTimeout)(run, time);
 			}
 			#if nodejs
 			setTimeoutNextTick();


### PR DESCRIPTION
```
(node:17784) TimeoutOverflowWarning: 1000000000000 does not fit into a 32-bit signed integer.
EntryPoint.hx:20
```

In addition to https://github.com/HaxeFoundation/haxe/commit/190a46da18a72d96f9e50095cbef83454ce965ab , prevent passing big value to setTimeout. Suggested by Nicolas.