### PR TITLE
apply _std rule when parsing

### DIFF
--- a/src/core/path.ml
+++ b/src/core/path.ml
@@ -44,6 +44,8 @@ let parse_path f =
 		| [x] ->
 			check_invalid_char x;
 			[],x
+		| _ :: ("_std" :: l) ->
+			loop l
 		| x :: l ->
 			check_package_name x;
 			let path,name = loop l in

--- a/tests/server/src/cases/issues/Issue12245.hx
+++ b/tests/server/src/cases/issues/Issue12245.hx
@@ -1,0 +1,45 @@
+package cases.issues;
+
+import haxe.io.Path;
+
+class Issue12245 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", "function main() {\n\ttrace(haxe.io.Bytes.alloc(0));\n}");
+		var args = ["-main", "Main", "--js", "bin/main.js", "--no-output"];
+		runHaxe(args);
+		assertSuccess();
+
+		var std = Path.removeTrailingSlashes(utils.macro.BuildHub.getStd());
+		var bytes = new FsPath('$std/js/_std/haxe/io/Bytes.hx');
+
+		// Used to loop forever spawning core-api typing contexts, because the
+		// display file was registered under its file-derived dotpath
+		// js._std.haxe.io.Bytes instead of haxe.io.Bytes
+		final res = runHaxeJson(args, DisplayMethods.Diagnostics, {file: bytes});
+		assertSuccess();
+		// Only assert on errors: warning-level diagnostics (e.g. unused vars)
+		// legitimately occur in the real std file
+		for (r in res)
+			Assert.equals(0, r.diagnostics.filter(d -> d.severity == Error).length);
+
+		// Used to fail with "Invalid commandline class : js._std.haxe.io.Bytes
+		// should be haxe.io.Bytes"
+		runHaxeJson(args, DisplayMethods.Hover, {file: bytes, offset: 0});
+		assertSuccess();
+	}
+
+	// "Reload window" scenario: the diagnostics request on the _std file is
+	// the first thing the fresh server sees, without a prior compilation
+	function testWithoutPriorCompile(_) {
+		vfs.putContent("Main.hx", "function main() {\n\ttrace(haxe.io.Bytes.alloc(0));\n}");
+		var args = ["-main", "Main", "--js", "bin/main.js", "--no-output"];
+
+		var std = Path.removeTrailingSlashes(utils.macro.BuildHub.getStd());
+		var bytes = new FsPath('$std/js/_std/haxe/io/Bytes.hx');
+
+		final res = runHaxeJson(args, DisplayMethods.Diagnostics, {file: bytes});
+		assertSuccess();
+		for (r in res)
+			Assert.equals(0, r.diagnostics.filter(d -> d.severity == Error).length);
+	}
+}


### PR DESCRIPTION
Closes #12245 

This is my [original](https://github.com/HaxeFoundation/haxe/issues/12245#issuecomment-2943091023) fix for the issue, which I had Claude double check:

**Root** **cause** — it's an ordering bug: in `compile` (compiler.ml:333), `process_display_file` runs *before* `Setup.initialize_target` (line 347), and it's target init that registers `<std>/js/_std/` as a class path. The shortest-dotpath scan in `get_module_path_from_file_path` therefore never sees that class path and derives the alien dotpath `js._std.haxe.io.Bytes`. Typing that `@:coreApi` class under the wrong path makes core-api loading spawn a fresh core context which resolves the display file again under the alien path — unbounded recursion, each round re-typing the entire std. Non-`_std` std files don't hang (verified as control).

> More stuff is needed to make display API actually work there

Claude only found things that were not fine _then_ but have been fixed since then.

Since the real cause is the init ordering, an alternative fix is moving `process_display_file` after `initialize_target`. The `parse_path` approach is broader though: it also covers `eval/_std` (the macro class path never lands in `com.class_paths`). And Simon already [okayed it](https://github.com/HaxeFoundation/haxe/issues/12245#issuecomment-3546571537).