### PR TITLE
[server] do not cache typing that was degraded by diagnostics

### DIFF
--- a/src/compiler/io/compilerMessage.ml
+++ b/src/compiler/io/compilerMessage.ml
@@ -66,6 +66,8 @@ let add_module_message com (m : module_def) msg p depth message_kind =
 let add_module_diagnostic com (m : module_def) cm =
 	if com.display.dms_full_typing then
 		DynArray.add m.m_extra.m_cache_bound_objects (Message cm);
+	if cm_severity cm = MessageSeverity.Error && com.part_scope.message_capture = None then
+		com.part_scope.has_error <- true;
 	if is_diagnostics com then
 		com.part_scope.messages <- cm :: com.part_scope.messages
 

--- a/src/context/common.ml
+++ b/src/context/common.ml
@@ -822,20 +822,8 @@ let is_diagnostics com = match com.part_scope.report_mode with
 
 let is_compilation com = com.display.dms_kind = DMNone && not (is_diagnostics com)
 
-(** Returns true when there is an error that should be reported/acted upon.
-    In compilation mode, any has_error is significant.
-    In display mode, has_error can be set transiently during type resolution
-    without producing actual error messages, so we require messages to exist.
-    Diagnostics-only messages (DKMissingFields, DKUnresolvedIdentifier) are
-    not counted as reportable errors — they are diagnostics data that should
-    not prevent context caching. *)
 let has_error_to_report com =
-	let has_reportable_message = List.exists (fun cm ->
-		match cm.cm_diagnostics_kind with
-		| MessageKind.DKMissingFields | MessageKind.DKUnresolvedIdentifier -> false
-		| _ -> true
-	) com.part_scope.messages in
-	com.part_scope.has_error && (is_compilation com || has_reportable_message)
+	com.part_scope.has_error && (is_compilation com || com.part_scope.messages <> [])
 
 let activate_message_capture com buf =
 	let old_capture = com.part_scope.message_capture in

--- a/tests/server/src/cases/ServerTests.hx
+++ b/tests/server/src/cases/ServerTests.hx
@@ -311,44 +311,40 @@ class ServerTests extends TestCase {
 		assertReuse("HelloWorld");
 	}
 
