### PR TITLE
[cpp] Avoid write barriers for cpp.Function fields

### DIFF
--- a/src/generators/cpp/cppContext.ml
+++ b/src/generators/cpp/cppContext.ml
@@ -89,7 +89,10 @@ let hash_keys hash =
   !key_list
 
 let is_gc_element ctx member_type =
-  Gctx.defined ctx.ctx_common Define.HxcppGcGenerational && (is_object_element member_type)
+  Gctx.defined ctx.ctx_common Define.HxcppGcGenerational &&
+  match member_type with
+  | CppAst.TCppFunction _ -> false
+  | _ -> is_object_element member_type
 
 let strip_file ctx file = match Gctx.defined ctx Define.AbsolutePath with
   | true -> Path.get_full_path file

--- a/tests/misc/cpp/projects/Issue13001/Main.hx
+++ b/tests/misc/cpp/projects/Issue13001/Main.hx
@@ -1,0 +1,20 @@
+class Main {
+	static function main():Void {
+		var holder = new NativeCallbackHolder(cpp.Callable.fromStaticFunction(increment));
+		if (holder.callback.call(41) != 42) {
+			throw "Invalid native callback result";
+		}
+	}
+
+	static function increment(value:Int):Int {
+		return value + 1;
+	}
+}
+
+class NativeCallbackHolder {
+	public var callback:cpp.Function<Int->Int, cpp.abi.Abi>;
+
+	public function new(callback:cpp.Function<Int->Int, cpp.abi.Abi>) {
+		this.callback = callback;
+	}
+}

--- a/tests/misc/cpp/projects/Issue13001/compile.hxml
+++ b/tests/misc/cpp/projects/Issue13001/compile.hxml
@@ -1,0 +1,3 @@
+-main Main
+-D HXCPP_GC_GENERATIONAL
+-cpp out


### PR DESCRIPTION
## Summary

Do not emit generational GC write barriers for `cpp.Function` instance fields.

With `HXCPP_GC_GENERATIONAL` enabled, assigning such a field generated an `HX_OBJ_WB_SET` call. This macro expects an object-like value with an `mPtr` member, but `cpp::Function` is a native function-pointer wrapper and does not have one, causing the generated C++ to fail to compile.

## Fix

Exclude `TCppFunction` from GC write-barrier generation while keeping it classified as an object element for the other code paths that rely on that classification.

## Tests

Added a C++ regression test which:

- Enables `HXCPP_GC_GENERATIONAL`
- Stores a native callback in a `cpp.Function` instance field
- Calls the stored callback and verifies its result

The targeted misc test passes successfully.

Closes #13001