### PR TITLE
[display] import completion: suggest qualified paths for unqualified type prefixes

### DIFF
--- a/src/context/display/displayPath.ml
+++ b/src/context/display/displayPath.ml
@@ -207,6 +207,8 @@ let handle_path_display ctx path p =
 			with Not_found ->
 				()
 			end
+		| (IDKModule([],s),p),DMDefault ->
+			DisplayToplevel.collect_and_raise ctx TKType WithType.no_value CRImport (s,p) p
 		| (IDKModule(sl,s),p),_ ->
 			raise (Parser.TypePath(sl,None,true,p))
 		| (IDKSubType(sl,sm,st),p),(DMDefinition | DMTypeDefinition) ->

--- a/tests/server/src/cases/display/IImport.hx
+++ b/tests/server/src/cases/display/IImport.hx
@@ -65,4 +65,44 @@ class IImport extends DisplayTestCase {
 		eq(true, hasPath(fields(1), "Context"));
 		eq(false, hasPath(fields(1), "Context.hl"));
 	}
+
+	/**
+		import Fo{-1-};
+
+		class Main {}
+	**/
+	function testUnqualifiedModule(_) {
+		vfs.putContent("src/pack/to/Foo.hx", "package pack.to;\nclass Foo {}\nclass Bar {}");
+		runHaxeJson(["-cp", "src"], ServerMethods.ReadClassPaths, {wait: true});
+		eq(true, hasFullPath(fields(1), "pack.to", "Foo"));
+	}
+
+	/**
+		import Ba{-1-};
+
+		class Main {}
+	**/
+	function testUnqualifiedSubType(_) {
+		vfs.putContent("src/pack/to/Foo.hx", "package pack.to;\nclass Foo {}\nclass Bar {}");
+		runHaxeJson(["-cp", "src"], ServerMethods.ReadClassPaths, {wait: true});
+		eq(true, hasFullPath(fields(1), "pack.to", "Bar"));
+	}
+
+	/**
+		using Fo{-1-};
+
+		class Main {}
+	**/
+	function testUnqualifiedUsing(_) {
+		vfs.putContent("src/pack/to/Foo.hx", "package pack.to;\nclass Foo {}\nclass Bar {}");
+		runHaxeJson(["-cp", "src"], ServerMethods.ReadClassPaths, {wait: true});
+		eq(true, hasFullPath(fields(1), "pack.to", "Foo"));
+	}
+
+	function hasFullPath<T>(items:Array<DisplayItem<T>>, pack:String, typeName:String):Bool {
+		return items.exists(t -> switch (t.kind) {
+			case Type: t.args.path.typeName == typeName && t.args.path.pack.join(".") == pack;
+			case _: false;
+		});
+	}
 }


### PR DESCRIPTION
`import Fo|` and `using Fo|` fell into legacy type path completion, which only lists root-package modules. Raise a toplevel `CRImport` collection instead, so clients can suggest `pack.to.Foo` (and module sub-types, e.g. `Ba|` -> `pack.to.Foo.Bar`) with fully-qualified insert text. Qualified prefixes (`import pack.Fo|`) keep the package-scoped listing.