### PR TITLE
Store main thread in Jvm.init()

### DIFF
--- a/std/jvm/Jvm.hx
+++ b/std/jvm/Jvm.hx
@@ -39,6 +39,9 @@ import jvm.annotation.EnumValueReflectionInformation;
 @:keep
 @:native('haxe.jvm.Jvm')
 class Jvm {
+	// https://github.com/HaxeFoundation/haxe/issues/12985
+	static var mainThread:sys.thread.Thread;
+	
 	public static function init():Void {
 		#if std_encoding_utf8
 		try {
@@ -46,6 +49,8 @@ class Jvm {
 			java.lang.System.setErr(new java.io.PrintStream(java.lang.System.err, true, "utf-8"));
 		} catch (e:java.io.UnsupportedEncodingException) {}
 		#end
+		
+		mainThread = sys.thread.Thread.main();
 	}
 
 	static public function getNativeType<T>(obj:T):java.lang.Class<T> {


### PR DESCRIPTION
Edit: this actually does not fix my event loop problem. We actually need to probe the `haxe.EventLoop` class in the main function in order to capture the correct "main eventloop" into the TLS....

I made a temp patch lib here: https://github.com/kevinresol/haxe12985/blob/main/src/haxe/issue12985/Patch.hx


~~A quick fix that is probably not ideal as it still brings in 3 extra classes (w/ full dce) into the output jar for a minimal `trace()` Haxe app. But they are quite minimal (see below) and I think we should have it.~~

~~A more proper fix is probably to store only the native java thread ref, and update `sys.thread.Thread` to use it.~~

See #12985

<img width="1077" height="204" alt="Screenshot 2026-07-16 at 21 55 16" src="https://github.com/user-attachments/assets/05401ba5-0b5a-479d-b7f9-9119daa5f11e" />
<img width="1073" height="350" alt="Screenshot 2026-07-16 at 21 55 09" src="https://github.com/user-attachments/assets/442f00ae-f187-4975-a73d-a30dcace4736" />
<img width="1073" height="865" alt="Screenshot 2026-07-16 at 21 55 24" src="https://github.com/user-attachments/assets/2dc4d15d-26b4-4e85-bb5d-d382a2ae4fc1" />

