### PR TITLE
[hl/std] Prevent StringBuf expand overflow

### DIFF
--- a/std/hl/_std/StringBuf.hx
+++ b/std/hl/_std/StringBuf.hx
@@ -41,9 +41,13 @@
 	}
 
 	inline function __expand(need:Int):Void {
-		var nsize = (size * 3) >> 1;
+		var nsize = size + (size >> 1);
+		if (nsize < size)
+			nsize = 0x7FFF0000;
 		if (need > nsize)
 			nsize = need;
+		if (nsize <= size)
+			throw "StringBuf maximum capacity reached";
 		var b2 = new hl.Bytes(nsize);
 		b2.blit(0, b, 0, pos);
 		b = b2;

--- a/tests/hlcode/src/Macro.hx
+++ b/tests/hlcode/src/Macro.hx
@@ -229,6 +229,11 @@ class Macro {
 			// Remove source line prefix from instruction lines: ".12    @0" → "@0"
 			trimmed = ~/^\.\d+[ \t]+/.replace(trimmed, "");
 
+			// Normalize dynset constant in "dynset 7[@159],0" → "dynset 7[@0],0"
+			trimmed = ~/\bdynset (\d+)\[@(\d+)\],(\d+)/.map(trimmed, function(r) {
+				return "dynset " + r.matched(1) + "[@" + getGlobalId("str_" + r.matched(2)) + "]," + r.matched(3);
+			});
+
 			// Normalize global IDs in "global R, G" (OGetGlobal): G is the global index
 			trimmed = ~/\bglobal (\d+), (\d+)/.map(trimmed, function(r) {
 				return "global " + r.matched(1) + ", " + getGlobalId(r.matched(2));


### PR DESCRIPTION
The maximum StringBuf size was limited to `INT_MAX/3` by the `(size* 3) >> 1`, this PR allows it to grow up to nearly `INT_MAX` and throw appropriate exception on too large buffer size.

```haxe
function main() {
	var bytes = haxe.io.Bytes.alloc(454624961); // ~450 MB
	var hex = bytes.toHex(); // ~900M chars (~1.8 GB), triggers StringBuf expand overflow that result in segfault later
	trace(hex.length);
}
```