### PR TITLE
Expand env vars in all arguments

### DIFF
--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -253,6 +253,7 @@ let parse_args args =
 					add (IncludeModule arg)));
 			loop rest
 	in
+	let args = List.map Helper.expand_env args in (* TODO: test this *)
 	loop args;
 	DynArray.to_list parsed
 

--- a/src/compiler/args.ml
+++ b/src/compiler/args.ml
@@ -253,7 +253,15 @@ let parse_args args =
 					add (IncludeModule arg)));
 			loop rest
 	in
-	let args = List.map Helper.expand_env args in (* TODO: test this *)
+	let rec hack_loop acc args = match args with
+		| "--run" :: _ ->
+			(List.rev acc) @ args
+		| [] ->
+			List.rev acc
+		| arg :: args ->
+			hack_loop (Helper.expand_env arg :: acc) args
+	in
+	let args = hack_loop [] args in (* TODO: test this *)
 	loop args;
 	DynArray.to_list parsed
 


### PR DESCRIPTION
Yuxiao found that we broke this in #12737. There used to be an extra `loop` that would `expand_env` all arguments, so I'm bringing that back for now.

This currently causes consistent failures in the sys tests, which suggests that some behavior changed somewhere after all. 