### PR TITLE
[lua] Strip trailing ".0" from whole-valued floats in Std.string

### DIFF
--- a/std/lua/_lua/_hx_tostring.lua
+++ b/std/lua/_lua/_hx_tostring.lua
@@ -48,7 +48,20 @@ function _hx_tostring(obj, depth)
         elseif obj == _G.math.NEGATIVE_INFINITY then return "-Infinity"
         elseif obj == 0 then return "0"
         elseif obj ~= obj then return "NaN"
-        else return _G.tostring(obj)
+        else
+            -- Lua 5.3+ splits numbers into integer/float subtypes, so
+            -- tostring(1.0) == "1.0". Haxe prints whole-valued floats without
+            -- the trailing ".0" on every other target (js/python/neko/eval), so
+            -- strip it back off to keep Std.string consistent. Lua's float
+            -- formatter (%.14g) only ever appends an exact ".0" to
+            -- integer-looking output, so a suffix check is sufficient: scientific
+            -- notation ("1e+15"), fractions ("1.5") and NaN/Infinity are
+            -- untouched, and on Lua 5.1/LuaJIT (no ".0" suffix) this is a no-op.
+            local s = _G.tostring(obj)
+            if _G.string.sub(s, -2) == ".0" then
+                return _G.string.sub(s, 1, -3)
+            end
+            return s
         end
     elseif tstr == "boolean" then return _G.tostring(obj)
     elseif tstr == "userdata" then

--- a/tests/unit/src/unit/TestBasetypes.hx
+++ b/tests/unit/src/unit/TestBasetypes.hx
@@ -494,19 +494,13 @@ class TestBasetypes extends Test {
 		var v1:unit.MyAbstract.MyVector = new unit.MyAbstract.MyPoint3(1, 1, 1);
 		var v2:unit.MyAbstract.MyVector = new unit.MyAbstract.MyPoint3(1, 2, 3);
 		eq("(2,3,4)", v1 + v2);
-#if !lua
 		eq("(2,4,6)", v2 * 2.);
-#end
 		var v1Old = v1;
 		v1 *= 2.;
-#if !lua
 		eq("(2,2,2)", v1);
-#end
 		eq(v1Old, v1);
 		var v3 = v1 * 2.;
-#if !lua
 		eq("(4,4,4)", v3);
-#end
 		f(v1 == v3);
 
 		var i:unit.MyAbstract.MyInt = 1;

--- a/tests/unit/src/unit/issues/Issue3345.hx
+++ b/tests/unit/src/unit/issues/Issue3345.hx
@@ -24,7 +24,6 @@ private abstract Meters(Float) from Float {
 }
 
 class Issue3345 extends Test {
-	#if !lua
 	function test() {
 		var acc:Meters = .0;
 		for (i in 0...10)
@@ -36,5 +35,4 @@ class Issue3345 extends Test {
 			acc -= 10;
 		eq("-100(m)", acc);
 	}
-	#end
 }


### PR DESCRIPTION
On Lua 5.3+, numbers split into integer/float subtypes, so `tostring(1.0)` yields `"1.0"` (via `%.14g`) while `tostring(1)` yields `"1"`. This made `Std.string` on Lua print whole-valued floats with a spurious trailing `.0` — `Std.string(2.0*3)` → `"6.0"`, an abstract `toString` → `"100.0(m)"` — diverging from **every** other target (js/python/neko/eval → `6`, `100(m)`). Lua 5.1/LuaJIT have no subtypes and never showed this.

`Std.string(x:Dynamic)` erases the static Int/Float distinction, so the fix belongs at runtime in `_hx_tostring`, the single funnel for number→string conversion. Lua's float formatter only ever appends an *exact* `.0` to integer-looking output, so a 2-char suffix strip is sufficient — scientific notation (`1e+15`), fractions (`1.5`), and NaN/Infinity are untouched, and on Lua 5.1/LuaJIT it is a no-op.

## Testing

Built from source (5.0.0-preview.1) and ran `tests/unit` on Lua 5.5.0 (which has the subtype split, so the bug manifests). This re-enables the `TestBasetypes` and `Issue3345` (#3345) assertions that were guarded with `#if !lua` solely because of this bug.

- All 11529 assertions pass with the fix.
- Reverting just the runtime change (keeping the un-guarded tests) reproduces exactly the 5 expected failures:
  - `Issue3345`: `"100.0(m)"` / `"-100.0(m)"` instead of `"100(m)"` / `"-100(m)"`
  - `TestBasetypes`: `"(2.0,4.0,6.0)"`, `"(2.0,2.0,2.0)"`, `"(4.0,4.0,4.0)"` instead of the integer-formatted expectations.
