### PR TITLE
Overload display fixes

### DIFF
--- a/src/typing/callUnification.ml
+++ b/src/typing/callUnification.ml
@@ -424,8 +424,9 @@ let unify_field_call ctx fa el_typed el p inline =
 					) known_monos;
 					ctx.e.monomorphs <- current_monos;
 					check_unknown_ident err;
+					let delayed_display = extract_delayed_display() in
 					let candidates,failures = loop candidates in
-					candidates,(cf,err,extract_delayed_display()) :: failures
+					candidates,(cf,err,delayed_display) :: failures
 				end
 		in
 		loop candidates

--- a/src/typing/typer.ml
+++ b/src/typing/typer.ml
@@ -113,7 +113,11 @@ let maybe_type_against_enum ctx f with_type iscall p =
 			let e = try
 				f()
 			with
-			| Error { err_message = Unknown_ident n; err_sub = sub } ->
+			| Error ({ err_message = Unknown_ident n; err_sub = sub } as err) ->
+				if ctx.f.in_display && ctx.com.display.dms_kind = DMDefault then begin
+					restore();
+					raise_error err
+				end;
 				restore();
 				raise_or_display_message ctx (StringError.string_error n fields ("Identifier '" ^ n ^ "' is not part of " ^ s_type_path path)) p;
 				AKExpr (mk (TConst TNull) (mk_mono()) p)

--- a/src/typing/typerDisplay.ml
+++ b/src/typing/typerDisplay.ml
@@ -229,7 +229,7 @@ let rec handle_signature_display ctx e_ast with_type =
 				in
 				loop (if keep t then (t,doc,values) :: acc else acc) tl
 			| [] ->
-				acc
+				List.rev acc
 		in
 		let overloads = match loop [] tl with [] -> tl | tl -> tl in
 		let overloads = List.map (fun (t,doc,values) -> (convert_function_signature ctx values t,doc)) overloads in
@@ -241,7 +241,11 @@ let rec handle_signature_display ctx e_ast with_type =
 			| Some c -> can_access ctx c cf stat
 			| None -> true
 		in
-		let l = (t,cf) :: List.rev_map (fun cf -> map cf.cf_type,cf) cf.cf_overloads in
+		let l = if is_wacky_overload then
+			(List.map (fun cf' -> map cf'.cf_type,cf') cf.cf_overloads) @ [t,cf]
+		else
+			(t,cf) :: List.rev_map (fun cf' -> map cf'.cf_type,cf') cf.cf_overloads
+		in
 		let l = List.filter (fun (_,cf) -> can_access cf) l in
 		let l = List.map (fun (t,cf') ->
 			(* Ghetto overloads have their documentation on the main field. *)

--- a/tests/server/src/cases/display/Completion.hx
+++ b/tests/server/src/cases/display/Completion.hx
@@ -103,6 +103,52 @@ class Completion extends DisplayTestCase {
 
 	/**
 		class Main {
+			extern inline overload static function foo(a:haxe.ds.Option<Bool>, cb:() -> {}) {};
+			extern inline overload static function foo(a:Int, cb:() -> {}) {};
+
+			extern inline overload static function foo2(a:Int, cb:() -> {}) {};
+			extern inline overload static function foo2(a:haxe.ds.Option<Bool>, cb:() -> {}) {};
+
+			static function main() {
+				foo({-1-}
+				foo(R{-2-}
+				foo2({-3-}
+				foo2(R{-4-}
+			}
+		}
+	**/
+	function testIssueOverloadCompletion(_) {
+		eq(true, hasField(fields(1), "Some", null, "enum"));
+		eq(true, hasField(fields(1), "None", null, "enum"));
+		eq(true, hasField(fields(2), "Some", null, "enum"));
+		eq(true, hasField(fields(2), "None", null, "enum"));
+
+		eq(false, hasField(fields(3), "Some", null, "enum"));
+		eq(false, hasField(fields(3), "None", null, "enum"));
+		eq(false, hasField(fields(4), "Some", null, "enum"));
+		eq(false, hasField(fields(4), "None", null, "enum"));
+	}
+
+	/**
+		class Main {
+			@:overload(function(a:Int, cb:() -> {}):Void {})
+			static function foo(a:haxe.ds.Option<Bool>, cb:() -> {}) {};
+
+			static function main() {
+				foo({-1-}
+				foo(R{-2-}
+			}
+		}
+	**/
+	function testIssueMetadataOverloadCompletion(_) {
+		eq(true, hasField(fields(1), "Some", null, "enum"));
+		eq(true, hasField(fields(1), "None", null, "enum"));
+		eq(true, hasField(fields(2), "Some", null, "enum"));
+		eq(true, hasField(fields(2), "None", null, "enum"));
+	}
+
+	/**
+		class Main {
 			static function main() {
 				var s = { foo: 1 };
 				"foo".

--- a/tests/server/src/cases/display/Signature.hx
+++ b/tests/server/src/cases/display/Signature.hx
@@ -296,4 +296,18 @@ class Signature extends DisplayTestCase {
 		sigEq(0, [["a:Int", "b:Int"]], signature(1));
 		sigEq(1, [["a:Int", "b:Int"]], signature(2));
 	}
+
+	/**
+		class Some {
+			extern inline overload static function foo(a:String, cb:() -> Void) {};
+			extern inline overload static function foo(a:Int, cb:() -> Void) {};
+
+			function main() {
+				foo({-1-}
+			}
+		}
+	**/
+	function testIssueOverloadSignature(_) {
+		sigEq(0, [["a:String", "cb:(() -> Void)"], ["a:Int", "cb:(() -> Void)"]], signature(1));
+	}
 }


### PR DESCRIPTION
- `typerDisplay` change inverts signature overloads list, currently it's displayed incorrectly in IDE
- `typer` change fixes `foo(S|` completion by re-raising `Unknown_ident` error, so there is still `Some`/`None` reported fields in completion while typing names
- `callUnification` change fixes `foo(<completion>)` case, when `foo` signature has second argument like `(a:Option<Bool>, cb:() -> Void)` and `foo(<inserted null display value>)` gets `Not_enough_arguments` for second `cb` argument. Now completion items for first overload is preserved, since `extract_delayed_display` should be called before `loop candidates`, that processes second `Int` overload, also gets `Not_enough_arguments` error and incorrectly overwrites `ctx.g.delayed_display` with `Int` overload)