### PR TITLE
[docs] Document cppia Module.fromString/fromData

### DIFF
--- a/std/cpp/cppia/Module.hx
+++ b/std/cpp/cppia/Module.hx
@@ -25,8 +25,19 @@ package cpp.cppia;
 @:native("::hx::CppiaLoadedModule")
 @:build(cpp.cppia.HostClasses.include())
 extern class Module {
+	/**
+		Load the CPPIA module encoded in the string `sourceCode`.
+
+		Note: only the ASCII CPPIA format can be represented as a `String`. CPPIA files in
+		the binary format should be loaded as `Bytes` and loaded using `Module.fromData`
+		instead.
+	**/
 	@:native("__scriptable_cppia_from_string")
 	static function fromString(sourceCode:String):Module;
+
+	/**
+		Load the CPPIA module encoded in `data`.
+	**/
 	@:native("__scriptable_cppia_from_data")
 	static function fromData(data:haxe.io.BytesData):Module;
 


### PR DESCRIPTION
To clarify that fromString is only safe to use with ascii cppia files, because the binary format may not be representable as a string.

Closes https://github.com/HaxeFoundation/hxcpp/issues/837