### PR TITLE
[hl] keep argument optionality when generating abstract method stubs

### DIFF
--- a/src/generators/genhl.ml
+++ b/src/generators/genhl.ml
@@ -3562,9 +3562,9 @@ let generate_member ctx c f =
 					| Coro(tl,tr) -> Common.expand_coro_type ctx.com.basic tl tr
 					| _ -> die "" __LOC__
 				in
-				let args = List.map (fun (n,_,t) ->
+				let args = List.map (fun (n,o,t) ->
 					let v = Type.alloc_var VGenerated n t null_pos in
-					(v,None)
+					(v,if o then Some (mk (TConst TNull) t_dynamic null_pos) else None)
 				) tl in
 				{
 					tf_args = args;

--- a/tests/unit/src/unit/issues/IssueAbstractMethodOptArg.hx
+++ b/tests/unit/src/unit/issues/IssueAbstractMethodOptArg.hx
@@ -1,0 +1,17 @@
+package unit.issues;
+
+@:keep private abstract class Base {
+	public function new() {}
+	public abstract function f( x : Int, flag : Bool = false ) : Int;
+	public abstract function g( x : Int, ?name : String ) : Int;
+}
+
+class IssueAbstractMethodOptArg extends Test {
+	@:keep static function callAbstract( b : Base ) {
+		return b.f(1) + b.f(1, true) + b.g(1) + b.g(1, "ab");
+	}
+
+	function test() {
+		eq(true, callAbstract != null);
+	}
+}


### PR DESCRIPTION
An abstract method has no body, so generate_member synthesizes a `throw null` one - but it built the argument list from the function type while dropping the opt flag, and passed None as the default value:

    let args = List.map (fun (n,_,t) -> ... (v,None)) tl

make_fun derives ref-ness from exactly that None/Some: an optional argument whose type is not nullable is passed as hl.Ref. So the stub got a plain `bool` where every call site - which computes the type from the declared TFun through to_type, and does honour opt - built a `ref(bool)`:

    fun@19848 (Database,DataObject,bool):void     <- stub
    false 6 / ref 8,&6 / callmethod 7[4](2,8)     <- call site

hl-check reports "Register N(ref(bool)) should be bool and not ref(bool)" and hl/c generation dies in Hl2c.rassign. It only shows up on a direct call to the stub: with a concrete override in the program the call is virtual and lands on the real function instead.

Carry the opt flag over and use the null sentinel make_fun already understands for "optional, no default", so the stub's signature matches to_type of the field type for both nullable and non-nullable optionals.