### PR TITLE
[neko] Implement semaphore using lock primitives

### DIFF
--- a/std/neko/_std/sys/thread/Semaphore.hx
+++ b/std/neko/_std/sys/thread/Semaphore.hx
@@ -12,7 +12,7 @@ package sys.thread;
 	}
 
 	public function tryAcquire(?timeout:Float):Bool {
-		return lock_wait(s, timeout);
+		return lock_wait(s, timeout ?? 0.);
 	}
 
 	public function release():Void {

--- a/std/neko/_std/sys/thread/Semaphore.hx
+++ b/std/neko/_std/sys/thread/Semaphore.hx
@@ -4,23 +4,22 @@ package sys.thread;
 	var s:Dynamic;
 
 	public function new(value:Int):Void {
-		s = semaphore_create(value);
+		s = lock_create(value);
 	}
 
 	public function acquire():Void {
-		semaphore_acquire(s);
+		lock_wait(s);
 	}
 
 	public function tryAcquire(?timeout:Float):Bool {
-		return semaphore_try_acquire(s, timeout);
+		return lock_wait(s, timeout);
 	}
 
 	public function release():Void {
-		semaphore_release(s);
+		lock_release(s);
 	}
 
-	static var semaphore_create = neko.Lib.loadLazy("std", "semaphore_create", 1);
-	static var semaphore_try_acquire = neko.Lib.loadLazy("std", "semaphore_try_acquire", 2);
-	static var semaphore_acquire = neko.Lib.loadLazy("std", "semaphore_acquire", 1);
-	static var semaphore_release = neko.Lib.loadLazy("std", "semaphore_release", 1);
+	static var lock_create = neko.Lib.loadLazy("std", "lock_create", 1);
+	static var lock_release = neko.Lib.load("std", "lock_release", 1);
+	static var lock_wait = neko.Lib.load("std", "lock_wait", 2);
 }

--- a/std/neko/_std/sys/thread/Semaphore.hx
+++ b/std/neko/_std/sys/thread/Semaphore.hx
@@ -21,5 +21,5 @@ package sys.thread;
 
 	static var lock_create = neko.Lib.loadLazy("std", "lock_create", 1);
 	static var lock_release = neko.Lib.load("std", "lock_release", 1);
-	static var lock_wait = neko.Lib.load("std", "lock_wait", 2);
+	static var lock_wait:(Dynamic, ?Float) -> Bool = neko.Lib.load("std", "lock_wait", 2);
 }


### PR DESCRIPTION
Rather than requiring a new set of primitives that are essentially equivalent, we can instead just implement the Semaphore using the lock primitives.

We only have to introduce one more primitive for this, which is a `lock_create` that sets an initial count: https://github.com/HaxeFoundation/neko/pull/324.