-	function testDiagnosticsCacheBoundMissingFields() {
+	function testDiagnosticsMissingFieldsNotCached() {
 		vfs.putContent("MissingFieldsDep.hx", getTemplate("diagnostics/MissingFieldsDep.hx"));
 		vfs.putContent("MissingFieldsMain.hx", getTemplate("diagnostics/MissingFieldsMain.hx"));
 		var args = ["--main", "MissingFieldsMain", "--interp"];
-		// First diagnostics run: types both modules, creates MissingFields on Dep, caches both
 		var res1 = runHaxeJson(args, DisplayMethods.Diagnostics, {
 			fileContents: [{file: new FsPath("MissingFieldsMain.hx")}, {file: new FsPath("MissingFieldsDep.hx")}]
 		});
 		final diags1 = findDiagnosticsFor(res1, "MissingFieldsDep.hx");
 		Assert.notNull(diags1);
 		Assert.notNull(diags1.find(d -> d.kind == MissingFields));
-		// Invalidate Main only, so Dep stays cached
 		runHaxeJson([], ServerMethods.Invalidate, {file: new FsPath("MissingFieldsMain.hx")});
-		// Second diagnostics run: Main retyped, Dep reused from cache, MissingFields replayed
 		var res2 = runHaxeJson(args, DisplayMethods.Diagnostics, {
 			fileContents: [{file: new FsPath("MissingFieldsMain.hx")}, {file: new FsPath("MissingFieldsDep.hx")}]
 		});
-		assertReuse("MissingFieldsDep");
+		// Dep was not invalidated, but the previous run typed it with downgraded errors
+		Assert.isFalse(hasMessage("reusing MissingFieldsDep"));
 		final diags2 = findDiagnosticsFor(res2, "MissingFieldsDep.hx");
 		Assert.notNull(diags2);
 		Assert.notNull(diags2.find(d -> d.kind == MissingFields));
 	}
 
-	function testDiagnosticsCacheBoundFilterOnReplay() {
+	function testDiagnosticsMissingFieldsInCompilation() {
 		vfs.putContent("MissingFieldsDep.hx", getTemplate("diagnostics/MissingFieldsDep.hx"));
 		vfs.putContent("MissingFieldsMain.hx", getTemplate("diagnostics/MissingFieldsMain.hx"));
 		var args = ["--main", "MissingFieldsMain", "--interp"];
-		// Diagnostics run: types both modules, caches Dep with MissingFields cache-bound object
 		var res = runHaxeJson(args, DisplayMethods.Diagnostics, {
 			fileContents: [{file: new FsPath("MissingFieldsMain.hx")}, {file: new FsPath("MissingFieldsDep.hx")}]
 		});
 		final diags = findDiagnosticsFor(res, "MissingFieldsDep.hx");
 		Assert.notNull(diags);
 		Assert.notNull(diags.find(d -> d.kind == MissingFields));
-		// Normal compilation: Dep reused from cache, MissingFields NOT replayed (filtered by RMDiagnostics)
 		runHaxe(args);
-		// No error messages from filtered diagnostics (only normal "Field needed by" errors)
-		Assert.isFalse(hasErrorMessage("unimplemented"));
+		Assert.isFalse(hasMessage("reusing MissingFieldsDep"));
+		assertErrorMessage("Field doSomething needed by IFoo is missing");
 	}
 
 	function testDiagnosticsMultipleOpenFiles() {

--- a/tests/server/src/cases/issues/Issue12995.hx
+++ b/tests/server/src/cases/issues/Issue12995.hx
@@ -1,0 +1,39 @@
+package cases.issues;
+
+import haxe.display.Diagnostic;
+
+class Issue12995 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue12995/Main.hx"));
+		var args = ["-main", "Main"];
+
+		runHaxe(args);
+		assertErrorMessage("Class<Foo> has no field bar");
+
+		var res = runHaxeJson(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")});
+		Assert.equals(1, res.length);
+		var diags:Array<Diagnostic<Dynamic>> = cast res[0].diagnostics;
+		Assert.isTrue(diags.exists(d -> d.kind == MissingFields));
+
+		runHaxe(args);
+		Assert.isFalse(hasMessage("reusing Main"));
+		assertErrorMessage("Class<Foo> has no field bar");
+	}
+
+	function testUnresolvedIdentifier(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue12995/Unresolved.hx"));
+		var args = ["-main", "Main"];
+
+		runHaxe(args);
+		assertErrorMessage("Unknown identifier : unresolvedIdentifier");
+
+		var res = runHaxeJson(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")});
+		Assert.equals(1, res.length);
+		var diags:Array<Diagnostic<Dynamic>> = cast res[0].diagnostics;
+		Assert.isTrue(diags.exists(d -> d.kind == DKUnresolvedIdentifier));
+
+		runHaxe(args);
+		Assert.isFalse(hasMessage("reusing Main"));
+		assertErrorMessage("Unknown identifier : unresolvedIdentifier");
+	}
+}

--- a/tests/server/src/cases/issues/Issue13013.hx
+++ b/tests/server/src/cases/issues/Issue13013.hx
@@ -1,0 +1,17 @@
+package cases.issues;
+
+class Issue13013 extends TestCase {
+	function test(_) {
+		vfs.putContent("Main.hx", getTemplate("issues/Issue13013/Main.hx"));
+		var args = ["-main", "Main", "--js", "out.js"];
+
+		runHaxe(args);
+		assertErrorMessage("Unknown identifier : foo");
+
+		runHaxeJson(args, DisplayMethods.Diagnostics, {file: new FsPath("Main.hx")});
+
+		runHaxe(args);
+		Assert.isFalse(hasMessage("reusing Main"));
+		assertErrorMessage("Unknown identifier : foo");
+	}
+}

--- a/tests/server/test/templates/issues/Issue12995/Main.hx
+++ b/tests/server/test/templates/issues/Issue12995/Main.hx
@@ -1,0 +1,7 @@
+class Foo {}
+
+class Main {
+	static function main() {
+		Foo.bar();
+	}
+}

--- a/tests/server/test/templates/issues/Issue12995/Unresolved.hx
+++ b/tests/server/test/templates/issues/Issue12995/Unresolved.hx
@@ -1,0 +1,5 @@
+class Main {
+	static function main() {
+		var v = unresolvedIdentifier;
+	}
+}

--- a/tests/server/test/templates/issues/Issue13013/Main.hx
+++ b/tests/server/test/templates/issues/Issue13013/Main.hx
@@ -1,0 +1,1 @@
+function main() trace(foo);


### PR DESCRIPTION
Typing in diagnostics mode downgrades errors like missing fields or unresolved identifiers to diagnostics and carries on with made up types (t_dynamic, fresh monomorphs, TConst TNull), so the modules it produces describe code that does not typecheck. Caching them meant later requests reused such modules, and compilations silently dropped the error because diagnostics-only messages are filtered out when replayed outside of diagnostics mode.

has_error_to_report exempted those messages in order to not prevent context caching. The exemption is inert at both of its reporting call sites (displayProcessing sits behind dms_exit_during_typing, which is false for DMNone, and flush_context returns early for RMDiagnostics), so the cache save was its only live consumer. Removing it restores the condition #12797 used before #12815 introduced the exemption.

add_module_diagnostic now also marks the context as errored, like the other add functions, so this no longer depends on error_in_diagnostics_run happening to set the flag at every call site.

The two cache-bound diagnostics tests written alongside the exemption asserted the reuse itself; they now assert that such modules are typed again and that a compilation reports the real error.

Closes #12995
Closes #12996
Closes #13013