### PR TITLE
Add JSON_UNESCAPED_SLASHES option to json_encode

### DIFF
--- a/std/php/_std/haxe/Json.hx
+++ b/std/php/_std/haxe/Json.hx
@@ -79,7 +79,7 @@ class Json {
 			return JsonPrinter.print(value, replacer, space);
 		}
 
-		var json = Global.json_encode(convertBeforeEncode(value));
+		var json = Global.json_encode(convertBeforeEncode(value), Const.JSON_UNESCAPED_SLASHES);
 		if (Global.json_last_error() != Const.JSON_ERROR_NONE) {
 			return throw Global.json_last_error_msg();
 		}


### PR DESCRIPTION
Pass `JSON_UNESCAPED_SLASHES` to PHP's native `json_encode` in `haxe.Json.stringify`.

PHP escapes `/` as `"\/"` by default, while other targets (JS `JSON.stringify`, Haxe `JsonPrinter`, etc.) leave / unescaped. Both forms are valid JSON and parse identically, but the encoded strings differ across targets (which necessarily increases difficulty if cross-platform libraries want to test the encoded string).

`JSON_UNESCAPED_SLASHES` has been available since PHP 5.4 (2012), which is what Haxe required since 3.4.0. Enabling it by default aligns PHP output with other targets without changing decoded values.

See #724 