### PR TITLE
[cpp] Fix unreflective iterators causing Null Function error

### DIFF
--- a/src/core/texpr.ml
+++ b/src/core/texpr.ml
@@ -638,10 +638,10 @@ let rec type_constant_value basic (e,p) =
 let is_constant_value basic e =
 	try (ignore (type_constant_value basic e); true) with Error {err_message = Custom _} -> false
 
-let for_remap basic v etype e1 e2 p =
-	let v' = alloc_var VGenerated (gen_local_prefix ^ v.v_name) etype e1.epos in
-	let ev' = mk (TLocal v') etype e1.epos in
-	let t1 = (Abstract.follow_with_abstracts etype) in
+let for_remap basic v e1 e2 p =
+	let v' = alloc_var VGenerated (gen_local_prefix ^ v.v_name) e1.etype e1.epos in
+	let ev' = mk (TLocal v') e1.etype e1.epos in
+	let t1 = (Abstract.follow_with_abstracts e1.etype) in
 	let ehasnext = mk (TField(ev',try quick_field t1 "hasNext" with Not_found -> raise_typing_error (s_type (print_context()) t1 ^ " has no field hasNext()") p)) (tfun [] basic.tbool) e1.epos in
 	let ehasnext = mk (TCall(ehasnext,[])) basic.tbool ehasnext.epos in
 	let enext = mk (TField(ev',quick_field t1 "next")) (tfun [] v.v_type) e1.epos in

--- a/src/typing/forLoop.ml
+++ b/src/typing/forLoop.ml
@@ -457,7 +457,7 @@ module IterationKind = struct
 			begin try
 				optimize_for_loop_iterator ctx v e1 e2 p
 			with Exit ->
-				Texpr.for_remap ctx.t v (ctx.t.titerator pt) e1 e2 p
+				Texpr.for_remap ctx.t v e1 e2 p
 			end
 		| IteratorGenericStack c ->
 			let tcell = (try (PMap.find "head" c.cl_fields).cf_type with Not_found -> die "" __LOC__) in

--- a/tests/unit/src/unit/issues/Issue12369.hx
+++ b/tests/unit/src/unit/issues/Issue12369.hx
@@ -1,0 +1,34 @@
+package unit.issues;
+
+@:unreflective
+private class MyIterator {
+	var count = 0;
+	final max:Int;
+
+	public function new(max:Int) {
+		this.max = max;
+	}
+
+	public function hasNext():Bool {
+		return count < max;
+	}
+
+	public function next() {
+		return count++;
+	}
+}
+
+class Issue12369 extends Test {
+	#if cpp
+	function test() {
+		final expected = [0, 1];
+		final actual = [];
+
+		for (i in new MyIterator(2)) {
+			actual.push(i);
+		}
+
+		aeq(expected, actual);
+	}
+	#end
+}


### PR DESCRIPTION
Unreflective iterators were broken in 0b2b0daacd9125317fa355c85df69c26acbeb83d, because the iterator fields are now accessed via dynamic field lookup instead of direct calls (which is also less optimal in general). This partially reverts 4a181fd28faa9b307fd57323a1ad30bb71b94d3a, which fixes #12369.

Presumably, the original commit was intended to fix: https://github.com/HaxeFoundation/haxe/pull/11891#issuecomment-2604686033, so this probably requires testing (and ideally a proper test case) to prevent that issue from returning. @yuxiaomao would you be able to check if this causes that `has no field hasNext()` error to return?