### PR TITLE
[lua] Support luajit native ops in hx_bit_clamp

### DIFF
--- a/std/lua/_lua/_hx_bit_clamp.lua
+++ b/std/lua/_lua/_hx_bit_clamp.lua
@@ -9,7 +9,7 @@ local _hx_bit_clamp_native = (function()
             end
             if v > 2251798999999999 then v = v*2 end
             if (v ~= v or math.abs(v) == _G.math.huge) then return nil end
-            return (v & 0x7FFFFFFF) - (v & 0x80000000)
+            return (v & 0x7FFFFFFF) - math.abs(v & 0x80000000)
         end
     ]])
     if ok and fn then return fn() end

--- a/tests/runci/targets/Lua.hx
+++ b/tests/runci/targets/Lua.hx
@@ -90,11 +90,11 @@ class Lua {
 
 		getLuaDependencies();
 
-		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4", "-l5.5", "-j2.0", "-j@v2.1"]) {
+		for (lv in ["-l5.1", "-l5.2", "-l5.3", "-l5.4", "-l5.5", "-j2.0", "-j2.1"]) {
 			// luajit 2.0 was missing arm64 support
 			if (System.arch == Arm64 && lv == "-j2.0") continue;
 
-			final envpath = getInstallPath() + '/lua_env/lua${lv.replace("@v", "")}';
+			final envpath = getInstallPath() + '/lua_env/lua$lv';
 			addToPATH(envpath + '/bin');
 
 			Sys.println('--------------------');


### PR DESCRIPTION
luajit 2.1 now also has native bitwise operators, but they have the same semantics as its bit library. Unlike lua 5.3+ native operators which operate on 32-bit unsigned integers, these operate on signed integers. Therefore for luajit compatibility, we also need to insert a `math.abs` call here similar to the luajit "bit" implementation.

See:
https://github.com/LuaJIT/LuaJIT/commit/a2ce8114f107464473070427e69e84f4923bd08a

The `math.abs` call is redundant on lua 5.3+, but maybe its not worth introducing the extra complexity to avoid it. Either way, it will be easier to deal with after merging #12600.


<details><summary>This patch resolves the lua ci failures</summary>

```
src/unit/TestMainNow.hx:6: Generated at: 2026-08-20 09:24:22
src/unit/TestMain.hx:29: START
utest/ui/text/PrintReport.hx:52: 
assertations: 11527
successes: 11498
errors: 2
failures: 27
warnings: 0
execution time: 0.413

results: SOME TESTS FAILURES (success: false)
unit.TestInt64
  testNegateOverflow_Issue7485: ERROR E
    NumberFormatError: Underflow
Called from <unknown>.parseString (bin/unit.lua line 5933)
Called from <unknown>.testNegateOverflow_Issue7485 (bin/unit.lua line 26037)
Called from <unknown>.execute (bin/unit.lua line 28125)
Called from bin/unit.lua line 103715
Called from <unknown>.runTest (bin/unit.lua line 103713)
Called from ... line null
Called from <unknown>.runFixture (bin/unit.lua line 103304)
Called from <unknown>.runFixtures (bin/unit.lua line 103494)
Called from <unknown>.runCases (bin/unit.lua line 103458)
Called from <unknown>.run (bin/unit.lua line 103359)
Called from bin/unit.lua line 103290
Called from <unknown>.main (bin/unit.lua line 31195)
Called from bin/unit.lua line 105817
Called from [builtin#21] line null
Called from bin/unit.lua line 105816
  testParseString: ERROR ...FE
    line: 497, expected "9223361737523110299331675807" but it is "9223372036854775807"
    NumberFormatError: Underflow
Called from <unknown>.parseString (bin/unit.lua line 5933)
Called from bin/unit.lua line 27386
Called from <unknown>.testParseString (bin/unit.lua line 27390)
Called from <unknown>.execute (bin/unit.lua line 28117)
Called from bin/unit.lua line 103715
Called from ... line null
Called from <unknown>.runFixture (bin/unit.lua line 103304)
Called from <unknown>.runFixtures (bin/unit.lua line 103494)
Called from <unknown>.runCases (bin/unit.lua line 103458)
Called from <unknown>.run (bin/unit.lua line 103359)
Called from bin/unit.lua line 103290
Called from <unknown>.main (bin/unit.lua line 31195)
Called from bin/unit.lua line 105817
Called from [builtin#21] line null
Called from bin/unit.lua line 105816
  testDefaultArg: FAILURE ......F
    line: 671, expected "9223372036854775807" but it is "9223361737523110299331675807"
  testToString: FAILURE .....FFF
    line: 155, expected "9223361737523110299331675807" but it is "9223372036854775807"
    line: 156, expected "9223361737523110299331675809" but it is "-9223372036854775807"
    line: 157, expected "9223361737523110299331675808" but it is "-9223372036854775808"
  testMath: FAILURE FFF.F
    line: 429, expected "5637144575805306377480741068150313129220965" but it is "572248275467371265"
    line: 430, expected "5637144575805306377480741068150313129220965" but it is "572248275467371265"
    line: 435, expected "3449665318" but it is "-6489849317865727676"
    line: 446, expected -1 but it is 0
  testMultiplication: FAILURE .FFFFF..
    line: 266, expected true
    line: 270, expected true
    line: 274, expected true
    line: 278, expected true
    line: 283, expected true
unit.TestBasetypes
  testInt64Map: FAILURE ....F.............
    line: 286, expected "-8589934597#8589934597" but it is "-8589934597#12884901893"
unit.TestDefaultArgs
  testInt64Default: FAILURE ..F.
    line: 63, expected "9223372036854775807" but it is "9223361737523110299331675807"
unit.TestSerialize
  test: FAILURE ..............................................................F.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................
    line: 62, expected true
unit.TestNumericSuffixes
  testBinSuffixes: FAILURE ....F
    line: 35, expected "9223361737523110299331675807" but it is "9223372036854775807"
  testHexSuffixes: FAILURE ....F
    line: 27, expected "9223361737523110299331675807" but it is "9223372036854775807"
  testIntSuffixes: FAILURE ...FF
    line: 9, expected "2998424043511575956490" but it is "3000000000000"
    line: 10, expected "9223361737523110299331675807" but it is "9223372036854775807"
unit.teststd.haxe.TestInt32
  test: FAILURE .FF.F..FF...F.......
    line: 11, expected 2147483648 but it is -2147483648
    line: 12, expected 2147483648 but it is -2147483648
    line: 14, expected 2147483648 but it is -2147483648
    line: 18, expected 2147483648 but it is -2147483648
    line: 20, expected 4294967295 but it is -1
    line: 25, expected 4294967294 but it is -2
```
</details>