### PR TITLE
fix(js): keep Bytes.toHex character codes non-null

### DIFF
--- a/std/js/_std/haxe/io/Bytes.hx
+++ b/std/js/_std/haxe/io/Bytes.hx
@@ -156,7 +156,7 @@ class Bytes {
 
 	public function toHex():String {
 		var s = new StringBuf();
-		var chars = [];
+		var chars:Array<Int> = [];
 		var str = "0123456789abcdef";
 		for (i in 0...str.length)
 			chars.push(str.charCodeAt(i));

--- a/tests/unit/src/unit/issues/Issue13003.hx
+++ b/tests/unit/src/unit/issues/Issue13003.hx
@@ -1,0 +1,40 @@
+package unit.issues;
+
+class Issue13003 extends Test {
+	#if js
+	function test() {
+		eq("Array<Int>", bytesToHexLookupType());
+
+		var bytes = haxe.io.Bytes.alloc(6);
+		for (index => value in [0x00, 0x0F, 0x10, 0x7F, 0x80, 0xFF])
+			bytes.set(index, value);
+		eq("000f107f80ff", bytes.toHex());
+	}
+	#end
+
+	macro static function bytesToHexLookupType() {
+		var bytes = switch haxe.macro.Context.getType("haxe.io.Bytes") {
+			case TInst(type, _):
+				type.get();
+			case type:
+				haxe.macro.Context.error('Expected haxe.io.Bytes to be a class, got ${haxe.macro.TypeTools.toString(type)}', haxe.macro.Context.currentPos());
+		}
+		var toHex = Lambda.find(bytes.fields.get(), field -> field.name == "toHex");
+		if (toHex == null)
+			haxe.macro.Context.error("Could not find haxe.io.Bytes.toHex", bytes.pos);
+
+		var lookupType = null;
+		function visit(expression:haxe.macro.Type.TypedExpr) {
+			switch expression.expr {
+				case TVar(variable, _) if (variable.name == "chars"):
+					lookupType = haxe.macro.TypeTools.toString(variable.t);
+				case _:
+					haxe.macro.TypedExprTools.iter(expression, visit);
+			}
+		}
+		visit(toHex.expr());
+		if (lookupType == null)
+			haxe.macro.Context.error("Could not find the haxe.io.Bytes.toHex lookup table", toHex.pos);
+		return macro $v{lookupType};
+	}
+}


### PR DESCRIPTION
Fixes #13003.

## Why

The JavaScript standard library correctly types `String.charCodeAt` as
`Null<Int>` because an arbitrary index can be outside the string.

`Bytes.toHex`, however, reads the fixed hexadecimal alphabet only at indices
from `0` through `str.length - 1`:

```haxe
var chars = [];
var str = "0123456789abcdef";

for (i in 0...str.length)
  chars.push(str.charCodeAt(i));
```

Every value added to this particular lookup table is therefore an `Int`, but
the unannotated array is inferred as `Array<Null<Int>>`.

That difference is invisible in ordinary JavaScript output because Haxe types
are erased. It matters to typed custom generators, though. The later
`StringBuf.addChar(c:Int)` and `String.fromCharCode(code:Int)` calls are inline,
so their `Int` parameter boundaries no longer exist in the final typed
expression. A strict TypeScript generator can consequently receive a nullable
array read inside raw JavaScript syntax:

```ts
const chars: (number | null)[] = [];

s_b += String.fromCodePoint(chars[c >> 4] ?? null);
s_b += String.fromCodePoint(chars[c & 15] ?? null);
```

TypeScript reports both arguments because `number | null` is not assignable to
the host API's `number` parameter.

## What

Declare the lookup table's intended element type:

```diff
-var chars = [];
+var chars:Array<Int> = [];
```

## How

The annotation records the local invariant where the table is constructed,
before inlining can erase later parameter boundaries.

A typed custom generator can now observe the ordinary Haxe call boundary:

- source expression: `Null<Int>`
- `Array<Int>.push` parameter: `Int`

For example, Genes renders that already-typed boundary as:

```ts
const chars: number[] = [];

chars.push(Register.unsafeCast<number>(HxOverrides.cca(str, i)));

s_b += String.fromCodePoint(chars[c >> 4]!);
s_b += String.fromCodePoint(chars[c & 15]!);
```

`Register.unsafeCast<number>` is an identity operation used by that generator:
it returns the same value once without conversion or validation. The important
part for Haxe is not the helper spelling; it is that the final typed tree still
contains the exact `Null<Int>`-to-`Int` call boundary instead of requiring a
generator to infer a type from raw JavaScript template text.

Classic JavaScript remains unchanged:

```js
const chars = [];
chars.push(HxOverrides.cca(str, i));
s_b += String.fromCodePoint(chars[c >> 4]);
s_b += String.fromCodePoint(chars[c & 15]);
```

## Tests

The new JavaScript unit test checks both parts of the contract:

- a macro inspects the final typed `Bytes.toHex` field and requires the local
  lookup table to be `Array<Int>`;
- a runtime vector verifies that bytes `00 0f 10 7f 80 ff` produce
  `000f107f80ff`.

Validation performed:

- proved the regression test fails as `Array<Null<Int>>` without the annotation
  and passes as `Array<Int>` with it;
- ran the JavaScript unit suite: 11,439 assertions, 0 failures;
- compiled and ran representative `Bytes.toHex` vectors with Haxe 4.3.7;
- compared complete classic JavaScript outputs before and after the annotation:
  byte-identical SHA-256 hashes;
- regenerated the package-neutral downstream strict-TypeScript fixture with a
  temporarily patched Haxe 4.3.7: exactly 16 diagnostics became exactly 14,
  removing only the two `Bytes.toHex` argument reports.

## Scope

This does not change `String.charCodeAt`'s general nullable contract, add raw
syntax recognition to a custom generator, or introduce a downstream standard
library override. It only states the stronger invariant already established by
this bounded loop.

Prepared by the GameCarry agent.
