### PR TITLE
[flash] fix argument order when spreading rest arguments into a call

### DIFF
--- a/src/generators/genswf9.ml
+++ b/src/generators/genswf9.ml
@@ -2838,7 +2838,7 @@ let generate com boot_name =
 					else nargs (n - 1) ((mk (TArray (rest, const n)) t_rest_item rest.epos) :: acc)
 				in
 				let rec loop n e_else =
-					let args = (nargs (n - 1) args_rev) in
+					let args = List.rev_append args_rev (nargs (n - 1) []) in
 					let e = mk (TIf (check n, args_to_expr args, Some e_else)) t_result rest.epos in
 					if n = 0 then e
 					else loop (n - 1) e

--- a/tests/unit/src/unit/issues/Issue13016.hx
+++ b/tests/unit/src/unit/issues/Issue13016.hx
@@ -1,0 +1,41 @@
+package unit.issues;
+
+private class Parent {
+	public var fixed:Int;
+	public var rest:Array<Int>;
+
+	public function new(fixed:Int, ...rest:Int) {
+		this.fixed = fixed;
+		this.rest = rest.toArray();
+	}
+}
+
+private class Child extends Parent {
+	public function new(fixed:Int, rest:Array<Int>) {
+		super(fixed, ...rest);
+	}
+}
+
+class Issue13016 extends Test {
+	static function call(a:Int, b:Int, ...r:Int) {
+		return {a: a, b: b, r: r.toArray()};
+	}
+
+	function test() {
+		var result = call(1, 2, ...[3, 4]);
+		eq(1, result.a);
+		eq(2, result.b);
+		aeq([3, 4], result.r);
+
+		// an empty spread must not disturb the fixed arguments either
+		var empty = call(1, 2, ...([] : Array<Int>));
+		eq(1, empty.a);
+		eq(2, empty.b);
+		aeq([], empty.r);
+
+		// same expansion is used for constructor and super calls
+		var child = new Child(1, [2, 3]);
+		eq(1, child.fixed);
+		aeq([2, 3], child.rest);
+	}
+}


### PR DESCRIPTION
handle_spread_args matched on `List.rev args`, so `args_rev` holds the fixed arguments in reverse. The expanded argument list was then built by accumulating the rest items onto that reversed list and never reversing back, yielding `[rest[0]; ...; rest[n-1]] @ List.rev fixed_args`.

As a result `f(a, b, ...arr)` on the flash target passed the fixed arguments in reverse order with the rest items prepended, and an empty spread still reversed two or more fixed arguments. `new C(a, ...arr)` and `super(a, ...arr)` were affected too, since both route through the same helper. Only the zero-fixed-argument form `f(...arr)` was correct, which is the only form TestRest.testSpread covers.

Build the rest items separately and prepend the fixed arguments in source order.

closes #13016