### PR TITLE
Avoid source-offset padding when parsing expressions

### DIFF
--- a/src/syntax/parserEntry.ml
+++ b/src/syntax/parserEntry.ml
@@ -209,12 +209,12 @@ class dead_block_collector conds = object(self)
 end
 
 (* parse main *)
-let parse config entry lctx code file =
+let parse ?(skip_header=true) config entry lctx code file =
 	let defines = config.defines in
 	let in_macro = Define.defined defines Define.Macro in
 	let ctx = Parser.create_context lctx config in_macro code in
 	let entry = entry ctx in
-	Lexer.skip_header code;
+	if skip_header then Lexer.skip_header code;
 
 	let sharp_error s p =
 		let line = StringError.string_error ("#" ^ s) ["#if";"#elseif";"#else";"#end";"#error";"#line"] "Unknown token" in
@@ -368,7 +368,7 @@ let parse config entry lctx code file =
 			let last = (match Stream.peek s with None -> last_token ctx s | Some t -> t) in
 			error (Unexpected (fst last)) (pos last)
 
-let parse_string config entry s p error inlined =
+let parse_string ?(offset=0) config entry s p error inlined =
 	let old_display = display_position#get in
 	let restore() =
 		if not inlined then begin
@@ -382,8 +382,13 @@ let parse_string config entry s p error inlined =
 	end else
 		config
 	in
+	let code = Lexer.lexbuf_from_utf8_string s in
+	if offset > 0 then
+		Sedlexing.set_position code {Lexing.pos_fname = p.pfile; pos_lnum = 1; pos_bol = 0; pos_cnum = offset};
 	let result = try
-		parse config entry lctx (Lexer.lexbuf_from_utf8_string s) p.pfile
+		(* A virtual prefix replaces the old spaces, including their prevention of
+		   BOM/shebang handling away from the beginning of the source. *)
+		parse ~skip_header:(offset = 0) config entry lctx code p.pfile
 	with Error (e,pe) ->
 		restore();
 		error (error_msg e) (if inlined then pe else p)
@@ -398,8 +403,9 @@ let parse_string config entry s p error inlined =
 	result
 
 let parse_expr_string config s p error inl =
-	let s = if p.pmin > 0 then (String.make p.pmin ' ') ^ s else s in
-	let result = parse_string config expr s p error inl in
+	(* Source coordinates must not require allocating and lexing a prefix for
+	   every expression, notably each braced string interpolation. *)
+	let result = parse_string ~offset:(max 0 p.pmin) config expr s p error inl in
 	if inl then
 		result
 	else begin

--- a/tests/misc/eval/projects/ParseExpressionOffset/Main.hx
+++ b/tests/misc/eval/projects/ParseExpressionOffset/Main.hx
@@ -1,0 +1,80 @@
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+
+/** Checks expression ranges independently of the parser's offset mechanism. */
+class Main {
+	public static macro function check():Expr {
+		for (offset in [0, 1, 17, 1000000]) {
+			final position = Context.makePosition({file: "offset-input.hx", min: offset, max: offset + 91});
+			final expression = Context.parseInlineString("1 + 2", position);
+			function positionRange(value:Position, start:Int, end:Int):Void {
+				final actual = Context.getPosInfos(value);
+				if (actual.file != "offset-input.hx" || actual.min != offset + start || actual.max != offset + end)
+					throw 'unexpected source range at offset $offset: ${actual.min}-${actual.max}';
+			}
+			function range(value:Expr, start:Int, end:Int):Void {
+				positionRange(value.pos, start, end);
+			}
+			range(expression, 0, 5);
+			switch expression.expr {
+				case EBinop(OpAdd, left, right):
+					range(left, 0, 1);
+					range(right, 4, 5);
+				case _: throw "addition expression changed";
+			}
+			final ordinary = Context.parse("1 + 2", position);
+			function checkOrdinary(value:Expr):Void {
+				range(value, 0, 91);
+				ExprTools.iter(value, checkOrdinary);
+			}
+			checkOrdinary(ordinary);
+			// Unicode positions count decoded characters, not UTF-8 bytes.
+			final unicode = Context.parseInlineString('"é" + "🦊"', position);
+			range(unicode, 0, 9);
+			switch unicode.expr {
+				case EBinop(OpAdd, left, right):
+					range(left, 0, 3);
+					range(right, 6, 9);
+				case _: throw "Unicode addition expression changed";
+			}
+			final multiline = Context.parseInlineString("1 +\n2", position);
+			range(multiline, 0, 5);
+			switch multiline.expr {
+				case EBinop(OpAdd, left, right):
+					range(left, 0, 1);
+					range(right, 4, 5);
+				case _: throw "multiline addition expression changed";
+			}
+			var rejected = false;
+			try {
+				Context.parseInlineString("1 + )", position);
+			} catch (error:haxe.macro.Expr.Error) {
+				rejected = true;
+				positionRange(error.pos, 4, 5);
+				if (error.message != "Expected expression")
+					throw 'parse diagnostic changed: ${error.message}';
+			}
+			if (!rejected)
+				throw "invalid expression was accepted";
+		}
+		for (header in ["#!ignored\n", "\uFEFF"]) {
+			Context.parseInlineString(header + "1", Context.makePosition({file: "header.hx", min: 0, max: 0}));
+			var rejected = false;
+			try {
+				Context.parseInlineString(header + "1", Context.makePosition({file: "header.hx", min: 17, max: 17}));
+			} catch (_:haxe.macro.Expr.Error) {
+				rejected = true;
+			}
+			if (!rejected)
+				throw "nonzero source offset admitted a file header";
+		}
+		return macro null;
+	}
+
+	static function main():Void {
+		final value = 3;
+		if ('outer ${'inner ${value + 1}'}' != "outer inner 4")
+			throw "nested interpolation changed";
+	}
+}

--- a/tests/misc/eval/projects/ParseExpressionOffset/compile.hxml
+++ b/tests/misc/eval/projects/ParseExpressionOffset/compile.hxml
@@ -1,0 +1,3 @@
+--macro Main.check()
+-main Main
+--interp


### PR DESCRIPTION
Large Haxe files with many `${...}` expressions spend excessive time parsing string interpolation. Each expression currently allocates and scans spaces up to its source offset. The total work grows quadratically as the file gains expressions.

This change initializes the lexer at the source offset directly. It preserves the expression ranges without allocating the prefix. At nonzero offsets, the parser still rejects file headers such as a BOM or shebang.

The regression checks exact expression and operand ranges at offsets 0, 1, 17, and 1,000,000. It also covers ordinary parse remapping, Unicode, newlines, error positions, header handling, and nested interpolation. Both the original and patched compiler pass these compatibility checks. The upstream miscellaneous-test runner passes `ParseExpressionOffset`, `Issue3188`, `Issue9336`, and `Issue11004`.


