### PR TITLE
[typer] fix up-constraint list corruption in Monomorph.add_down_constraint

### DIFF
--- a/src/core/tUnification.ml
+++ b/src/core/tUnification.ml
@@ -158,7 +158,7 @@ module Monomorph = struct
 	let add_down_constraint m constr =
 		m.tm_down_constraints <- constr :: m.tm_down_constraints;
 		match constr with
-		| MMono (m2,s) -> m2.tm_up_constraints <- (TMono m,s) :: m.tm_up_constraints
+		| MMono (m2,s) -> m2.tm_up_constraints <- (TMono m,s) :: m2.tm_up_constraints
 		| _ -> ()
 
 	let constraint_of_type name t = match follow t with

--- a/tests/misc/eval/projects/Issue12977/Main.hx
+++ b/tests/misc/eval/projects/Issue12977/Main.hx
@@ -1,0 +1,12 @@
+class Main {
+	static function f<A:C, B:C, C>(a:A, b:B, c:C):Void {}
+
+	static function main() {
+		#if case_violate_a
+		f(1, "ok", "str");
+		#end
+		#if case_violate_b
+		f("ok", 1, "str");
+		#end
+	}
+}

--- a/tests/misc/eval/projects/Issue12977/compile-fail.hxml
+++ b/tests/misc/eval/projects/Issue12977/compile-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+-D case_violate_a

--- a/tests/misc/eval/projects/Issue12977/compile-fail.hxml.stderr
+++ b/tests/misc/eval/projects/Issue12977/compile-fail.hxml.stderr
@@ -1,0 +1,3 @@
+Main.hx:6: characters 14-19 : Constraint check failure for f.A
+Main.hx:6: characters 14-19 : ... Int should be String
+Main.hx:6: characters 14-19 : ... For function argument 'c'

--- a/tests/misc/eval/projects/Issue12977/compile2-fail.hxml
+++ b/tests/misc/eval/projects/Issue12977/compile2-fail.hxml
@@ -1,0 +1,2 @@
+--main Main
+-D case_violate_b

--- a/tests/misc/eval/projects/Issue12977/compile2-fail.hxml.stderr
+++ b/tests/misc/eval/projects/Issue12977/compile2-fail.hxml.stderr
@@ -1,0 +1,3 @@
+Main.hx:9: characters 14-19 : Constraint check failure for f.B
+Main.hx:9: characters 14-19 : ... Int should be String
+Main.hx:9: characters 14-19 : ... For function argument 'c'


### PR DESCRIPTION
The mirror edge wrote `(TMono m,s) :: m.tm_up_constraints` into `m2.tm_up_constraints`, i.e. `m`'s list instead of `m2`'s own. This both discarded `m2`'s previously recorded lower bounds and aliased `m`'s list into `m2`. With `f<A:C, B:C, C>`, processing `B`'s constraint erased `C`'s edge to `A`; if `C` was inferred after the other params, the `A:C` bound was never enforced and unsound calls were accepted.

Splicing `m`'s list was not needed for transitivity either: `collect_up_constraints` already recurses through unbound mono entries at check time, and the symmetric mirror in `add_up_constraint` appends to the other monomorph's own list. Note that this makes constraint checking stricter: lower bounds that were previously dropped are now enforced.

Present since https://github.com/HaxeFoundation/haxe/pull/10233.