### PR TITLE
StringTools fastCodeAt make the default case fall back to using String charCodeAt

### DIFF
--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -470,7 +470,7 @@ class StringTools {
 		return lua.lib.luautf8.Utf8.byte(s, index + 1);
 		#end
 		#else
-		return untyped s.cca(index);
+		return s.charCodeAt(index);
 		#end
 	}
 

--- a/std/StringTools.hx
+++ b/std/StringTools.hx
@@ -463,6 +463,10 @@ class StringTools {
 		return if (index >= s.length) -1 else python.internal.UBuiltins.ord(python.Syntax.arrayAccess(s, index));
 		#elseif hl
 		return @:privateAccess s.bytes.getUI16(index << 1);
+		#elseif eval
+		return untyped s.cca(index);
+		#elseif php
+		return untyped s.cca(index);
 		#elseif lua
 		#if lua_vanilla
 		return lua.NativeStringTools.byte(s, index + 1);


### PR DESCRIPTION
This fixes an issue where a target not yet defined in the conditionals for StringTools.fastCodeAt, can still compile by using String charCodeAt.