### PR TITLE
[hl] add isFolder to chooseFile api

### DIFF
--- a/std/hl/UI.hx
+++ b/std/hl/UI.hx
@@ -132,6 +132,9 @@ typedef FileOptions = {
 	var ?filterIndex:Int;
 	var ?fileName:String;
 	var ?title:String;
+#if (hl_ver >= version("2.0.0"))
+	var ?isFolder: Bool;
+#end
 }
 
 /**
@@ -206,6 +209,10 @@ class UI {
 		}
 		if (opts.window != null)
 			out.window = opts.window.h;
+#if (hl_ver >= version("2.0.0"))
+		if (opts.isFolder != null)
+			out.isFolder = opts.isFolder;
+#end
 		var str = _chooseFile(save, out);
 		return str == null ? null : String.fromUCS2(str);
 	}


### PR DESCRIPTION
This add the ability to specify that we want a folder instead of a file when prompting the user with the native choose file dialog.

Depends on https://github.com/HaxeFoundation/hashlink/pull/979 (but the two commits can be merged independently because the changes are backwards and forwards compatible)