### PR TITLE
[typer] guard monomorph constraint traversals against cyclic graphs 

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -297,14 +297,8 @@ module Monomorph = struct
 		| TMono m2 ->
 			if m != m2 then begin match m2.tm_type with
 			| None ->
-				List.iter (fun constr -> match constr with
-					| MMono(m3,_) when m3 == m2 -> ()
-					| _ -> add_down_constraint m2 constr
-				) m.tm_down_constraints;
-				List.iter (fun ((t,_) as constr) -> match t with
-					| TMono m3 when m3 == m2 -> ()
-					| _ -> add_up_constraint m2 constr
-				) m.tm_up_constraints;
+				List.iter (add_down_constraint m2) m.tm_down_constraints;
+				List.iter (add_up_constraint m2) m.tm_up_constraints;
 				List.iter (fun modi ->
 					add_modifier m2 modi
 				) m.tm_modifiers;

--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -178,24 +178,21 @@ module Monomorph = struct
 
 	(* Note: This function is called by printing and others and should thus not modify state. *)
 
-	let rec classify_down_constraints m =
+	let classify_down_constraints m =
 		let types = DynArray.create () in
 		let fields = ref PMap.empty in
 		let is_open = ref false in
+		let visited = ref [m] in
 		let rec check constr = match constr with
 			| MMono(m2,name) ->
-				begin match m2.tm_type with
-				| None ->
-					let kind = classify_down_constraints m2 in
-					begin match kind with
-					| CUnknown ->
-						()
-					| _ ->
+				if not (List.memq m2 !visited) then begin
+					visited := m2 :: !visited;
+					match m2.tm_type with
+					| None ->
 						(* Recursively inherit constraints. *)
 						List.iter check m2.tm_down_constraints
-					end
-				| Some t ->
-					List.iter (fun constr -> check constr) (constraint_of_type name t)
+					| Some t ->
+						List.iter (fun constr -> check constr) (constraint_of_type name t)
 				end;
 			| MField cf ->
 				fields := PMap.add cf.cf_name cf !fields;
@@ -246,6 +243,7 @@ module Monomorph = struct
 			List.iter (fun constr -> check_down_constraints constr t) l
 
 	let collect_up_constraints m =
+		let visited = ref [m] in
 		let rec collect m acc =
 			List.fold_left (fun acc (t,name) ->
 				match t with
@@ -255,7 +253,12 @@ module Monomorph = struct
 						(match follow t with
 						| TMono _ -> acc
 						| _ -> (t,name) :: acc)
-					| None -> collect m2 acc
+					| None ->
+						if List.memq m2 !visited then acc
+						else begin
+							visited := m2 :: !visited;
+							collect m2 acc
+						end
 					)
 				| _ -> (t,name) :: acc
 			) acc m.tm_up_constraints
@@ -294,8 +297,14 @@ module Monomorph = struct
 		| TMono m2 ->
 			if m != m2 then begin match m2.tm_type with
 			| None ->
-				List.iter (add_down_constraint m2) m.tm_down_constraints;
-				List.iter (add_up_constraint m2) m.tm_up_constraints;
+				List.iter (fun constr -> match constr with
+					| MMono(m3,_) when m3 == m2 -> ()
+					| _ -> add_down_constraint m2 constr
+				) m.tm_down_constraints;
+				List.iter (fun ((t,_) as constr) -> match t with
+					| TMono m3 when m3 == m2 -> ()
+					| _ -> add_up_constraint m2 constr
+				) m.tm_up_constraints;
 				List.iter (fun modi ->
 					add_modifier m2 modi
 				) m.tm_modifiers;

--- a/tests/unit/src/unit/TestConstrainedMonomorphs.hx
+++ b/tests/unit/src/unit/TestConstrainedMonomorphs.hx
@@ -2,6 +2,8 @@ package unit;
 
 import utest.Assert;
 
+private typedef IdentityOf<T> = T;
+
 private class MyNotString {
 	var s:String;
 
@@ -129,6 +131,20 @@ class TestConstrainedMonomorphs extends Test {
 		// unbounded recursion (compiler hang)
 		var x = null;
 		constrainedToSibling(x, x);
+		noAssert();
+	}
+
+	static function constrainedToNullOfSibling<A:Null<B>, B>(a:A, b:B):Void {}
+
+	static function constrainedToTypedefOfSibling<A:IdentityOf<B>, B>(a:A, b:B):Void {}
+
+	function testUnifyMonoWithFollowTransparentConstraintTarget() {
+		// Null<B> and typedefs follow to the bare monomorph, creating the same
+		// mono-mono constraint edge as a direct A:B constraint
+		var x = null;
+		constrainedToNullOfSibling(x, x);
+		var y = null;
+		constrainedToTypedefOfSibling(y, y);
 		noAssert();
 	}
 

--- a/tests/unit/src/unit/TestConstrainedMonomorphs.hx
+++ b/tests/unit/src/unit/TestConstrainedMonomorphs.hx
@@ -121,4 +121,15 @@ class TestConstrainedMonomorphs extends Test {
 	}
 	#end
 
+	static function constrainedToSibling<A:B, B>(a:A, b:B):Void {}
+
+	function testUnifyMonoWithItsConstraintTarget() {
+		// unifying A with B replays A's mono-mono constraint onto B itself;
+		// the resulting self-edge sent classify_down_constraints into
+		// unbounded recursion (compiler hang)
+		var x = null;
+		constrainedToSibling(x, x);
+		noAssert();
+	}
+
 }


### PR DESCRIPTION
`Monomorph.bind`'s mono-merge branch could replay a constraint of the form `MMono(m2)` onto `m2` itself (`f<A:B, B>` called with the same untyped value for both arguments unifies `A` with `B` and copies `A`'s constraints to `B`). The resulting self-edge sent `classify_down_constraints` into unbounded mutual recursion with check, hanging the compiler.

- `classify_down_constraints`: track visited monomorphs and expand each one at most once. This also replaces the recursive pre-classification used to decide whether to inherit constraints; that check was equivalent to inheriting unconditionally (a `CUnknown` subtree contributes no leaves) but walked the subtree once per level, exponentially in chain depth.
- `collect_up_constraints`: same visited guard.